### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "a7577363f7",
-  "targetRevisionAtLastExport": "1f7948aa7",
+  "sourceRevisionAtLastExport": "ab06e520db",
+  "targetRevisionAtLastExport": "b9f58f3ae",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/ChangeLog-2018-09-11
+++ b/implementation-contributed/javascriptcore/ChangeLog-2018-09-11
@@ -1,0 +1,23391 @@
+2018-09-10  Michael Saboff  <msaboff@apple.com>
+
+        Test262 failure with Named Capture Groups - using a reference before the group is defined
+        https://bugs.webkit.org/show_bug.cgi?id=189407
+
+        Reviewed by Alex Christensen.
+
+        Re-enabled previously failing test.
+
+        * test262.yaml:
+        * test262/expectations.yaml:
+
+2018-09-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Remove loadModule function in jsc.cpp
+        https://bugs.webkit.org/show_bug.cgi?id=184808
+
+        Reviewed by Darin Adler.
+
+        Use `import` expression instead.
+
+        * modules/different-view.js:
+        (from.string_appeared_here.shouldThrow): Deleted.
+        * modules/fallback-ambiguous.js:
+        (from.string_appeared_here.shouldThrow): Deleted.
+        * modules/import-error.js:
+        (from.string_appeared_here.shouldThrow): Deleted.
+        (shouldThrow): Deleted.
+        * modules/indirect-export-error.js:
+        (from.string_appeared_here.shouldThrow): Deleted.
+        (shouldThrow): Deleted.
+        * modules/namespace-error.js:
+        (from.string_appeared_here.shouldThrow): Deleted.
+
+2018-09-07  Mark Lam  <mark.lam@apple.com>
+
+        Ensure that handleIntrinsicCall() is only applied on op_call shaped instructions.
+        https://bugs.webkit.org/show_bug.cgi?id=189317
+        <rdar://problem/44152198>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-189317.js: Added.
+        (testGetter):
+        (testSetter):
+
+2018-09-06  Yusuke Suzuki  <yusukesuzuki@slowstart.org>
+
+        [DFG] DFG should handle String#toString
+        https://bugs.webkit.org/show_bug.cgi?id=189151
+
+        Reviewed by Saam Barati.
+
+        The error message in String#toString and String#valueOf is poor, which will be
+        handled in a separate bug[1].
+
+        [1]: https://bugs.webkit.org/show_bug.cgi?id=189357
+
+        * microbenchmarks/string-object-to-string.js: Added.
+        (test):
+        * microbenchmarks/string-object-value-of.js: Added.
+        (test):
+        * stress/string-to-string-error.js: Added.
+        (shouldThrow):
+        (test):
+        * stress/string-to-string.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        (test3):
+        * stress/string-value-of-error.js: Added.
+        (shouldThrow):
+        (test):
+        * stress/string-value-of.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        (test3):
+
+2018-09-06  Michael Saboff  <msaboff@apple.com>
+
+        Improper speculation type for Math.pow(NaN, 0) in Abstract Interpreter
+        https://bugs.webkit.org/show_bug.cgi?id=189380
+
+        Reviewed by Saam Barati.
+
+        New test.
+
+        * stress/math-pow-nan-to-zero-spec-type.js: Added.
+        (func):
+        (test):
+
+2018-09-06  Mark Lam  <mark.lam@apple.com>
+
+        Gardening: Move regress-189185.js under JSTests/wasm.
+        https://bugs.webkit.org/show_bug.cgi?id=189347
+
+        Unreviewed.
+
+        * stress/regress-189185.js: Removed.
+        * wasm/regress/regress-189185.js: Copied from JSTests/stress/regress-189185.js.
+
+2018-09-05  Mark Lam  <mark.lam@apple.com>
+
+        JSPropertyNameEnumerator::visitChildren() needs to visit its m_cachedStructureID.
+        https://bugs.webkit.org/show_bug.cgi?id=189124
+        <rdar://problem/43863605>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-189124.js: Added.
+
+2018-09-05  Ross Kirsling  <ross.kirsling@sony.com>
+
+        [ESNext] Symbol.prototype.description
+        https://bugs.webkit.org/show_bug.cgi?id=186686
+
+        Reviewed by Keith Miller.
+
+        * stress/symbol-description.js:
+        Add tests for empty and null symbol cases.
+
+        * test262/config.yaml:
+        Enable Symbol.prototype.description tests.
+
+2018-09-05  David Fenton  <david_fenton@apple.com>
+
+        [32-bit JSC tests] Exception: ReferenceError: Can't find variable: WebAssembly.
+        https://bugs.webkit.org/show_bug.cgi?id=189312.
+
+        Unreviewed test gardening.
+
+        * stress/regress-189185.js:
+
+2018-09-05  Mark Lam  <mark.lam@apple.com>
+
+        isAsyncGeneratorMethodParseMode() should check for SourceParseMode::AsyncGeneratorWrapperMethodMode.
+        https://bugs.webkit.org/show_bug.cgi?id=189292
+        <rdar://problem/38907433>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-189292.js: Added.
+
+2018-09-04  David Fenton  <david_fenton@apple.com>
+
+        Skip Test on 32-bit platforms.
+        https://bugs.webkit.org/show_bug.cgi?id=189185.
+
+        Unreviewed test gardening.
+
+        * stress/regress-189185.js:
+
+2018-09-03  Mark Lam  <mark.lam@apple.com>
+
+        The watchdog sometimes fails to terminate a script.
+        https://bugs.webkit.org/show_bug.cgi?id=189227
+        <rdar://problem/39932857>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-189227-watchdog-on-infinite-loop.js: Added.
+
+2018-09-02  Yusuke Suzuki  <yusukesuzuki@slowstart.org>
+
+        Implement Object.fromEntries
+        https://bugs.webkit.org/show_bug.cgi?id=188481
+
+        Reviewed by Darin Adler.
+
+        * stress/object-from-entries.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (shouldBe.JSON.stringify.Object.getOwnPropertyDescriptor):
+        (shouldBe.set get shouldThrow):
+
+2018-08-24  Yusuke Suzuki  <yusukesuzuki@slowstart.org>
+
+        Function object should convert params to string before throw a parsing error
+        https://bugs.webkit.org/show_bug.cgi?id=188874
+
+        Reviewed by Darin Adler.
+
+        * stress/function-body-to-string-before-parameter-syntax-check.js: Added.
+        (shouldThrow):
+
+2018-08-31  Mark Lam  <mark.lam@apple.com>
+
+        Fix exception check accounting in constructJSWebAssemblyCompileError().
+        https://bugs.webkit.org/show_bug.cgi?id=189185
+        <rdar://problem/39786007>
+
+        Reviewed by Michael Saboff.
+
+        * stress/regress-189185.js: Added.
+        (new.WebAssembly.CompileError.valueOf):
+
+2018-08-31  Mark Lam  <mark.lam@apple.com>
+
+        Fix exception check accounting in JSDataView::defineOwnProperty().
+        https://bugs.webkit.org/show_bug.cgi?id=189186
+        <rdar://problem/39786049>
+
+        Reviewed by Michael Saboff.
+
+        * stress/regress-189186.js: Added.
+
+2018-08-31  Mark Lam  <mark.lam@apple.com>
+
+        Add missing exception check in arrayProtoFuncLastIndexOf().
+        https://bugs.webkit.org/show_bug.cgi?id=189184
+        <rdar://problem/39785959>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/regress-189184.js: Added.
+
+2018-08-31  Saam barati  <sbarati@apple.com>
+
+        convertToRegExpMatchFastGlobal must use KnownString as the child use kind
+        https://bugs.webkit.org/show_bug.cgi?id=189173
+        <rdar://problem/43501645>
+
+        Reviewed by Michael Saboff.
+
+        * stress/may-exit-should-be-false-regexp-constant-folding.js: Added.
+        (foo):
+        (bar):
+
+2018-08-30  Saam barati  <sbarati@apple.com>
+
+        CSE DataViewGet* DFG nodes
+        https://bugs.webkit.org/show_bug.cgi?id=188768
+
+        Reviewed by Yusuke Suzuki.
+
+        * microbenchmarks/dataview-cse.js: Added.
+        (assert):
+        (test):
+        * stress/dataview-get-cse.js: Added.
+        (assert):
+        (test1.foo):
+        (test1):
+        (test2.foo):
+        (test2):
+        (test3.foo):
+        (test3):
+        (test4.foo):
+        (test4):
+        (test5.foo):
+        (test5):
+        (test6.foo):
+        (test6):
+
+2018-08-30  Yusuke Suzuki  <yusukesuzuki@slowstart.org>
+
+        output of toString() of Generator is wrong
+        https://bugs.webkit.org/show_bug.cgi?id=188952
+
+        Reviewed by Saam Barati.
+
+        * stress/function-to-string.js: Added.
+        (shouldBe):
+        (shouldBe.test):
+        (test):
+        (shouldBe.async.test):
+        (async.test):
+        (shouldBe.async):
+        (async):
+        * test262/expectations.yaml:
+
+2018-08-29  Mark Lam  <mark.lam@apple.com>
+
+        Add some missing exception checks in JSRopeString::resolveRopeToAtomicString().
+        https://bugs.webkit.org/show_bug.cgi?id=189132
+        <rdar://problem/42513068>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-189132.js: Added.
+
+2018-08-27  Yusuke Suzuki  <yusukesuzuki@slowstart.org>
+
+        [WebAssembly] Parse wasm modules in a streaming fashion
+        https://bugs.webkit.org/show_bug.cgi?id=188943
+
+        Reviewed by Mark Lam.
+
+        Wasm parsing error should not report the total byte size since streaming parsing does not
+        want to load all the bytes.
+        Add a simple test wasm/stress/streaming-basic.js for initial streaming parsing implementation.
+
+        * wasm/function-tests/invalid-duplicate-export.js:
+        * wasm/function-tests/memory-alignment.js:
+        (const.op.of.WASM.opcodes):
+        * wasm/function-tests/memory-section-and-import.js:
+        * wasm/function-tests/void-argument-type-should-be-a-validation-error.js:
+        * wasm/js-api/Module-compile.js:
+        (async.testPromiseAPI):
+        * wasm/js-api/element.js:
+        (assert.throws.new.WebAssembly.Module.builder.WebAssembly):
+        (assert.throws):
+        * wasm/js-api/global-error.js:
+        (assert.throws.new.WebAssembly.Module.bin):
+        (assert.throws):
+        * wasm/js-api/table.js:
+        (new.WebAssembly.Module):
+        (assert.throws):
+        (assertBadTableImport):
+        * wasm/js-api/test_Data.js:
+        (DataSectionWithoutMemory):
+        * wasm/js-api/test_Start.js:
+        (InvalidStartFunctionIndex):
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties.switch):
+        * wasm/js-api/version.js:
+        * wasm/stress/nameSection.wasm: Added.
+        * wasm/stress/streaming-basic.js: Added.
+        (check):
+
+2018-08-27  Mark Lam  <mark.lam@apple.com>
+
+        Fix exception throwing code so that topCallFrame and topEntryFrame stay true to their names.
+        https://bugs.webkit.org/show_bug.cgi?id=188577
+        <rdar://problem/42985684>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-188577.js: Added.
+
+2018-08-24  Yusuke Suzuki  <yusukesuzuki@slowstart.org>
+
+        [JSC] Array.prototype.reverse modifies JSImmutableButterfly
+        https://bugs.webkit.org/show_bug.cgi?id=188794
+
+        Reviewed by Saam Barati.
+
+        * stress/reverse-with-immutable-butterfly.js: Added.
+        (shouldBe):
+        (reverseInt):
+        (reverseDouble):
+        (reverseContiguous):
+
+2018-08-22  Saam barati  <sbarati@apple.com>
+
+        Make data-view-access.js run less time to prevent timeouts on 32-bit
+
+        * microbenchmarks/data-view-accesses.js:
+
+2018-08-22  Mark Lam  <mark.lam@apple.com>
+
+        The DFG CFGSimplification phase shouldn’t jettison a block when it’s the target of both branch directions.
+        https://bugs.webkit.org/show_bug.cgi?id=188298
+        <rdar://problem/42888427>
+
+        Reviewed by Saam Barati.
+
+        * stress/bug-188298.js: Added.
+
+2018-08-20  Saam barati  <sbarati@apple.com>
+
+        Inline DataView accesses into DFG/FTL
+        https://bugs.webkit.org/show_bug.cgi?id=188573
+        <rdar://problem/43286746>
+
+        Reviewed by Michael Saboff.
+
+        * microbenchmarks/data-view-accesses-2.js: Added.
+        (assert):
+        (let.p.of.Object.keys.let.str):
+        (let.p.of.Object.keys):
+        (test):
+        * microbenchmarks/data-view-accesses.js: Added.
+        (assert):
+        (let.p.of.Object.keys.let.str):
+        (let.p.of.Object.keys):
+        * stress/dataview-jit-bounds-checks.js: Added.
+        (assert):
+        (let.p.of.Object.keys.let.str):
+        (let.p.of.Object.keys):
+        * stress/dataview-jit-get.js: Added.
+        (assert):
+        (test1.bigEndian):
+        (test1.littleEndian):
+        (test1.biEndian):
+        (test1):
+        (test2.bigEndian):
+        (test2.littleEndian):
+        (test2.biEndian):
+        (test2):
+        (test3.bigEndian):
+        (test3.littleEndian):
+        (test3.biEndian):
+        (test3):
+        (test4.bigEndian):
+        (test4.littleEndian):
+        (test4.biEndian):
+        (test4):
+        (test5.bigEndian):
+        (test5.littleEndian):
+        (test5.biEndian):
+        (test5):
+        (test6.bigEndian):
+        (test6.littleEndian):
+        (test6.biEndian):
+        (test6):
+        (test7.load):
+        (test7):
+        (test8.load):
+        (test8):
+        * stress/dataview-jit-neuter.js: Added.
+        (assert):
+        (test.load):
+        (test):
+        (test2.load):
+        (test2):
+        * stress/dataview-jit-set.js: Added.
+        (assert):
+        (isLittleEndian):
+        (readByte):
+        (readHex):
+        (test.storeLittleEndian):
+        (test.storeBigEndian):
+        (test.store):
+        (test):
+        (test2.storeLittleEndian):
+        (test2.storeBigEndian):
+        (test2.store):
+        (test2):
+        (test3.storeLittleEndian):
+        (test3.storeBigEndian):
+        (test3.store):
+        (test3):
+        (test4.storeLittleEndian):
+        (test4.storeBigEndian):
+        (test4.store):
+        (test4):
+        (test5.storeLittleEndian):
+        (test5.storeBigEndian):
+        (test5.store):
+        (test5):
+        (test6.storeLittleEndian):
+        (test6.storeBigEndian):
+        (test6.store):
+        (test6):
+        (test7.store):
+        (test7):
+        (test8.store):
+        (test8):
+        * stress/dataview-jit-unaligned-accesses.js: Added.
+        (assert):
+        (let.p.of.Object.keys.let.str):
+        (let.p.of.Object.keys):
+
+2018-08-20  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [YARR] Extend size of fixed characters bulk matching in 64bit platform
+        https://bugs.webkit.org/show_bug.cgi?id=181989
+
+        Reviewed by Michael Saboff.
+
+        * stress/characters-regexp-ignore-case.js: Added.
+        (shouldBe):
+        (testH):
+        (testHe):
+        (testHel):
+        (testHell):
+        (testHello):
+        (testHelloW):
+        (testHelloWo):
+        (testHelloWor):
+        (testHelloWorl):
+        (testHelloWorld):
+        * stress/characters-regexp.js: Added.
+        (shouldBe):
+        (testH):
+        (testHe):
+        (testHel):
+        (testHell):
+        (testHello):
+        (testHelloW):
+        (testHelloWo):
+        (testHelloWor):
+        (testHelloWorl):
+        (testHelloWorld):
+
+2018-08-17  Saam barati  <sbarati@apple.com>
+
+        intersectionOfPastValuesAtHead must filter values after they've observed an invalidation point
+        https://bugs.webkit.org/show_bug.cgi?id=188707
+        <rdar://problem/43015442>
+
+        Reviewed by Mark Lam.
+
+        * stress/cfa-expected-values-must-set-clobbered-to-false.js: Added.
+        (foo):
+        (let.comp.valueOf):
+        (result):
+
+2018-08-10  Keith Miller  <keith_miller@apple.com>
+
+        Slicing an ArrayBuffer with a long number returns an ArrayBuffer with byteLength zero
+        https://bugs.webkit.org/show_bug.cgi?id=185127
+
+        Reviewed by Saam Barati.
+
+        Rebaseline the expectations.
+
+        * test262/expectations.yaml:
+
+2018-08-10  Yusuke Suzuki  <yusukesuzuki@slowstart.org>
+
+        Date.UTC should not return NaN with only Year param
+        https://bugs.webkit.org/show_bug.cgi?id=188378
+
+        Reviewed by Keith Miller.
+
+        * ChakraCore.yaml:
+        * ChakraCore/test/Date/dateutc.baseline-jsc: Added.
+        * stress/date-utc-optional.js: Added.
+        (shouldBe):
+        * test262/expectations.yaml:
+
+2018-08-08  Keith Miller  <keith_miller@apple.com>
+
+        Array.prototype.sort should call @toLength instead of ">>> 0"
+        https://bugs.webkit.org/show_bug.cgi?id=188430
+
+        Reviewed by Saam Barati.
+
+        * test262/expectations.yaml:
+
+2018-08-08  Keith Miller  <keith_miller@apple.com>
+
+        Array.prototype.sort should throw TypeError if param is a not callable object
+        https://bugs.webkit.org/show_bug.cgi?id=188382
+
+        Reviewed by Saam Barati.
+
+        * test262/expectations.yaml:
+
+2018-08-01  Andy VanWagoner  <andy@vanwagoner.family>
+
+        [INTL] Implement hourCycle in DateTimeFormat
+        https://bugs.webkit.org/show_bug.cgi?id=188006
+
+        Reviewed by Darin Adler.
+
+        Removed fixed hourCycle expectations.
+
+        * test262/expectations.yaml:
+
+2018-07-25  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Record CoW status in ArrayProfile correctly
+        https://bugs.webkit.org/show_bug.cgi?id=187949
+
+        Reviewed by Saam Barati.
+
+        * stress/array-profile-should-record-copy-on-write.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        (test3):
+
+2018-07-26  Mark Lam  <mark.lam@apple.com>
+
+        arrayProtoPrivateFuncConcatMemcpy() should handle copying from an Undecided type array.
+        https://bugs.webkit.org/show_bug.cgi?id=188065
+        <rdar://problem/42515726>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-188065.js: Added.
+
+2018-07-25  Andy VanWagoner  <andy@vanwagoner.family>
+
+        [INTL] Call Typed Array elements toLocaleString with locale and options
+        https://bugs.webkit.org/show_bug.cgi?id=185796
+
+        Reviewed by Keith Miller.
+
+        Remove now passing TypedArray toLocaleString expectation.
+
+        * test262/expectations.yaml:
+
+2018-07-25  Andy VanWagoner  <andy@vanwagoner.family>
+
+        [INTL] Intl constructor lengths should be configurable
+        https://bugs.webkit.org/show_bug.cgi?id=187960
+
+        Reviewed by Saam Barati.
+
+        Removed fixed length expectations, and updated Intl.Locale expectations
+        that error differently since r234127.
+
+        * test262/expectations.yaml:
+
+2018-07-24  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r234183.
+        https://bugs.webkit.org/show_bug.cgi?id=187983
+
+        cause regression in Kraken gaussian blur and desaturate
+        (Requested by yusukesuzuki on #webkit).
+
+        Reverted changeset:
+
+        "[JSC] Record CoW status in ArrayProfile"
+        https://bugs.webkit.org/show_bug.cgi?id=187949
+        https://trac.webkit.org/changeset/234183
+
+2018-07-24  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Record CoW status in ArrayProfile
+        https://bugs.webkit.org/show_bug.cgi?id=187949
+
+        Reviewed by Saam Barati.
+
+        * stress/array-profile-should-record-copy-on-write.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        (test3):
+
+2018-07-23  Saam Barati  <sbarati@apple.com>
+
+        need to didFoldClobberWorld when we constant fold GetByVal
+        https://bugs.webkit.org/show_bug.cgi?id=187917
+        <rdar://problem/42505095>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/get-by-val-fold-did-clobber-world.js: Added.
+        (__f_443):
+
+2018-07-23  Andy VanWagoner  <andy@vanwagoner.family>
+
+        [INTL] Language tags are not canonicalized
+        https://bugs.webkit.org/show_bug.cgi?id=185836
+
+        Reviewed by Keith Miller.
+
+        Remove expected failures that have been fixed.
+
+        * test262/expectations.yaml:
+
+2018-07-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] GetByIdVariant and InByIdVariant do not need slot base if they are not "hit" variants
+        https://bugs.webkit.org/show_bug.cgi?id=187891
+
+        Reviewed by Saam Barati.
+
+        * stress/in-miss-variant-merge.js: Added.
+        (shouldBe):
+        (test):
+        * stress/miss-variant-merge.js: Added.
+        (shouldBe):
+        (test):
+
+2018-07-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Fold GetByVal if the indexed value is non configurable and non writable
+        https://bugs.webkit.org/show_bug.cgi?id=186462
+
+        Reviewed by Saam Barati.
+
+        * stress/folding-get-by-val-with-read-only-dont-delete-object.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        (test3):
+        (test4):
+        (test5):
+        * stress/folding-get-by-val-with-read-only-dont-delete-runtime-array.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        (test5):
+        * stress/folding-get-by-val-with-read-only-dont-delete.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        (test3):
+        (test4):
+        (test5):
+
+2018-06-02  Filip Pizlo  <fpizlo@apple.com>
+
+        We should support CreateThis in the FTL
+        https://bugs.webkit.org/show_bug.cgi?id=164904
+
+        Reviewed by Yusuke Suzuki.
+
+        * microbenchmarks/polyvariant-get-by-id-shorter-tower.js: Added.
+        (polyvariant):
+        (Foo.prototype.func):
+        (Foo):
+        (foo):
+        (Bar.prototype.func):
+        (Bar):
+        (bar):
+        * microbenchmarks/polyvariant-get-by-id-tower.js: Added.
+        (polyvariant):
+        (Foo.prototype.func):
+        (Foo):
+        (foo):
+        (Bar.prototype.func):
+        (Bar):
+        (bar):
+        (Baz.prototype.func):
+        (Baz):
+        (baz):
+
+2018-07-20  Michael Saboff  <msaboff@apple.com>
+
+        DFG AbstractInterpreter: CheckArray filters array modes for DirectArguments/ScopedArguments using only NonArray
+        https://bugs.webkit.org/show_bug.cgi?id=187827
+        rdar://problem/42146858
+
+        Reviewed by Saam Barati.
+
+        New regression tests.
+
+        * stress/direct-arguments-check-array.js: Added.
+        (setup.f2):
+        (setup):
+        (forOfArray):
+        (forOfArgs):
+        (callEveryOnArgs):
+        * stress/scoped-arguments-check-array.js: Added.
+        (setup.foo):
+        (setup.f2):
+        (setup):
+        (forOfArray):
+        (forOfArgs):
+        (callEveryOnArgs):
+
+2018-07-20  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Fold GetByVal if Array is CoW
+        https://bugs.webkit.org/show_bug.cgi?id=186459
+
+        Reviewed by Saam Barati.
+
+        * stress/folding-get-by-val-with-immutable-butterfly-out-of-bounds-foldable.js: Added.
+        (shouldBe):
+        (test0):
+        (test1):
+        (test2):
+        (test3):
+        (test4):
+        (test5):
+        * stress/folding-get-by-val-with-immutable-butterfly-out-of-bounds.js: Added.
+        (shouldBe):
+        (test0):
+        (test1):
+        (test2):
+        (test3):
+        (test4):
+        (test5):
+        * stress/folding-get-by-val-with-immutable-butterfly-with-types.js: Added.
+        (shouldBe):
+        (test0):
+        (test1):
+        (test2):
+        (test3):
+        (test4):
+        (test5):
+        * stress/folding-get-by-val-with-immutable-butterfly.js: Added.
+        (shouldBe):
+        (checking):
+        (test):
+
+2018-07-20  Saam Barati  <sbarati@apple.com>
+
+        CompareEq should be using KnownOtherUse instead of OtherUse
+        https://bugs.webkit.org/show_bug.cgi?id=186814
+        <rdar://problem/39720030>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/compare-eq-should-use-known-other-use.js: Added.
+        (bar):
+        (i.func):
+
+2018-07-20  David Fenton  <david_fenton@apple.com>
+
+        stress/spread-forward-varargs-stack-overflow.js is timing out in 32 bit JSC tests.
+        https://bugs.webkit.org/show_bug.cgi?id=187698
+
+        Unreviewed test gardening, skipped test in 32 Bit JSC.
+
+        * stress/spread-forward-varargs-stack-overflow.js:
+
+2018-07-18  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        JSON.stringify should emit non own properties if second array argument includes
+        https://bugs.webkit.org/show_bug.cgi?id=187724
+
+        Reviewed by Mark Lam.
+
+        * stress/json-stringify-getter-call.js: Added.
+        (shouldBe):
+        (A.prototype.get cocoa):
+        (A.prototype.get cappuccino):
+        (A):
+        (shouldBe.JSON.stringify):
+
+2018-07-18  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] JSON.stringify's replacer should use `isArray` instead of JSArray checks
+        https://bugs.webkit.org/show_bug.cgi?id=187755
+
+        Reviewed by Mark Lam.
+
+        * stress/json-stringify-gap-calculation-should-be-after-replacer-check.js: Added.
+        (shouldThrow):
+        (shouldThrow.string.toString):
+        * test262/expectations.yaml:
+
+2018-07-12  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Generator and AsyncGeneratorMethod's prototype is incorrect
+        https://bugs.webkit.org/show_bug.cgi?id=187585
+
+        Reviewed by Darin Adler.
+
+        * stress/default-proto-for-async-generator.js: Added.
+        (shouldBe):
+        (async.asyncGenerator):
+        * stress/default-proto-for-generator.js: Added.
+        (shouldBe):
+        (generator):
+        * stress/prototype-for-async-generator.js: Added.
+        (shouldBe):
+        (async.asyncGenerator):
+        (A.prototype.async.asyncGenerator):
+        (A):
+        * test262/expectations.yaml:
+
+2018-07-11  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip JSC test stress/keep-checks-when-converting-to-lazy-js-constant-in-strength-reduction.js
+        https://bugs.webkit.org/show_bug.cgi?id=187559
+
+        Unreviewed test gardening.
+
+        * stress/keep-checks-when-converting-to-lazy-js-constant-in-strength-reduction.js:
+
+2018-07-11  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Iterator of Array.keys() returns object in wrong order
+        https://bugs.webkit.org/show_bug.cgi?id=185197
+
+        Reviewed by Keith Miller.
+
+        We align the shape of our iterator result to the spec: {value,done} instead of {done,value}.
+
+        * stress/iterator-field-order.js: Added.
+        (shouldBe):
+        (shouldBe.JSON.stringify.array.values.next):
+        (shouldBe.JSON.stringify.array.keys.next):
+        (shouldBe.JSON.stringify.array.entries.next):
+        (async.asyncIterator):
+        (iterator.next.then):
+        (generator):
+        (shouldBe.JSON.stringify.generator.next):
+        (shouldBe.JSON.stringify.map.keys.next):
+        (shouldBe.JSON.stringify.map.values.next):
+        (shouldBe.JSON.stringify.map.entries.next):
+        (set new):
+
+2018-07-11  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, clean up test262 expectations
+
+        * test262/expectations.yaml:
+
+2018-07-10  Mark Lam  <mark.lam@apple.com>
+
+        constructArray() should always allocate the requested length.
+        https://bugs.webkit.org/show_bug.cgi?id=187543
+        <rdar://problem/41947884>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-187543-2.js: Added.
+        * stress/regress-187543-3.js: Added.
+        * stress/regress-187543.js: Added.
+
+2018-07-10  Keith Miller  <keith_miller@apple.com>
+
+        hasOwnProperty returns true for out of bounds property index on TypedArray
+        https://bugs.webkit.org/show_bug.cgi?id=187520
+
+        Reviewed by Saam Barati.
+
+        getOwnPropertySlot returns true on out of bounds indicies for
+        TypedArrays, which is incorrect.
+
+        * stress/typedarray-hasOwnProperty-out-of-bounds.js: Added.
+        (test):
+
+2018-07-10  Michael Saboff  <msaboff@apple.com>
+
+        DFG JIT: compileMathIC produces incorrect machine code
+        https://bugs.webkit.org/show_bug.cgi?id=187537
+
+        Reviewed by Saam Barati.
+
+        Added new test case.
+
+        * stress/arith-mul-with-constants.js:
+        (testArithMulWithTypeConfusedConstant.testMult):
+        (testArithMulWithTypeConfusedConstant):
+
+2018-07-10  Michael Saboff  <msaboff@apple.com>
+
+        YARR: . doesn't match non-BMP Unicode characters in some cases
+        https://bugs.webkit.org/show_bug.cgi?id=187248
+
+        Reviewed by Geoffrey Garen.
+
+        New regression test.
+
+        * stress/regexp-with-nonBMP-any.js: Added.
+
+2018-07-09  Michael Saboff  <msaboff@apple.com>
+
+        REGRESSION (ICU-62100.0.1): JSC test mozilla-tests.yaml/ecma/String/15.5.4.12-3.js is failing
+        https://bugs.webkit.org/show_bug.cgi?id=187495
+
+        Reviewed by Saam Barati.
+
+        Commented out the Georgian section of this toUpper() test since Unicode 11 added new upper case characters for
+        most of this range.
+
+        * mozilla/ecma/String/15.5.4.12-3.js:
+        (getTestCases):
+        (DecimalToHexString):
+
+2018-07-02  Sukolsak Sakshuwong  <sukolsak@gmail.com>
+
+        RegExp.exec returns wrong value with a long integer quantifier
+        https://bugs.webkit.org/show_bug.cgi?id=187042
+
+        Reviewed by Saam Barati.
+
+        * stress/regexp-large-quantifier.js: Added.
+        (testRegExp):
+        * stress/regress-159744.js:
+
+2018-07-02  Ryosuke Niwa  <rniwa@webkit.org>
+
+        Repository fix after r233427 and r233443.
+        Added back the test which got erroneously deleted in r233443.
+
+        * stress/instanceof-non-object-prototype.js:
+
+2018-07-02  Keith Miller  <keith_miller@apple.com>
+
+        InstanceOf IC should do generic if the prototype is not an object.
+        https://bugs.webkit.org/show_bug.cgi?id=187250
+
+        Reviewed by Mark Lam.
+
+        * stress/instanceof-non-object-prototype.js: Added.
+        (let):
+        (test):
+        (i.catch):
+
+2018-06-30  Mark Lam  <mark.lam@apple.com>
+
+        Builtins and host functions should get their own structures.
+        https://bugs.webkit.org/show_bug.cgi?id=187211
+        <rdar://problem/41646336>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-187211.js: Added.
+
+2018-06-29  Saam Barati  <sbarati@apple.com>
+
+        We shouldn't recurse into the parser when gathering metadata about various function offsets
+        https://bugs.webkit.org/show_bug.cgi?id=184074
+        <rdar://problem/37165897>
+
+        Reviewed by Mark Lam.
+
+        * microbenchmarks/try-get-by-id-basic.js:
+        (const.bench.f.const.fooPlusBar.createBuiltin):
+        * microbenchmarks/try-get-by-id-polymorphic.js:
+        (fooPlusBar.createBuiltin):
+        * stress/array-push-with-force-exit.js:
+        * stress/dont-crash-on-stack-overflow-when-parsing-builtin.js: Added.
+        (f):
+        * stress/dont-crash-on-stack-overflow-when-parsing-default-constructor.js: Added.
+        (foo):
+        (prototype.runNearStackLimit):
+        * stress/is-constructor.js:
+        * stress/tailCallForwardArguments.js:
+        (putFuncToPrivateName.createBuiltin):
+
+2018-06-27  Mark Lam  <mark.lam@apple.com>
+
+        DFG's compileReallocatePropertyStorage() and compileAllocatePropertyStorage() slow paths should also clear unused properties.
+        https://bugs.webkit.org/show_bug.cgi?id=187091
+        <rdar://problem/41395624>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/regress-187091.js: Added.
+
+2018-06-27  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] ArrayPatternNode::emitDirectBinding does not return assignment target value if dst is nullptr
+        https://bugs.webkit.org/show_bug.cgi?id=185943
+
+        Reviewed by Mark Lam.
+
+        * stress/direct-binding-return-result.js: Added.
+        (shouldBe):
+        (test):
+
+2018-06-26  Mark Lam  <mark.lam@apple.com>
+
+        eval() is wrong about the LiteralParser never throwing any exceptions.
+        https://bugs.webkit.org/show_bug.cgi?id=187074
+        <rdar://problem/41461099>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-187074.js: Added.
+
+2018-06-26  Mark Lam  <mark.lam@apple.com>
+
+        ASSERTION FAILED: length > butterfly->vectorLength() in JSObject::ensureLengthSlow().
+        https://bugs.webkit.org/show_bug.cgi?id=187060
+        <rdar://problem/41452767>
+
+        Reviewed by Keith Miller.
+
+        * stress/regress-187060.js: Added.
+
+2018-06-25  Mark Lam  <mark.lam@apple.com>
+
+        constructArray() should set m_numValuesInVector to the specified length.
+        https://bugs.webkit.org/show_bug.cgi?id=187010
+        <rdar://problem/41392167>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-187010.js: Added.
+
+2018-06-25  Mark Lam  <mark.lam@apple.com>
+
+        Add missing exception check in RegExpObjectInlines.h's collectMatches.
+        https://bugs.webkit.org/show_bug.cgi?id=187006
+        <rdar://problem/41418412>
+
+        Reviewed by Keith Miller.
+
+        * stress/regress-187006.js: Added.
+
+2018-06-22  Keith Miller  <keith_miller@apple.com>
+
+        unshift should zero unused property storage
+        https://bugs.webkit.org/show_bug.cgi?id=186960
+
+        Reviewed by Saam Barati.
+
+        * stress/array-unshift-zero-property-storage.js: Added.
+        (run):
+        (test):
+
+2018-06-22  Mark Lam  <mark.lam@apple.com>
+
+        PropertyCondition::isValidValueForAttributes() should also consider deleted values.
+        https://bugs.webkit.org/show_bug.cgi?id=186943
+        <rdar://problem/41370337>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-186943.js: Added.
+
+2018-06-22  Keith Miller  <keith_miller@apple.com>
+
+        performProxyCall should toThis the value passed to its handler
+        https://bugs.webkit.org/show_bug.cgi?id=186951
+
+        Reviewed by Mark Lam.
+
+        * stress/proxy-call-apply-handler-to-this.js: Added.
+        (applyHandler):
+        (let.f.new.Proxy):
+        (withScope):
+        (lexicalScope):
+        (strictEvalScope):
+        (BigInt):
+
+2018-06-20  Keith Miller  <keith_miller@apple.com>
+
+        flattenDictionaryStruture needs to zero inline storage.
+        https://bugs.webkit.org/show_bug.cgi?id=186869
+
+        Reviewed by Saam Barati.
+
+        * stress/flatten-object-zero-unused-inline-properties.js: Added.
+
+2018-06-19  Saam Barati  <sbarati@apple.com>
+
+        DirectArguments::create needs to initialize to undefined instead of the empty value
+        https://bugs.webkit.org/show_bug.cgi?id=186818
+        <rdar://problem/38415177>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/create-direct-arguments-in-osr-should-initialize-to-undefined.js: Added.
+        (foo):
+        (bar):
+
+2018-06-19  Tadeu Zagallo  <tzagallo@apple.com>
+
+        ShadowChicken crashes with stack overflow in the LLInt
+        https://bugs.webkit.org/show_bug.cgi?id=186540
+        <rdar://problem/39682133>
+
+        Reviewed by Saam Barati.
+
+        Add test that stack overflows and crashes on ShadowChicken when JIT is
+        disabled and forceDebuggerBytecodeGeneration is enabled.
+
+        * stress/llint-stack-overflow-debugging-opcodes.js: Added.
+        (foo):
+        (catch):
+
+2018-06-19  Leo Balter  <leonardo.balter@gmail.com>
+
+        [test262-runner] More updates to the skip list
+        https://bugs.webkit.org/show_bug.cgi?id=186786
+
+        Reviewed by Michael Saboff.
+
+        * test262/config.yaml:
+        * test262/expectations.yaml:
+
+2018-06-19  Saam Barati  <sbarati@apple.com>
+
+        Wasm: Any function argument of type Void should be a validation error
+        https://bugs.webkit.org/show_bug.cgi?id=186794
+        <rdar://problem/41140257>
+
+        Reviewed by Keith Miller.
+
+        * wasm/Builder.js:
+        (const._normalizeFunctionSignature):
+        * wasm/function-tests/void-argument-type-should-be-a-validation-error.js: Added.
+        (getBinary):
+        * wasm/self-test/test_BuilderJSON.js:
+
+2018-06-18  Keith Miller  <keith_miller@apple.com>
+
+        Properly zero unused property storage offsets
+        https://bugs.webkit.org/show_bug.cgi?id=186692
+
+        Reviewed by Filip Pizlo.
+
+        * stress/butterfly-zero-unused-butterfly-properties.js: Added.
+
+2018-06-18  Michael Saboff  <msaboff@apple.com>
+
+        Support Unicode 11 in RegExp
+        https://bugs.webkit.org/show_bug.cgi?id=186685
+
+        Reviewed by Mark Lam.
+
+        * test262/config.yaml: Removed from skip list Unicode 11 property tests as they
+        are now supported.  Added new bug reference for still failing
+        test/built-ins/RegExp/property-escapes/character-class.js test.
+
+        * test262/test/built-ins/RegExp/property-escapes/unsupported-binary-properties.js:
+        Removed "Extended_Pictographic" from unsupported properties since Unicode 11 now supports them.
+
+2018-06-16  Leo Balter  <leonardo.balter@gmail.com>
+
+        Update Test262 2018-06-15
+        https://bugs.webkit.org/show_bug.cgi?id=186695
+
+        Reviewed by Michael Saboff.
+
+        Also update the skip list - in the config file - with new failures
+        * test262/config.yaml:
+        * test262/expectations.yaml:
+        * test262/harness/testIntl.js:
+        (getInvalidLanguageTags):
+        * test262/latest-changes-summary.txt:
+        * test262/test/built-ins/Date/parse/time-value-maximum-range.js: Added.
+        * test262/test/built-ins/Date/parse/zero.js: Added.
+        * test262/test/built-ins/JSON/stringify/bigint-cross-realm.js: Added.
+        (other.BigInt.prototype.toJSON):
+        * test262/test/built-ins/Object/prototype/toString/symbol-tag-non-str-bigint.js: Added.
+        * test262/test/built-ins/Object/prototype/toString/symbol-tag-override-bigint.js: Added.
+        * test262/test/built-ins/Reflect/ownKeys/return-on-corresponding-order-large-index.js: Added.
+        * test262/test/built-ins/RegExp/property-escapes/character-class.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/ASCII.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/ASCII_Hex_Digit.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Alphabetic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Any.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Assigned.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Bidi_Control.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Bidi_Mirrored.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Case_Ignorable.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Cased.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Changes_When_Casefolded.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Changes_When_Casemapped.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Changes_When_Lowercased.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Changes_When_NFKC_Casefolded.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Changes_When_Titlecased.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Changes_When_Uppercased.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Dash.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Default_Ignorable_Code_Point.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Deprecated.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Diacritic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Emoji.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Emoji_Component.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Emoji_Modifier.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Emoji_Modifier_Base.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Emoji_Presentation.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Extended_Pictographic.js: Added.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Extender.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Cased_Letter.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Close_Punctuation.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Connector_Punctuation.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Control.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Currency_Symbol.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Dash_Punctuation.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Decimal_Number.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Enclosing_Mark.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Final_Punctuation.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Format.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Initial_Punctuation.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Letter.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Letter_Number.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Line_Separator.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Lowercase_Letter.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Mark.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Math_Symbol.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Modifier_Letter.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Modifier_Symbol.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Nonspacing_Mark.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Number.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Open_Punctuation.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Other.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Other_Letter.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Other_Number.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Other_Punctuation.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Other_Symbol.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Paragraph_Separator.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Private_Use.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Punctuation.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Separator.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Space_Separator.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Spacing_Mark.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Surrogate.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Symbol.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Titlecase_Letter.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Unassigned.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/General_Category_-_Uppercase_Letter.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Grapheme_Base.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Grapheme_Extend.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Hex_Digit.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/IDS_Binary_Operator.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/IDS_Trinary_Operator.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/ID_Continue.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/ID_Start.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Ideographic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Join_Control.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Logical_Order_Exception.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Lowercase.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Math.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Noncharacter_Code_Point.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Pattern_Syntax.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Pattern_White_Space.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Quotation_Mark.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Radical.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Regional_Indicator.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Adlam.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Ahom.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Anatolian_Hieroglyphs.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Arabic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Armenian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Avestan.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Balinese.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Bamum.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Bassa_Vah.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Batak.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Bengali.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Bhaiksuki.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Bopomofo.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Brahmi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Braille.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Buginese.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Buhid.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Canadian_Aboriginal.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Carian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Caucasian_Albanian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Chakma.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Cham.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Cherokee.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Common.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Coptic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Cuneiform.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Cypriot.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Cyrillic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Deseret.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Devanagari.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Dogra.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Kaithi.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Duployan.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Egyptian_Hieroglyphs.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Elbasan.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Ethiopic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Georgian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Glagolitic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Gothic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Grantha.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Greek.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Gujarati.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Gunjala_Gondi.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Chakma.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Gurmukhi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Han.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Hangul.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Hanifi_Rohingya.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Ahom.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Hanunoo.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Hatran.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Hebrew.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Hiragana.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Imperial_Aramaic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Inherited.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Inscriptional_Pahlavi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Inscriptional_Parthian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Javanese.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Kaithi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Kannada.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Katakana.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Kayah_Li.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Kharoshthi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Khmer.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Khojki.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Khudawadi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Lao.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Latin.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Lepcha.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Limbu.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Linear_A.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Linear_B.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Lisu.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Lycian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Lydian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Mahajani.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Makasar.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Lycian.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Malayalam.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Mandaic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Manichaean.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Marchen.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Masaram_Gondi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Medefaidrin.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Carian.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Meetei_Mayek.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Mende_Kikakui.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Meroitic_Cursive.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Meroitic_Hieroglyphs.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Miao.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Modi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Mongolian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Mro.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Multani.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Myanmar.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Nabataean.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_New_Tai_Lue.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Newa.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Nko.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Nushu.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Ogham.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Ol_Chiki.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Old_Hungarian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Old_Italic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Old_North_Arabian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Old_Permic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Old_Persian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Old_Sogdian.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Gothic.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Old_South_Arabian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Old_Turkic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Oriya.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Osage.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Osmanya.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Pahawh_Hmong.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Palmyrene.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Pau_Cin_Hau.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Phags_Pa.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Phoenician.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Psalter_Pahlavi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Rejang.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Runic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Samaritan.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Saurashtra.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Sharada.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Shavian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Siddham.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_SignWriting.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Sinhala.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Sogdian.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Lycian.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Sora_Sompeng.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Soyombo.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Sundanese.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Syloti_Nagri.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Syriac.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Tagalog.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Tagbanwa.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Tai_Le.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Tai_Tham.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Tai_Viet.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Takri.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Tamil.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Tangut.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Telugu.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Thaana.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Thai.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Tibetan.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Tifinagh.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Tirhuta.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Ugaritic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Vai.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Warang_Citi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Yi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Zanabazar_Square.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Adlam.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Ahom.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Anatolian_Hieroglyphs.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Arabic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Armenian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Avestan.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Balinese.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Bamum.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Bassa_Vah.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Batak.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Bengali.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Bhaiksuki.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Bopomofo.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Brahmi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Braille.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Buginese.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Buhid.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Canadian_Aboriginal.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Carian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Caucasian_Albanian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Chakma.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Cham.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Cherokee.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Common.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Coptic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Cuneiform.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Cypriot.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Cyrillic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Deseret.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Devanagari.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Dogra.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Mahajani.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Duployan.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Egyptian_Hieroglyphs.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Elbasan.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Ethiopic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Georgian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Glagolitic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Gothic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Grantha.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Greek.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Gujarati.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Gunjala_Gondi.js: Added.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Gurmukhi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Han.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Hangul.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Hanifi_Rohingya.js: Added.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Hanunoo.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Hatran.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Hebrew.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Hiragana.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Imperial_Aramaic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Inherited.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Inscriptional_Pahlavi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Inscriptional_Parthian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Javanese.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Kaithi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Kannada.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Katakana.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Kayah_Li.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Kharoshthi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Khmer.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Khojki.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Khudawadi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Lao.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Latin.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Lepcha.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Limbu.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Linear_A.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Linear_B.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Lisu.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Lycian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Lydian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Mahajani.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Makasar.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Adlam.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Malayalam.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Mandaic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Manichaean.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Marchen.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Masaram_Gondi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Medefaidrin.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Avestan.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Meetei_Mayek.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Mende_Kikakui.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Meroitic_Cursive.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Meroitic_Hieroglyphs.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Miao.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Modi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Mongolian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Mro.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Multani.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Myanmar.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Nabataean.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_New_Tai_Lue.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Newa.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Nko.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Nushu.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Ogham.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Ol_Chiki.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Old_Hungarian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Old_Italic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Old_North_Arabian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Old_Permic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Old_Persian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Old_Sogdian.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_-_Khojki.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Old_South_Arabian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Old_Turkic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Oriya.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Osage.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Osmanya.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Pahawh_Hmong.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Palmyrene.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Pau_Cin_Hau.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Phags_Pa.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Phoenician.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Psalter_Pahlavi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Rejang.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Runic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Samaritan.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Saurashtra.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Sharada.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Shavian.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Siddham.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_SignWriting.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Sinhala.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Sogdian.js: Copied from JSTests/test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Manichaean.js.
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Sora_Sompeng.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Soyombo.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Sundanese.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Syloti_Nagri.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Syriac.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Tagalog.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Tagbanwa.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Tai_Le.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Tai_Tham.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Tai_Viet.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Takri.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Tamil.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Tangut.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Telugu.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Thaana.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Thai.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Tibetan.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Tifinagh.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Tirhuta.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Ugaritic.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Vai.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Warang_Citi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Yi.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Zanabazar_Square.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Sentence_Terminal.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Soft_Dotted.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Terminal_Punctuation.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Unified_Ideograph.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Uppercase.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/Variation_Selector.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/White_Space.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/XID_Continue.js:
+        * test262/test/built-ins/RegExp/property-escapes/generated/XID_Start.js:
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/internal-regexp-lastindex-not-zero.js: Removed.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/isregexp-called-once.js: Renamed from JSTests/test262/test/built-ins/RegExp/prototype/Symbol.matchAll/isregexp-internal-regexp-is-false.js.
+        (o.get Symbol):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/isregexp-internal-regexp-throws.js: Removed.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/regexpcreate-this-throws.js:
+        * test262/test/built-ins/Symbol/matchAll/prop-desc.js:
+        * test262/test/built-ins/Symbol/prototype/description/description-symboldescriptivestring.js: Added.
+        * test262/test/built-ins/Symbol/prototype/description/descriptor.js: Added.
+        * test262/test/built-ins/Symbol/prototype/description/get.js: Added.
+        * test262/test/built-ins/Symbol/prototype/description/is-not-own-property.js: Added.
+        * test262/test/built-ins/Symbol/prototype/description/this-val-non-symbol.js: Added.
+        * test262/test/built-ins/Symbol/prototype/description/this-val-symbol.js: Added.
+        * test262/test/built-ins/Symbol/prototype/description/wrapper.js: Added.
+        * test262/test/intl402/Intl/getCanonicalLocales/Locale-object.js: Added.
+        * test262/test/intl402/Locale/constructor-options-collation-invalid.js:
+        * test262/test/intl402/Locale/constructor-options-collation-valid.js:
+        * test262/test/intl402/Locale/constructor-options-hourcycle-valid.js:
+        * test262/test/intl402/Locale/constructor-options-language-invalid.js:
+        * test262/test/intl402/Locale/constructor-options-numberingsystem-invalid.js:
+        * test262/test/intl402/Locale/constructor-options-numberingsystem-valid.js:
+        * test262/test/intl402/Locale/constructor-tag.js: Added.
+        (canonical.of.Object.entries):
+        * test262/test/intl402/Locale/likely-subtags.js: Added.
+        (maximal.of.Object.entries):
+        (minimal.of.Object.entries):
+        * test262/test/intl402/Locale/prototype/baseName/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/baseName/name.js: Added.
+        * test262/test/intl402/Locale/prototype/baseName/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/calendar/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/calendar/name.js: Added.
+        * test262/test/intl402/Locale/prototype/calendar/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/caseFirst/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/caseFirst/name.js: Added.
+        * test262/test/intl402/Locale/prototype/caseFirst/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/collation/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/collation/name.js: Added.
+        * test262/test/intl402/Locale/prototype/collation/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/hourCycle/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/hourCycle/name.js: Added.
+        * test262/test/intl402/Locale/prototype/hourCycle/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/language/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/language/name.js: Added.
+        * test262/test/intl402/Locale/prototype/language/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/maximize/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/minimize/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/numberingSystem/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/numberingSystem/name.js: Added.
+        * test262/test/intl402/Locale/prototype/numberingSystem/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/numeric/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/numeric/name.js: Added.
+        * test262/test/intl402/Locale/prototype/numeric/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/region/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/region/name.js: Added.
+        * test262/test/intl402/Locale/prototype/region/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/script/branding.js: Added.
+        * test262/test/intl402/Locale/prototype/script/name.js: Added.
+        * test262/test/intl402/Locale/prototype/script/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/toString/branding.js: Added.
+        * test262/test/intl402/NumberFormat/length.js:
+        * test262/test/intl402/PluralRules/prototype/resolvedOptions/pluralCategories.js: Added.
+        * test262/test/language/expressions/tagged-template/template-object-template-map.js: Added.
+        (tag):
+        * test262/test/language/expressions/tagged-template/template-object.js:
+        (templateObject.tag):
+        * test262/test/language/literals/numeric/numeric-separator-literal-bil-bd-nsl-bd-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-bil-nsl-bd-dunder-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-bil-nsl-bd-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-dd-nsl-dds-dunder-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-dd-nsl-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-dds-nsl-dds-dunder-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-dds-nsl-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-dil-dot-dds-nsl-ep-dd-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-dil-dot-nsl-ep-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-dil-dot-nsl-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-dot-dds-nsl-ep-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-dot-nsl-ep-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-dot-nsl-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-hil-hd-nsl-hd-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-hil-nsl-hd-dunder-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-hil-nsl-hd-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-nzd-nsl-dds-dunder-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-nzd-nsl-dds-leading-zero-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-oil-nsl-od-dunder-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-oil-nsl-od-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-oil-od-nsl-od-err.js:
+        * test262/test/language/literals/numeric/numeric-separator-literal-unicode-err.js:
+        * test262/test262-Revision.txt:
+
+2018-06-16  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Reduce OSRExit for Kraken/crypto-aes due to CoW array
+        https://bugs.webkit.org/show_bug.cgi?id=186721
+
+        Reviewed by Keith Miller.
+
+        * stress/array-slice-cow.js: Added.
+        (shouldBe):
+        (testInt32):
+        (testDouble):
+        (testContiguous):
+
+2018-06-15  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Spread onto PhantomNewArrayBuffer assumes JSFixedArray, but JSImmutableButterfly is returned
+        https://bugs.webkit.org/show_bug.cgi?id=186460
+
+        Reviewed by Saam Barati.
+
+        * stress/spread-escapes-but-new-array-buffer-does-not-double.js: Added.
+        (assert):
+        (getProperties):
+        (theFunc):
+        (let.obj.valueOf):
+
+2018-06-14  Leo Balter  <leonardo.balter@gmail.com>
+
+        Test262-Runner: Update config list with some failing tests
+        https://bugs.webkit.org/show_bug.cgi?id=185628
+
+        Reviewed by Michael Saboff.
+
+        The config list is updated to match some slow / hanging tests that are currenctly failing
+        due to the length used in Array or Array like objects.
+
+        This also adds matching bugs for known features that are still in progress and not enabled
+        yet.
+        * test262/config.yaml:
+
+2018-06-12  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Update test262 for Array#sort
+        https://bugs.webkit.org/show_bug.cgi?id=186458
+
+        * test262/expectations.yaml:
+
+2018-06-10  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Array.prototype.sort should rejects null comparator
+        https://bugs.webkit.org/show_bug.cgi?id=186458
+
+        Reviewed by Keith Miller.
+
+        * ChakraCore/test/Array/array_sort.baseline-jsc:
+        * stress/array-sort-bad-comparator.js:
+        (test):
+        * stress/sort-null-comparator.js: Removed.
+        * test262/expectations.yaml:
+
+2018-06-07  Saam Barati  <sbarati@apple.com>
+
+        Make DFG to FTL OSR entry code more sane by removing bad RELEASE_ASSERTS and making it trigger compiles in outer loops before inner ones
+        https://bugs.webkit.org/show_bug.cgi?id=186218
+        <rdar://problem/38449540>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/dont-crash-ftl-osr-entry.js: Added.
+
+2018-06-06  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Compare operations do not respect negative zeros
+        https://bugs.webkit.org/show_bug.cgi?id=183729
+
+        Reviewed by Saam Barati.
+
+        * stress/comparison-ignore-negative-zero.js: Added.
+        (shouldBe):
+        (zero):
+        (negativeZero):
+        (object.valueOf):
+        (test):
+
+2018-06-06  Saam Barati  <sbarati@apple.com>
+
+        generateConditionsForInstanceOf needs to see if the object has a poly proto structure before assuming it has a constant prototype
+        https://bugs.webkit.org/show_bug.cgi?id=186363
+
+        Rubber-stamped by Filip Pizlo.
+
+        * stress/instance-of-on-poly-proto-opc-should-not-crash.js: Added.
+
+2018-06-05  David Fenton  <david_fenton@apple.com>
+
+        Temporarily Skip JSC stress test failures that are consistently occurring.
+        https://bugs.webkit.org/show_bug.cgi?id=186283
+
+        Unreviewed test gardening.
+
+        * executableAllocationFuzz.yaml:
+        * slowMicrobenchmarks/default-derived-constructor.js:
+        * stress/put-direct-index-broken-2.js:
+        * stress/splay-flash-access.js:
+        * stress/spread-forward-call-varargs-stack-overflow.js:
+
+2018-06-04  Keith Miller  <keith_miller@apple.com>
+
+        Add test for CoW conversions in the DFG/FTL
+        https://bugs.webkit.org/show_bug.cgi?id=186295
+
+        Reviewed by Saam Barati.
+
+        * stress/arrayprofile-should-not-convert-get-by-val-cow.js: Added.
+        (assertEq):
+        (withArrayArgInt32):
+        (withArrayLiteralInt32):
+        (withArrayArgDouble):
+        (withArrayLiteralDouble):
+        (withArrayArgContiguous):
+        (withArrayLiteralContiguous):
+        (test):
+
+2018-06-02  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for addition operations
+        https://bugs.webkit.org/show_bug.cgi?id=179002
+
+        Reviewed by Yusuke Suzuki.
+
+        * bigIntTests.yaml:
+        * stress/addition-order-evaluation.js: Added.
+        * stress/big-int-add-wrapped-value.js: Added.
+        * stress/big-int-addition-basic.js: Added.
+        * stress/big-int-addition-jit.js: Added.
+        * stress/big-int-addition-memory-stress.js: Added.
+        * stress/big-int-addition-string-coercion.js: Added.
+        * stress/big-int-addition-to-primitive-precedence.js: Added.
+        * stress/big-int-addition-to-primitive.js: Added.
+        * stress/big-int-addition-type-error.js: Added.
+        * stress/big-int-no-conversion-to-number.js:
+        * stress/big-int-sub-wrapped-value.js: Added.
+        * stress/big-int-subtraction-basic.js: Added.
+        * stress/big-int-subtraction-jit.js: Added.
+        * stress/big-int-subtraction-type-error.js: Added.
+        * stress/sub-order-evaluation.js: Added.
+
+2018-06-02  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r232439.
+        https://bugs.webkit.org/show_bug.cgi?id=186238
+
+        It breaks gtk-linux-32-release (Requested by caiolima on
+        #webkit).
+
+        Reverted changeset:
+
+        "[ESNext][BigInt] Implement support for addition operations"
+        https://bugs.webkit.org/show_bug.cgi?id=179002
+        https://trac.webkit.org/changeset/232439
+
+2018-06-01  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Baseline op_jtrue emits an insane amount of code
+        https://bugs.webkit.org/show_bug.cgi?id=185708
+
+        Reviewed by Filip Pizlo.
+
+        * stress/logical-not-masquerades-as-undefined.js: Added.
+        (shouldBe):
+        (test):
+        * stress/logical-not.js: Added.
+        (shouldBe):
+        (test):
+
+2018-06-02  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Remove WeakReferenceHarvester
+        https://bugs.webkit.org/show_bug.cgi?id=186102
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/create-many-weak-map.js: Added.
+
+2018-06-02  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Object.create should have intrinsic
+        https://bugs.webkit.org/show_bug.cgi?id=186200
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/object-create-null.js: Added.
+        (test):
+        * microbenchmarks/object-create-unknown-object-prototype.js: Added.
+        (test):
+        * microbenchmarks/object-create-untyped-prototype.js: Added.
+        (test):
+        * stress/get-by-pname-only-prototype-properties.js: Added.
+        (foo):
+        * stress/object-create-define.js: Added.
+        (shouldBe):
+        (test):
+        * stress/object-create-null-external.js: Added.
+        (shouldBe):
+        (test):
+        * stress/object-create-null.js: Added.
+        (shouldBe):
+        (test):
+        * stress/object-create-prototype.js: Added.
+        (shouldBe):
+        (test):
+        * stress/object-create-undefined.js: Added.
+        (shouldThrow):
+        (i.shouldThrow):
+
+2018-06-02  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for addition operations
+        https://bugs.webkit.org/show_bug.cgi?id=179002
+
+        Reviewed by Yusuke Suzuki.
+
+        * bigIntTests.yaml:
+        * stress/addition-order-evaluation.js: Added.
+        * stress/big-int-add-wrapped-value.js: Added.
+        * stress/big-int-addition-basic.js: Added.
+        * stress/big-int-addition-jit.js: Added.
+        * stress/big-int-addition-memory-stress.js: Added.
+        * stress/big-int-addition-string-coercion.js: Added.
+        * stress/big-int-addition-to-primitive-precedence.js: Added.
+        * stress/big-int-addition-to-primitive.js: Added.
+        * stress/big-int-addition-type-error.js: Added.
+        * stress/big-int-no-conversion-to-number.js:
+        * stress/big-int-sub-wrapped-value.js: Added.
+        * stress/big-int-subtraction-basic.js: Added.
+        * stress/big-int-subtraction-jit.js: Added.
+        * stress/big-int-subtraction-type-error.js: Added.
+        * stress/sub-order-evaluation.js: Added.
+
+2018-05-29  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Add Symbol.prototype.description getter
+        https://bugs.webkit.org/show_bug.cgi?id=186053
+
+        Reviewed by Keith Miller.
+
+        * stress/symbol-description.js: Added.
+        (shouldBe):
+        (shouldThrow):
+
+2018-05-30  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] InById should be converted to MatchStructure
+        https://bugs.webkit.org/show_bug.cgi?id=185803
+
+        Reviewed by Keith Miller.
+
+        * microbenchmarks/in-by-id-match.js: Added.
+        (test):
+        * microbenchmarks/in-by-id-removed.js: Added.
+        (test):
+        * stress/in-by-id-constant.js: Added.
+        (shouldBe):
+        (test1):
+        * stress/in-by-id-match-invalid.js: Added.
+        (shouldBe):
+        (test1):
+        * stress/in-by-id-match.js: Added.
+        (shouldBe):
+        (test1):
+
+2018-05-31  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for "=<" and ">=" relational operation
+        https://bugs.webkit.org/show_bug.cgi?id=185929
+
+        Reviewed by Yusuke Suzuki.
+
+        * bigIntTests.yaml:
+        * stress/big-int-greater-than-or-equal-jit.js: Added.
+        * stress/big-int-greater-than-or-equal-order-of-evaluation.js: Added.
+        * stress/big-int-greater-than-or-equal-wrapped-values.js: Added.
+        * stress/big-int-greater-than-or-equal.js: Added.
+        * stress/big-int-less-than-or-equal-general.js: Added.
+        * stress/big-int-less-than-or-equal-jit.js: Added.
+        * stress/big-int-less-than-or-equal-order-of-evaluation.js: Added.
+        * stress/big-int-less-than-or-equal-wrapped-values.js: Added.
+
+2018-05-31  Saam Barati  <sbarati@apple.com>
+
+        Cache toString results for CoW arrays
+        https://bugs.webkit.org/show_bug.cgi?id=186160
+
+        Reviewed by Keith Miller.
+
+        * microbenchmarks/to-string-on-cow-array.js: Added.
+        (foo):
+
+2018-05-31  Keith Miller  <keith_miller@apple.com>
+
+        Rebaseline test for change in Error.stack behavior.
+
+        * stress/error-stack-trace-limit.js:
+        (numberOfFrames):
+
+2018-05-30  Saam Barati  <sbarati@apple.com>
+
+        DFG combined liveness needs to say that the machine CodeBlock's arguments are live
+        https://bugs.webkit.org/show_bug.cgi?id=186121
+        <rdar://problem/39377796>
+
+        Reviewed by Keith Miller.
+
+        * stress/combined-liveness-needs-to-say-arguments-are-live.js: Added.
+        (baz):
+        (foo):
+
+2018-05-30  Keith Miller  <keith_miller@apple.com>
+
+        Unreviewed, uncomment erroneously commented test code.
+
+        * stress/error-stack-trace-limit.js:
+
+2018-05-30  Keith Miller  <keith_miller@apple.com>
+
+        LLInt get_by_id prototype caching doesn't properly handle changes
+        https://bugs.webkit.org/show_bug.cgi?id=186112
+
+        Reviewed by Filip Pizlo.
+
+        * stress/llint-proto-get-by-id-cache-change-prototype.js: Added.
+        (foo):
+        * stress/llint-proto-get-by-id-cache-intercept-value.js: Added.
+        (foo):
+
+2018-05-30  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for "%" operation
+        https://bugs.webkit.org/show_bug.cgi?id=184327
+
+        Reviewed by Yusuke Suzuki.
+
+        * bigIntTests.yaml:
+        * stress/big-int-mod-memory-stress.js: Added.
+        * stress/big-int-mod-to-primitive-precedence.js: Added.
+        * stress/big-int-mod-to-primitive.js: Added.
+        * stress/big-int-mod-type-error.js: Added.
+        * stress/big-int-mod-wrapped-value.js: Added.
+        * stress/big-int-mod.js: Added.
+
+2018-05-29  Caitlin Potter  <caitp@igalia.com>
+
+        [JSTests] update test262 expectations after r232261
+        https://bugs.webkit.org/show_bug.cgi?id=184267
+
+        Reviewed by Saam Barati.
+
+        * test262/expectations.yaml:
+
+2018-05-29  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for "<" and ">" relational operation
+        https://bugs.webkit.org/show_bug.cgi?id=185379
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/big-int-greater-than-general.js: Added.
+        * stress/big-int-greater-than-jit.js: Added.
+        * stress/big-int-greater-than-order-of-evaluation.js: Added.
+        * stress/big-int-greater-than-wrapped-values.js: Added.
+        * stress/big-int-less-than-general.js: Added.
+        * stress/big-int-less-than-jit.js: Added.
+        * stress/big-int-less-than-order-of-evaluation.js: Added.
+        * stress/big-int-less-than-wrapped-values.js: Added.
+
+2018-05-29  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] Fix Array.prototype.concat fast case when single argument is Proxy
+        https://bugs.webkit.org/show_bug.cgi?id=184267
+
+        Reviewed by Saam Barati.
+
+        * stress/array-concat-fast-spread-proxy.js: Copied from JSTests/stress/array-concat-spread-proxy.js.
+        (arrayEq):
+        (catch):
+        * stress/array-concat-spread-proxy.js:
+
+2018-05-27  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement "+" and "-" unary operation
+        https://bugs.webkit.org/show_bug.cgi?id=182214
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/big-int-negate-basic.js: Added.
+        * stress/big-int-negate-jit.js: Added.
+        * stress/big-int-unary-plus.js: Added.
+
+2018-05-26  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Rename Array#flatten to flat
+        https://bugs.webkit.org/show_bug.cgi?id=186012
+
+        Reviewed by Saam Barati.
+
+        * stress/array-flatten.js:
+        (shouldThrow):
+        * test262/expectations.yaml:
+
+2018-05-23  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Upgrade test262 to May 24 version
+        https://bugs.webkit.org/show_bug.cgi?id=185937
+
+        Reviewed by Darin Adler.
+
+        * test262/expectations.yaml:
+        * test262/harness/doneprintHandle.js:
+        (DONE):
+        * test262/latest-changes-summary.txt:
+        * test262/test/annexB/language/eval-code/direct/global-block-decl-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/direct/global-block-decl-eval-global-existing-non-enumerable-global-init.js: Added.
+        * test262/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-existing-non-enumerable-global-init.js: Copied from JSTests/test262/test/annexB/language/eval-code/direct/global-if-decl-else-decl-a-eval-global-existing-global-init.js.
+        * test262/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-existing-non-enumerable-global-init.js: Copied from JSTests/test262/test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-existing-global-init.js.
+        * test262/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-existing-non-enumerable-global-init.js: Copied from JSTests/test262/test/annexB/language/eval-code/direct/global-if-decl-else-stmt-eval-global-existing-global-init.js.
+        * test262/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-existing-non-enumerable-global-init.js: Copied from JSTests/test262/test/annexB/language/eval-code/direct/global-if-decl-no-else-eval-global-existing-global-init.js.
+        * test262/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-existing-non-enumerable-global-init.js: Copied from JSTests/test262/test/annexB/language/eval-code/direct/global-if-stmt-else-decl-eval-global-existing-global-init.js.
+        * test262/test/annexB/language/eval-code/direct/global-switch-case-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/direct/global-switch-case-eval-global-existing-non-enumerable-global-init.js: Added.
+        * test262/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-existing-non-enumerable-global-init.js: Added.
+        * test262/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/indirect/global-block-decl-eval-global-existing-non-enumerable-global-init.js: Added.
+        * test262/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-existing-non-enumerable-global-init.js: Copied from JSTests/test262/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-a-eval-global-existing-global-init.js.
+        * test262/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-existing-non-enumerable-global-init.js: Copied from JSTests/test262/test/annexB/language/eval-code/indirect/global-if-decl-else-decl-b-eval-global-existing-global-init.js.
+        * test262/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-existing-non-enumerable-global-init.js: Copied from JSTests/test262/test/annexB/language/eval-code/indirect/global-if-decl-else-stmt-eval-global-existing-global-init.js.
+        * test262/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-existing-non-enumerable-global-init.js: Copied from JSTests/test262/test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-existing-global-init.js.
+        * test262/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-existing-non-enumerable-global-init.js: Copied from JSTests/test262/test/annexB/language/eval-code/indirect/global-if-stmt-else-decl-eval-global-existing-global-init.js.
+        * test262/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/indirect/global-switch-case-eval-global-existing-non-enumerable-global-init.js: Added.
+        * test262/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-existing-global-init.js:
+        * test262/test/annexB/language/eval-code/indirect/global-switch-dflt-eval-global-existing-non-enumerable-global-init.js: Added.
+        * test262/test/annexB/language/global-code/block-decl-global-existing-global-init.js: Added.
+        (262.evalScript.f):
+        * test262/test/annexB/language/global-code/block-decl-global-existing-non-enumerable-global-init.js: Added.
+        (262.evalScript.f):
+        * test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-global-init.js: Added.
+        (262.evalScript.true.f):
+        (else._f):
+        * test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-non-enumerable-global-init.js: Added.
+        (262.evalScript.true.f):
+        (else._f):
+        * test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-global-init.js: Added.
+        (262.evalScript.false._f):
+        (else.f):
+        * test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-non-enumerable-global-init.js: Added.
+        (262.evalScript.false._f):
+        (else.f):
+        * test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-global-init.js: Added.
+        (262.evalScript.true.f):
+        * test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-non-enumerable-global-init.js: Added.
+        (262.evalScript.true.f):
+        * test262/test/annexB/language/global-code/if-decl-no-else-global-existing-global-init.js: Added.
+        (262.evalScript.true.f):
+        * test262/test/annexB/language/global-code/if-decl-no-else-global-existing-non-enumerable-global-init.js: Added.
+        (262.evalScript.true.f):
+        * test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-global-init.js: Added.
+        (else.f):
+        * test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-non-enumerable-global-init.js: Added.
+        (else.f):
+        * test262/test/annexB/language/global-code/switch-case-global-existing-global-init.js: Added.
+        (262.evalScript.switch.case.1):
+        (262.evalScript.switch):
+        * test262/test/annexB/language/global-code/switch-case-global-existing-non-enumerable-global-init.js: Added.
+        (262.evalScript.switch.case.1):
+        (262.evalScript.switch):
+        * test262/test/annexB/language/global-code/switch-dflt-global-existing-global-init.js: Added.
+        (262.evalScript.switch.default):
+        (262.evalScript.switch):
+        * test262/test/annexB/language/global-code/switch-dflt-global-existing-non-enumerable-global-init.js: Added.
+        (262.evalScript.switch.default):
+        (262.evalScript.switch):
+        * test262/test/built-ins/Array/prototype/flat/array-like-objects.js: Renamed from JSTests/test262/test/built-ins/Array/prototype/flatten/array-like-objects.js.
+        * test262/test/built-ins/Array/prototype/flat/bound-function-call.js: Renamed from JSTests/test262/test/built-ins/Array/prototype/flatten/bound-function-call.js.
+        * test262/test/built-ins/Array/prototype/flat/empty-array-elements.js: Renamed from JSTests/test262/test/built-ins/Array/prototype/flatten/empty-array-elements.js.
+        * test262/test/built-ins/Array/prototype/flat/empty-object-elements.js: Renamed from JSTests/test262/test/built-ins/Array/prototype/flatten/empty-object-elements.js.
+        * test262/test/built-ins/Array/prototype/flat/length.js: Added.
+        * test262/test/built-ins/Array/prototype/flat/name.js: Added.
+        * test262/test/built-ins/Array/prototype/flat/non-numeric-depth-should-not-throw.js: Renamed from JSTests/test262/test/built-ins/Array/prototype/flatten/non-numeric-depth-should-not-throw.js.
+        * test262/test/built-ins/Array/prototype/flat/non-object-ctor-throws.js: Renamed from JSTests/test262/test/built-ins/Array/prototype/flatten/non-object-ctor-throws.js.
+        * test262/test/built-ins/Array/prototype/flat/null-undefined-elements.js: Added.
+        * test262/test/built-ins/Array/prototype/flat/null-undefined-input-throws.js: Renamed from JSTests/test262/test/built-ins/Array/prototype/flatten/null-undefined-input-throws.js.
+        * test262/test/built-ins/Array/prototype/flat/positive-infinity.js: Renamed from JSTests/test262/test/built-ins/Array/prototype/flatten/positive-infinity.js.
+        * test262/test/built-ins/Array/prototype/flat/prop-desc.js: Renamed from JSTests/test262/test/built-ins/Array/prototype/flatten/prop-desc.js.
+        * test262/test/built-ins/Array/prototype/flat/symbol-object-create-null-depth-throws.js: Renamed from JSTests/test262/test/built-ins/Array/prototype/flatten/symbol-object-create-null-depth-throws.js.
+        * test262/test/built-ins/Array/prototype/flatten/length.js: Removed.
+        * test262/test/built-ins/Array/prototype/flatten/name.js: Removed.
+        * test262/test/built-ins/Array/prototype/flatten/null-undefined-elements.js: Removed.
+        * test262/test/built-ins/AsyncGeneratorPrototype/next/name.js:
+        * test262/test/built-ins/AsyncGeneratorPrototype/return/name.js:
+        * test262/test/built-ins/AsyncGeneratorPrototype/throw/name.js:
+        * test262/test/built-ins/Math/acosh/nan-returns.js:
+        * test262/test/built-ins/Math/asinh/asinh-specialVals.js:
+        * test262/test/built-ins/Math/atanh/atanh-specialVals.js:
+        * test262/test/built-ins/Math/cbrt/cbrt-specialValues.js:
+        * test262/test/built-ins/Math/cbrt/prop-desc.js:
+        * test262/test/built-ins/Math/cosh/cosh-specialVals.js:
+        * test262/test/built-ins/Math/expm1/expm1-specialVals.js:
+        * test262/test/built-ins/Math/log10/Log10-specialVals.js:
+        * test262/test/built-ins/Math/log2/log2-basicTests.js:
+        * test262/test/built-ins/Math/sign/sign-specialVals.js:
+        * test262/test/built-ins/Math/sinh/sinh-specialVals.js:
+        * test262/test/built-ins/Math/tanh/tanh-specialVals.js:
+        * test262/test/built-ins/Math/trunc/trunc-sampleTests.js:
+        * test262/test/built-ins/Math/trunc/trunc-specialVals.js:
+        * test262/test/built-ins/Object/internals/DefineOwnProperty/consistent-value-regexp-dollar1.js: Added.
+        * test262/test/built-ins/Object/internals/DefineOwnProperty/consistent-writable-regexp-dollar1.js: Added.
+        * test262/test/intl402/Intl/getCanonicalLocales/descriptor.js:
+        * test262/test/intl402/Intl/getCanonicalLocales/duplicates.js:
+        * test262/test/intl402/Locale/constructor-getter-order.js: Added.
+        (new.Intl.Locale.toString):
+        (get language):
+        (get script):
+        (get region):
+        (get calendar):
+        (get collation):
+        (get hourCycle):
+        (get caseFirst):
+        (get numeric):
+        (get numberingSystem):
+        * test262/test/intl402/Locale/constructor-locale-object.js: Added.
+        * test262/test/intl402/Locale/constructor-non-iana-canon.js: Added.
+        * test262/test/intl402/Locale/constructor-options-casefirst-invalid.js: Added.
+        (valueOf):
+        (const.invalidCaseFirstOption.of.invalidCaseFirstOptions.new.Intl.Locale):
+        * test262/test/intl402/Locale/constructor-options-casefirst-valid.js: Added.
+        (toString):
+        * test262/test/intl402/Locale/constructor-options-collation-invalid.js: Added.
+        (const.invalidCollationOption.of.invalidCollationOptions.new.Intl.Locale):
+        * test262/test/intl402/Locale/constructor-options-collation-valid.js: Added.
+        * test262/test/intl402/Locale/constructor-options-hourcycle-invalid.js: Added.
+        (const.invalidHourCycleOption.of.invalidHourCycleOptions.new.Intl.Locale):
+        * test262/test/intl402/Locale/constructor-options-hourcycle-valid.js: Added.
+        (toString):
+        * test262/test/intl402/Locale/constructor-options-language-grandfathered.js: Added.
+        * test262/test/intl402/Locale/constructor-options-language-valid.js:
+        (toString):
+        * test262/test/intl402/Locale/constructor-options-numberingsystem-invalid.js: Added.
+        (const.invalidNumberingSystemOption.of.invalidNumberingSystemOptions.new.Intl.Locale):
+        * test262/test/intl402/Locale/constructor-options-numberingsystem-valid.js: Added.
+        * test262/test/intl402/Locale/constructor-options-numeric-valid.js: Added.
+        (valueOf):
+        * test262/test/intl402/Locale/constructor-options-region-valid.js:
+        * test262/test/intl402/Locale/constructor-options-script-valid.js:
+        (toString):
+        * test262/test/intl402/Locale/constructor-parse-twice.js: Added.
+        * test262/test/intl402/Locale/constructor-tag-tostring.js: Added.
+        (CustomError):
+        (WrongCustomError):
+        (const.errors.get Symbol):
+        (throw.new.CustomError):
+        (throw.new.CustomError.get toString):
+        (throw.new.CustomError.get valueOf):
+        (throw.new.WrongCustomError.get valueOf):
+        (throw.new.WrongCustomError):
+        * test262/test/intl402/Locale/constructor-unicode-ext-invalid.js: Added.
+        * test262/test/intl402/Locale/constructor-unicode-ext-valid.js: Added.
+        (canonical.of.Object.entries):
+        * test262/test/intl402/Locale/extensions-grandfathered.js: Added.
+        (of.testData.value.of.Object.entries):
+        * test262/test/intl402/Locale/extensions-private.js: Added.
+        * test262/test/intl402/Locale/getters-grandfathered.js: Added.
+        * test262/test/intl402/Locale/getters-missing.js: Added.
+        * test262/test/intl402/Locale/getters-privateuse.js: Added.
+        * test262/test/intl402/Locale/getters.js: Added.
+        * test262/test/intl402/Locale/invalid-tag-throws-symbol.js:
+        * test262/test/intl402/Locale/likely-subtags-grandfathered.js: Added.
+        * test262/test/intl402/Locale/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/baseName/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/calendar/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/caseFirst/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/collation/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/constructor/prop-desc.js: Copied from JSTests/test262/test/intl402/Locale/prototype/constructor.js.
+        * test262/test/intl402/Locale/prototype/hourCycle/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/language/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/maximize/length.js:
+        * test262/test/intl402/Locale/prototype/maximize/prop-desc.js:
+        * test262/test/intl402/Locale/prototype/minimize/length.js: Copied from JSTests/test262/test/intl402/Locale/prototype/maximize/length.js.
+        * test262/test/intl402/Locale/prototype/minimize/name.js: Added.
+        * test262/test/intl402/Locale/prototype/minimize/prop-desc.js: Copied from JSTests/test262/test/intl402/Locale/prototype/constructor.js.
+        * test262/test/intl402/Locale/prototype/numberingSystem/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/numeric/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/region/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/script/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/toString/prop-desc.js: Renamed from JSTests/test262/test/intl402/Locale/prototype/constructor.js.
+        * test262/test/intl402/Locale/prototype/toStringTag/toStringTag.js: Renamed from JSTests/test262/test/intl402/Locale/prototype/toStringTag.js.
+        * test262/test/intl402/Number/prototype/toLocaleString/length.js:
+        * test262/test/intl402/NumberFormat/length.js:
+        * test262/test/intl402/NumberFormat/name.js:
+        * test262/test/intl402/NumberFormat/prop-desc.js:
+        * test262/test/intl402/PluralRules/length.js:
+        * test262/test/intl402/PluralRules/name.js:
+        * test262/test/intl402/PluralRules/prop-desc.js: Copied from JSTests/test262/test/intl402/NumberFormat/prop-desc.js.
+        * test262/test/language/expressions/addition/bigint-and-number.js:
+        * test262/test/language/expressions/addition/bigint-arithmetic.js:
+        (testAdd): Deleted.
+        * test262/test/language/expressions/addition/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/addition/bigint-toprimitive.js:
+        * test262/test/language/expressions/addition/bigint-wrapped-values.js:
+        * test262/test/language/expressions/bitwise-and/bigint-and-number.js:
+        * test262/test/language/expressions/bitwise-and/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/bitwise-and/bigint-non-primitive.js:
+        (assert.sameValue.Symbol.toPrimitive):
+        (assert.sameValue.0b011n.Symbol.toPrimitive):
+        (assert.sameValue.valueOf):
+        (assert.sameValue.0b011n.valueOf):
+        (assert.sameValue.toString):
+        (assert.sameValue.0b011n.toString):
+        * test262/test/language/expressions/bitwise-and/bigint-toprimitive.js:
+        * test262/test/language/expressions/bitwise-and/bigint-wrapped-values.js:
+        * test262/test/language/expressions/bitwise-not/bigint-non-primitive.js:
+        (assert.sameValue.Symbol.toPrimitive):
+        (assert.sameValue.valueOf):
+        (assert.sameValue.toString):
+        * test262/test/language/expressions/bitwise-or/bigint-and-number.js:
+        * test262/test/language/expressions/bitwise-or/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/bitwise-or/bigint-non-primitive.js:
+        (assert.sameValue.Symbol.toPrimitive):
+        (assert.sameValue.0b011n.Symbol.toPrimitive):
+        (assert.sameValue.valueOf):
+        (assert.sameValue.0b011n.valueOf):
+        (assert.sameValue.toString):
+        (assert.sameValue.0b011n.toString):
+        * test262/test/language/expressions/bitwise-or/bigint-toprimitive.js:
+        * test262/test/language/expressions/bitwise-or/bigint-wrapped-values.js:
+        * test262/test/language/expressions/bitwise-xor/bigint-and-number.js:
+        * test262/test/language/expressions/bitwise-xor/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/bitwise-xor/bigint-non-primitive.js:
+        (assert.sameValue.Symbol.toPrimitive):
+        (assert.sameValue.0b011n.Symbol.toPrimitive):
+        (assert.sameValue.valueOf):
+        (assert.sameValue.0b011n.valueOf):
+        (assert.sameValue.toString):
+        (assert.sameValue.0b011n.toString):
+        * test262/test/language/expressions/bitwise-xor/bigint-toprimitive.js:
+        * test262/test/language/expressions/bitwise-xor/bigint-wrapped-values.js:
+        * test262/test/language/expressions/division/bigint-and-number.js:
+        * test262/test/language/expressions/division/bigint-arithmetic.js:
+        (testDiv): Deleted.
+        * test262/test/language/expressions/division/bigint-complex-infinity.js:
+        * test262/test/language/expressions/division/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/division/bigint-toprimitive.js:
+        * test262/test/language/expressions/division/bigint-wrapped-values.js:
+        * test262/test/language/expressions/does-not-equals/bigint-and-bigint.js:
+        * test262/test/language/expressions/does-not-equals/bigint-and-boolean.js:
+        * test262/test/language/expressions/does-not-equals/bigint-and-incomparable-primitive.js:
+        * test262/test/language/expressions/does-not-equals/bigint-and-non-finite.js:
+        * test262/test/language/expressions/does-not-equals/bigint-and-number-extremes.js:
+        * test262/test/language/expressions/does-not-equals/bigint-and-number.js:
+        * test262/test/language/expressions/does-not-equals/bigint-and-object.js:
+        (assert.sameValue.0n.valueOf):
+        (assert.sameValue.valueOf):
+        (assert.sameValue.0n.toString):
+        (assert.sameValue.toString):
+        (assert.sameValue.900719925474099101n.valueOf):
+        (assert.sameValue.900719925474099101n.toString):
+        * test262/test/language/expressions/does-not-equals/bigint-and-string.js:
+        * test262/test/language/expressions/equals/bigint-and-bigint.js:
+        * test262/test/language/expressions/equals/bigint-and-boolean.js:
+        * test262/test/language/expressions/equals/bigint-and-incomparable-primitive.js:
+        * test262/test/language/expressions/equals/bigint-and-non-finite.js:
+        * test262/test/language/expressions/equals/bigint-and-number-extremes.js:
+        * test262/test/language/expressions/equals/bigint-and-number.js:
+        * test262/test/language/expressions/equals/bigint-and-object.js:
+        (assert.sameValue.0n.valueOf):
+        (assert.sameValue.valueOf):
+        (assert.sameValue.0n.toString):
+        (assert.sameValue.toString):
+        (assert.sameValue.900719925474099101n.valueOf):
+        (assert.sameValue.900719925474099101n.toString):
+        * test262/test/language/expressions/equals/bigint-and-string.js:
+        * test262/test/language/expressions/exponentiation/bigint-and-number.js:
+        * test262/test/language/expressions/exponentiation/bigint-arithmetic.js:
+        (testExpt): Deleted.
+        * test262/test/language/expressions/exponentiation/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/exponentiation/bigint-negative-exponent-throws.js: Renamed from JSTests/test262/test/language/expressions/exponentiation/bigint-exp-operator-negative-throws.js.
+        * test262/test/language/expressions/exponentiation/bigint-toprimitive.js:
+        * test262/test/language/expressions/exponentiation/bigint-wrapped-values.js:
+        * test262/test/language/expressions/exponentiation/bigint-zero-base-zero-exponent.js:
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-bigint.js:
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-incomparable-string.js:
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-non-finite.js:
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-number-extremes.js:
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-number.js:
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-string.js:
+        * test262/test/language/expressions/greater-than/11.8.2-1.js:
+        (obj1.valueOf):
+        (obj2.valueOf):
+        * test262/test/language/expressions/greater-than/11.8.2-2.js:
+        (obj1.valueOf):
+        (obj2.toString):
+        * test262/test/language/expressions/greater-than/11.8.2-3.js:
+        (obj1.toString):
+        (obj2.valueOf):
+        * test262/test/language/expressions/greater-than/11.8.2-4.js:
+        (obj1.toString):
+        (obj2.toString):
+        * test262/test/language/expressions/greater-than/bigint-and-bigint.js:
+        * test262/test/language/expressions/greater-than/bigint-and-boolean.js:
+        * test262/test/language/expressions/greater-than/bigint-and-incomparable-string.js:
+        * test262/test/language/expressions/greater-than/bigint-and-non-finite.js:
+        * test262/test/language/expressions/greater-than/bigint-and-number-extremes.js:
+        * test262/test/language/expressions/greater-than/bigint-and-number.js:
+        * test262/test/language/expressions/greater-than/bigint-and-string.js:
+        * test262/test/language/expressions/greater-than/bigint-and-symbol.js: Added.
+        * test262/test/language/expressions/left-shift/bigint-and-number.js:
+        * test262/test/language/expressions/left-shift/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/left-shift/bigint-non-primitive.js:
+        (assert.sameValue.Symbol.toPrimitive):
+        (assert.sameValue.valueOf):
+        (assert.sameValue.toString):
+        (assert.sameValue.0b101n.Symbol.toPrimitive):
+        (assert.sameValue.0b101n.valueOf):
+        (assert.sameValue.0b101n.toString):
+        (valueOf):
+        * test262/test/language/expressions/left-shift/bigint-toprimitive.js:
+        * test262/test/language/expressions/left-shift/bigint-wrapped-values.js:
+        * test262/test/language/expressions/less-than-or-equal/11.8.3-1.js:
+        (obj1.valueOf):
+        (obj2.valueOf):
+        * test262/test/language/expressions/less-than-or-equal/11.8.3-2.js:
+        (obj1.valueOf):
+        (obj2.toString):
+        * test262/test/language/expressions/less-than-or-equal/11.8.3-3.js:
+        (obj1.toString):
+        (obj2.valueOf):
+        * test262/test/language/expressions/less-than-or-equal/11.8.3-4.js:
+        (obj1.toString):
+        (obj2.toString):
+        * test262/test/language/expressions/less-than-or-equal/11.8.3-5.js: Removed.
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-bigint.js:
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-incomparable-string.js:
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-non-finite.js:
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-number-extremes.js:
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-number.js:
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-string.js:
+        * test262/test/language/expressions/less-than/bigint-and-bigint.js:
+        * test262/test/language/expressions/less-than/bigint-and-boolean.js:
+        * test262/test/language/expressions/less-than/bigint-and-incomparable-string.js:
+        * test262/test/language/expressions/less-than/bigint-and-non-finite.js:
+        * test262/test/language/expressions/less-than/bigint-and-number-extremes.js:
+        * test262/test/language/expressions/less-than/bigint-and-number.js:
+        * test262/test/language/expressions/less-than/bigint-and-string.js:
+        * test262/test/language/expressions/less-than/bigint-and-symbol.js: Added.
+        * test262/test/language/expressions/modulus/bigint-and-number.js:
+        * test262/test/language/expressions/modulus/bigint-arithmetic.js:
+        (testMod): Deleted.
+        * test262/test/language/expressions/modulus/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/modulus/bigint-modulo-zero.js:
+        * test262/test/language/expressions/modulus/bigint-toprimitive.js:
+        * test262/test/language/expressions/modulus/bigint-wrapped-values.js:
+        * test262/test/language/expressions/multiplication/bigint-and-number.js:
+        * test262/test/language/expressions/multiplication/bigint-arithmetic.js:
+        (testMul): Deleted.
+        * test262/test/language/expressions/multiplication/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/multiplication/bigint-toprimitive.js:
+        * test262/test/language/expressions/multiplication/bigint-wrapped-values.js:
+        * test262/test/language/expressions/right-shift/bigint-and-number.js:
+        * test262/test/language/expressions/right-shift/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/right-shift/bigint-non-primitive.js:
+        (assert.sameValue.Symbol.toPrimitive):
+        (assert.sameValue.valueOf):
+        (assert.sameValue.toString):
+        (assert.sameValue.0b101n.Symbol.toPrimitive):
+        (assert.sameValue.0b101n.valueOf):
+        (assert.sameValue.0b101n.toString):
+        (valueOf):
+        * test262/test/language/expressions/right-shift/bigint-toprimitive.js:
+        * test262/test/language/expressions/right-shift/bigint-wrapped-values.js:
+        * test262/test/language/expressions/strict-does-not-equals/bigint-and-bigint.js:
+        * test262/test/language/expressions/strict-does-not-equals/bigint-and-boolean.js:
+        * test262/test/language/expressions/strict-does-not-equals/bigint-and-incomparable-primitive.js:
+        * test262/test/language/expressions/strict-does-not-equals/bigint-and-non-finite.js:
+        * test262/test/language/expressions/strict-does-not-equals/bigint-and-number-extremes.js:
+        * test262/test/language/expressions/strict-does-not-equals/bigint-and-number.js:
+        * test262/test/language/expressions/strict-does-not-equals/bigint-and-object.js:
+        (assert.sameValue.0n.valueOf):
+        (assert.sameValue.valueOf):
+        (assert.sameValue.0n.toString):
+        (assert.sameValue.toString):
+        (assert.sameValue.900719925474099101n.valueOf):
+        (assert.sameValue.900719925474099101n.toString):
+        * test262/test/language/expressions/strict-does-not-equals/bigint-and-string.js:
+        * test262/test/language/expressions/strict-equals/bigint-and-bigint.js:
+        * test262/test/language/expressions/strict-equals/bigint-and-boolean.js:
+        * test262/test/language/expressions/strict-equals/bigint-and-incomparable-primitive.js:
+        * test262/test/language/expressions/strict-equals/bigint-and-non-finite.js:
+        * test262/test/language/expressions/strict-equals/bigint-and-number-extremes.js:
+        * test262/test/language/expressions/strict-equals/bigint-and-number.js:
+        * test262/test/language/expressions/strict-equals/bigint-and-object.js:
+        (assert.sameValue.0n.valueOf):
+        (assert.sameValue.valueOf):
+        (assert.sameValue.0n.toString):
+        (assert.sameValue.toString):
+        (assert.sameValue.900719925474099101n.valueOf):
+        (assert.sameValue.900719925474099101n.toString):
+        * test262/test/language/expressions/strict-equals/bigint-and-string.js:
+        * test262/test/language/expressions/subtraction/bigint-and-number.js:
+        * test262/test/language/expressions/subtraction/bigint-arithmetic.js:
+        (testSub): Deleted.
+        * test262/test/language/expressions/subtraction/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/subtraction/bigint-toprimitive.js:
+        * test262/test/language/expressions/subtraction/bigint-wrapped-values.js:
+        * test262/test/language/expressions/unary-minus/bigint-non-primitive.js:
+        (assert.sameValue.Symbol.toPrimitive):
+        (assert.sameValue.valueOf):
+        (assert.sameValue.toString):
+        * test262/test/language/expressions/unary-plus/bigint-throws.js:
+        * test262/test/language/expressions/unsigned-right-shift/bigint-and-number.js:
+        * test262/test/language/expressions/unsigned-right-shift/bigint-errors.js:
+        (Symbol.toPrimitive):
+        (0n.Symbol.toPrimitive):
+        (valueOf):
+        (0n.valueOf):
+        (toString):
+        (0n.toString):
+        * test262/test/language/expressions/unsigned-right-shift/bigint-non-primitive.js:
+        (Symbol.toPrimitive):
+        (valueOf):
+        (toString):
+        (0b101n.Symbol.toPrimitive):
+        (0b101n.valueOf):
+        (0b101n.toString):
+        (valueOf.valueOf):
+        * test262/test/language/expressions/unsigned-right-shift/bigint-toprimitive.js:
+        * test262/test/language/expressions/unsigned-right-shift/bigint-wrapped-values.js:
+        * test262/test/language/literals/numeric/numeric-followed-by-ident.js: Added.
+        * test262/test/language/literals/string/line-continuation-double.js: Added.
+        * test262/test/language/literals/string/line-continuation-single.js: Added.
+        * test262/test262-Revision.txt:
+
+2018-05-25  Mark Lam  <mark.lam@apple.com>
+
+        for-in loops should preserve and restore the TDZ stack for each of its internal loops.
+        https://bugs.webkit.org/show_bug.cgi?id=185995
+        <rdar://problem/40173142>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-185995.js: Added.
+
+2018-05-23  Keith Miller  <keith_miller@apple.com>
+
+        Define length on CoW array should properly convert to writable
+        https://bugs.webkit.org/show_bug.cgi?id=185927
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/cow-define-length-as-value.js: Added.
+        (test):
+
+2018-05-23  Michael Saboff  <msaboff@apple.com>
+
+        Date.parse() doesn't properly handle input outside of ES Spec limits
+        https://bugs.webkit.org/show_bug.cgi?id=185868
+
+        Reviewed by Mark Lam.
+
+        New test.
+
+        * stress/date-parse-ranges.js: Added.
+        (shouldBe):
+        (throw.new.Error):
+        (shouldBeNaN):
+
+2018-05-23  Rick Waldron  <waldron.rick@gmail.com>
+
+        Conversion misspelled "Convertion" in error message string
+        https://bugs.webkit.org/show_bug.cgi?id=185436
+
+        Reviewed by Saam Barati, Michael Saboff.
+
+        * bigIntTests.yaml:
+
+2018-05-23  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, skip test if memoryLimited is specified
+        https://bugs.webkit.org/show_bug.cgi?id=185888
+
+        * stress/regress-185888.js:
+
+2018-05-22  Mark Lam  <mark.lam@apple.com>
+
+        BytecodeGeneratorification shouldn't add a ValueProfile if the JIT is disabled.
+        https://bugs.webkit.org/show_bug.cgi?id=185896
+        <rdar://problem/40471403>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-185896.js: Added.
+
+2018-05-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Fix CachedCall's argument count if RegExp has named captures
+        https://bugs.webkit.org/show_bug.cgi?id=185587
+
+        Reviewed by Mark Lam.
+
+        * test262/expectations.yaml:
+
+2018-05-22  Mark Lam  <mark.lam@apple.com>
+
+        StringImpl utf8 conversion should not fail silently.
+        https://bugs.webkit.org/show_bug.cgi?id=185888
+        <rdar://problem/40464506>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-185888.js: Added.
+
+2018-05-22  Keith Miller  <keith_miller@apple.com>
+
+        We should have a CoW storage for NewArrayBuffer arrays.
+        https://bugs.webkit.org/show_bug.cgi?id=185003
+
+        Reviewed by Filip Pizlo.
+
+        * stress/cow-convert-contiguous-to-array-storage.js: Added.
+        (createBuffer):
+        (shouldBe):
+        (test):
+        * stress/cow-convert-double-to-array-storage.js: Added.
+        (createBuffer):
+        (shouldBe):
+        (test):
+        * stress/cow-convert-double-to-contiguous.js: Added.
+        (createBuffer):
+        (shouldBe):
+        (test):
+        * stress/cow-convert-int32-to-array-storage.js: Added.
+        (createBuffer):
+        (shouldBe):
+        (test):
+        * stress/cow-convert-int32-to-contiguous.js: Added.
+        (createBuffer):
+        (shouldBe):
+        (test):
+        * stress/cow-convert-int32-to-double.js: Added.
+        (createBuffer):
+        (shouldBe):
+        (test):
+        * stress/put-on-cow-prototype.js: Added.
+        (putByVal):
+        (putById):
+
+2018-05-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, reland InById cache
+        https://bugs.webkit.org/show_bug.cgi?id=185682
+
+        * stress/in-by-id-accessors.js: Added.
+        (shouldBe):
+        (test):
+        (protoGetter.__proto__.get hello):
+        (protoSetter.__proto__.set hello):
+        (i.shouldBe.test.get hello):
+        (i.shouldBe.test.set hello):
+        * stress/in-by-id-ai.js: Added.
+        (shouldBe):
+        (test):
+        * stress/in-by-id-custom-accessors.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        * stress/in-by-id-custom-values.js: Added.
+        (shouldBe):
+        (test):
+        * stress/in-by-id-operation.js: Added.
+        (shouldBe):
+        (test):
+        (selfCache):
+        * stress/in-by-id-proxy.js: Added.
+        (shouldBe):
+        (test):
+        (handler.has):
+
+2018-05-21  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r231998 and r232017.
+        https://bugs.webkit.org/show_bug.cgi?id=185842
+
+        causes crashes on 32 JSC bot (Requested by realdawei on
+        #webkit).
+
+        Reverted changesets:
+
+        "[JSC] JSC should have consistent InById IC"
+        https://bugs.webkit.org/show_bug.cgi?id=185682
+        https://trac.webkit.org/changeset/231998
+
+        "Unreviewed, fix 32bit and scope release"
+        https://bugs.webkit.org/show_bug.cgi?id=185682
+        https://trac.webkit.org/changeset/232017
+
+2018-05-19  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] JSC should have consistent InById IC
+        https://bugs.webkit.org/show_bug.cgi?id=185682
+
+        Reviewed by Filip Pizlo.
+
+        * stress/in-by-id-accessors.js: Added.
+        (shouldBe):
+        (test):
+        (protoGetter.__proto__.get hello):
+        (protoSetter.__proto__.set hello):
+        (i.shouldBe.test.get hello):
+        (i.shouldBe.test.set hello):
+        * stress/in-by-id-ai.js: Added.
+        (shouldBe):
+        (test):
+        * stress/in-by-id-custom-accessors.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        * stress/in-by-id-custom-values.js: Added.
+        (shouldBe):
+        (test):
+        * stress/in-by-id-operation.js: Added.
+        (shouldBe):
+        (test):
+        (selfCache):
+        * stress/in-by-id-proxy.js: Added.
+        (shouldBe):
+        (test):
+        (handler.has):
+
+2018-05-18  Keith Miller  <keith_miller@apple.com>
+
+        op_in should mark if it sees out of bounds accesses
+        https://bugs.webkit.org/show_bug.cgi?id=185792
+
+        Reviewed by Filip Pizlo.
+
+        * stress/has-indexed-property-array-storage-ftl.js:
+        (test2):
+        * stress/has-indexed-property-slow-put-array-storage-ftl.js:
+        (test2):
+
+2018-05-18  Mark Lam  <mark.lam@apple.com>
+
+        Add missing exception check.
+        https://bugs.webkit.org/show_bug.cgi?id=185786
+        <rdar://problem/35686560>
+
+        Reviewed by Michael Saboff.
+
+        * stress/regress-185786.js: Added.
+
+2018-05-16  Filip Pizlo  <fpizlo@apple.com>
+
+        JSC should have InstanceOf inline caching
+        https://bugs.webkit.org/show_bug.cgi?id=185652
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/instanceof-always-hit-one.js: Added.
+        * microbenchmarks/instanceof-always-hit-two.js: Added.
+        * microbenchmarks/instanceof-dynamic.js: Added.
+        * microbenchmarks/instanceof-sometimes-hit.js: Added.
+        * stress/instanceof-dynamic-proxy-check-structure.js: Added.
+        * stress/instanceof-dynamic-proxy-loop.js: Added.
+        * stress/instanceof-dynamic-proxy.js: Added.
+        * stress/instanceof-hit-one-object-then-another.js: Added.
+        * stress/instanceof-hit-two-objects-then-another.js: Added.
+        * stress/instanceof-prototype-change.js: Added.
+        * stress/instanceof-prototype-change-to-hit.js: Added.
+        * stress/instanceof-prototype-change-to-null.js: Added.
+        * stress/instanceof-prototype-change-watchpointable.js: Added.
+
+2018-05-17  Michael Saboff  <msaboff@apple.com>
+
+        We don't throw SyntaxErrors for runtime generated regular expressions with errors
+        https://bugs.webkit.org/show_bug.cgi?id=185755
+
+        Reviewed by Keith Miller.
+
+        New regression test.
+
+        * stress/regexp-with-runtime-syntax-errors.js: Added.
+        (testThrowsSyntaxtError):
+        (fromExecWithBadUnicodeEscape):
+        (fromTestWithBadUnicodeProperty):
+        (fromSplitWithBadUnicodeIdentity):
+        (fromMatchWithBadUnicodeBackReference):
+        (fromReplaceWithBadUnicodeEscape):
+        (fromSearchWithBadUnicodeEscape):
+
+2018-05-16  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for "/" operation
+        https://bugs.webkit.org/show_bug.cgi?id=183996
+
+        Reviewed by Yusuke Suzuki.
+
+        * bigIntTests.yaml:
+        * stress/big-int-div-jit.js: Added.
+        * stress/big-int-div-memory-stress.js: Added.
+        * stress/big-int-div-to-primitive-precedence.js: Added.
+        * stress/big-int-div-to-primitive.js: Added.
+        * stress/big-int-div-type-error.js: Added.
+        * stress/big-int-div-wrapped-value.js: Added.
+        * stress/big-int-division.js: Added.
+
+2018-05-16  Saam Barati  <sbarati@apple.com>
+
+        Constant fold CheckTypeInfoFlags on ImplementsDefaultHasInstance
+        https://bugs.webkit.org/show_bug.cgi?id=185670
+
+        Reviewed by Yusuke Suzuki.
+
+        * microbenchmarks/constant-fold-check-type-info-flags.js: Added.
+        * stress/dont-constant-fold-check-type-info-on-bound-function.js: Added.
+
+2018-05-16  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r231845.
+        https://bugs.webkit.org/show_bug.cgi?id=185702
+
+        it is breaking Apple High Sierra 32-bit JSC bot (Requested by
+        caiolima on #webkit).
+
+        Reverted changeset:
+
+        "[ESNext][BigInt] Implement support for "/" operation"
+        https://bugs.webkit.org/show_bug.cgi?id=183996
+        https://trac.webkit.org/changeset/231845
+
+2018-05-16  Filip Pizlo  <fpizlo@apple.com>
+
+        DFG models InstanceOf incorrectly
+        https://bugs.webkit.org/show_bug.cgi?id=185694
+
+        Reviewed by Keith Miller.
+
+        * stress/instanceof-proxy-check-structure.js: Added.
+        (Foo):
+        (Bar):
+        (doBadThings):
+        (getPrototypeOf):
+        (foo):
+        (i.new.Bar):
+        (new.Bar):
+        * stress/instanceof-proxy-loop.js: Added.
+        (Foo):
+        (Bar):
+        (doBadThings):
+        (getPrototypeOf):
+        (foo):
+        * stress/instanceof-proxy.js: Added.
+        (Foo):
+        (Bar):
+        (doBadThings):
+        (getPrototypeOf):
+        (foo):
+
+2018-05-16  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for "/" operation
+        https://bugs.webkit.org/show_bug.cgi?id=183996
+
+        Reviewed by Yusuke Suzuki.
+
+        * bigIntTests.yaml:
+        * stress/big-int-div-jit.js: Added.
+        * stress/big-int-div-memory-stress.js: Added.
+        * stress/big-int-div-to-primitive-precedence.js: Added.
+        * stress/big-int-div-to-primitive.js: Added.
+        * stress/big-int-div-type-error.js: Added.
+        * stress/big-int-div-wrapped-value.js: Added.
+        * stress/big-int-division.js: Added.
+
+2018-05-14  Leo Balter  <leonardo.balter@gmail.com>
+
+        Fix a legacy CRLF eol from Test262
+        https://bugs.webkit.org/show_bug.cgi?id=185565
+
+        Reviewed by Yusuke Suzuki.
+
+        * test262/config.yaml:
+        * test262/test/built-ins/Math/cbrt/prop-desc.js:
+
+2018-05-14  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] timeClip(-0) should produce +0
+        https://bugs.webkit.org/show_bug.cgi?id=185589
+
+        Reviewed by Saam Barati.
+
+        Fix several test262 failures.
+
+        * stress/date-negative-zero.js: Added.
+        (shouldBe):
+        * test262/expectations.yaml:
+
+2018-05-13  Caio Lima  <ticaiolima@gmail.com>
+
+        [BigInt] stress/big-int-spec-to-primitive.js test is failing
+        https://bugs.webkit.org/show_bug.cgi?id=185582
+
+        Reviewed by Yusuke Suzuki.
+
+        This patch is removing the use of ```numberOfDFGCompiles``` from 
+        stress/big-int-spec-to-primitive.js because it makes this est fail
+        sometimes.
+
+        * stress/big-int-spec-to-primitive.js:
+
+2018-05-13  Andy VanWagoner  <andy@vanwagoner.family>
+
+        [INTL] Improve spec & test262 compliance for Intl APIs
+        https://bugs.webkit.org/show_bug.cgi?id=185578
+
+        Reviewed by Yusuke Suzuki.
+
+        Remove intl402 failures that have been fixed.
+
+        * test262/expectations.yaml:
+        * stress/regress-178385.js: toStringTag is configurable, but not writable.
+
+2018-05-11  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for "*" operation
+        https://bugs.webkit.org/show_bug.cgi?id=183721
+
+        Reviewed by Yusuke Suzuki.
+
+        * bigIntTests.yaml:
+        * stress/big-int-mul-jit.js: Added.
+        * stress/big-int-mul-to-primitive-precedence.js: Added.
+        * stress/big-int-mul-to-primitive.js: Added.
+        * stress/big-int-mul-type-error.js: Added.
+        * stress/big-int-mul-wrapped-value.js: Added.
+        * stress/big-int-multiplication.js: Added.
+        * stress/big-int-multiply-memory-stress.js: Added.
+
+2018-05-11  Michael Saboff  <msaboff@apple.com>
+
+        [DFG] Compiler uses incorrect output register for NumberIsInteger operation
+        https://bugs.webkit.org/show_bug.cgi?id=185328
+
+        Reviewed by Keith Miller.
+
+        New regression test.
+
+        * stress/isInteger-doesnt-overwrite-argument.js: Added.
+        (testIsInteger):
+
+2018-05-09  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Object.assign for final objects should be faster
+        https://bugs.webkit.org/show_bug.cgi?id=185348
+
+        Reviewed by Saam Barati.
+
+        * stress/object-assign-fast-path.js: Added.
+        (shouldBe):
+        (checkProperty):
+
+2018-05-10  Leo Balter  <leonardo.balter@gmail.com>
+
+        Update Test262 tests through the new import script - 20180509
+        https://bugs.webkit.org/show_bug.cgi?id=185482
+
+        Reviewed by Michael Saboff.
+
+        Also update the test262/expecatations.yaml with the recent imported files.
+
+        * test262/expectations.yaml:
+        * test262/harness/compareIterator.js: Added.
+        (assert.compareIterator):
+        * test262/harness/nativeFunctionMatcher.js:
+        (const.assertToStringOrNativeFunction):
+        (const.assertNativeFunction):
+        * test262/harness/regExpUtils.js:
+        * test262/harness/testIntl.js:
+        (getInvalidLanguageTags):
+        * test262/harness/testTypedArray.js:
+        * test262/harness/wellKnownIntrinsicObjects.js: Added.
+        (WellKnownIntrinsicObjects.forEach.wkio.catch):
+        * test262/latest-changes-summary.txt: Added.
+        * test262/test/annexB/language/eval-code/direct/block-decl-nostrict.js: Copied from JSTests/test262/test/language/eval-code/direct/block-decl-strict-caller.js.
+        (catch):
+        * test262/test/annexB/language/eval-code/direct/switch-case-decl-nostrict.js: Copied from JSTests/test262/test/language/eval-code/direct/switch-case-decl-strict-source.js.
+        (catch):
+        * test262/test/annexB/language/eval-code/direct/switch-dflt-decl-nostrict.js: Copied from JSTests/test262/test/language/eval-code/direct/switch-dflt-decl-strict-caller.js.
+        (catch):
+        * test262/test/annexB/language/function-code/block-decl-nested-blocks-with-fun-decl.js: Added.
+        (g.f):
+        (g):
+        * test262/test/annexB/language/function-code/block-decl-nostrict.js: Copied from JSTests/test262/test/language/function-code/block-decl-strict.js.
+        (catch):
+        (f):
+        * test262/test/annexB/language/function-code/switch-case-decl-nostrict.js: Copied from JSTests/test262/test/language/function-code/switch-case-decl-strict.js.
+        (catch):
+        (switch.case.1):
+        (switch):
+        * test262/test/annexB/language/function-code/switch-dflt-decl-nostrict.js: Copied from JSTests/test262/test/language/function-code/switch-dflt-decl-strict.js.
+        (catch):
+        (switch.default):
+        (switch):
+        * test262/test/built-ins/Array/prototype/filter/target-array-with-non-writable-property.js: Added.
+        (a.Symbol.species):
+        (r.a.filter):
+        * test262/test/built-ins/Array/prototype/indexOf/calls-only-has-on-prototype-after-length-zeroed.js: Added.
+        (allowProxyTraps.has):
+        (fromIndex.valueOf):
+        * test262/test/built-ins/Array/prototype/lastIndexOf/calls-only-has-on-prototype-after-length-zeroed.js: Added.
+        (allowProxyTraps.has):
+        (fromIndex.valueOf):
+        * test262/test/built-ins/Array/prototype/map/target-array-with-non-writable-property.js: Added.
+        (a.Symbol.species):
+        (r.a.map):
+        * test262/test/built-ins/Array/prototype/slice/target-array-with-non-writable-property.js: Added.
+        (a.Symbol.species):
+        * test262/test/built-ins/Array/prototype/splice/property-traps-order-with-species.js: Added.
+        (a.Symbol.species):
+        * test262/test/built-ins/Array/prototype/splice/target-array-with-non-writable-property.js: Added.
+        (a.Symbol.species):
+        * test262/test/built-ins/Atomics/Symbol.toStringTag.js:
+        * test262/test/built-ins/Atomics/add/bad-range.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/add/good-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/add/non-views.js:
+        * test262/test/built-ins/Atomics/add/nonshared-int-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/add/shared-nonint-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/and/bad-range.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/and/good-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/and/non-views.js:
+        * test262/test/built-ins/Atomics/and/nonshared-int-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/and/shared-nonint-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/compareExchange/bad-range.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/compareExchange/good-views.js:
+        (testWithTypedArrayConstructors):
+        (view): Deleted.
+        * test262/test/built-ins/Atomics/compareExchange/non-views.js:
+        * test262/test/built-ins/Atomics/compareExchange/nonshared-int-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/compareExchange/shared-nonint-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/exchange/bad-range.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/exchange/good-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/exchange/non-views.js:
+        * test262/test/built-ins/Atomics/exchange/nonshared-int-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/exchange/shared-nonint-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/isLockFree/corner-cases.js:
+        (hide):
+        * test262/test/built-ins/Atomics/isLockFree/value.js:
+        (testIsLockFree): Deleted.
+        * test262/test/built-ins/Atomics/load/bad-range.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/load/good-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/load/non-views.js:
+        * test262/test/built-ins/Atomics/load/nonshared-int-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/load/shared-nonint-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/or/bad-range.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/or/good-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/or/non-views.js:
+        * test262/test/built-ins/Atomics/or/nonshared-int-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/or/shared-nonint-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/prop-desc.js:
+        * test262/test/built-ins/Atomics/proto.js:
+        * test262/test/built-ins/Atomics/store/bad-range.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/store/good-views.js:
+        (testWithTypedArrayConstructors):
+        (ToInteger):
+        * test262/test/built-ins/Atomics/store/non-views.js:
+        * test262/test/built-ins/Atomics/store/nonshared-int-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/store/shared-nonint-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/sub/bad-range.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/sub/good-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/sub/non-views.js:
+        * test262/test/built-ins/Atomics/sub/nonshared-int-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/sub/shared-nonint-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/wait/bad-range.js: Copied from JSTests/test262/test/built-ins/Atomics/wake/bad-range.js.
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/wait/cannot-suspend-throws.js:
+        * test262/test/built-ins/Atomics/wait/did-timeout.js:
+        (getReport):
+        * test262/test/built-ins/Atomics/wait/false-for-timeout-agent.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/false-for-timeout.js.
+        (getReport):
+        (262.agent.start.valueOf.valueOf):
+        (toPrimitive.Symbol.toPrimitive):
+        (262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/false-for-timeout.js:
+        (valueOf.valueOf):
+        (toPrimitive.Symbol.toPrimitive):
+        (getReport): Deleted.
+        (262.agent.start.262.agent.receiveBroadcast): Deleted.
+        * test262/test/built-ins/Atomics/wait/good-views.js:
+        (r.getReport):
+        (getReport):
+        * test262/test/built-ins/Atomics/wait/nan-for-timeout.js:
+        (getReport):
+        * test262/test/built-ins/Atomics/wait/negative-index-throws.js:
+        * test262/test/built-ins/Atomics/wait/negative-timeout-agent.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/negative-timeout.js.
+        (getReport):
+        (262.agent.start.262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/negative-timeout.js:
+        (262.agent.start.262.agent.receiveBroadcast): Deleted.
+        (getReport): Deleted.
+        * test262/test/built-ins/Atomics/wait/no-spurious-wakeup.js:
+        (getReport):
+        * test262/test/built-ins/Atomics/wait/non-int32-typedarray-throws.js:
+        * test262/test/built-ins/Atomics/wait/non-shared-bufferdata-throws.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/nonshared-bufferdata-throws.js.
+        * test262/test/built-ins/Atomics/wait/not-a-typedarray-throws.js:
+        * test262/test/built-ins/Atomics/wait/not-an-object-throws.js:
+        * test262/test/built-ins/Atomics/wait/null-bufferdata-throws.js:
+        * test262/test/built-ins/Atomics/wait/null-for-timeout-agent.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/false-for-timeout.js.
+        (getReport):
+        (262.agent.start.valueOf.valueOf):
+        (toPrimitive.Symbol.toPrimitive):
+        (262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/null-for-timeout.js:
+        (valueOf.valueOf):
+        (toPrimitive.Symbol.toPrimitive):
+        (getReport): Deleted.
+        (262.agent.start.262.agent.receiveBroadcast): Deleted.
+        * test262/test/built-ins/Atomics/wait/object-for-timeout-agent.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/false-for-timeout.js.
+        (getReport):
+        (262.agent.start.valueOf.valueOf):
+        (toString.toString):
+        (toPrimitive.Symbol.toPrimitive):
+        (262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/object-for-timeout.js:
+        (valueOf.valueOf):
+        (toString.toString):
+        (toPrimitive.Symbol.toPrimitive):
+        (getReport): Deleted.
+        (262.agent.start.262.agent.receiveBroadcast): Deleted.
+        * test262/test/built-ins/Atomics/wait/out-of-range-index-throws.js:
+        * test262/test/built-ins/Atomics/wait/poisoned-object-for-timeout-throws-agent.js: Added.
+        (getReport):
+        (262.agent.start.poisonedValueOf.valueOf):
+        (poisonedToPrimitive.Symbol.toPrimitive):
+        (262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/poisoned-object-for-timeout-throws.js:
+        (poisonedValueOf.valueOf):
+        (poisonedToPrimitive.Symbol.toPrimitive):
+        (getReport): Deleted.
+        (262.agent.start.262.agent.receiveBroadcast): Deleted.
+        * test262/test/built-ins/Atomics/wait/symbol-for-index-throws-agent.js: Added.
+        (getReport):
+        (262.agent.start.poisonedValueOf.valueOf):
+        (poisonedToPrimitive.Symbol.toPrimitive):
+        (262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/symbol-for-index-throws.js:
+        (poisonedToPrimitive.Symbol.toPrimitive):
+        (poisoned.valueOf): Deleted.
+        (poisonedWithString.get valueOf): Deleted.
+        (poisonedToPrimitive.get Symbol): Deleted.
+        * test262/test/built-ins/Atomics/wait/symbol-for-timeout-throws-agent.js: Added.
+        (getReport):
+        (262.agent.start.262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/symbol-for-timeout-throws.js:
+        (poisonedValueOf.valueOf):
+        (poisonedToPrimitive.Symbol.toPrimitive):
+        (getReport): Deleted.
+        (262.agent.start.262.agent.receiveBroadcast): Deleted.
+        * test262/test/built-ins/Atomics/wait/symbol-for-value-throws-agent.js: Added.
+        (getReport):
+        (262.agent.start.poisonedValueOf.valueOf):
+        (poisonedToPrimitive.Symbol.toPrimitive):
+        (262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/symbol-for-value-throws.js: Added.
+        (poisonedValueOf.valueOf):
+        (poisonedToPrimitive.Symbol.toPrimitive):
+        * test262/test/built-ins/Atomics/wait/true-for-timeout-agent.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/null-for-timeout.js.
+        (getReport):
+        (262.agent.start.valueOf.valueOf):
+        (toPrimitive.Symbol.toPrimitive):
+        (262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/true-for-timeout.js:
+        (valueOf.valueOf):
+        (toPrimitive.Symbol.toPrimitive):
+        (getReport): Deleted.
+        (262.agent.start.262.agent.receiveBroadcast): Deleted.
+        * test262/test/built-ins/Atomics/wait/undefined-for-timeout.js:
+        (getReport):
+        * test262/test/built-ins/Atomics/wait/undefined-index-defaults-to-zero.js:
+        (262.agent.start.262.agent.receiveBroadcast):
+        (getReport):
+        * test262/test/built-ins/Atomics/wait/value-not-equal.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/wait-index-value-not-equal.js.
+        (getReport):
+        (262.agent.start.262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/wait-index-value-not-equal.js:
+        (262.agent.start.262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/waiterlist-block-indexedposition-wake.js: Added.
+        (getReport):
+        (262.agent.start.262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/waiterlist-order-of-operations-is-fifo.js: Added.
+        (getReport):
+        (262.agent.start.262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/was-woken-before-timeout.js:
+        (getReport):
+        (262.agent.start.262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wait/was-woken.js:
+        (getReport):
+        (262.agent.start.262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wake/bad-range.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/wake/count-boundary-cases.js: Renamed from JSTests/test262/test/built-ins/Atomics/wake/counts.js.
+        * test262/test/built-ins/Atomics/wake/count-defaults-to-infinity-missing.js: Added.
+        (getReport):
+        (262.agent.start.262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wake/count-defaults-to-infinity-undefined.js: Added.
+        (getReport):
+        (262.agent.start.262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wake/count-from-nans.js: Added.
+        * test262/test/built-ins/Atomics/wake/count-symbol-throws.js: Added.
+        * test262/test/built-ins/Atomics/wake/count-tointeger-throws-then-wake-throws.js: Added.
+        (poisoned.valueOf):
+        * test262/test/built-ins/Atomics/wake/good-views.js:
+        * test262/test/built-ins/Atomics/wake/negative-count.js: Renamed from JSTests/test262/test/built-ins/Atomics/wake/wake-negative.js.
+        * test262/test/built-ins/Atomics/wake/negative-index-throws.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/negative-index-throws.js.
+        (poisoned.valueOf):
+        * test262/test/built-ins/Atomics/wake/non-int32-typedarray-throws.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/non-int32-typedarray-throws.js.
+        (poisoned.valueOf):
+        * test262/test/built-ins/Atomics/wake/non-shared-bufferdata-throws.js: Renamed from JSTests/test262/test/built-ins/Atomics/wait/nonshared-bufferdata-throws.js.
+        (poisoned.valueOf):
+        * test262/test/built-ins/Atomics/wake/non-views.js:
+        * test262/test/built-ins/Atomics/wake/nonshared-int-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/wake/not-a-typedarray-throws.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/not-a-typedarray-throws.js.
+        (poisoned.valueOf):
+        * test262/test/built-ins/Atomics/wake/not-an-object-throws.js: Added.
+        (poisoned.valueOf):
+        * test262/test/built-ins/Atomics/wake/null-bufferdata-throws.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/null-bufferdata-throws.js.
+        (poisoned.valueOf):
+        * test262/test/built-ins/Atomics/wake/out-of-range-index-throws.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/out-of-range-index-throws.js.
+        (poisoned.valueOf):
+        * test262/test/built-ins/Atomics/wake/shared-nonint-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/wake/symbol-for-index-throws.js: Added.
+        (poisonedValueOf.valueOf):
+        (poisonedToPrimitive.Symbol.toPrimitive):
+        * test262/test/built-ins/Atomics/wake/undefined-index-defaults-to-zero.js: Copied from JSTests/test262/test/built-ins/Atomics/wait/undefined-index-defaults-to-zero.js.
+        (262.agent.start.262.agent.receiveBroadcast):
+        (getReport):
+        * test262/test/built-ins/Atomics/wake/wake-all-on-loc.js:
+        (262.agent.start.262.agent.receiveBroadcast):
+        (getReport):
+        (waitUntil):
+        * test262/test/built-ins/Atomics/wake/wake-all.js:
+        (262.agent.start.262.agent.receiveBroadcast):
+        (getReport):
+        (waitUntil):
+        * test262/test/built-ins/Atomics/wake/wake-in-order.js:
+        (getReport):
+        (waitUntil):
+        * test262/test/built-ins/Atomics/wake/wake-nan.js:
+        (getReport):
+        * test262/test/built-ins/Atomics/wake/wake-one.js:
+        (getReport):
+        (waitUntil):
+        * test262/test/built-ins/Atomics/wake/wake-rewake-noop.js: Added.
+        (getReport):
+        (waitUntil):
+        (262.agent.start.262.agent.receiveBroadcast):
+        * test262/test/built-ins/Atomics/wake/wake-two.js:
+        (getReport):
+        * test262/test/built-ins/Atomics/wake/wake-with-no-agents-waiting.js: Added.
+        (262.agent.start.262.agent.receiveBroadcast):
+        (waitUntil):
+        * test262/test/built-ins/Atomics/wake/wake-with-no-matching-agents-waiting.js: Added.
+        (262.agent.start.262.agent.receiveBroadcast):
+        (waitUntil):
+        * test262/test/built-ins/Atomics/wake/wake-zero.js:
+        (i.262.agent.start.262.agent.receiveBroadcast):
+        (getReport):
+        (waitUntil):
+        * test262/test/built-ins/Atomics/xor/bad-range.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/xor/good-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/xor/non-views.js:
+        * test262/test/built-ins/Atomics/xor/nonshared-int-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/Atomics/xor/shared-nonint-views.js:
+        (testWithTypedArrayConstructors):
+        * test262/test/built-ins/BigInt/asIntN/bigint-tobigint-errors.js:
+        * test262/test/built-ins/BigInt/asIntN/bigint-tobigint-toprimitive.js:
+        * test262/test/built-ins/BigInt/asIntN/bigint-tobigint-wrapped-values.js:
+        * test262/test/built-ins/BigInt/asIntN/bits-toindex-errors.js:
+        * test262/test/built-ins/BigInt/asIntN/bits-toindex-toprimitive.js:
+        * test262/test/built-ins/BigInt/asIntN/bits-toindex-wrapped-values.js:
+        * test262/test/built-ins/BigInt/asUintN/bigint-tobigint-errors.js:
+        * test262/test/built-ins/BigInt/asUintN/bigint-tobigint-toprimitive.js:
+        * test262/test/built-ins/BigInt/asUintN/bigint-tobigint-wrapped-values.js:
+        * test262/test/built-ins/BigInt/asUintN/bits-toindex-errors.js:
+        * test262/test/built-ins/BigInt/asUintN/bits-toindex-toprimitive.js:
+        * test262/test/built-ins/BigInt/asUintN/bits-toindex-wrapped-values.js:
+        * test262/test/built-ins/BigInt/constructor-empty-string.js:
+        * test262/test/built-ins/BigInt/constructor-from-binary-string.js:
+        * test262/test/built-ins/BigInt/constructor-from-decimal-string.js:
+        * test262/test/built-ins/BigInt/constructor-from-hex-string.js:
+        * test262/test/built-ins/BigInt/constructor-from-octal-string.js:
+        * test262/test/built-ins/BigInt/constructor-from-string-syntax-errors.js:
+        * test262/test/built-ins/BigInt/constructor-integer.js: Added.
+        * test262/test/built-ins/BigInt/constructor-trailing-leading-spaces.js:
+        * test262/test/built-ins/BigInt/issafeinteger-true.js: Removed.
+        * test262/test/built-ins/BigInt/out-of-bounds-integer-rangeerror.js: Removed.
+        * test262/test/built-ins/BigInt/prototype/Symbol.toStringTag.js:
+        * test262/test/built-ins/BigInt/prototype/toString/default-radix.js: Added.
+        * test262/test/built-ins/BigInt/prototype/toString/thisbigintvalue-not-valid-throws.js:
+        * test262/test/built-ins/BigInt/prototype/valueOf/cross-realm.js: Added.
+        * test262/test/built-ins/BigInt/tostring-throws.js: Copied from JSTests/test262/test/built-ins/BigInt/value-of-throws.js.
+        * test262/test/built-ins/BigInt/valueof-throws.js: Renamed from JSTests/test262/test/built-ins/BigInt/value-of-throws.js.
+        (BigInt.valueOf):
+        * test262/test/built-ins/DataView/prototype/setBigInt64/set-values-return-undefined.js:
+        (values.forEach):
+        * test262/test/built-ins/Function/prototype/bind/length-exceeds-int32.js: Added.
+        (f):
+        * test262/test/built-ins/Function/prototype/toString/anonymous-intrinsics.js: Removed.
+        * test262/test/built-ins/Function/prototype/toString/bound-function.js:
+        (assertNativeFunction):
+        (let.f): Deleted.
+        * test262/test/built-ins/Function/prototype/toString/built-in-function-object.js: Added.
+        * test262/test/built-ins/Function/prototype/toString/intrinsics.js: Removed.
+        * test262/test/built-ins/Function/prototype/toString/proxy-arrow-function.js: Added.
+        (assertNativeFunction.new.Proxy):
+        * test262/test/built-ins/Function/prototype/toString/proxy-async-function.js: Added.
+        (assertNativeFunction.new.Proxy.async):
+        * test262/test/built-ins/Function/prototype/toString/proxy-async-generator-function.js: Added.
+        (assertNativeFunction.new.Proxy.async):
+        * test262/test/built-ins/Function/prototype/toString/proxy-async-generator-method-definition.js: Added.
+        (assertNativeFunction.new.Proxy.async.method):
+        (apply):
+        * test262/test/built-ins/Function/prototype/toString/proxy-async-method-definition.js: Added.
+        (assertNativeFunction.new.Proxy.async.method):
+        (apply):
+        * test262/test/built-ins/Function/prototype/toString/proxy-bound-function.js: Added.
+        (assertNativeFunction.new.Proxy):
+        (bind):
+        * test262/test/built-ins/Function/prototype/toString/proxy-class.js: Added.
+        (assertNativeFunction):
+        * test262/test/built-ins/Function/prototype/toString/proxy-function-expression.js: Added.
+        (assertNativeFunction.new.Proxy):
+        * test262/test/built-ins/Function/prototype/toString/proxy-generator-function.js: Added.
+        (assertNativeFunction.new.Proxy):
+        * test262/test/built-ins/Function/prototype/toString/proxy-method-definition.js: Added.
+        (assertNativeFunction.new.Proxy.method):
+        (apply):
+        * test262/test/built-ins/Function/prototype/toString/proxy-non-callable-throws.js: Added.
+        * test262/test/built-ins/Function/prototype/toString/proxy.js: Removed.
+        * test262/test/built-ins/Function/prototype/toString/well-known-intrinsic-object-functions.js: Added.
+        (WellKnownIntrinsicObjects.forEach):
+        * test262/test/built-ins/JSON/prop-desc.js: Added.
+        * test262/test/built-ins/Math/acosh/nan-returns.js:
+        * test262/test/built-ins/Math/asinh/asinh-specialVals.js:
+        * test262/test/built-ins/Math/atanh/atanh-specialVals.js:
+        * test262/test/built-ins/Math/cbrt/cbrt-specialValues.js:
+        * test262/test/built-ins/Math/cbrt/prop-desc.js:
+        * test262/test/built-ins/Math/cosh/cosh-specialVals.js:
+        * test262/test/built-ins/Math/expm1/expm1-specialVals.js:
+        * test262/test/built-ins/Math/log10/Log10-specialVals.js:
+        * test262/test/built-ins/Math/log2/log2-basicTests.js:
+        * test262/test/built-ins/Math/prop-desc.js:
+        * test262/test/built-ins/Math/sign/sign-specialVals.js:
+        * test262/test/built-ins/Math/sinh/sinh-specialVals.js:
+        * test262/test/built-ins/Math/tanh/tanh-specialVals.js:
+        * test262/test/built-ins/Math/trunc/trunc-sampleTests.js:
+        * test262/test/built-ins/Math/trunc/trunc-specialVals.js:
+        * test262/test/built-ins/Object/assign/strings-and-symbol-order.js: Added.
+        * test262/test/built-ins/Object/keys/property-traps-order-with-proxied-array.js: Added.
+        (get t):
+        * test262/test/built-ins/Reflect/Reflect.js: Removed.
+        * test262/test/built-ins/Reflect/prop-desc.js: Added.
+        * test262/test/built-ins/Reflect/properties.js: Removed.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/internal-regexp-lastindex-not-zero.js: Added.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/isregexp-internal-regexp-is-false.js: Added.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/isregexp-internal-regexp-throws.js: Added.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/isregexp-this-throws.js: Added.
+        (obj.get Symbol):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/length.js: Added.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/name.js: Added.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/prop-desc.js: Added.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/regexpcreate-this-throws.js: Added.
+        (obj.toString):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/species-constructor-get-constructor-throws.js: Added.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/species-constructor-get-species-throws.js: Added.
+        (regexp.get Symbol):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/species-constructor-is-not-object-throws.js: Added.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/species-constructor-is-undefined.js: Added.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/species-constructor-species-is-not-constructor.js: Added.
+        (callMatchAll):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/species-constructor-species-is-null-or-undefined.js: Added.
+        (TestWithConstructor):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/species-constructor-species-throws.js: Added.
+        (regexp.Symbol.species):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/species-constructor.js: Added.
+        (regexp.Symbol.species):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/species-regexp-get-global-throws.js: Added.
+        (regexp.Symbol.species):
+        (get assert):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/species-regexp-get-unicode-throws.js: Added.
+        (regexp.Symbol.species):
+        (get assert):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/string-tostring-throws.js: Added.
+        (obj.valueOf):
+        (obj.toString):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/string-tostring.js: Added.
+        (obj.toString):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/this-get-flags-throws.js: Added.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/this-get-flags.js: Added.
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/this-lastindex-cached.js: Added.
+        (regexp.lastIndex.valueOf):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/this-not-object-throws.js: Added.
+        (callMatchAll):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/this-tolength-lastindex-throws.js: Added.
+        (regexp.lastIndex.valueOf):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/this-tostring-flags-throws.js: Added.
+        (value.valueOf):
+        (value.toString):
+        * test262/test/built-ins/RegExp/prototype/Symbol.matchAll/this-tostring-flags.js: Added.
+        (value.toString):
+        * test262/test/built-ins/RegExpStringIteratorPrototype/Symbol.toStringTag.js: Added.
+        * test262/test/built-ins/RegExpStringIteratorPrototype/ancestry.js: Added.
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/custom-regexpexec-call-throws.js: Added.
+        (RegExp.prototype.exec):
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/custom-regexpexec-get-throws.js: Added.
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/custom-regexpexec-match-get-0-throws.js: Added.
+        (return.get string_appeared_here):
+        (RegExp.prototype.exec):
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/custom-regexpexec-match-get-0-tostring-throws.js: Added.
+        (return.toString):
+        (RegExp.prototype.exec):
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/custom-regexpexec-match-get-0-tostring.js: Added.
+        (execResult.get string_appeared_here):
+        (RegExp.prototype.exec):
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/custom-regexpexec-not-callable.js: Added.
+        (TestWithRegExpExec):
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/custom-regexpexec.js: Added.
+        (callNextWithExecReturnValue.RegExp.prototype.exec):
+        (callNextWithExecReturnValue):
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/length.js: Added.
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/name.js: Added.
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/next-iteration-global.js: Added.
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/next-iteration.js: Added.
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/next-missing-internal-slots.js: Added.
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/prop-desc.js: Added.
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/regexp-tolength-lastindex-throws.js: Added.
+        (RegExp.prototype.exec):
+        * test262/test/built-ins/RegExpStringIteratorPrototype/next/this-is-not-object-throws.js: Added.
+        (callNext):
+        * test262/test/built-ins/String/prototype/matchAll/length.js: Added.
+        * test262/test/built-ins/String/prototype/matchAll/name.js: Added.
+        * test262/test/built-ins/String/prototype/matchAll/prop-desc.js: Added.
+        * test262/test/built-ins/String/prototype/matchAll/regexp-get-matchAll-throws.js: Added.
+        * test262/test/built-ins/String/prototype/matchAll/regexp-is-null.js: Added.
+        * test262/test/built-ins/String/prototype/matchAll/regexp-is-undefined.js: Added.
+        * test262/test/built-ins/String/prototype/matchAll/regexp-matchAll-invocation.js: Added.
+        (obj.Symbol.matchAll):
+        * test262/test/built-ins/String/prototype/matchAll/regexp-matchAll-throws.js: Added.
+        (regexp.Symbol.matchAll):
+        * test262/test/built-ins/String/prototype/matchAll/regexp-prototype-get-matchAll-throws.js: Added.
+        * test262/test/built-ins/String/prototype/matchAll/regexp-prototype-has-no-matchAll.js: Added.
+        * test262/test/built-ins/String/prototype/matchAll/regexp-prototype-matchAll-invocation.js: Added.
+        (RegExp.prototype.Symbol.matchAll):
+        * test262/test/built-ins/String/prototype/matchAll/regexp-prototype-matchAll-throws.js: Added.
+        (RegExp.prototype.Symbol.matchAll):
+        * test262/test/built-ins/String/prototype/matchAll/this-val-non-obj-coercible.js: Added.
+        * test262/test/built-ins/Symbol/matchAll/cross-realm.js: Added.
+        * test262/test/built-ins/Symbol/matchAll/prop-desc.js: Added.
+        * test262/test/harness/testTypedArray.js:
+        * test262/test/intl402/Array/prototype/toLocaleString/calls-toLocaleString-number-elements.js: Added.
+        * test262/test/intl402/Intl/getCanonicalLocales/invalid-tags.js:
+        * test262/test/intl402/Locale/constructor-newtarget-undefined.js: Added.
+        * test262/test/intl402/Locale/constructor-options-calendar-invalid.js: Added.
+        (const.invalidCalendarOption.of.invalidCalendarOptions.new.Intl.Locale):
+        * test262/test/intl402/Locale/constructor-options-calendar-valid.js: Added.
+        * test262/test/intl402/Locale/constructor-options-language-invalid.js: Added.
+        (const.invalidLanguageOption.of.invalidLanguageOptions.new.Intl.Locale):
+        * test262/test/intl402/Locale/constructor-options-language-valid.js: Added.
+        (toString):
+        * test262/test/intl402/Locale/constructor-options-region-invalid.js: Added.
+        (const.invalidRegionOption.of.invalidRegionOptions.new.Intl.Locale):
+        * test262/test/intl402/Locale/constructor-options-region-valid.js: Added.
+        * test262/test/intl402/Locale/constructor-options-script-invalid.js: Added.
+        (const.invalidScriptOption.of.invalidScriptOptions.new.Intl.Locale):
+        * test262/test/intl402/Locale/constructor-options-script-valid.js: Added.
+        (toString):
+        * test262/test/intl402/Locale/function-prototype.js: Added.
+        * test262/test/intl402/Locale/instance-extensibility.js: Added.
+        * test262/test/intl402/Locale/instance.js: Added.
+        * test262/test/intl402/Locale/invalid-tag-throws-boolean.js: Added.
+        * test262/test/intl402/Locale/invalid-tag-throws-null.js: Added.
+        * test262/test/intl402/Locale/invalid-tag-throws-number.js: Added.
+        * test262/test/intl402/Locale/invalid-tag-throws-symbol.js: Added.
+        * test262/test/intl402/Locale/invalid-tag-throws-undefined.js: Added.
+        * test262/test/intl402/Locale/invalid-tag-throws.js: Added.
+        (const.invalidTag.of.getInvalidLanguageTags):
+        * test262/test/intl402/Locale/length.js: Added.
+        * test262/test/intl402/Locale/name.js: Added.
+        * test262/test/intl402/Locale/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/constructor.js: Added.
+        * test262/test/intl402/Locale/prototype/maximize/length.js: Added.
+        * test262/test/intl402/Locale/prototype/maximize/name.js: Added.
+        * test262/test/intl402/Locale/prototype/maximize/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/prop-desc.js: Added.
+        * test262/test/intl402/Locale/prototype/toStringTag.js: Added.
+        * test262/test/intl402/TypedArray/prototype/toLocaleString/calls-toLocaleString-number-elements.js: Added.
+        (testWithTypedArrayConstructors):
+        * test262/test/language/asi/S7.9_A11_T8.js:
+        (else.x.1): Deleted.
+        * test262/test/language/asi/S7.9_A4.js:
+        (catch):
+        * test262/test/language/asi/S7.9_A5.1_T1.js:
+        * test262/test/language/asi/S7.9_A5.3_T1.js:
+        * test262/test/language/block-scope/syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js: Added.
+        (g.f):
+        (g):
+        * test262/test/language/destructuring/binding/initialization-requires-object-coercible-null.js:
+        * test262/test/language/destructuring/binding/initialization-requires-object-coercible-undefined.js:
+        * test262/test/language/destructuring/binding/initialization-returns-normal-completion-for-empty-objects.js:
+        * test262/test/language/destructuring/binding/syntax/array-elements-with-initializer.js:
+        * test262/test/language/destructuring/binding/syntax/array-elements-with-object-patterns.js:
+        * test262/test/language/destructuring/binding/syntax/array-elements-without-initializer.js:
+        * test262/test/language/destructuring/binding/syntax/array-pattern-with-elisions.js:
+        * test262/test/language/destructuring/binding/syntax/array-pattern-with-no-elements.js:
+        * test262/test/language/destructuring/binding/syntax/array-rest-elements.js:
+        * test262/test/language/destructuring/binding/syntax/object-pattern-with-no-property-list.js:
+        * test262/test/language/destructuring/binding/syntax/property-list-bindings-elements.js:
+        * test262/test/language/destructuring/binding/syntax/property-list-followed-by-a-single-comma.js:
+        * test262/test/language/destructuring/binding/syntax/property-list-single-name-bindings.js:
+        * test262/test/language/destructuring/binding/syntax/property-list-with-property-list.js:
+        * test262/test/language/destructuring/binding/syntax/recursive-array-and-object-patterns.js:
+        * test262/test/language/eval-code/direct/block-decl-eval-source-is-strict-nostrict.js: Copied from JSTests/test262/test/language/eval-code/direct/block-decl-strict-source.js.
+        * test262/test/language/eval-code/direct/block-decl-eval-source-is-strict-onlystrict.js: Renamed from JSTests/test262/test/language/eval-code/direct/block-decl-strict-source.js.
+        (catch):
+        * test262/test/language/eval-code/direct/block-decl-onlystrict.js: Renamed from JSTests/test262/test/language/eval-code/direct/block-decl-strict-caller.js.
+        * test262/test/language/eval-code/direct/switch-case-decl-eval-source-is-strict-nostrict.js: Renamed from JSTests/test262/test/language/eval-code/direct/switch-case-decl-strict-source.js.
+        * test262/test/language/eval-code/direct/switch-case-decl-eval-source-is-strict-onlystrict.js: Copied from JSTests/test262/test/language/eval-code/direct/switch-case-decl-strict-caller.js.
+        (catch):
+        * test262/test/language/eval-code/direct/switch-case-decl-onlystrict.js: Renamed from JSTests/test262/test/language/eval-code/direct/switch-case-decl-strict-caller.js.
+        * test262/test/language/eval-code/direct/switch-dflt-decl-eval-source-is-strict-nostrict.js: Renamed from JSTests/test262/test/language/eval-code/direct/switch-dflt-decl-strict-source.js.
+        * test262/test/language/eval-code/direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js: Copied from JSTests/test262/test/language/eval-code/direct/switch-dflt-decl-strict-caller.js.
+        (catch):
+        * test262/test/language/eval-code/direct/switch-dflt-decl-onlystrict.js: Renamed from JSTests/test262/test/language/eval-code/direct/switch-dflt-decl-strict-caller.js.
+        * test262/test/language/expressions/async-arrow-function/await-as-param-ident-nested-arrow-parameter-position.js: Added.
+        (async):
+        * test262/test/language/expressions/async-arrow-function/await-as-param-nested-arrow-body-position.js: Added.
+        (async):
+        * test262/test/language/expressions/async-arrow-function/await-as-param-nested-arrow-parameter-position.js: Added.
+        (async.a):
+        * test262/test/language/expressions/async-arrow-function/await-as-param-rest-nested-arrow-parameter-position.js: Added.
+        (async.a):
+        * test262/test/language/expressions/async-arrow-function/escaped-async-line-terminator.js: Added.
+        * test262/test/language/expressions/async-generator/generator-created-after-decl-inst.js: Added.
+        (g.async.a):
+        * test262/test/language/expressions/class/class-name-ident-await-escaped-module.js: Added.
+        (C):
+        * test262/test/language/expressions/class/class-name-ident-await-escaped.js: Added.
+        (C):
+        * test262/test/language/expressions/class/class-name-ident-await-module.js: Added.
+        (C):
+        * test262/test/language/expressions/class/class-name-ident-await.js: Added.
+        (C):
+        * test262/test/language/expressions/class/class-name-ident-let-escaped.js: Added.
+        (C):
+        * test262/test/language/expressions/class/class-name-ident-let.js: Added.
+        (C):
+        * test262/test/language/expressions/class/class-name-ident-static-escaped.js: Added.
+        (C):
+        * test262/test/language/expressions/class/class-name-ident-static.js: Added.
+        * test262/test/language/expressions/class/class-name-ident-yield-escaped.js: Added.
+        (C):
+        * test262/test/language/expressions/class/class-name-ident-yield.js: Added.
+        (C):
+        * test262/test/language/expressions/class/constructor-this-tdz-during-initializers.js: Added.
+        (Base):
+        (C):
+        * test262/test/language/expressions/class/fields-run-once-on-double-super.js: Added.
+        (Base):
+        (C):
+        * test262/test/language/expressions/generators/generator-created-after-decl-inst.js: Added.
+        (g):
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-incomparable-string.js: Added.
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-string.js: Added.
+        * test262/test/language/expressions/greater-than/bigint-and-boolean.js: Added.
+        * test262/test/language/expressions/greater-than/bigint-and-incomparable-string.js: Added.
+        * test262/test/language/expressions/greater-than/bigint-and-string.js: Added.
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-incomparable-string.js: Added.
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-string.js: Added.
+        * test262/test/language/expressions/less-than/bigint-and-boolean.js: Added.
+        * test262/test/language/expressions/less-than/bigint-and-incomparable-string.js: Added.
+        * test262/test/language/expressions/less-than/bigint-and-string.js: Added.
+        * test262/test/language/expressions/object/method-definition/generator-super-prop-param.js:
+        * test262/test/language/function-code/block-decl-onlystrict.js: Renamed from JSTests/test262/test/language/function-code/block-decl-strict.js.
+        * test262/test/language/function-code/switch-case-decl-onlystrict.js: Renamed from JSTests/test262/test/language/function-code/switch-case-decl-strict.js.
+        * test262/test/language/function-code/switch-dflt-decl-onlystrict.js: Renamed from JSTests/test262/test/language/function-code/switch-dflt-decl-strict.js.
+        * test262/test/language/line-terminators/S7.3_A2.3.js: Removed.
+        * test262/test/language/line-terminators/S7.3_A2.4.js: Removed.
+        * test262/test/language/literals/regexp/invalid-optional-lookbehind.js: Copied from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/regexp/invalid-optional-negative-lookbehind.js: Copied from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/regexp/invalid-range-lookbehind.js: Copied from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/regexp/invalid-range-negative-lookbehind.js: Copied from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/regexp/u-invalid-optional-lookahead.js: Copied from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/regexp/u-invalid-optional-lookbehind.js: Copied from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/regexp/u-invalid-optional-negative-lookahead.js: Copied from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/regexp/u-invalid-optional-negative-lookbehind.js: Copied from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/regexp/u-invalid-range-lookahead.js: Copied from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/regexp/u-invalid-range-lookbehind.js: Copied from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/regexp/u-invalid-range-negative-lookahead.js: Copied from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/regexp/u-invalid-range-negative-lookbehind.js: Renamed from JSTests/test262/test/language/literals/regexp/u-invalid-quantifiable-assertion.js.
+        * test262/test/language/literals/string/line-separator-eval.js: Added.
+        * test262/test/language/literals/string/line-separator.js: Added.
+        * test262/test/language/literals/string/paragraph-separator-eval.js: Added.
+        * test262/test/language/literals/string/paragraph-separator.js: Added.
+        * test262/test/language/module-code/early-strict-mode.js:
+        * test262/test/language/statements/async-generator/generator-created-after-decl-inst.js: Added.
+        (async.g):
+        * test262/test/language/statements/break/S12.8_A8_T1.js:
+        (catch):
+        * test262/test/language/statements/break/S12.8_A8_T2.js:
+        (catch):
+        * test262/test/language/statements/class/class-name-ident-await-escaped-module.js: Added.
+        (aw):
+        * test262/test/language/statements/class/class-name-ident-await-escaped.js: Added.
+        (aw):
+        * test262/test/language/statements/class/class-name-ident-await-module.js: Added.
+        (await):
+        * test262/test/language/statements/class/class-name-ident-await.js: Added.
+        (await):
+        * test262/test/language/statements/class/class-name-ident-let-escaped.js: Added.
+        (l):
+        * test262/test/language/statements/class/class-name-ident-let.js: Added.
+        (let):
+        * test262/test/language/statements/class/class-name-ident-static-escaped.js: Added.
+        (st):
+        * test262/test/language/statements/class/class-name-ident-static.js: Added.
+        * test262/test/language/statements/class/class-name-ident-yield-escaped.js: Added.
+        (yi):
+        * test262/test/language/statements/class/class-name-ident-yield.js: Added.
+        (yield):
+        * test262/test/language/statements/continue/S12.7_A8_T1.js:
+        (catch):
+        * test262/test/language/statements/continue/S12.7_A8_T2.js:
+        (catch):
+        * test262/test/language/statements/generators/generator-created-after-decl-inst.js: Added.
+        (g):
+        * test262/test/language/statements/try/early-catch-duplicates.js:
+        * test262/test/language/statements/try/early-catch-function.js: Added.
+        (f.catch.e):
+        (f):
+        * test262/test/language/statements/try/early-catch-lex.js:
+        * test262/test/language/statements/try/early-catch-var.js:
+        * test262/test262-Revision.txt:
+
+2018-05-09  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for "==" operation
+        https://bugs.webkit.org/show_bug.cgi?id=184474
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/big-int-equals-basic.js: Added.
+        * stress/big-int-equals-to-primitive-precedence.js: Added.
+        * stress/big-int-equals-wrapped-value.js: Added.
+
+2018-05-08  Valerie R Young  <valerie@bocoup.com>
+
+        test262/Runner.pm: move input files to JSTests/test262
+        https://bugs.webkit.org/show_bug.cgi?id=185389
+
+        Reviewed by Michael Saboff.
+
+        * test262/config.yaml: Renamed from Tools/Scripts/test262/config.yaml.
+        * test262/expectations.yaml: Renamed from Tools/Scripts/test262/expectations.yaml.
+
+2018-05-05  Filip Pizlo  <fpizlo@apple.com>
+
+        DFG AI should have O(1) clobbering
+        https://bugs.webkit.org/show_bug.cgi?id=185287
+
+        Reviewed by Saam Barati.
+
+        * stress/simple-ai-effect.js: Added.
+        (bar):
+        (foo):
+
+2018-05-04  Keith Miller  <keith_miller@apple.com>
+
+        isCacheableArrayLength should return true for undecided arrays
+        https://bugs.webkit.org/show_bug.cgi?id=185309
+
+        Reviewed by Michael Saboff.
+
+        * stress/get-array-length-undecided.js: Added.
+        (test):
+
+2018-05-04  Dominik Infuehr  <dinfuehr@igalia.com>
+
+        Disable tests on systems with limited memory
+        https://bugs.webkit.org/show_bug.cgi?id=185296
+
+        Reviewed by Saam Barati.
+
+        Test doesn't work with a limited amount of memory. I tried to reduce memory usage
+        but then it was hard to reproduce the failure the test was originally made to test.
+
+        * stress/array-reverse-doesnt-clobber.js:
+
+2018-05-03  Saam Barati  <sbarati@apple.com>
+
+        Don't prevent CreateThis being folded to NewObject when the structure is poly proto
+        https://bugs.webkit.org/show_bug.cgi?id=185177
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/construct-poly-proto-object.js: Added.
+        (foo.A):
+        (foo):
+        * stress/allocation-sinking-new-object-with-poly-proto.js: Added.
+        (foo.A):
+        (foo):
+        (makePolyProto):
+        (bar):
+        (baz):
+
+2018-05-03  Michael Saboff  <msaboff@apple.com>
+
+        OSR entry pruning of Program Bytecodes doesn't take into account try/catch
+        https://bugs.webkit.org/show_bug.cgi?id=185281
+
+        Reviewed by Saam Barati.
+
+        New regression test.
+
+        * stress/baseline-osrentry-catch-is-reachable.js: Added.
+        (i.j.catch):
+
+2018-05-03  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r231197.
+
+        The test added with this change crashes on the 32-bit JSC bot.
+
+        Reverted changeset:
+
+        "Correctly detect string overflow when using the 'Function'
+        constructor"
+        https://bugs.webkit.org/show_bug.cgi?id=184883
+        https://trac.webkit.org/changeset/231197
+
+2018-05-02  Filip Pizlo  <fpizlo@apple.com>
+
+        JSC should know how to cache custom getter accesses on the prototype chain
+        https://bugs.webkit.org/show_bug.cgi?id=185213
+
+        Reviewed by Keith Miller.
+
+        * microbenchmarks/get-custom-getter.js: Added.
+        (test):
+
+2018-05-02  Robin Morisset  <rmorisset@apple.com>
+
+        emitCodeToGetArgumentsArrayLength should not crash on PhantomNewArrayWithSpread
+        https://bugs.webkit.org/show_bug.cgi?id=183172
+
+        Reviewed by Filip Pizlo.
+
+        * stress/length-of-new-array-with-spread.js: Added.
+        (foo):
+        (bar):
+        (baz):
+
+2018-05-01  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Add SameValue DFG node
+        https://bugs.webkit.org/show_bug.cgi?id=185065
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/object-is.js: Added.
+        (incognito):
+        (sameValue):
+        (test1):
+        (test2):
+        (test3):
+        (test4):
+        (test5):
+        (test6):
+        * stress/object-is.js: Added.
+        (shouldBe):
+        (is1):
+        (is2):
+        (is3):
+        (is4):
+        (is5):
+        (is6):
+        (is7):
+        (is8):
+        (is9):
+        (is10):
+        (is11):
+        (is12):
+        (is13):
+        (is14):
+        (is15):
+
+2018-05-01  Robin Morisset  <rmorisset@apple.com>
+
+        Correctly detect string overflow when using the 'Function' constructor
+        https://bugs.webkit.org/show_bug.cgi?id=184883
+        <rdar://problem/36320331>
+
+        Reviewed by Filip Pizlo.
+
+        I put this regression test in the 'slowMicrobenchmarks' directory because it takes nearly 30s to run, and I am not sure where else to put it.
+
+        * slowMicrobenchmarks/function-constructor-with-huge-strings.js: Added.
+        (catch):
+
+2018-05-01  Robin Morisset  <rmorisset@apple.com>
+
+        IntlObject.cpp::removeUnicodeLocaleExtension() should not touch locales that end in '-u'
+        https://bugs.webkit.org/show_bug.cgi?id=185162
+
+        Reviewed by Filip Pizlo.
+
+        * stress/incomplete-unicode-locale.js: Added.
+        (catch):
+
+2018-05-01  Dominik Infuehr  <dinfuehr@igalia.com>
+
+        Add SetCallee as DFG-Operation
+        https://bugs.webkit.org/show_bug.cgi?id=184582
+
+        Reviewed by Filip Pizlo.
+
+        Added test that runs into infinite loop without updating the callee and
+        therefore emitting SetCallee in DFG for recursive tail calls.
+
+        * stress/closure-recursive-tail-call-infinite-loop.js: Added.
+        (Foo):
+        (second):
+        (first):
+        (return.closure):
+        (createClosure):
+
+2018-04-30  Saam Barati  <sbarati@apple.com>
+
+        ToString constant folds without preserving checks, causing us to break assumptions that the code would OSR exit
+        https://bugs.webkit.org/show_bug.cgi?id=185149
+        <rdar://problem/39455917>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/keep-checks-when-converting-to-lazy-js-constant-in-strength-reduction.js: Added.
+
+2018-04-29  Filip Pizlo  <fpizlo@apple.com>
+
+        LICM shouldn't hoist nodes if hoisted nodes exited in that code block
+        https://bugs.webkit.org/show_bug.cgi?id=185126
+
+        Reviewed by Saam Barati.
+        
+        I found this bug by accident when I was writing this test for something else.
+        
+        This change also speeds up other benchmarks of this case that we already had. They are all called
+        the licm-dragons tests.
+
+        * microbenchmarks/licm-dragons-two-structures.js: Added.
+        (foo):
+
+2018-04-29  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r231137.
+        https://bugs.webkit.org/show_bug.cgi?id=185118
+
+        It is breaking Test262 language/expressions/multiplication
+        /order-of-evaluation.js (Requested by caiolima on #webkit).
+
+        Reverted changeset:
+
+        "[ESNext][BigInt] Implement support for "*" operation"
+        https://bugs.webkit.org/show_bug.cgi?id=183721
+        https://trac.webkit.org/changeset/231137
+
+2018-04-28  Saam Barati  <sbarati@apple.com>
+
+        We don't model regexp effects properly
+        https://bugs.webkit.org/show_bug.cgi?id=185059
+        <rdar://problem/39736150>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regexp-exec-test-effectful-last-index.js: Added.
+        (assert):
+        (foo):
+        (i.regexLastIndex.toString):
+        (bar):
+
+2018-04-28  Rick Waldron  <waldron.rick@gmail.com>
+
+        Token misspelled "tocken" in error message string
+        https://bugs.webkit.org/show_bug.cgi?id=185030
+
+        Reviewed by Saam Barati.
+
+        * ChakraCore/test/Basics/IdsWithEscapes.baseline-jsc: Fix typo "tocken" => "token"
+        * stress/destructuring-assignment-syntax.js: Fix typo "tocken" => "token"
+        * stress/error-messages-for-in-operator-should-not-crash.js: Fix typo "tocken" => "token"
+        * stress/reserved-word-with-escape.js: Fix typo "tocken" => "token"
+        (testSyntaxError.String.raw.v):
+        (String.raw.SyntaxError.Cannot.use.the.keyword.string_appeared_here.as.a.name):
+        (testSyntaxError.String.raw.a):
+
+2018-04-28  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for "*" operation
+        https://bugs.webkit.org/show_bug.cgi?id=183721
+
+        Reviewed by Saam Barati.
+
+        * bigIntTests.yaml:
+        * stress/big-int-mul-jit.js: Added.
+        * stress/big-int-mul-to-primitive-precedence.js: Added.
+        * stress/big-int-mul-to-primitive.js: Added.
+        * stress/big-int-mul-type-error.js: Added.
+        * stress/big-int-mul-wrapped-value.js: Added.
+        * stress/big-int-multiplication.js: Added.
+        * stress/big-int-multiply-memory-stress.js: Added.
+
+2018-04-28  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r231131.
+        https://bugs.webkit.org/show_bug.cgi?id=185112
+
+        It is breaking Debug build due to unchecked exception
+        (Requested by caiolima on #webkit).
+
+        Reverted changeset:
+
+        "[ESNext][BigInt] Implement support for "*" operation"
+        https://bugs.webkit.org/show_bug.cgi?id=183721
+        https://trac.webkit.org/changeset/231131
+
+2018-04-27  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for "*" operation
+        https://bugs.webkit.org/show_bug.cgi?id=183721
+
+        Reviewed by Saam Barati.
+
+        * bigIntTests.yaml:
+        * stress/big-int-mul-jit.js: Added.
+        * stress/big-int-mul-to-primitive-precedence.js: Added.
+        * stress/big-int-mul-to-primitive.js: Added.
+        * stress/big-int-mul-type-error.js: Added.
+        * stress/big-int-mul-wrapped-value.js: Added.
+        * stress/big-int-multiplication.js: Added.
+        * stress/big-int-multiply-memory-stress.js: Added.
+
+2018-04-27  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r231086.
+
+        Caused JSC test failures due to an unchecked exception.
+
+        Reverted changeset:
+
+        "[ESNext][BigInt] Implement support for "*" operation"
+        https://bugs.webkit.org/show_bug.cgi?id=183721
+        https://trac.webkit.org/changeset/231086
+
+2018-04-27  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed test gardening, update expectations for test262/intl402/PluralRules tests after r231047.
+
+        * test262.yaml: Mark tests as passing.
+
+2018-04-26  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement support for "*" operation
+        https://bugs.webkit.org/show_bug.cgi?id=183721
+
+        Reviewed by Saam Barati.
+
+        * bigIntTests.yaml:
+        * stress/big-int-mul-jit.js: Added.
+        * stress/big-int-mul-to-primitive-precedence.js: Added.
+        * stress/big-int-mul-to-primitive.js: Added.
+        * stress/big-int-mul-type-error.js: Added.
+        * stress/big-int-mul-wrapped-value.js: Added.
+        * stress/big-int-multiplication.js: Added.
+        * stress/big-int-multiply-memory-stress.js: Added.
+
+2018-04-25  Robin Morisset  <rmorisset@apple.com>
+
+        In FTLLowerDFGToB3.cpp::compileCreateRest, always use a contiguous array as the indexing type when under isWatchingHavingABadTimeWatchpoint
+        https://bugs.webkit.org/show_bug.cgi?id=184773
+        <rdar://problem/37773612>
+
+        Reviewed by Filip Pizlo.
+
+        This bug requires a race between the thread doing FTL compilation and the main thread, but it triggers in 100% of cases (before the fix) on my machine
+        so I decided to add it to the stress tests nonetheless.
+
+        * stress/create-rest-while-having-a-bad-time.js: Added.
+        (f):
+        (g):
+        (h):
+
+2018-04-25  Keith Miller  <keith_miller@apple.com>
+
+        Add missing scope release to functionProtoFuncToString
+        https://bugs.webkit.org/show_bug.cgi?id=184995
+
+        Reviewed by Saam Barati.
+
+        * stress/function-toString-arrow.js: Added.
+        (async):
+
+2018-04-24  Keith Miller  <keith_miller@apple.com>
+
+        fromCharCode is missing some exception checks
+        https://bugs.webkit.org/show_bug.cgi?id=184952
+
+        Reviewed by Saam Barati.
+
+        * stress/fromCharCode-exception-check.js: Added.
+        (get catch):
+
+2018-04-24  Mark Lam  <mark.lam@apple.com>
+
+        Gardening: test fix after r230863.
+        https://bugs.webkit.org/show_bug.cgi?id=184846
+        <rdar://problem/39390672>
+
+        Not reviewed.
+
+        * stress/json-stringified-overflow-2.js:
+        (catch):
+        * stress/json-stringified-overflow.js:
+        (catch):
+
+2018-04-20  JF Bastien  <jfbastien@apple.com>
+
+        Handle more JSON stringify OOM
+        https://bugs.webkit.org/show_bug.cgi?id=184846
+        <rdar://problem/39390672>
+
+        Reviewed by Mark Lam.
+
+        * stress/json-stringified-overflow-2.js: Added. Same as the one
+        below, but with a bigger input which will trigger a different code
+        path.
+        (catch):
+        * stress/json-stringified-overflow.js: Modify the test to only
+        catch OOM on stringification. not on string creation.
+
+2018-04-18  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [WebAssembly][Modules] Import tables in wasm modules
+        https://bugs.webkit.org/show_bug.cgi?id=184738
+
+        Reviewed by JF Bastien.
+
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports.js:
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/imports.wasm:
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/imports.wat:
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/re-export.js:
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/sum.wasm:
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/sum.wat:
+        * wasm/modules/wasm-imports-wasm-exports.js:
+        * wasm/modules/wasm-imports-wasm-exports/imports.wasm:
+        * wasm/modules/wasm-imports-wasm-exports/imports.wat:
+        * wasm/modules/wasm-imports-wasm-exports/sum.wasm:
+        * wasm/modules/wasm-imports-wasm-exports/sum.wat:
+
+2018-04-18  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [WebAssembly][Modules] Import globals from wasm modules
+        https://bugs.webkit.org/show_bug.cgi?id=184736
+
+        Reviewed by JF Bastien.
+
+        * wasm.yaml:
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports.js:
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/imports.wasm:
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/imports.wat:
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/re-export.js:
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/sum.wasm:
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/sum.wat:
+        * wasm/modules/wasm-imports-wasm-exports.js:
+        * wasm/modules/wasm-imports-wasm-exports/imports.wasm:
+        * wasm/modules/wasm-imports-wasm-exports/imports.wat:
+        * wasm/modules/wasm-imports-wasm-exports/sum.wasm:
+        * wasm/modules/wasm-imports-wasm-exports/sum.wat:
+
+2018-04-18  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, reland r230697, r230720, and r230724.
+        https://bugs.webkit.org/show_bug.cgi?id=184600
+
+        * wasm.yaml:
+        * wasm/modules/constant.wasm: Added.
+        * wasm/modules/constant.wat: Added.
+        * wasm/modules/default-import-star-error.js: Added.
+        (then):
+        * wasm/modules/default-import-star-error/entry.wasm: Added.
+        * wasm/modules/default-import-star-error/entry.wat: Added.
+        * wasm/modules/default-import-star-error/t0.js: Added.
+        * wasm/modules/default-import-star-error/t1.js: Added.
+        * wasm/modules/default-import-star-error/t2.js: Added.
+        (export.default.Cocoa):
+        * wasm/modules/js-wasm-cycle.js: Added.
+        * wasm/modules/js-wasm-cycle/entry.js: Added.
+        (from.string_appeared_here.export.return42):
+        * wasm/modules/js-wasm-cycle/sum.wasm: Added.
+        * wasm/modules/js-wasm-cycle/sum.wat: Added.
+        * wasm/modules/js-wasm-function-namespace.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-function.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-global-namespace.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-global.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-memory-namespace.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-memory.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-start.js: Added.
+        (then):
+        * wasm/modules/js-wasm-table-namespace.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-table.js: Added.
+        (assert.throws):
+        * wasm/modules/memory.wasm: Added.
+        * wasm/modules/memory.wat: Added.
+        * wasm/modules/run-from-wasm.wasm: Added.
+        * wasm/modules/run-from-wasm.wat: Added.
+        * wasm/modules/run-from-wasm/check.js: Added.
+        (export.check):
+        * wasm/modules/start.wasm: Added.
+        * wasm/modules/start.wat: Added.
+        * wasm/modules/sum.wasm: Added.
+        * wasm/modules/sum.wat: Added.
+        * wasm/modules/table.wasm: Added.
+        * wasm/modules/table.wat: Added.
+        * wasm/modules/wasm-imports-js-exports.js: Added.
+        * wasm/modules/wasm-imports-js-exports/imports.wasm: Added.
+        * wasm/modules/wasm-imports-js-exports/imports.wat: Added.
+        * wasm/modules/wasm-imports-js-exports/sum.js: Added.
+        (export.sum):
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports.js: Added.
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/imports.wasm: Added.
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/imports.wat: Added.
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/re-export.js: Added.
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/sum.wasm: Added.
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/sum.wat: Added.
+        * wasm/modules/wasm-imports-wasm-exports.js: Added.
+        * wasm/modules/wasm-imports-wasm-exports/imports.wasm: Added.
+        * wasm/modules/wasm-imports-wasm-exports/imports.wat: Added.
+        * wasm/modules/wasm-imports-wasm-exports/sum.wasm: Added.
+        * wasm/modules/wasm-imports-wasm-exports/sum.wat: Added.
+        * wasm/modules/wasm-js-cycle.js: Added.
+        * wasm/modules/wasm-js-cycle/entry.wasm: Added.
+        * wasm/modules/wasm-js-cycle/entry.wat: Added.
+        * wasm/modules/wasm-js-cycle/sum.js: Added.
+        (from.string_appeared_here.export.sum):
+        * wasm/modules/wasm-wasm-cycle.js: Added.
+        * wasm/modules/wasm-wasm-cycle/entry.wasm: Added.
+        * wasm/modules/wasm-wasm-cycle/entry.wat: Added.
+        * wasm/modules/wasm-wasm-cycle/sum.wasm: Added.
+        * wasm/modules/wasm-wasm-cycle/sum.wat: Added.
+
+2018-04-17  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r230697, r230720, and r230724.
+        https://bugs.webkit.org/show_bug.cgi?id=184717
+
+        These caused multiple failures on the Test262 testers.
+        (Requested by mlewis13 on #webkit).
+
+        Reverted changesets:
+
+        "[WebAssembly][Modules] Prototype wasm import"
+        https://bugs.webkit.org/show_bug.cgi?id=184600
+        https://trac.webkit.org/changeset/230697
+
+        "[WebAssembly][Modules] Implement function import from wasm
+        modules"
+        https://bugs.webkit.org/show_bug.cgi?id=184689
+        https://trac.webkit.org/changeset/230720
+
+        "[JSC] Rename runWebAssembly to runWebAssemblySuite"
+        https://bugs.webkit.org/show_bug.cgi?id=184703
+        https://trac.webkit.org/changeset/230724
+
+2018-04-17  JF Bastien  <jfbastien@apple.com>
+
+        A put is not an ExistingProperty put when we transition a structure because of an attributes change
+        https://bugs.webkit.org/show_bug.cgi?id=184706
+        <rdar://problem/38871451>
+
+        Reviewed by Saam Barati.
+
+        * stress/put-by-id-direct-strict-transition.js: Added.
+        (const.foo):
+        (j.const.obj.set hello):
+        * stress/put-by-id-direct-transition.js: Added.
+        (const.foo):
+        (j.const.obj.set hello):
+        * stress/put-getter-setter-by-id-strict-transition.js: Added.
+        (const.foo):
+        (j.const.obj.set hello):
+        * stress/put-getter-setter-by-id-transition.js: Added.
+        (const.foo):
+        (j.const.obj.set hello):
+
+2018-04-16  Filip Pizlo  <fpizlo@apple.com>
+
+        PutStackSinkingPhase should know that KillStack means ConflictingFlush
+        https://bugs.webkit.org/show_bug.cgi?id=184672
+
+        Reviewed by Michael Saboff.
+
+        * stress/sink-put-stack-over-kill-stack.js: Added.
+        (avocado_1):
+        (apricot_0):
+        (__c_0):
+        (banana_2):
+
+2018-04-17  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Rename runWebAssembly to runWebAssemblySuite
+        https://bugs.webkit.org/show_bug.cgi?id=184703
+
+        Reviewed by JF Bastien.
+
+        And add runWebAssembly as a command to simplely run wasm modules.
+
+        * wasm.yaml:
+
+2018-04-17  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [WebAssembly][Modules] Implement function import from wasm modules
+        https://bugs.webkit.org/show_bug.cgi?id=184689
+
+        Reviewed by JF Bastien.
+
+        * wasm.yaml:
+        * wasm/modules/js-wasm-cycle.js: Added.
+        * wasm/modules/js-wasm-cycle/entry.js: Added.
+        (from.string_appeared_here.export.return42):
+        * wasm/modules/js-wasm-cycle/sum.wasm: Added.
+        * wasm/modules/js-wasm-cycle/sum.wat: Added.
+        * wasm/modules/run-from-wasm.wasm: Added.
+        * wasm/modules/run-from-wasm.wat: Added.
+        * wasm/modules/run-from-wasm/check.js: Added.
+        (export.check):
+        * wasm/modules/wasm-imports-js-exports.js: Added.
+        * wasm/modules/wasm-imports-js-exports/imports.wasm: Added.
+        * wasm/modules/wasm-imports-js-exports/imports.wat: Added.
+        * wasm/modules/wasm-imports-js-exports/sum.js: Added.
+        (export.sum):
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports.js: Added.
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/imports.wasm: Added.
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/imports.wat: Added.
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/re-export.js: Added.
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/sum.wasm: Added.
+        * wasm/modules/wasm-imports-js-re-exports-wasm-exports/sum.wat: Added.
+        * wasm/modules/wasm-imports-wasm-exports.js: Added.
+        * wasm/modules/wasm-imports-wasm-exports/imports.wasm: Added.
+        * wasm/modules/wasm-imports-wasm-exports/imports.wat: Added.
+        * wasm/modules/wasm-imports-wasm-exports/sum.wasm: Added.
+        * wasm/modules/wasm-imports-wasm-exports/sum.wat: Added.
+        * wasm/modules/wasm-js-cycle.js: Added.
+        * wasm/modules/wasm-js-cycle/entry.wasm: Added.
+        * wasm/modules/wasm-js-cycle/entry.wat: Added.
+        * wasm/modules/wasm-js-cycle/sum.js: Added.
+        (from.string_appeared_here.export.sum):
+        * wasm/modules/wasm-wasm-cycle.js: Added.
+        * wasm/modules/wasm-wasm-cycle/entry.wasm: Added.
+        * wasm/modules/wasm-wasm-cycle/entry.wat: Added.
+        * wasm/modules/wasm-wasm-cycle/sum.wasm: Added.
+        * wasm/modules/wasm-wasm-cycle/sum.wat: Added.
+
+2018-04-16  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [WebAssembly][Modules] Prototype wasm import
+        https://bugs.webkit.org/show_bug.cgi?id=184600
+
+        Reviewed by JF Bastien.
+
+        Add wasm and wat files since module loader want to load wasm files from FS.
+        Currently, importing the other modules from wasm is not supported.
+
+        * wasm.yaml:
+        * wasm/modules/constant.wasm: Added.
+        * wasm/modules/constant.wat: Added.
+        * wasm/modules/js-wasm-function-namespace.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-function.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-global-namespace.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-global.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-memory-namespace.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-memory.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-start.js: Added.
+        (then):
+        * wasm/modules/js-wasm-table-namespace.js: Added.
+        (assert.throws):
+        * wasm/modules/js-wasm-table.js: Added.
+        (assert.throws):
+        * wasm/modules/memory.wasm: Added.
+        * wasm/modules/memory.wat: Added.
+        * wasm/modules/start.wasm: Added.
+        * wasm/modules/start.wat: Added.
+        * wasm/modules/sum.wasm: Added.
+        * wasm/modules/sum.wat: Added.
+        * wasm/modules/table.wasm: Added.
+        * wasm/modules/table.wat: Added.
+
+2018-04-14  Filip Pizlo  <fpizlo@apple.com>
+
+        Function.prototype.caller shouldn't return generator bodies
+        https://bugs.webkit.org/show_bug.cgi?id=184630
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/function-caller-async-arrow-function-body.js: Added.
+        * stress/function-caller-async-function-body.js: Added.
+        * stress/function-caller-async-generator-body.js: Added.
+        * stress/function-caller-generator-body.js: Added.
+        * stress/function-caller-generator-method-body.js: Added.
+
+2018-04-12  Tomas Popela  <tpopela@redhat.com>
+
+        Unreviewed, skip JIT tests if it isn't enabled
+
+        See https://bugs.webkit.org/show_bug.cgi?id=182730.
+
+        * stress/big-int-spec-to-primitive.js:
+        * stress/big-int-spec-to-this.js:
+
+2018-04-10  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Add support for BigInt in SpeculatedType
+        https://bugs.webkit.org/show_bug.cgi?id=182470
+
+        Reviewed by Saam Barati.
+
+        * stress/big-int-spec-to-primitive.js: Added.
+        * stress/big-int-spec-to-this.js: Added.
+        * stress/big-int-strict-equals-jit.js: Added.
+        * stress/big-int-strict-spec-to-this.js: Added.
+        * stress/big-int-type-of-proven-type.js: Added.
+
+2018-04-10  Filip Pizlo  <fpizlo@apple.com>
+
+        DFG AI and clobberize should agree with each other
+        https://bugs.webkit.org/show_bug.cgi?id=184440
+
+        Reviewed by Saam Barati.
+        
+        Add tests for all of the bugs I fixed.
+
+        * stress/direct-arguments-out-of-bounds-change-structure.js: Added.
+        (foo):
+        * stress/new-typed-array-cse-effects.js: Added.
+        (foo):
+        * stress/scoped-arguments-out-of-bounds-change-structure.js: Added.
+        (foo.theO):
+        (foo):
+        * stress/string-from-char-code-change-structure-not-dead.js: Added.
+        (foo):
+        (i.valueOf):
+        (weirdValue.valueOf):
+        * stress/string-from-char-code-change-structure.js: Added.
+        (foo):
+        (i.valueOf):
+        (weirdValue.valueOf):
+
+2018-04-09  Leo Balter  <leonardo.balter@gmail.com>
+
+        Fix errant Test262 files CRLF to LF for consistency with the original source
+        https://bugs.webkit.org/show_bug.cgi?id=184425
+
+        Reviewed by Yusuke Suzuki.
+
+        * test262/test/built-ins/Math/acosh/nan-returns.js:
+        * test262/test/built-ins/Math/asinh/asinh-specialVals.js:
+        * test262/test/built-ins/Math/atanh/atanh-specialVals.js:
+        * test262/test/built-ins/Math/cbrt/cbrt-specialValues.js:
+        * test262/test/built-ins/Math/cbrt/prop-desc.js:
+        * test262/test/built-ins/Math/cosh/cosh-specialVals.js:
+        * test262/test/built-ins/Math/expm1/expm1-specialVals.js:
+        * test262/test/built-ins/Math/log10/Log10-specialVals.js:
+        * test262/test/built-ins/Math/log2/log2-basicTests.js:
+        * test262/test/built-ins/Math/sign/sign-specialVals.js:
+        * test262/test/built-ins/Math/sinh/sinh-specialVals.js:
+        * test262/test/built-ins/Math/tanh/tanh-specialVals.js:
+        * test262/test/built-ins/Math/trunc/trunc-sampleTests.js:
+        * test262/test/built-ins/Math/trunc/trunc-specialVals.js:
+
+2018-04-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, remove incorrect entry in test262.yaml
+        https://bugs.webkit.org/show_bug.cgi?id=184266
+
+        * test262.yaml:
+
+2018-04-08  Valerie Young  <valerie@bocoup.com>
+
+        [JSC] Update Test262 to April 6 version
+        https://bugs.webkit.org/show_bug.cgi?id=184266
+
+        Rubber stamped by Yusuke Suzuki.
+
+2018-04-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Introduce op_get_by_id_direct
+        https://bugs.webkit.org/show_bug.cgi?id=183970
+
+        Reviewed by Filip Pizlo.
+
+        * stress/generator-prototype-copy.js: Added.
+        (gen):
+        (catch):
+        Adopted JF's tests.
+
+        * stress/generator-type-check.js: Added.
+        (shouldThrow):
+        (foo2):
+        (i.shouldThrow):
+        * stress/get-by-id-direct-getter.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (obj.get hello):
+        (builtin.createBuiltin):
+        (obj2.get length):
+        * stress/get-by-id-direct.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (builtin.createBuiltin):
+        * test262.yaml:
+        We fixed long-standing spec compatibility issue.
+        As a result, this patch makes several test262 tests passed!
+
+
+2018-04-07  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, annotate test with @skip if $memoryLimited
+        https://bugs.webkit.org/show_bug.cgi?id=183894
+
+        * stress/json-stringified-overflow.js:
+
+2018-04-06  Alexey Proskuryakov  <ap@apple.com>
+
+        Add svn:eol-style to line-terminator-normalisation-CR.js
+        https://bugs.webkit.org/show_bug.cgi?id=184341
+
+        * test262/test/built-ins/Function/prototype/toString/line-terminator-normalisation-CR.js: Added property svn:eol-style.
+
+2018-04-06  Ross Kirsling  <ross.kirsling@sony.com>
+
+        Unreviewed, remove errant LF from existing test262 test for CR line endings.
+
+        * test262/test/built-ins/Function/prototype/toString/line-terminator-normalisation-CR.js:
+
+2018-04-05  Ross Kirsling  <ross.kirsling@sony.com>
+
+        Unreviewed, rolling out r230320.
+
+        Revert fix, as the root cause lies elsewhere.
+
+        Reverted changeset:
+
+        "[test262] Mark line-terminator-normalisation-CR.js as a
+        binary file."
+        https://bugs.webkit.org/show_bug.cgi?id=184341
+        https://trac.webkit.org/changeset/230320
+
+2018-04-05  Ross Kirsling  <ross.kirsling@sony.com>
+
+        [test262] Mark line-terminator-normalisation-CR.js as a binary file.
+        https://bugs.webkit.org/show_bug.cgi?id=184341
+
+        Reviewed by Yusuke Suzuki.
+
+        This test is all about CR line endings, but `svn-apply` can't deal with them.
+        Treating the file as binary ensures that its contents never are never shown in a diff.
+
+        * .gitattributes: Added.
+
+2018-04-05  Robin Morisset  <rmorisset@apple.com>
+
+        Fix testcase (missing try/catch).
+        https://bugs.webkit.org/show_bug.cgi?id=183657
+
+        Unreviewed.
+
+        * stress/large-unshift-splice.js
+
+2018-04-04  Filip Pizlo  <fpizlo@apple.com>
+
+        REGRESSION(r222563): removed DoubleReal type check causes tons of crashes because CSE has never known how to handle SaneChain
+        https://bugs.webkit.org/show_bug.cgi?id=184319
+
+        Reviewed by Saam Barati.
+
+        * stress/array-push-nan-to-double-array-cse-sane-and-insane-chain.js: Added.
+        (foo):
+        (bar):
+        * stress/array-push-nan-to-double-array.js: Added.
+        (foo):
+        (bar):
+
+2018-04-03  Mark Lam  <mark.lam@apple.com>
+
+        Test js-fixed-array-out-of-memory.js should be excluded for memory limited devices.
+        https://bugs.webkit.org/show_bug.cgi?id=184284
+
+        Reviewed by Saam Barati.
+
+        * stress/js-fixed-array-out-of-memory.js:
+
+2018-03-31  Filip Pizlo  <fpizlo@apple.com>
+
+        JSC crash in JIT code with for-of loop and Array/Set iterators
+        https://bugs.webkit.org/show_bug.cgi?id=183174
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/hoist-get-by-offset-tower-with-inferred-types.js: Added. This test shows that fixing the bug didn't break hoisting of GetByOffset with inferred types. I confirmed that if I did break it, this test slows down by >7x.
+        (foo):
+        * stress/hoist-get-by-offset-with-control-dependent-inferred-type.js: Added. This test shows that the bug is fixed.
+        (f):
+
+2018-03-30  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: support DataView compilation
+        https://bugs.webkit.org/show_bug.cgi?id=183342
+
+        Reviewed by Mark Lam.
+
+        Test WebAssembly compilation using a DataView with offset.
+
+        * wasm/regress/183342.js: Added.
+        (attempt.catch):
+
+2018-03-30  Filip Pizlo  <fpizlo@apple.com>
+
+        Bytecode generator should not get_from_scope something that may be a hole into a variable that is already live
+        https://bugs.webkit.org/show_bug.cgi?id=184189
+
+        Reviewed by JF Bastien.
+
+        * stress/load-hole-from-scope-into-live-var.js: Added.
+        (result.eval.try.switch):
+        (catch):
+
+2018-03-30  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r230102.
+
+        Caused assertion failures on JSC bots.
+
+        Reverted changeset:
+
+        "A stack overflow in the parsing of a builtin (called by
+        createExecutable) cause a crash instead of a catchable js
+        exception"
+        https://bugs.webkit.org/show_bug.cgi?id=184074
+        https://trac.webkit.org/changeset/230102
+
+2018-03-30  Robin Morisset  <rmorisset@apple.com>
+
+        Inlining of a function that ends in op_unreachable in a non-tail position triggers an ASSERT
+        https://bugs.webkit.org/show_bug.cgi?id=183812
+
+        Reviewed by Keith Miller.
+
+        * stress/inlining-unreachable-non-tail.js: Added.
+        (foo.):
+        (foo):
+
+2018-03-30  Robin Morisset  <rmorisset@apple.com>
+
+        A stack overflow in the parsing of a builtin (called by createExecutable) cause a crash instead of a catchable js exception
+        https://bugs.webkit.org/show_bug.cgi?id=184074
+        <rdar://problem/37165897>
+
+        Reviewed by Keith Miller.
+
+        * stress/stack-overflow-while-parsing-builtin.js: Added.
+        (f):
+
+2018-03-30  Robin Morisset  <rmorisset@apple.com>
+
+        Out-of-bounds accesses due to a missing check for MAX_STORAGE_VECTOR_LENGTH in unshiftCountForAnyIndexingType
+        https://bugs.webkit.org/show_bug.cgi?id=183657
+
+        Reviewed by Keith Miller.
+
+        * stress/large-unshift-splice.js: Added.
+        (make_contig_arr):
+
+2018-03-28  Robin Morisset  <rmorisset@apple.com>
+
+        appendQuotedJSONString stops on arithmetic overflow instead of propagating it upwards
+        https://bugs.webkit.org/show_bug.cgi?id=183894
+
+        Reviewed by Saam Barati.
+
+        * stress/json-stringified-overflow.js: Added.
+        (catch):
+
+2018-03-26  Filip Pizlo  <fpizlo@apple.com>
+
+        DFG should know that CreateThis can be effectful
+        https://bugs.webkit.org/show_bug.cgi?id=184013
+
+        Reviewed by Saam Barati.
+
+        * stress/create-this-property-change.js: Added.
+        (Foo):
+        (RealBar):
+        (get if):
+        * stress/create-this-structure-change-without-cse.js: Added.
+        (Foo):
+        (RealBar):
+        (get if):
+        * stress/create-this-structure-change.js: Added.
+        (Foo):
+        (RealBar):
+        (get if):
+
+2018-03-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Introduces fused compare and jump
+        https://bugs.webkit.org/show_bug.cgi?id=177100
+
+        Reviewed by Mark Lam.
+
+        * stress/fused-jeq-slow.js: Added.
+        (shouldBe):
+        (testJEQ):
+        (testJNEQB):
+        (testJEQB):
+        (testJNEQF):
+        (testJEQF):
+        * stress/fused-jeq.js: Added.
+        (shouldBe):
+        (testJEQ):
+        (testJNEQB):
+        (testJEQB):
+        (testJNEQF):
+        (testJEQF):
+        * stress/fused-jstricteq-slow.js: Added.
+        (shouldBe):
+        (testJSTRICTEQ):
+        (testJNSTRICTEQB):
+        (testJSTRICTEQB):
+        (testJNSTRICTEQF):
+        (testJSTRICTEQF):
+        * stress/fused-jstricteq.js: Added.
+        (shouldBe):
+        (testJSTRICTEQ):
+        (testJNSTRICTEQB):
+        (testJSTRICTEQB):
+        (testJNSTRICTEQF):
+        (testJSTRICTEQF):
+
+2018-03-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Clear MustGenerate for ToString(Number) converted from NumberToStringWithRadix
+        https://bugs.webkit.org/show_bug.cgi?id=183559
+
+        Reviewed by Mark Lam.
+
+        * stress/double-to-string-in-loop-removed.js: Added.
+        (test):
+        * stress/int32-to-string-in-loop-removed.js: Added.
+        (test):
+        * stress/int52-to-string-in-loop-removed.js: Added.
+        (test):
+
+2018-03-22  Michael Saboff  <msaboff@apple.com>
+
+        Race Condition in arrayProtoFuncReverse() causes wrong results or crash
+        https://bugs.webkit.org/show_bug.cgi?id=183901
+
+        Reviewed by Keith Miller.
+
+        New test.
+
+        * stress/array-reverse-doesnt-clobber.js: Added.
+        (testArrayReverse):
+        (createArrayOfArrays):
+        (createArrayStorage):
+
+2018-03-21  Filip Pizlo  <fpizlo@apple.com>
+
+        ScopedArguments should do poisoning and index masking
+        https://bugs.webkit.org/show_bug.cgi?id=183863
+
+        Reviewed by Mark Lam.
+        
+        Adds another stress test of scoped arguments.
+
+        * stress/scoped-arguments-test.js: Added.
+        (foo):
+
+2018-03-20  Saam Barati  <sbarati@apple.com>
+
+        We need to do proper bookkeeping of exitOK when inserting constants when sinking NewArrayBuffer
+        https://bugs.webkit.org/show_bug.cgi?id=183795
+        <rdar://problem/38298694>
+
+        Reviewed by JF Bastien.
+
+        * stress/sink-phantom-new-array-buffer-exit-ok.js: Added.
+        (foo):
+        (bar):
+
+2018-03-16  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Add vectorLengthHint for NewArray
+        https://bugs.webkit.org/show_bug.cgi?id=183694
+
+        Reviewed by Saam Barati.
+
+        * stress/vector-length-hint-array-constructor.js: Added.
+        (shouldBe):
+        (test):
+        * stress/vector-length-hint-new-array.js: Added.
+        (shouldBe):
+        (test):
+
+2018-03-13  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Make ArraySlice(0) code tight
+        https://bugs.webkit.org/show_bug.cgi?id=183590
+
+        Reviewed by Saam Barati.
+
+        * stress/array-slice-with-zero.js: Added.
+        (shouldBe):
+        (test):
+        (test2):
+        * stress/array-slice-zero-args.js: Added.
+        (shouldBe):
+        (test):
+
+2018-03-14  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] fix order of evaluation for ClassDefinitionEvaluation
+        https://bugs.webkit.org/show_bug.cgi?id=183523
+
+        Reviewed by Keith Miller.
+
+        Computed property names need to be evaluated in source order during class
+        definition evaluation, as it's observable (and specified to work this way).
+
+        This change improves compatibility with Chromium.
+
+        * stress/class_elements.js: Added.
+        (test):
+        (test.C.prototype.effect):
+        (test.C.effect):
+        (test.C.prototype.get effect):
+        (test.C.prototype.set effect):
+        (test.C):
+
+2018-03-11  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] AI should convert CreateThis to NewObject if the prototype object is proved
+        https://bugs.webkit.org/show_bug.cgi?id=183310
+
+        Reviewed by Filip Pizlo.
+
+        * stress/ai-create-this-to-new-object-fire.js: Added.
+        (assert):
+        (test):
+        (func):
+        (check):
+        (test.body.A):
+        (test.body.B):
+        (test.body):
+        * stress/ai-create-this-to-new-object.js: Added.
+        (assert):
+        (test):
+        (func):
+        (check):
+        (test.body.A):
+        (test.body.B):
+        (test.body):
+
+2018-03-10  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [FTL] Drop NewRegexp for String.prototype.match with RegExp + global flag
+        https://bugs.webkit.org/show_bug.cgi?id=181848
+
+        Reviewed by Sam Weinig.
+
+        * microbenchmarks/regexp-u-global-es5.js: Added.
+        (fn):
+        * microbenchmarks/regexp-u-global-es6.js: Added.
+        (fn):
+        * stress/materialized-regexp-has-correct-last-index-set-by-match-at-osr-exit.js: Added.
+        (shouldBe):
+        (test):
+        (i.switch):
+        * stress/materialized-regexp-has-correct-last-index-set-by-match.js: Added.
+        (shouldBe):
+        (test):
+
+2018-03-07  Dominik Infuehr  <dinfuehr@igalia.com>
+
+        Disable test stress/var-injection-cache-invalidation.js on systems with limited memory
+        https://bugs.webkit.org/show_bug.cgi?id=183334
+
+        Reviewed by Žan Doberšek.
+
+        * stress/var-injection-cache-invalidation.js:
+
+2018-03-06  Dominik Infuehr  <dinfuehr@igalia.com>
+
+        [ARM] Disable tests that run out of memory
+        https://bugs.webkit.org/show_bug.cgi?id=182699
+
+        Reviewed by Žan Doberšek.
+
+        Skip tests that run of of memory. Do not run
+        modules/module-jit-reachability.js without LLInt to prevent
+        running out of executable memory.
+
+        * modules.yaml:
+        * modules/module-jit-reachability.js:
+        * stress/has-own-property-name-cache-string-keys.js:
+        * stress/has-own-property-name-cache-symbol-keys.js:
+
+2018-03-01  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        ASSERTION FAILED: matchContextualKeyword(m_vm->propertyNames->async)
+        https://bugs.webkit.org/show_bug.cgi?id=183173
+
+        Reviewed by Saam Barati.
+
+        * stress/async-arrow-function-in-class-heritage.js: Added.
+        (testSyntax):
+        (testSyntaxError):
+        (SyntaxError):
+
+2018-03-01  Saam Barati  <sbarati@apple.com>
+
+        We need to clear cached structures when having a bad time
+        https://bugs.webkit.org/show_bug.cgi?id=183256
+        <rdar://problem/36245022>
+
+        Reviewed by Mark Lam.
+
+        * stress/having-a-bad-time-with-derived-arrays.js: Added.
+        (assert):
+        (defineSetter):
+        (iterate):
+        (doSlice):
+
+2018-02-28  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        JSC crash with `import("")`
+        https://bugs.webkit.org/show_bug.cgi?id=183175
+
+        Reviewed by Saam Barati.
+
+        * stress/import-with-empty-string.js: Added.
+
+2018-02-27  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, skip FTL tests if FTL is disabled
+        https://bugs.webkit.org/show_bug.cgi?id=183071
+
+        * stress/has-indexed-property-array-storage-ftl.js:
+        * stress/has-indexed-property-slow-put-array-storage-ftl.js:
+
+2018-02-25  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [FTL] Support PutByVal(ArrayStorage/SlowPutArrayStorage)
+        https://bugs.webkit.org/show_bug.cgi?id=182965
+
+        Reviewed by Saam Barati.
+
+        * stress/put-by-val-array-storage.js: Added.
+        (shouldBe):
+        (testArrayStorageInBounds):
+        * stress/put-by-val-direct-out-of-bounds-setter.js: Added.
+        (shouldBe):
+        (testInt32.createBuiltin):
+        (set for):
+        * stress/put-by-val-slow-put-array-storage.js: Added.
+        (shouldBe):
+        (testArrayStorageInBounds):
+
+2018-02-26  Saam Barati  <sbarati@apple.com>
+
+        validateStackAccess should not validate if the offset is within the stack bounds
+        https://bugs.webkit.org/show_bug.cgi?id=183067
+        <rdar://problem/37749988>
+
+        Reviewed by Mark Lam.
+
+        * stress/dont-validate-stack-offset-in-b3-because-it-might-be-guarded-by-control-flow.js: Added.
+        (assert):
+        (test.a):
+        (test.b):
+        (test):
+
+2018-02-26  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, skip FTL tests if FTL is disabled
+        https://bugs.webkit.org/show_bug.cgi?id=183071
+
+        * stress/has-indexed-property-array-storage-ftl.js:
+        * stress/has-indexed-property-slow-put-array-storage-ftl.js:
+
+2018-02-23  Saam Barati  <sbarati@apple.com>
+
+        Make Number.isInteger an intrinsic
+        https://bugs.webkit.org/show_bug.cgi?id=183088
+
+        Reviewed by JF Bastien.
+
+        * stress/number-is-integer-intrinsic.js: Added.
+
+2018-02-23  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        WebAssembly: cache memory address / size on instance
+        https://bugs.webkit.org/show_bug.cgi?id=177305
+
+        Reviewed by JF Bastien.
+
+        * wasm/function-tests/memory-reuse.js: Added.
+        (createWasmInstance):
+        (doCheckTrap):
+        (doMemoryGrow):
+        (doCheck):
+        (checkWasmInstancesWithSharedMemory):
+
+2018-02-23  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Implement $vm.ftlTrue function for FTL testing
+        https://bugs.webkit.org/show_bug.cgi?id=183071
+
+        Reviewed by Mark Lam.
+
+        * stress/dead-fiat-value-to-int52-then-exit-not-double.js:
+        (foo):
+        * stress/dead-fiat-value-to-int52-then-exit-not-int52.js:
+        (foo):
+        * stress/dead-fiat-value-to-int52.js:
+        (foo):
+        * stress/dead-osr-entry-value.js:
+        (foo):
+        * stress/fiat-value-to-int52-then-exit-not-double.js:
+        (foo):
+        * stress/fiat-value-to-int52-then-exit-not-int52.js:
+        (foo):
+        * stress/fiat-value-to-int52-then-fail-to-fold.js:
+        (foo):
+        * stress/fiat-value-to-int52-then-fold.js:
+        (foo):
+        * stress/fiat-value-to-int52.js:
+        (foo):
+        * stress/fold-based-on-int32-proof-mul-branch.js:
+        (foo):
+        * stress/fold-profiled-call-to-call.js:
+        (foo):
+        * stress/fold-to-double-constant-then-exit.js:
+        (foo):
+        * stress/fold-to-int52-constant-then-exit.js:
+        (foo):
+        * stress/fold-to-primitive-in-cfa.js:
+        (foo):
+        * stress/fold-to-primitive-to-identity-in-cfa.js:
+        (foo):
+        * stress/has-indexed-property-array-storage-ftl.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        * stress/has-indexed-property-slow-put-array-storage-ftl.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        * stress/int52-ai-add-then-filter-int32.js:
+        (foo):
+        * stress/int52-ai-mul-and-clean-neg-zero-then-filter-int32.js:
+        (foo):
+        * stress/int52-ai-mul-then-filter-int32.js:
+        (foo):
+        * stress/int52-ai-neg-then-filter-int32.js:
+        (foo):
+        * stress/int52-ai-sub-then-filter-int32.js:
+        (foo):
+        * stress/licm-pre-header-cannot-exit-nested.js:
+        (foo):
+        * stress/licm-pre-header-cannot-exit.js:
+        (foo):
+        * stress/sparse-array-entry-update-144067.js:
+        (useMemoryToTriggerGCs):
+        * stress/test-spec-misc.js:
+        (foo):
+        * stress/tricky-array-bounds-checks.js:
+        (foo):
+
+2018-02-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [FTL] Support HasIndexedProperty for ArrayStorage and SlowPutArrayStorage
+        https://bugs.webkit.org/show_bug.cgi?id=182792
+
+        Reviewed by Mark Lam.
+
+        * stress/has-indexed-property-array-storage.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        * stress/has-indexed-property-slow-put-array-storage.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+
+2018-02-20  Saam Barati  <sbarati@apple.com>
+
+        DFG::VarargsForwardingPhase should eliminate getting argument length
+        https://bugs.webkit.org/show_bug.cgi?id=182959
+
+        Reviewed by Keith Miller.
+
+        * microbenchmarks/forward-arguments-dont-escape-on-arguments-length.js: Added.
+
+2018-02-14  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [FTL] Support ArrayPush for ArrayStorage
+        https://bugs.webkit.org/show_bug.cgi?id=182782
+
+        Reviewed by Saam Barati.
+
+        Existing array-push-multiple-storage.js covers ArrayPush(ArrayStorage) multiple arguments case.
+
+        * stress/array-push-array-storage-beyond-int32.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-array-storage.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-array-storage-beyond-int32.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-storage-continuous.js: Added.
+        (shouldBe):
+        (test):
+
+2018-02-14  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [FTL] Support ArrayPop for ArrayStorage
+        https://bugs.webkit.org/show_bug.cgi?id=182783
+
+        Reviewed by Saam Barati.
+
+        * stress/array-pop-array-storage.js: Added.
+        (shouldBe):
+        (test):
+
+2018-02-14  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [FTL] Add Arrayify for ArrayStorage and SlowPutArrayStorage
+        https://bugs.webkit.org/show_bug.cgi?id=182731
+
+        Reviewed by Saam Barati.
+
+        * stress/arrayify-array-storage-array.js: Added.
+        (shouldBe):
+        (testArrayStorage):
+        * stress/arrayify-array-storage-non-array.js: Added.
+        (shouldBe):
+        (testArrayStorage):
+        * stress/arrayify-array-storage.js: Added.
+        (shouldBe):
+        (testArrayStorage):
+        * stress/arrayify-slow-put-array-storage-pass-array-storage.js: Added.
+        (shouldBe):
+        (testArrayStorage):
+        * stress/arrayify-slow-put-array-storage.js: Added.
+        (shouldBe):
+        (testArrayStorage):
+
+2018-02-19  Saam Barati  <sbarati@apple.com>
+
+        Don't use JSFunction's allocation profile when getting the prototype can be effectful
+        https://bugs.webkit.org/show_bug.cgi?id=182942
+        <rdar://problem/37584764>
+
+        Reviewed by Mark Lam.
+
+        * stress/get-prototype-create-this-effectful.js: Added.
+
+2018-02-16  Saam Barati  <sbarati@apple.com>
+
+        Fix bugs from r228411
+        https://bugs.webkit.org/show_bug.cgi?id=182851
+        <rdar://problem/37577732>
+
+        Reviewed by JF Bastien.
+
+        * stress/constant-folding-phase-insert-check-handle-varargs.js: Added.
+
+2018-02-15  Filip Pizlo  <fpizlo@apple.com>
+
+        Unreviewed, roll out r228366 since it did not progress anything.
+
+        * stress/gc-error-stack.js: Removed.
+        * stress/no-gc-error-stack.js: Removed.
+
+2018-02-15  Tomas Popela  <tpopela@redhat.com>
+
+        Many stress tests fail with JIT disabled
+        https://bugs.webkit.org/show_bug.cgi?id=182730
+
+        Reviewed by Saam Barati.
+
+        These tests are broken by design if the JIT is disabled - they test
+        the return value of numberOfDFGCompiles(), which is always set to
+        1000000.0 in TestRunnerUtils.cpp and makes the tests to fail.
+
+        * stress/arith-abs-on-various-types.js:
+        * stress/arith-abs-to-arith-negate-range-optimizaton.js:
+        * stress/arith-acos-on-various-types.js:
+        * stress/arith-acosh-on-various-types.js:
+        * stress/arith-asin-on-various-types.js:
+        * stress/arith-asinh-on-various-types.js:
+        * stress/arith-atan-on-various-types.js:
+        * stress/arith-atanh-on-various-types.js:
+        * stress/arith-cbrt-on-various-types.js:
+        * stress/arith-ceil-on-various-types.js:
+        * stress/arith-clz32-on-various-types.js:
+        * stress/arith-cos-on-various-types.js:
+        * stress/arith-cosh-on-various-types.js:
+        * stress/arith-expm1-on-various-types.js:
+        * stress/arith-floor-on-various-types.js:
+        * stress/arith-fround-on-various-types.js:
+        * stress/arith-log-on-various-types.js:
+        * stress/arith-log10-on-various-types.js:
+        * stress/arith-log2-on-various-types.js:
+        * stress/arith-negate-on-various-types.js:
+        * stress/arith-round-on-various-types.js:
+        * stress/arith-sin-on-various-types.js:
+        * stress/arith-sinh-on-various-types.js:
+        * stress/arith-sqrt-on-various-types.js:
+        * stress/arith-tan-on-various-types.js:
+        * stress/arith-tanh-on-various-types.js:
+        * stress/arith-trunc-on-various-types.js:
+        * stress/compare-strict-eq-on-various-types.js:
+
+2018-02-14  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip stress/new-largeish-contiguous-array-with-size.js on arm.
+
+        Unreviewed test gardening.
+
+        * stress/new-largeish-contiguous-array-with-size.js:
+
+2018-02-14  Saam Barati  <sbarati@apple.com>
+
+        Setting a VMTrap shouldn't look at topCallFrame since that may imply we're in C code and holding the malloc lock
+        https://bugs.webkit.org/show_bug.cgi?id=182801
+
+        Reviewed by Keith Miller.
+
+        * stress/watchdog-dont-malloc-when-in-c-code.js: Added.
+
+2018-02-14  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip JSC test stress/activation-sink-default-value-tdz-error.js on debug.
+        https://bugs.webkit.org/show_bug.cgi?id=182526
+
+        Unreviewed test gardening.
+
+        * stress/activation-sink-default-value-tdz-error.js:
+
+2018-02-13  Saam Barati  <sbarati@apple.com>
+
+        putDirectIndexSlowOrBeyondVectorLength needs to convert to dictionary indexing mode always if attributes are present
+        https://bugs.webkit.org/show_bug.cgi?id=182755
+        <rdar://problem/37080864>
+
+        Reviewed by Keith Miller.
+
+        * stress/always-enter-dictionary-indexing-mode-with-getter.js: Added.
+        (test1.o.get 10005):
+        (test1):
+        (test2.o.get 1000):
+        (test2):
+
+2018-02-13  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] cache TaggedTemplate arrays by callsite rather than by contents
+        https://bugs.webkit.org/show_bug.cgi?id=182717
+
+        Reviewed by Yusuke Suzuki.
+
+        https://github.com/tc39/ecma262/pull/890 imposes a change to template
+        literals, to allow template callsite arrays to be collected when the
+        code containing the tagged template call is collected. This spec change
+        has received concensus and been ratified.
+
+        This change eliminates the eternal map associating template contents
+        with arrays.
+
+        * stress/tagged-template-object-collect.js: Renamed from JSTests/stress/tagged-template-registry-key-collect.js.
+        * stress/tagged-template-object.js: Renamed from JSTests/stress/tagged-template-registry-key.js.
+        * stress/tagged-templates-identity.js:
+        * stress/template-string-tags-eval.js:
+        * test262.yaml:
+
+2018-02-13  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Support GetArrayLength on ArrayStorage in the FTL
+        https://bugs.webkit.org/show_bug.cgi?id=182625
+
+        Reviewed by Saam Barati.
+
+        * stress/array-storage-length.js: Added.
+        (shouldBe):
+        (testInBound):
+        (testUncountable):
+        (testSlowPutInBound):
+        (testSlowPutUncountable):
+        * stress/undecided-length.js: Added.
+        (shouldBe):
+        (test2):
+
+2018-02-12  Saam Barati  <sbarati@apple.com>
+
+        DFG::emitCodeToGetArgumentsArrayLength needs to handle NewArrayBuffer/PhantomNewArrayBuffer
+        https://bugs.webkit.org/show_bug.cgi?id=182706
+        <rdar://problem/36833681>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/get-array-length-phantom-new-array-buffer.js: Added.
+        (effects):
+        (foo):
+
+2018-02-09  Filip Pizlo  <fpizlo@apple.com>
+
+        Don't waste memory for error.stack
+        https://bugs.webkit.org/show_bug.cgi?id=182656
+
+        Reviewed by Saam Barati.
+        
+        Tests the policy.
+
+        * stress/gc-error-stack.js: Added. Shows that the GC forgets frames now.
+        * stress/no-gc-error-stack.js: Added. Shows that the GC won't forget things if you ask for the stack.
+
+2018-02-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Update Test262 to Feb 9 version
+        https://bugs.webkit.org/show_bug.cgi?id=182468
+
+        Reviewed by Saam Barati.
+
+2018-02-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, fix invalid line terminator in old test262 file part 2
+        https://bugs.webkit.org/show_bug.cgi?id=182468
+
+        * test262/test/built-ins/Function/prototype/toString/line-terminator-normalisation-CR.js:
+
+2018-02-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, fix invalid line terminator in old test262 file
+        https://bugs.webkit.org/show_bug.cgi?id=182468
+
+        * test262/test/language/literals/regexp/7.8.5-1.js:
+
+2018-02-06  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Implement Array.prototype.flatMap and Array.prototype.flatten
+        https://bugs.webkit.org/show_bug.cgi?id=182440
+
+        Reviewed by Darin Adler.
+
+        * stress/array-flatmap.js: Added.
+        (shouldBe):
+        (shouldBeArray):
+        (shouldThrow):
+        (var):
+        * stress/array-flatten.js: Added.
+        (shouldBe):
+        (shouldBeArray):
+        * test262.yaml:
+        * test262/test/built-ins/Array/prototype/flatMap/depth-always-one.js:
+        (3.flatMap):
+        Pick test262 82c6148980332febe92a544a1fb653718e9fdb57 change.
+
+2018-02-06  Keith Miller  <keith_miller@apple.com>
+
+        put_to_scope/get_from_scope should not cache lexical scopes when expecting a global object
+        https://bugs.webkit.org/show_bug.cgi?id=182549
+        <rdar://problem/36189995>
+
+        Reviewed by Saam Barati.
+
+        * stress/var-injection-cache-invalidation.js: Added.
+        (allocateLotsOfThings):
+        (test):
+
+2018-02-03  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, follow up for test262 update
+        https://bugs.webkit.org/show_bug.cgi?id=182288
+
+        * test262.yaml:
+
+2018-02-02  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Update test262 to Jan 30 version
+        https://bugs.webkit.org/show_bug.cgi?id=182288
+
+        Unreviewed test gardening.
+
+        * test262.yaml: Remove entry for missing test language/expressions/assignment/white-space.js
+
+2018-02-02  Saam Barati  <sbarati@apple.com>
+
+        When BytecodeParser inserts Unreachable after ForceOSRExit it needs to update ArgumentPositions for Flushes it inserts
+        https://bugs.webkit.org/show_bug.cgi?id=182368
+        <rdar://problem/36932466>
+
+        Reviewed by Mark Lam.
+
+        * stress/flush-after-force-exit-in-bytecodeparser-needs-to-update-argument-positions.js: Added.
+        (runNearStackLimit.t):
+        (runNearStackLimit):
+        (try.runNearStackLimit):
+        (catch):
+
+2018-02-02  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Update test262 to Jan 30 version
+        https://bugs.webkit.org/show_bug.cgi?id=182288
+
+        Rubber stamped by Saam Barati.
+
+        This patch updates test262 to the latest one, Jan 30 version.
+        Since added and changed files are too many, we cannot create ChangeLog.
+        The following files are changed.
+
+        Several files are intentionally omitted due to merge failures. We should investigate how to merge files
+        including some special line terminators (like u2028, u2029).
+
+        * test262.yaml:
+        * test262/test262-Revision.txt:
+        * test262/*:
+
+2018-02-02  Guillaume Emont  <guijemont@igalia.com>
+
+        JSTests: Skip mozilla/js1_5/Array/regress-157652.js on all memory limited platforms
+        https://bugs.webkit.org/show_bug.cgi?id=182411
+
+        Reviewed by Carlos Alberto Lopez Perez.
+
+        This is skipped only on arm memory limited platforms. Until recently
+        it was not a problem on MIPS as the butterfly was not initialized. But
+        since r227435, the butterfly is initialized in that test and therefore
+        memory is allocated, and the test typically takes around 512M, which
+        means it generally gets OOM-killed on the MIPS buildbot.
+
+        * mozilla/mozilla-tests.yaml:
+
+2018-02-01  Mark Lam  <mark.lam@apple.com>
+
+        Fix broken bounds check in FTL's compileGetMyArgumentByVal().
+        https://bugs.webkit.org/show_bug.cgi?id=182419
+        <rdar://problem/37044945>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-182419.js: Added.
+
+2018-02-01  Keith Miller  <keith_miller@apple.com>
+
+        Fix crashes due to mishandling custom sections.
+        https://bugs.webkit.org/show_bug.cgi?id=182404
+        <rdar://problem/36935863>
+
+        Reviewed by Saam Barati.
+
+        * wasm/Builder.js:
+        (export.default.Builder.prototype._registerSectionBuilders.const.section.in.WASM.description.section.switch.section.case.string_appeared_here.this.section):
+        * wasm/js-api/validate.js:
+        (assert.truthy):
+
+2018-01-31  Saam Barati  <sbarati@apple.com>
+
+        JSC incorrectly interpreting script, sets Global Property instead of Global Lexical variable (LiteralParser / JSONP path)
+        https://bugs.webkit.org/show_bug.cgi?id=182074
+        <rdar://problem/36846261>
+
+        Reviewed by Mark Lam.
+
+        * stress/jsonp-program-evaluate-path-must-consider-global-lexical-environment.js: Added.
+        (assert):
+        (let.func):
+        (let.o.foo):
+        (varFunc):
+
+2018-01-30  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, update test262 expects
+        https://bugs.webkit.org/show_bug.cgi?id=182232
+
+        * test262.yaml:
+
+2018-01-29  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Implement trimStart and trimEnd
+        https://bugs.webkit.org/show_bug.cgi?id=182233
+
+        Reviewed by Mark Lam.
+
+        * stress/trim.js: Added.
+        (shouldBe):
+        (startTest):
+        (endTest):
+        (trimTest):
+
+2018-01-29  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Relax line terminators in String to make JSON subset of JS
+        https://bugs.webkit.org/show_bug.cgi?id=182232
+
+        Reviewed by Keith Miller.
+
+        * ChakraCore/test/es5/Lex_u3.baseline-jsc:
+        * stress/relaxed-line-terminators-in-string.js: Added.
+        (shouldBe):
+
+2018-01-29  Michael Saboff  <msaboff@apple.com>
+
+        REGRESSION (r227341): DFG_ASSERT failure at JSC::DFG::AtTailAbstractState::forNode()
+        https://bugs.webkit.org/show_bug.cgi?id=182249
+
+        Reviewed by Keith Miller.
+
+        New regression test.
+
+        * stress/compare-clobber-untypeduse.js: Added.
+
+2018-01-29  Matt Lewis  <jlewis3@apple.com>
+
+        Unreviewed, rolling out r227725.
+
+        This caused internal failures.
+
+        Reverted changeset:
+
+        "JSC Sampling Profiler: Detect tester and testee when sampling
+        in RegExp JIT"
+        https://bugs.webkit.org/show_bug.cgi?id=152729
+        https://trac.webkit.org/changeset/227725
+
+2018-01-29  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        JSC Sampling Profiler: Detect tester and testee when sampling in RegExp JIT
+        https://bugs.webkit.org/show_bug.cgi?id=152729
+
+        Reviewed by Saam Barati.
+
+        * stress/sampling-profiler-regexp.js: Added.
+        (platformSupportsSamplingProfiler.test):
+        (platformSupportsSamplingProfiler.baz):
+        (platformSupportsSamplingProfiler):
+
+2018-01-29  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] WeakMap#set should have DFG node
+        https://bugs.webkit.org/show_bug.cgi?id=180015
+
+        Reviewed by Saam Barati.
+
+        * stress/weakmap-set-change-get.js: Added.
+        (shouldBe):
+        (test):
+        * stress/weakmap-set-cse.js: Added.
+        (shouldBe):
+        (test):
+        * stress/weakset-add-change-get.js: Added.
+        (shouldBe):
+        * stress/weakset-add-cse.js: Added.
+        (shouldBe):
+
+2018-01-27  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        DFG strength reduction fails to convert NumberToStringWithValidRadixConstant for 0 to constant '0'
+        https://bugs.webkit.org/show_bug.cgi?id=182213
+
+        Reviewed by Mark Lam.
+
+        * stress/int32-min-to-string.js: Added.
+        (shouldBe):
+        (test2):
+        (test4):
+        (test8):
+        (test16):
+        (test32):
+        * stress/zero-to-string.js: Added.
+        (shouldBe):
+        (test2):
+        (test4):
+        (test8):
+        (test16):
+        (test32):
+
+2018-01-23  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Add more module scope related tests with code evaluation by string
+        https://bugs.webkit.org/show_bug.cgi?id=181983
+
+        Reviewed by Sam Weinig.
+
+        Add more module scope related tests. When the original tests are landed,
+        we do not have browser integration. This patch adds more module scope tests
+        with dynamically created script evaluation. We add tests with Function
+        constructor, direct eval, indirect eval, setTimeout, setInterval, and event handlers.
+
+        * modules/scopes-eval.js: Added.
+        (shouldBe):
+        * modules/scopes.js:
+        (shouldBe):
+
+2018-01-23  Filip Pizlo  <fpizlo@apple.com>
+
+        Unreviewed, retire some microbenchmarks that are proportionately very slow. Benchmark running time should be proportional to their value. Microbenchmarks have little value, so they should be very fast.
+
+        * microbenchmarks/array-push-3.js: Removed.
+        * microbenchmarks/bigswitch-indirect-symbol-or-undefined.js: Removed.
+        * microbenchmarks/double-to-int32.js: Removed.
+        * microbenchmarks/fake-iterators-that-throw-when-finished.js: Removed.
+        * microbenchmarks/ftl-polymorphic-bitand.js: Removed.
+        * microbenchmarks/ftl-polymorphic-bitor.js: Removed.
+        * microbenchmarks/ftl-polymorphic-bitxor.js: Removed.
+        * microbenchmarks/ftl-polymorphic-lshift.js: Removed.
+        * microbenchmarks/ftl-polymorphic-rshift.js: Removed.
+        * microbenchmarks/ftl-polymorphic-sub.js: Removed.
+        * microbenchmarks/ftl-polymorphic-urshift.js: Removed.
+        * microbenchmarks/map-constant-key.js: Removed.
+        * microbenchmarks/nested-function-parsing.js: Removed.
+        * microbenchmarks/rest-parameter-allocation-elimination.js: Removed.
+        * microbenchmarks/spread-large-array.js: Removed.
+        * microbenchmarks/string-add-constant-folding.js: Removed.
+        * microbenchmarks/to-lower-case.js: Removed.
+        * microbenchmarks/undefined-property-access.js: Removed.
+        * slowMicrobenchmarks/array-push-3.js: Copied from JSTests/microbenchmarks/array-push-3.js.
+        * slowMicrobenchmarks/bigswitch-indirect-symbol-or-undefined.js: Copied from JSTests/microbenchmarks/bigswitch-indirect-symbol-or-undefined.js.
+        * slowMicrobenchmarks/double-to-int32.js: Copied from JSTests/microbenchmarks/double-to-int32.js.
+        * slowMicrobenchmarks/fake-iterators-that-throw-when-finished.js: Copied from JSTests/microbenchmarks/fake-iterators-that-throw-when-finished.js.
+        * slowMicrobenchmarks/ftl-polymorphic-bitand.js: Copied from JSTests/microbenchmarks/ftl-polymorphic-bitand.js.
+        * slowMicrobenchmarks/ftl-polymorphic-bitor.js: Copied from JSTests/microbenchmarks/ftl-polymorphic-bitor.js.
+        * slowMicrobenchmarks/ftl-polymorphic-bitxor.js: Copied from JSTests/microbenchmarks/ftl-polymorphic-bitxor.js.
+        * slowMicrobenchmarks/ftl-polymorphic-lshift.js: Copied from JSTests/microbenchmarks/ftl-polymorphic-lshift.js.
+        * slowMicrobenchmarks/ftl-polymorphic-rshift.js: Copied from JSTests/microbenchmarks/ftl-polymorphic-rshift.js.
+        * slowMicrobenchmarks/ftl-polymorphic-sub.js: Copied from JSTests/microbenchmarks/ftl-polymorphic-sub.js.
+        * slowMicrobenchmarks/ftl-polymorphic-urshift.js: Copied from JSTests/microbenchmarks/ftl-polymorphic-urshift.js.
+        * slowMicrobenchmarks/map-constant-key.js: Copied from JSTests/microbenchmarks/map-constant-key.js.
+        * slowMicrobenchmarks/nested-function-parsing.js: Copied from JSTests/microbenchmarks/nested-function-parsing.js.
+        * slowMicrobenchmarks/rest-parameter-allocation-elimination.js: Copied from JSTests/microbenchmarks/rest-parameter-allocation-elimination.js.
+        * slowMicrobenchmarks/spread-large-array.js: Copied from JSTests/microbenchmarks/spread-large-array.js.
+        * slowMicrobenchmarks/string-add-constant-folding.js: Copied from JSTests/microbenchmarks/string-add-constant-folding.js.
+        * slowMicrobenchmarks/to-lower-case.js: Copied from JSTests/microbenchmarks/to-lower-case.js.
+        * slowMicrobenchmarks/undefined-property-access.js: Copied from JSTests/microbenchmarks/undefined-property-access.js.
+
+2018-01-23  Robin Morisset  <rmorisset@apple.com>
+
+        Update the argument count in DFGByteCodeParser::handleRecursiveCall
+        https://bugs.webkit.org/show_bug.cgi?id=181739
+        <rdar://problem/36627662>
+
+        Reviewed by Saam Barati.
+
+        * stress/recursive-tail-call-with-different-argument-count.js: Added.
+        (foo):
+        (bar):
+
+2018-01-22  Michael Saboff  <msaboff@apple.com>
+
+        DFG abstract interpreter needs to properly model effects of some Math ops
+        https://bugs.webkit.org/show_bug.cgi?id=181886
+
+        Reviewed by Saam Barati.
+
+        New regression test.
+
+        * stress/arith-nodes-abstract-interpreter-untypeduse.js: Added.
+        (test):
+
+2018-01-20  Caio Lima  <ticaiolima@gmail.com>
+
+        [JSC] NumberPrototype::extractRadixFromArgs incorrectly cast double to int32_t
+        https://bugs.webkit.org/show_bug.cgi?id=181182
+
+        Reviewed by Darin Adler.
+
+        * stress/big-int-prototype-to-string-cast-overflow.js: Added.
+        * stress/big-int-prototype-to-string-exception.js: Added.
+        * stress/big-int-prototype-to-string-wrong-values.js: Added.
+        * stress/number-prototype-to-string-cast-overflow.js: Added.
+        * stress/number-prototype-to-string-exception.js: Added.
+        * stress/number-prototype-to-string-wrong-values.js: Added.
+
+2018-01-19  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Disable Atomics when SharedArrayBuffer isn’t enabled
+        https://bugs.webkit.org/show_bug.cgi?id=181572
+
+        Unreviewed test gardening.
+
+        * test262.yaml: Skip tests that fail after this change.
+
+2018-01-19  Saam Barati  <sbarati@apple.com>
+
+        Kill ArithNegate's ArithProfile assert inside BytecodeParser
+        https://bugs.webkit.org/show_bug.cgi?id=181877
+        <rdar://problem/36630552>
+
+        Reviewed by Mark Lam.
+
+        * stress/arith-profile-for-negate-can-see-non-number-due-to-dfg-osr-exit-profiling.js: Added.
+        (runNearStackLimit):
+        (f1):
+        (f2):
+        (f3):
+        (i.catch):
+        (i.try.runNearStackLimit):
+        (catch):
+
+2018-01-19  Saam Barati  <sbarati@apple.com>
+
+        Spread's effects are modeled incorrectly both in AI and in Clobberize
+        https://bugs.webkit.org/show_bug.cgi?id=181867
+        <rdar://problem/36290415>
+
+        Reviewed by Michael Saboff.
+
+        * stress/ai-needs-to-model-spreads-effects.js: Added.
+        (try.p.Symbol.iterator):
+        (try.go):
+        (catch):
+        * stress/clobberize-needs-to-model-spread-effects.js: Added.
+        (assert):
+        (foo):
+        (a.Symbol.iterator):
+
+2018-01-19  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, reduce count of iteration to fix timing out debug JSC test
+        https://bugs.webkit.org/show_bug.cgi?id=181535
+
+        * stress/inserted-recovery-with-set-last-index.js:
+
+2018-01-17  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Introduce PhantomNewRegexp and RegExpExecNonGlobalOrSticky
+        https://bugs.webkit.org/show_bug.cgi?id=181535
+
+        Reviewed by Saam Barati.
+
+        * stress/inserted-recovery-with-set-last-index.js: Added.
+        (shouldBe):
+        (foo):
+        * stress/materialize-regexp-at-osr-exit.js: Added.
+        (shouldBe):
+        (test):
+        * stress/materialize-regexp-cyclic-regexp-at-osr-exit.js: Added.
+        (shouldBe):
+        (test):
+        * stress/materialize-regexp-cyclic-regexp.js: Added.
+        (shouldBe):
+        (test):
+        (i.switch):
+        * stress/materialize-regexp-cyclic.js: Added.
+        (shouldBe):
+        (test):
+        (i.switch):
+        * stress/materialize-regexp-referenced-from-phantom-regexp-cyclic.js: Added.
+        (bar):
+        (foo):
+        (test):
+        * stress/materialize-regexp-referenced-from-phantom-regexp.js: Added.
+        (bar):
+        (foo):
+        (test):
+        * stress/materialize-regexp.js: Added.
+        (shouldBe):
+        (test):
+        * stress/phantom-regexp-regexp-exec.js: Added.
+        (shouldBe):
+        (test):
+        * stress/phantom-regexp-string-match.js: Added.
+        (shouldBe):
+        (test):
+        * stress/regexp-last-index-sinking.js: Added.
+        (shouldBe):
+        (test):
+
+2018-01-17  Saam Barati  <sbarati@apple.com>
+
+        Disable Atomics when SharedArrayBuffer isn’t enabled
+        https://bugs.webkit.org/show_bug.cgi?id=181572
+        <rdar://problem/36553206>
+
+        Reviewed by Michael Saboff.
+
+        * stress/isLockFree.js:
+
+2018-01-17  Saam Barati  <sbarati@apple.com>
+
+        DFG::Node::convertToConstant needs to clear the varargs flags
+        https://bugs.webkit.org/show_bug.cgi?id=181697
+        <rdar://problem/36497332>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/dfg-node-convert-to-constant-must-clear-varargs-flags.js: Added.
+        (doIndexOf):
+        (bar):
+        (i.bar):
+
+2018-01-16  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r226937.
+
+        Tests added with this change are failing due to a missing
+        exception check.
+
+        Reverted changeset:
+
+        "[JSC] NumberPrototype::extractRadixFromArgs incorrectly cast
+        double to int32_t"
+        https://bugs.webkit.org/show_bug.cgi?id=181182
+        https://trac.webkit.org/changeset/226937
+
+2018-01-13  Caio Lima  <ticaiolima@gmail.com>
+
+        [JSC] NumberPrototype::extractRadixFromArgs incorrectly cast double to int32_t
+        https://bugs.webkit.org/show_bug.cgi?id=181182
+
+        Reviewed by Darin Adler.
+
+        * bigIntTests.yaml:
+        * stress/big-int-constructor.js:
+        * stress/big-int-prototype-to-string-cast-overflow.js: Added.
+        (assert):
+        (assertThrowRangeError):
+        * stress/number-prototype-to-string-cast-overflow.js: Added.
+        (assert):
+        (assertThrowRangeError):
+
+2018-01-12  Saam Barati  <sbarati@apple.com>
+
+        CheckStructure can be incorrectly subsumed by CheckStructureOrEmpty
+        https://bugs.webkit.org/show_bug.cgi?id=181177
+        <rdar://problem/36205704>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/check-structure-ir-ensures-empty-does-not-flow-through.js: Added.
+        (runNearStackLimit.t):
+        (runNearStackLimit):
+        (test.f):
+        (test):
+
+2018-01-12  Saam Barati  <sbarati@apple.com>
+
+        Each variant of a polymorphic inlined call should be exitOK at the top of the block
+        https://bugs.webkit.org/show_bug.cgi?id=181562
+        <rdar://problem/36445624>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/each-block-at-top-of-polymorphic-call-inlining-should-be-exitOK.js: Added.
+        (f):
+        (foo):
+
+2018-01-11  Saam Barati  <sbarati@apple.com>
+
+        When inserting Unreachable in byte code parser we need to flush all the right things
+        https://bugs.webkit.org/show_bug.cgi?id=181509
+        <rdar://problem/36423110>
+
+        Reviewed by Mark Lam.
+
+        * stress/proper-flushing-when-we-insert-unreachable-after-force-exit-in-bytecode-parser.js: Added.
+
+2018-01-11  Saam Barati  <sbarati@apple.com>
+
+        JITMathIC code in the FTL is wrong when code gets duplicated
+        https://bugs.webkit.org/show_bug.cgi?id=181525
+        <rdar://problem/36351993>
+
+        Reviewed by Michael Saboff and Keith Miller.
+
+        * stress/allow-math-ic-b3-code-duplication.js: Added.
+
+2018-01-11  Saam Barati  <sbarati@apple.com>
+
+        Our for-in caching is wrong when we add indexed properties on things in the prototype chain
+        https://bugs.webkit.org/show_bug.cgi?id=181508
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/for-in-prototype-with-indexed-properties-should-prevent-caching.js: Added.
+        (assert):
+        (test1.foo):
+        (test1):
+        (test2.foo):
+        (test2):
+
+2018-01-09  Mark Lam  <mark.lam@apple.com>
+
+        ASSERTION FAILED: pair.second->m_type & PropertyNode::Getter
+        https://bugs.webkit.org/show_bug.cgi?id=181388
+        <rdar://problem/36349351>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-181388.js: Added.
+
+2018-01-08  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: mask indexed accesses to Table
+        https://bugs.webkit.org/show_bug.cgi?id=181412
+        <rdar://problem/36363236>
+
+        Reviewed by Saam Barati.
+
+        Update error messages.
+
+        * wasm/js-api/table.js:
+        (assert.throws.WebAssembly.Table.prototype.grow):
+
+2018-01-08  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Disable SharedArrayBuffer tests missed in r226386.
+        https://bugs.webkit.org/show_bug.cgi?id=181266
+
+        Unreviewed test gardening.
+
+        * test262.yaml:
+
+2018-01-06  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Object.getOwnPropertyNames includes "arguments" and "caller" for bound functions
+        https://bugs.webkit.org/show_bug.cgi?id=181321
+
+        Reviewed by Saam Barati.
+
+        * stress/bound-function-does-not-have-caller-and-arguments.js: Added.
+        (shouldBe):
+        (testFunction):
+        * test262.yaml:
+
+2018-01-05  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, attempt to fix test262 after r226386.
+
+        * test262.yaml:
+
+2018-01-04  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Define defs for MapSet/SetAdd to participate in CSE
+        https://bugs.webkit.org/show_bug.cgi?id=179911
+
+        Reviewed by Saam Barati.
+
+        In addition to these tests, map-set-cse.js and set-add-cse.js work.
+
+        * stress/map-set-change-get.js: Added.
+        (shouldBe):
+        (test):
+        * stress/map-set-create-bucket.js: Added.
+        (shouldBe):
+        (test):
+        * stress/set-add-create-bucket.js: Added.
+        (shouldBe):
+
+2018-01-03  Michael Saboff  <msaboff@apple.com>
+
+        Disable SharedArrayBuffers from Web API
+        https://bugs.webkit.org/show_bug.cgi?id=181266
+
+        Reviewed by Saam Barati.
+
+        Disabled SharedArrayBuffer tests.
+
+        * stress/SharedArrayBuffer-opt.js:
+        * stress/SharedArrayBuffer.js:
+        * stress/array-buffer-byte-length.js:
+        * stress/atomics-add-uint32.js:
+        * stress/atomics-known-int-use.js:
+        * stress/atomics-neg-zero.js:
+        * stress/atomics-store-return.js:
+        * stress/lars-sab-workers.js:
+        * stress/regress-159779-1.js:
+        * stress/regress-159779-2.js:
+        * stress/regress-170473.js:
+        * test262.yaml:
+
+2018-01-03  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Failing test stress/big-int-constructor-oom.js into MIPS
+        https://bugs.webkit.org/show_bug.cgi?id=181258
+
+        Reviewed by Antonio Gomes.
+
+        * stress/big-int-constructor-gc.js:
+        * stress/big-int-constructor-oom.js:
+
+2018-01-03  Robin Morisset  <rmorisset@apple.com>
+
+        Inlining of a function that ends in op_unreachable crashes
+        https://bugs.webkit.org/show_bug.cgi?id=181027
+
+        Reviewed by Filip Pizlo.
+
+        * stress/inlining-unreachable.js: Added.
+        (bar):
+        (baz):
+        (i.catch):
+
+2018-01-02  Saam Barati  <sbarati@apple.com>
+
+        Incorrect assertion inside AccessCase
+        https://bugs.webkit.org/show_bug.cgi?id=181200
+        <rdar://problem/35494754>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/setter-same-base-and-rhs-invalid-assertion-inside-access-case.js: Added.
+        (ctor):
+        (theFunc):
+        (run):
+
+2018-01-02  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement BigIntConstructor and BigIntPrototype
+        https://bugs.webkit.org/show_bug.cgi?id=175359
+
+        Reviewed by Yusuke Suzuki.
+
+        * bigIntTests.yaml:
+        * stress/big-int-as-key.js: Added.
+        * stress/big-int-constructor-gc.js: Added.
+        * stress/big-int-constructor-oom.js: Added.
+        * stress/big-int-constructor-properties.js: Added.
+        * stress/big-int-constructor-prototype-prop-descriptor.js: Added.
+        * stress/big-int-constructor-prototype.js: Added.
+        * stress/big-int-constructor.js: Added.
+        * stress/big-int-function-apply.js:
+        * stress/big-int-length.js: Added.
+        * stress/big-int-prop-descriptor.js: Added.
+        * stress/big-int-proto-constructor.js: Added.
+        * stress/big-int-proto-name.js: Added.
+        * stress/big-int-prototype-properties.js: Added.
+        * stress/big-int-prototype-proto.js: Added.
+        * stress/big-int-prototype-value-of.js: Added.
+        * stress/big-int-prototype-symbol-to-string-tag.js: Added.
+        * stress/big-int-prototype-to-string-apply.js: Added.
+        * stress/big-int-to-object.js: Added.
+        * stress/big-int-to-string.js: Added.
+
+2017-12-28  Saam Barati  <sbarati@apple.com>
+
+        Assertion used to determine if something is an async generator is wrong
+        https://bugs.webkit.org/show_bug.cgi?id=181168
+        <rdar://problem/35640560>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/async-generator-assertion.js: Added.
+
+2017-12-21  Guillaume Emont  <guijemont@igalia.com>
+
+        Skip stress/splay-flash-access tests on memory limited platforms
+        https://bugs.webkit.org/show_bug.cgi?id=181086
+
+        Reviewed by Carlos Alberto Lopez Perez.
+
+        These tests use about 185M of memory, and occasionally get OOM-killed
+        on memory limited platforms.
+
+        * stress/splay-flash-access-1ms.js:
+        * stress/splay-flash-access.js:
+
+2017-12-21  Guillaume Emont  <guijemont@igalia.com>
+
+        Skip slow jsc tests on embedded platforms
+        https://bugs.webkit.org/show_bug.cgi?id=180937
+
+        Reviewed by Carlos Alberto Lopez Perez.
+
+        The tests typeProfiler/deltablue-for-of.js and
+        typeProfiler/getter-richards.js take a very long time in the
+        ftl-no-cjit-type-profiler-force-poly-proto on embedded platform, and
+        thus always timeout. They should be skipped on these platforms.
+
+        * typeProfiler/deltablue-for-of.js: Skip on arm*/mips.
+        * typeProfiler/getter-richards.js: Skip on arm*/mips.
+
+2017-12-19  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Do not check isValid() in op_new_regexp
+        https://bugs.webkit.org/show_bug.cgi?id=180970
+
+        Reviewed by Saam Barati.
+
+        * stress/regexp-syntax-error-invalid-flags.js: Added.
+        (shouldThrow):
+
+2017-12-18  Guillaume Emont  <guijemont@igalia.com>
+
+        Skip stress/call-apply-exponential-bytecode-size.js unless x86-64 or arm64
+        https://bugs.webkit.org/show_bug.cgi?id=180712
+
+        Reviewed by Michael Catanzaro.
+
+        stress/call-apply-exponential-bytecode-size.js crashes if the
+        ExecutableAllocator's fixedExecutableMemoryPoolSize is less than 64
+        MB. Currently it is 64 MB or more only on x86-64 and arm64, so we
+        should skip the test on other platforms.
+
+        * stress/call-apply-exponential-bytecode-size.js:
+
+2017-12-17  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [FTL] NewArrayBuffer should be sinked if it is only used for spreading
+        https://bugs.webkit.org/show_bug.cgi?id=179762
+
+        Reviewed by Saam Barati.
+
+        * stress/call-varargs-double-new-array-buffer.js: Added.
+        (assert):
+        (bar):
+        (foo):
+        * stress/call-varargs-spread-new-array-buffer.js: Added.
+        (assert):
+        (bar):
+        (foo):
+        * stress/call-varargs-spread-new-array-buffer2.js: Added.
+        (assert):
+        (bar):
+        (foo):
+        * stress/forward-varargs-double-new-array-buffer.js: Added.
+        (assert):
+        (test.baz):
+        (test.bar):
+        (test.foo):
+        (test):
+        * stress/new-array-buffer-sinking-osrexit.js: Added.
+        (target):
+        (test):
+        * stress/new-array-with-spread-double-new-array-buffer.js: Added.
+        (shouldBe):
+        (test):
+        * stress/new-array-with-spread-with-phantom-new-array-buffer.js: Added.
+        (shouldBe):
+        (target):
+        (test):
+        * stress/phantom-new-array-buffer-forward-varargs.js: Added.
+        (assert):
+        (test1.bar):
+        (test1.foo):
+        (test1):
+        (test2.bar):
+        (test2.foo):
+        (test3.baz):
+        (test3.bar):
+        (test3.foo):
+        (test4.baz):
+        (test4.bar):
+        (test4.foo):
+        * stress/phantom-new-array-buffer-forward-varargs2.js: Added.
+        (assert):
+        (test.baz):
+        (test.bar):
+        (test.foo):
+        (test):
+        * stress/phantom-new-array-buffer-osr-exit.js: Added.
+        (assert):
+        (baz):
+        (bar):
+        (effects):
+        (foo):
+
+2017-12-14  Saam Barati  <sbarati@apple.com>
+
+        The CleanUp after LICM is erroneously removing a Check
+        https://bugs.webkit.org/show_bug.cgi?id=180852
+        <rdar://problem/36063494>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/dont-run-cleanup-after-licm.js: Added.
+
+2017-12-14  Michael Saboff  <msaboff@apple.com>
+
+        REGRESSION (r225695): Repro crash on yahoo login page
+        https://bugs.webkit.org/show_bug.cgi?id=180761
+
+        Reviewed by JF Bastien.
+
+        New regression test.
+
+        * stress/regress-180761.js: Added.
+
+2017-12-13  Keith Miller  <keith_miller@apple.com>
+
+        JSObjects should have a mask for loading indexed properties
+        https://bugs.webkit.org/show_bug.cgi?id=180768
+
+        Reviewed by Mark Lam.
+
+        * stress/int16-put-by-val-in-and-out-of-bounds.js:
+        (test):
+
+2017-12-13  Saam Barati  <sbarati@apple.com>
+
+        Arrow functions need their own structure because they have different properties than sloppy functions
+        https://bugs.webkit.org/show_bug.cgi?id=180779
+        <rdar://problem/35814591>
+
+        Reviewed by Mark Lam.
+
+        * stress/arrow-function-needs-its-own-structure.js: Added.
+        (assert):
+        (readPrototype):
+        (noInline.let.f1):
+        (noInline):
+
+2017-12-13  Saam Barati  <sbarati@apple.com>
+
+        Fix how JSFunction handles "caller" and "arguments" for functions that don't have those properties
+        https://bugs.webkit.org/show_bug.cgi?id=163579
+        <rdar://problem/35455798>
+
+        Reviewed by Mark Lam.
+
+        * stress/caller-and-arguments-properties-for-functions-that-dont-have-them.js: Added.
+        (assert):
+        (test1):
+        (i.test1):
+        (i.test1.C):
+        (i.test1.async.foo):
+        (i.test1.foo):
+        (test2):
+
+2017-12-13  Saam Barati  <sbarati@apple.com>
+
+        TypeCheckHoistingPhase needs to emit a CheckStructureOrEmpty if it's doing it for |this|
+        https://bugs.webkit.org/show_bug.cgi?id=180734
+        <rdar://problem/35640547>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/type-check-hoisting-phase-hoist-check-structure-on-tdz-this-value.js: Added.
+        (__isPropertyOfType):
+        (__getProperties):
+        (__getObjects):
+        (__getRandomObject):
+        (theClass.):
+        (theClass):
+        (childClass):
+        (counter.catch):
+
+2017-12-12  Saam Barati  <sbarati@apple.com>
+
+        We need to model effects of Spread(@PhantomCreateRest) in Clobberize/PreciseLocalClobberize
+        https://bugs.webkit.org/show_bug.cgi?id=180725
+        <rdar://problem/35970511>
+
+        Reviewed by Michael Saboff.
+
+        * stress/model-effects-properly-of-spread-over-phantom-create-rest.js: Added.
+        (f1):
+        (f2):
+        (let.o2.valueOf):
+
+2017-12-12  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Implement optimized WeakMap and WeakSet
+        https://bugs.webkit.org/show_bug.cgi?id=179929
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/weak-map-key.js:
+        * microbenchmarks/weak-set-key.js: Copied from JSTests/microbenchmarks/weak-map-key.js.
+        (assert):
+        (objectKey):
+        (let.start.Date.now):
+        * stress/basic-weakmap.js: Added.
+        (shouldBe):
+        (test):
+        * stress/basic-weakset.js: Added.
+        (shouldBe):
+        (test.set new):
+        * stress/weakmap-cse-set-break.js: Added.
+        (shouldBe):
+        (test):
+        * stress/weakmap-cse.js: Added.
+        (shouldBe):
+        (test):
+        * stress/weakmap-gc.js: Added.
+        (test):
+        * stress/weakset-cse-add-break.js: Added.
+        (shouldBe):
+        (test.set new):
+        * stress/weakset-cse.js: Added.
+        (shouldBe):
+        (test.set new):
+        * stress/weakset-gc.js: Added.
+        (test.set add):
+        (test.set new):
+        (test):
+
+2017-12-12  Saam Barati  <sbarati@apple.com>
+
+        ConstantFoldingPhase rule for GetMyArgumentByVal must check for negative indices
+        https://bugs.webkit.org/show_bug.cgi?id=180723
+        <rdar://problem/35859726>
+
+        Reviewed by JF Bastien.
+
+        * stress/get-my-argument-by-val-constant-folding.js: Added.
+        (test):
+        (catch):
+
+2017-12-12  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESNext][BigInt] Implement BigInt literals and JSBigInt
+        https://bugs.webkit.org/show_bug.cgi?id=179000
+
+        Reviewed by Darin Adler and Yusuke Suzuki.
+
+        * bigIntTests.yaml: Added.
+        * stress/big-int-literal-line-terminator.js: Added.
+        * stress/big-int-literals.js: Added.
+        * stress/big-int-operations-error.js: Added.
+        * stress/big-int-type-of.js: Added.
+        * stress/big-int-white-space-trailing-leading.js: Added.
+        * stress/big-int-function-apply.js: Added.
+
+2017-12-11  Saam Barati  <sbarati@apple.com>
+
+        We need to disableCaching() in ErrorInstance when we materialize properties
+        https://bugs.webkit.org/show_bug.cgi?id=180343
+        <rdar://problem/35833002>
+
+        Reviewed by Mark Lam.
+
+        * stress/disable-caching-when-lazy-materializing-error-property-on-put.js: Added.
+        (assert):
+        (makeError):
+        (storeToStack):
+        (storeToStackAlreadyMaterialized):
+
+2017-12-05  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: don't eagerly checksum
+        https://bugs.webkit.org/show_bug.cgi?id=180441
+        <rdar://problem/35156628>
+
+        Reviewed by Saam Barati.
+
+        Checksum is now disabled, so tests only have <?> as the module
+        name.
+
+        * wasm/function-tests/nameSection.js:
+        * wasm/function-tests/stack-overflow.js:
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.assertOverflows):
+        (assertOverflows.assertThrows):
+        (assertOverflows):
+        * wasm/function-tests/stack-trace.js:
+
+2017-12-04  JF Bastien  <jfbastien@apple.com>
+
+        Proxy all functions, except the $ objects
+        https://bugs.webkit.org/show_bug.cgi?id=180375
+
+        Reviewed by Saam Barati.
+
+        It looks like this test may have broken some executions because I
+        call some internal objects. Explicitly ignore objects whose name
+        starts with "$" because it's a bad idea anyways.
+
+        * stress/proxy-all-the-parameters.js:
+        (generateObjects):
+        (get throw):
+
+2017-12-04  Saam Barati  <sbarati@apple.com>
+
+        We need to leave room on the top of the stack for the FTL TailCall slow path so it doesn't overwrite things we want to retrieve when doing a stack walk when throwing an exception
+        https://bugs.webkit.org/show_bug.cgi?id=180366
+        <rdar://problem/35685877>
+
+        Reviewed by Michael Saboff.
+
+        * stress/ftl-tail-call-throw-exception-from-slow-path-recover-stack-values.js: Added.
+        (theParent):
+        (test1.base.getParentStaticValue):
+        (test1.base):
+        (test1.__v_24888.prototype.set prop):
+        (test1.__v_24888):
+        (test2.base.getParentStaticValue):
+        (test2.base):
+        (test2.__v_24888.prototype.set prop):
+        (test2.__v_24888):
+        (test2):
+
+2017-12-01  JF Bastien  <jfbastien@apple.com>
+
+        Try proxying all function arguments
+        https://bugs.webkit.org/show_bug.cgi?id=180306
+
+        Reviewed by Saam Barati.
+
+        * stress/proxy-all-the-parameters.js: Added.
+        (isPropertyOfType):
+        (getProperties):
+        (generateObjects):
+        (getObjects):
+        (getFunctions):
+        (get throw):
+        (let.o.of.getObjects.let.f.of.getFunctions.catch):
+
+2017-12-01  JF Bastien  <jfbastien@apple.com>
+
+        JavaScriptCore: missing exception checks in Math functions that take more than one argument
+        https://bugs.webkit.org/show_bug.cgi?id=180297
+        <rdar://problem/35745556>
+
+        Reviewed by Mark Lam.
+
+        * stress/math-exceptions.js: Added.
+        (get try):
+        (catch):
+
+2017-12-01  JF Bastien  <jfbastien@apple.com>
+
+        JavaScriptCore: add test for weird class static getters
+        https://bugs.webkit.org/show_bug.cgi?id=180281
+        <rdar://problem/35592139>
+
+        Reviewed by Mark Lam.
+
+        I fixed a bug for it in r224927 and didn't add a test. Do so.
+
+        * stress/class-static-get-weird.js: Added.
+        (c.prototype.get name):
+        (c):
+        (c.prototype.get arguments):
+        (c.prototype.get caller):
+        (c.prototype.get length):
+
+2017-12-01  Saam Barati  <sbarati@apple.com>
+
+        Having a bad time needs to handle ArrayClass indexing type as well
+        https://bugs.webkit.org/show_bug.cgi?id=180274
+        <rdar://problem/35667869>
+
+        Reviewed by Keith Miller and Mark Lam.
+
+        * stress/array-prototype-slow-put-having-a-bad-time-2.js: Added.
+        (assert):
+        * stress/array-prototype-slow-put-having-a-bad-time.js: Added.
+        (assert):
+
+2017-12-01  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: restore cached stack limit after out-call
+        https://bugs.webkit.org/show_bug.cgi?id=179106
+        <rdar://problem/35337525>
+
+        Reviewed by Saam Barati.
+
+        * wasm/function-tests/double-instance.js: Added.
+        (const.imp.boom):
+        (const.imp.get callAnother):
+
+2017-11-30  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: improve stack trace
+        https://bugs.webkit.org/show_bug.cgi?id=179343
+
+        Reviewed by Saam Barati.
+
+        Update the tests to follow the new format. Notably, SHA1 module
+        hash is now included in traces, and stubs are properly identified.
+
+        * wasm/assert.js: Add an assertion which matches regular expressions.
+        * wasm/function-tests/nameSection.js:
+        * wasm/function-tests/stack-overflow.js:
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.assertOverflows):
+        (assertOverflows.assertThrows.wasm.1):
+        (assertOverflows.assertThrows.wasm.0):
+        (assertOverflows.assertThrows):
+        (assertOverflows):
+        * wasm/function-tests/stack-trace.js:
+        (import.Builder.from.string_appeared_here.assert): Deleted.
+        * wasm/function-tests/trap-after-cross-instance-call.js:
+        (wasmFrameCountFromError):
+        * wasm/function-tests/trap-load-2.js:
+        (wasmFrameCountFromError):
+        * wasm/function-tests/trap-load.js:
+        (wasmFrameCountFromError):
+
+2017-11-30  Mark Lam  <mark.lam@apple.com>
+
+        jsc shell's flashHeapAccess() should not do JS work after releasing access to the heap.
+        https://bugs.webkit.org/show_bug.cgi?id=180219
+        <rdar://problem/35696536>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-180219.js: Added.
+
+2017-11-30  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] operationHasIndexedProperty does not consider negative int32_t
+        https://bugs.webkit.org/show_bug.cgi?id=180190
+
+        Reviewed by Mark Lam.
+
+        * stress/operation-in-may-have-negative-int32-array-storage.js: Added.
+        (shouldBe):
+        (test1):
+        * stress/operation-in-may-have-negative-int32-contiguous-array.js: Added.
+        (shouldBe):
+        (test1):
+        * stress/operation-in-may-have-negative-int32-double-array.js: Added.
+        (shouldBe):
+        (test1):
+        * stress/operation-in-may-have-negative-int32-generic-array.js: Added.
+        (shouldBe):
+        (test1):
+        * stress/operation-in-may-have-negative-int32-int32-array.js: Added.
+        (shouldBe):
+        (test1):
+        * stress/operation-in-may-have-negative-int32.js: Added.
+        (shouldBe):
+        (test2):
+        * stress/operation-in-negative-int32-cast.js: Added.
+        (shouldBe):
+        (test1):
+
+2017-11-28  JF Bastien  <jfbastien@apple.com>
+
+        Strict and sloppy functions shouldn't share structure
+        https://bugs.webkit.org/show_bug.cgi?id=180103
+        <rdar://problem/35667847>
+
+        Reviewed by Saam Barati.
+
+        * stress/get-by-id-strict-arguments.js: Added. Used to not throw
+        because the IC was wrong.
+        (foo):
+        (bar):
+        (baz):
+        (catch):
+        * stress/get-by-id-strict-callee.js: Added. Not strictly necessary
+        in this patch, but may as well test odd strict mode corner cases.
+        (bar):
+        (baz):
+        (catch):
+        * stress/get-by-id-strict-caller.js: Added. Also IC'd wrong.
+        (foo):
+        (bar):
+        (baz):
+        (catch):
+        * stress/get-by-id-strict-nested-arguments-2.js: Added. Same as
+        next file, but with invalidation of the FunctionExecutable's
+        singletonFunction() to hit SpeculativeJIT::compileNewFunction's
+        slower path.
+        (foo):
+        (bar.const.x):
+        (bar.const.y):
+        (bar):
+        (catch):
+        * stress/get-by-id-strict-nested-arguments.js: Added. Make sure
+        strict nesting works correctly.
+        (foo):
+        (bar.baz):
+        (bar):
+        * stress/strict-function-structure.js: Added. The test used to
+        assert in objectProtoFuncHasOwnProperty.
+        (foo):
+        (bar):
+        (baz):
+        * stress/strict-nested-function-structure.js: Added. Nesting.
+        (foo):
+        (bar):
+        (baz.boo):
+        (baz):
+
+2017-11-29  Robin Morisset  <rmorisset@apple.com>
+
+        The recursive tail call optimisation is wrong on closures
+        https://bugs.webkit.org/show_bug.cgi?id=179835
+
+        Reviewed by Saam Barati.
+
+        * stress/closure-recursive-tail-call.js: Added.
+        (makeClosure):
+
+2017-11-27  JF Bastien  <jfbastien@apple.com>
+
+        JavaScript rest function parameter with negative index leads to bad DFG abstract interpretation
+        https://bugs.webkit.org/show_bug.cgi?id=180051
+        <rdar://problem/35614371>
+
+        Reviewed by Saam Barati.
+
+        * stress/rest-parameter-negative.js: Added.
+        (__f_5484):
+        (catch):
+        (__f_5485):
+        (__v_22598.catch):
+
+2017-11-27  Saam Barati  <sbarati@apple.com>
+
+        Spread can escape when CreateRest does not
+        https://bugs.webkit.org/show_bug.cgi?id=180057
+        <rdar://problem/35676119>
+
+        Reviewed by JF Bastien.
+
+        * stress/spread-escapes-but-create-rest-does-not.js: Added.
+        (assert):
+        (getProperties):
+        (theFunc):
+        (let.obj.valueOf):
+
+2017-11-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Add NormalizeMapKey DFG IR
+        https://bugs.webkit.org/show_bug.cgi?id=179912
+
+        Reviewed by Saam Barati.
+
+        * stress/map-untyped-normalize-cse.js: Added.
+        (shouldBe):
+        (test):
+        * stress/map-untyped-normalize.js: Added.
+        (shouldBe):
+        (test):
+        * stress/set-untyped-normalize-cse.js: Added.
+        (shouldBe):
+        (set return.set has.set has):
+        * stress/set-untyped-normalize.js: Added.
+        (shouldBe):
+        (set return.set has):
+
+2017-11-26  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [FTL] Support DeleteById and DeleteByVal
+        https://bugs.webkit.org/show_bug.cgi?id=180022
+
+        Reviewed by Saam Barati.
+
+        * stress/delete-by-id.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+        * stress/delete-by-val-ftl.js: Added.
+        (shouldBe):
+        (test1):
+        (test2):
+
+2017-11-26  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Introduce {Set,Map,WeakMap}Fields
+        https://bugs.webkit.org/show_bug.cgi?id=179925
+
+        Reviewed by Saam Barati.
+
+        * stress/map-set-clobber-map-get.js: Added.
+        (shouldBe):
+        (test):
+        * stress/map-set-does-not-clobber-set-has.js: Added.
+        (shouldBe):
+        * stress/map-set-does-not-clobber-weak-map-get.js: Added.
+        (shouldBe):
+        (test):
+        * stress/set-add-clobber-set-has.js: Added.
+        (shouldBe):
+        * stress/set-add-does-not-clobber-map-get.js: Added.
+        (shouldBe):
+
+2017-11-24  Mark Lam  <mark.lam@apple.com>
+
+        Move unsafe jsc shell test functions to the $vm object.
+        https://bugs.webkit.org/show_bug.cgi?id=179980
+
+        Reviewed by Yusuke Suzuki.
+
+        * controlFlowProfiler/driver/driver.js:
+        * controlFlowProfiler/execution-count.js:
+        * controlFlowProfiler/if-statement.js:
+        * controlFlowProfiler/loop-statements.js:
+        * controlFlowProfiler/switch-statements.js:
+        * controlFlowProfiler/test-jit.js:
+        * exceptionFuzz/3d-cube.js:
+        * exceptionFuzz/date-format-xparb.js:
+        * exceptionFuzz/earley-boyer.js:
+        * heapProfiler/basic-edges.js:
+        * heapProfiler/property-edge-types.js:
+        * microbenchmarks/try-get-by-id-basic.js:
+        * microbenchmarks/try-get-by-id-polymorphic.js:
+        * modules/namespace-object-try-get.js:
+        * stress/argument-count-bytecode.js:
+        * stress/argument-intrinsic-basic.js:
+        * stress/argument-intrinsic-inlining-use-caller-arg.js:
+        * stress/argument-intrinsic-inlining-with-result-escape.js:
+        * stress/argument-intrinsic-inlining-with-vararg-with-enough-arguments.js:
+        * stress/argument-intrinsic-inlining-with-vararg.js:
+        * stress/argument-intrinsic-nested-inlining.js:
+        * stress/argument-intrinsic-not-convert-to-get-argument.js:
+        * stress/argument-intrinsic-with-stack-write.js:
+        * stress/arity-mismatch-get-argument.js:
+        * stress/array-message-passing.js:
+        * stress/array-push-with-force-exit.js:
+        * stress/check-dom-with-signature.js:
+        * stress/check-sub-class.js:
+        * stress/compare-eq-incomplete-profile.js:
+        * stress/custom-get-set-inline-caching-one-level-up-proto-chain.js:
+        * stress/do-eval-virtual-call-correctly.js:
+        * stress/dom-jit-with-poly-proto.js:
+        * stress/domjit-exception-ic.js:
+        * stress/domjit-exception.js:
+        * stress/domjit-getter-complex-with-incorrect-object.js:
+        * stress/domjit-getter-complex.js:
+        * stress/domjit-getter-poly.js:
+        * stress/domjit-getter-proto.js:
+        * stress/domjit-getter-super-poly.js:
+        * stress/domjit-getter-try-catch-getter-as-get-by-id-register-restoration.js:
+        * stress/domjit-getter-type-check.js:
+        * stress/domjit-getter.js:
+        * stress/exit-during-inlined-arity-fixup-recover-proper-frame.js:
+        * stress/for-in-proxy-target-changed-structure.js:
+        * stress/for-in-proxy.js:
+        * stress/generational-opaque-roots.js:
+        * stress/global-const-redeclaration-setting-2.js:
+        * stress/global-const-redeclaration-setting-3.js:
+        * stress/global-const-redeclaration-setting-4.js:
+        * stress/global-const-redeclaration-setting-5.js:
+        * stress/global-const-redeclaration-setting.js:
+        * stress/import-basic.js:
+        * stress/import-from-eval.js:
+        * stress/import-reject-with-exception.js:
+        * stress/import-syntax.js:
+        * stress/impure-get-own-property-slot-inline-cache.js:
+        * stress/is-constructor.js:
+        * stress/istypedarrayview-intrinsic.js:
+        * stress/jsc-setImpureGetterDelegate-on-bad-type.js:
+        * stress/jsc-test-functions-should-be-more-robust.js:
+        * stress/object-toString-with-proxy.js:
+        * stress/poly-proto-custom-value-and-accessor.js:
+        * stress/proxy-inline-cache.js:
+        * stress/re-execute-error-module.js:
+        * stress/regress-150532.js:
+        * stress/regress-156992.js:
+        * stress/regress-179619.js:
+        * stress/resources/shadow-chicken-support.js:
+        * stress/runtime-array.js:
+        * stress/sampling-profiler-microtasks.js:
+        * stress/shadow-chicken-enabled.js:
+        * stress/spread-correct-global-object-on-exception.js:
+        * stress/super-get-by-id.js:
+        * stress/tailCallForwardArguments.js:
+        * stress/to-object-intrinsic-boolean-edge.js:
+        * stress/to-object-intrinsic-null-or-undefined-edge.js:
+        * stress/to-object-intrinsic-number-edge.js:
+        * stress/to-object-intrinsic-object-edge.js:
+        * stress/to-object-intrinsic-string-edge.js:
+        * stress/to-object-intrinsic-symbol-edge.js:
+        * stress/to-object-intrinsic.js:
+        * stress/try-catch-custom-getter-as-get-by-id.js:
+        * stress/try-get-by-id-poly-proto.js:
+        * stress/try-get-by-id-should-spill-registers-dfg.js:
+        * stress/try-get-by-id.js:
+        * typeProfiler/arrow-functions.js:
+        * typeProfiler/basic.js:
+        * typeProfiler/captured.js:
+        * typeProfiler/classes.js:
+        * typeProfiler/dfg-jit-optimizations.js:
+        * typeProfiler/dictionary-mode.js:
+        * typeProfiler/es6-block-scoping.js:
+        * typeProfiler/es6-classes.js:
+        * typeProfiler/inheritance.js:
+        * typeProfiler/int52-dfg.js:
+        * typeProfiler/loop.js:
+        * typeProfiler/optional-fields.js:
+        * typeProfiler/overflow.js:
+        * typeProfiler/return.js:
+        * typeProfiler/symbol.js:
+        * typeProfiler/weird-prototype-chain.js:
+
+2017-11-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Support MapSet / SetAdd intrinsics
+        https://bugs.webkit.org/show_bug.cgi?id=179858
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/map-has-and-set.js: Added.
+        (test):
+        * stress/map-set-check-failure.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        * stress/map-set-cse.js: Added.
+        (shouldBe):
+        (test):
+        * stress/set-add-check-failure.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (set shouldThrow):
+        * stress/set-add-cse.js: Added.
+        (shouldBe):
+
+2017-11-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Allow poly proto for intrinsic getters
+        https://bugs.webkit.org/show_bug.cgi?id=179550
+
+        Reviewed by Saam Barati.
+
+        This change is also tested by existing tests.
+
+            1. stress/intrinsic-getter-with-poly-proto.js
+            2. stress/poly-proto-intrinsic-getter-correctness.js
+
+        * stress/intrinsic-getter-with-poly-proto-getter-change.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/intrinsic-getter-with-poly-proto-proto-change.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+
+2017-11-20  Guillaume Emont  <guijemont@igalia.com>
+
+        Skip stress/unshiftCountSlowCase-correct-postCapacity.js on embedded Linux
+        https://bugs.webkit.org/show_bug.cgi?id=179744
+
+        Reviewed by Michael Catanzaro.
+
+        This test uses too much memory for our buildbots on these platforms
+        and gets OOM-killed.
+
+        * stress/unshiftCountSlowCase-correct-postCapacity.js:
+        Skip if $memoryLimited and linux.
+
+2017-11-17  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly JS API: throw when a promise can't be created
+        https://bugs.webkit.org/show_bug.cgi?id=179826
+        <rdar://problem/35455813>
+
+        Reviewed by Mark Lam.
+
+        Test WebAssembly.{compile,instantiate} where promise creation
+        fails because of a stack overflow.
+
+        * wasm/js-api/promise-stack-overflow.js: Added.
+        (const.runNearStackLimit.f.const.t):
+        (async.testCompile):
+        (async.testInstantiate):
+
+2017-11-16  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, mark regress-178385.js as memory exhausting
+
+        * stress/regress-178385.js:
+
+2017-11-16  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Mark test262/test/language/statements/class/definition/fn-name-static-precedence.js as passing after r224927.
+
+        Unreviewed test gardening.
+
+        * test262.yaml:
+
+2017-11-16  Robin Morisset  <rmorisset@apple.com>
+
+        REGRESSION (r224592): oss-fuzz: jsc: Null-dereference READ in JSC::JSCell::isObject (4216)
+        https://bugs.webkit.org/show_bug.cgi?id=179763
+        <rdar://problem/35550513>
+
+        Reviewed by Keith Miller.
+
+        Just adding a slightly cleaned-up version of the original fuzzer-found test.
+
+        * stress/tdz-this-in-try-catch.js: Added.
+        (__v_6388):
+        (__v_6392):
+
+2017-11-14  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Support Array::DirectArguments with OutOfBounds
+        https://bugs.webkit.org/show_bug.cgi?id=179594
+
+        Reviewed by Saam Barati.
+
+        * stress/direct-arguments-in-bounds-to-out-of-bounds.js: Added.
+        (shouldBe):
+        (args):
+        * stress/direct-arguments-out-of-bounds-watchpoint.js: Added.
+        (shouldBe):
+        (args):
+
+2017-11-14  Saam Barati  <sbarati@apple.com>
+
+        We need to set topCallFrame when calling Wasm::Memory::grow from the JIT
+        https://bugs.webkit.org/show_bug.cgi?id=179639
+        <rdar://problem/35513018>
+
+        Reviewed by JF Bastien.
+
+        * wasm/function-tests/grow-memory-cause-gc.js: Added.
+        (escape):
+        (i.func):
+
+2017-11-13  Mark Lam  <mark.lam@apple.com>
+
+        Add more overflow check book-keeping for MarkedArgumentBuffer.
+        https://bugs.webkit.org/show_bug.cgi?id=179634
+        <rdar://problem/35492517>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-179634.js: Added.
+
+2017-11-13  Mark Lam  <mark.lam@apple.com>
+
+        Make the jsc shell loadGetterFromGetterSetter() function more robust.
+        https://bugs.webkit.org/show_bug.cgi?id=179619
+        <rdar://problem/35492518>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-179619.js: Added.
+
+2017-11-12  Mark Lam  <mark.lam@apple.com>
+
+        We should ensure that operationStrCat2 and operationStrCat3 are never passed Symbols as arguments.
+        https://bugs.webkit.org/show_bug.cgi?id=179562
+        <rdar://problem/35467022>
+
+        Reviewed by Saam Barati.
+
+        * regress-179562.js: Added.
+
+2017-11-08  Saam Barati  <sbarati@apple.com>
+
+        A JSFunction's ObjectAllocationProfile should watch the poly prototype watchpoint so it can clear its object allocation profile
+        https://bugs.webkit.org/show_bug.cgi?id=177792
+
+        Reviewed by Yusuke Suzuki.
+
+        * microbenchmarks/poly-proto-clear-js-function-allocation-profile.js: Added.
+        (assert):
+        (foo.Foo.prototype.ensureX):
+        (foo.Foo):
+        (foo):
+        (access):
+
+2017-11-08  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Mark test262.yaml/test262/test/language/statements/try/tco-catch.js as passing.
+        https://bugs.webkit.org/show_bug.cgi?id=178592
+
+        Unreviewed test gardening.
+
+        * test262.yaml:
+
+2017-11-08  Robin Morisset  <rmorisset@apple.com>
+
+        Turn recursive tail calls into loops
+        https://bugs.webkit.org/show_bug.cgi?id=176601
+
+        Reviewed by Saam Barati.
+
+        Relanding after https://bugs.webkit.org/show_bug.cgi?id=178834.
+
+        Add some simple test that computes factorial in several ways, and other trivial computations.
+        They all tests the case where foo calls bar (in an inlineable way) that then does a tail call.
+        Depending on the nature of both calls, it is possible or not to turn the tail call into a loop.
+        I have no clear way of checking that the call was indeed transformed, but I can check that the code computes the right result
+        (which it doesn't if that tail call is transformed into a loop in the unsound cases).
+
+        * stress/inline-call-to-recursive-tail-call.js: Added.
+        (factorial.aux):
+        (factorial):
+        (factorial2.aux2):
+        (factorial2.id):
+        (factorial2):
+        (factorial3.aux3):
+        (factorial3):
+        (aux4):
+        (factorial4):
+        (foo):
+        (auxBar):
+        (bar):
+        (test):
+
+2017-11-07  Mark Lam  <mark.lam@apple.com>
+
+        AccessCase::generateImpl() should exclude the result register when restoring registers after a call.
+        https://bugs.webkit.org/show_bug.cgi?id=179355
+        <rdar://problem/35263053>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-179355.js: Added.
+
+2017-11-05  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        JIT call inline caches should cache calls to objects with getCallData/getConstructData traps
+        https://bugs.webkit.org/show_bug.cgi?id=144458
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/dfg-internal-function-call.js: Added.
+        (target):
+        * microbenchmarks/dfg-internal-function-construct.js: Added.
+        (target):
+        * microbenchmarks/dfg-internal-function-not-handled-call.js: Added.
+        (target):
+        * microbenchmarks/dfg-internal-function-not-handled-construct.js: Added.
+        (target):
+        * stress/dfg-internal-function-call.js: Added.
+        (shouldBe):
+        (target):
+        * stress/dfg-internal-function-construct.js: Added.
+        (shouldBe):
+        (target):
+        * stress/internal-function-call.js: Added.
+        (shouldBe):
+        * stress/internal-function-construct.js: Added.
+        (shouldBe):
+
+2017-11-05  Per Arne Vollan  <pvollan@apple.com>
+
+        [Win] Skip stress/regress-178385.js.
+        https://bugs.webkit.org/show_bug.cgi?id=179298
+
+        Unreviewed test gardening.
+
+        * stress/regress-178385.js:
+
+2017-11-03  Keith Miller  <keith_miller@apple.com>
+
+        Add test for ic with side effects
+        https://bugs.webkit.org/show_bug.cgi?id=179268
+
+        Reviewed by Saam Barati.
+
+        * stress/put-inline-cache-side-effects.js: Added.
+        (let.i.of.objs.keys):
+        (f):
+
+2017-11-03  Mark Lam  <mark.lam@apple.com>
+
+        CachedCall (and its clients) needs overflow checks.
+        https://bugs.webkit.org/show_bug.cgi?id=179185
+
+        Reviewed by JF Bastien.
+
+        * stress/regress-179185.js: Added.
+
+2017-11-02  Michael Saboff  <msaboff@apple.com>
+
+        DFG needs to handle code motion of code in for..in loop bodies
+        https://bugs.webkit.org/show_bug.cgi?id=179212
+
+        Reviewed by Keith Miller.
+
+        New regression test.
+
+        * stress/for-in-side-effects.js: Added.
+        (getPrototypeOf):
+        (reset):
+        (testWithoutFTL.f):
+        (testWithoutFTL):
+        (testWithFTL.f):
+        (testWithFTL):
+
+2017-11-02  Filip Pizlo  <fpizlo@apple.com>
+
+        AI does not correctly model the clobber case of ArithClz32
+        https://bugs.webkit.org/show_bug.cgi?id=179188
+
+        Reviewed by Michael Saboff.
+
+        * stress/arith-clz32-effects.js: Added.
+        (foo):
+        (valueOf):
+
+2017-11-01  Michael Saboff  <msaboff@apple.com>
+
+        Integer overflow in code generated by LoadVarargs processing in DFG and FTL.
+        https://bugs.webkit.org/show_bug.cgi?id=179140
+
+        Reviewed by Saam Barati.
+
+        New regression test.
+
+        * stress/regress-179140.js: Added.
+        (testWithoutFTL):
+        (testWithFTL):
+
+2017-11-01  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Introduce @toObject
+        https://bugs.webkit.org/show_bug.cgi?id=178726
+
+        Reviewed by Saam Barati.
+
+        * stress/array-copywithin.js:
+        (shouldThrow):
+        * stress/object-constructor-boolean-edge.js: Added.
+        (shouldBe):
+        (test):
+        * stress/object-constructor-global.js: Added.
+        (shouldBe):
+        * stress/object-constructor-null-edge.js: Added.
+        (shouldBe):
+        (test):
+        * stress/object-constructor-number-edge.js: Added.
+        (shouldBe):
+        (test):
+        * stress/object-constructor-object-edge.js: Added.
+        (shouldBe):
+        (test):
+        (i.arg):
+        * stress/object-constructor-string-edge.js: Added.
+        (shouldBe):
+        (test):
+        * stress/object-constructor-symbol-edge.js: Added.
+        (shouldBe):
+        (test):
+        * stress/object-constructor-undefined-edge.js: Added.
+        (shouldBe):
+        (test):
+        * stress/symbol-array-from.js: Added.
+        (shouldBe):
+        * stress/to-object-intrinsic-boolean-edge.js: Added.
+        (shouldBe):
+        (builtin.createBuiltin):
+        * stress/to-object-intrinsic-null-or-undefined-edge.js: Added.
+        (shouldThrow):
+        * stress/to-object-intrinsic-number-edge.js: Added.
+        (shouldBe):
+        (builtin.createBuiltin):
+        * stress/to-object-intrinsic-object-edge.js: Added.
+        (shouldBe):
+        (builtin.createBuiltin):
+        (i.arg):
+        * stress/to-object-intrinsic-string-edge.js: Added.
+        (shouldBe):
+        (builtin.createBuiltin):
+        * stress/to-object-intrinsic-symbol-edge.js: Added.
+        (shouldBe):
+        (builtin.createBuiltin):
+        * stress/to-object-intrinsic.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (builtin.createBuiltin):
+
+2017-10-27  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Introduce StringSlice
+        https://bugs.webkit.org/show_bug.cgi?id=178934
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/string-slice-empty.js: Added.
+        (slice):
+        * microbenchmarks/string-slice-one-char.js: Added.
+        (slice):
+        * microbenchmarks/string-slice.js: Added.
+        (slice):
+
+2017-10-26  Michael Saboff  <msaboff@apple.com>
+
+        REGRESSION(r222601): We fail to properly backtrack into a sub pattern of a parenthesis with non-zero minimum
+        https://bugs.webkit.org/show_bug.cgi?id=178890
+
+        Reviewed by Keith Miller.
+
+        New regression test.
+
+        * stress/regress-178890.js: Added.
+
+2017-10-26  Mark Lam  <mark.lam@apple.com>
+
+        JSRopeString::RopeBuilder::append() should check for overflows.
+        https://bugs.webkit.org/show_bug.cgi?id=178385
+        <rdar://problem/35027468>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-178385.js: Added.
+
+2017-10-26  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r223961.
+
+        The change that required this has been rolled out.
+
+        Reverted changeset:
+
+        "Mark test262.yaml/test262/test/language/statements/try/tco-
+        catch.js as passing."
+        https://bugs.webkit.org/show_bug.cgi?id=178592
+        https://trac.webkit.org/changeset/223961
+
+2017-10-25  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r223691 and r223729.
+        https://bugs.webkit.org/show_bug.cgi?id=178834
+
+        Broke Speedometer 2 React-Redux-TodoMVC test case (Requested
+        by rniwa on #webkit).
+
+        Reverted changesets:
+
+        "Turn recursive tail calls into loops"
+        https://bugs.webkit.org/show_bug.cgi?id=176601
+        https://trac.webkit.org/changeset/223691
+
+        "REGRESSION(r223691): DFGByteCodeParser.cpp:1483:83: warning:
+        comparison is always false due to limited range of data type
+        [-Wtype-limits]"
+        https://bugs.webkit.org/show_bug.cgi?id=178543
+        https://trac.webkit.org/changeset/223729
+
+2017-10-25  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Mark test262.yaml/test262/test/language/statements/try/tco-catch.js as passing.
+        https://bugs.webkit.org/show_bug.cgi?id=178592
+
+        Unreviewed test gardening.
+
+        * test262.yaml:
+
+2017-10-24  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [FTL] Support NewStringObject
+        https://bugs.webkit.org/show_bug.cgi?id=178737
+
+        Reviewed by Saam Barati.
+
+        * stress/new-string-object.js: Added.
+        (shouldBe):
+        (test):
+
+2017-10-15  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] modules can be visited more than once when resolving bindings through "star" exports as long as the exportName is different each time
+        https://bugs.webkit.org/show_bug.cgi?id=178308
+
+        Reviewed by Mark Lam.
+
+        * test262.yaml:
+
+2017-10-23  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Use fastJoin in Array#toString
+        https://bugs.webkit.org/show_bug.cgi?id=178062
+
+        Reviewed by Darin Adler.
+
+        * microbenchmarks/contiguous-array-to-string.js: Added.
+        (target):
+        * microbenchmarks/double-array-to-string.js: Added.
+        (target):
+        * microbenchmarks/int32-array-to-string.js: Added.
+        (target):
+
+2017-10-22  Zan Dobersek  <zdobersek@igalia.com>
+
+        stress/check-string-ident.js is improperly skipped
+        https://bugs.webkit.org/show_bug.cgi?id=178642
+
+        Reviewed by Saam Barati.
+
+        * stress/check-string-ident.js: Drop the defaultNoEagerRun directive
+        since it enforces the run-jsc-stress-tests script to still set up the
+        test to run, despite the skip directive that's used before.
+
+2017-10-20  Mark Lam  <mark.lam@apple.com>
+
+        Add a test case for r214334.
+        https://bugs.webkit.org/show_bug.cgi?id=169941
+        <rdar://problem/31221258>
+
+        Reviewed by JF Bastien.
+
+        * stress/regress-169941.js: Added.
+
+2017-10-19  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: no VM / JS version of everything but Instance
+        https://bugs.webkit.org/show_bug.cgi?id=177473
+
+        Reviewed by Filip Pizlo, Saam Barati.
+
+        - Exceeding max on memory growth now returns a range error as per
+        spec. This is a (very minor) breaking change: it used to throw OOM
+        error. Update the corresponding test.
+
+        * wasm/js-api/memory-grow.js:
+        (assertEq):
+        * wasm/js-api/table.js:
+        (assert.throws):
+
+2017-10-19  Mark Lam  <mark.lam@apple.com>
+
+        Stringifier::appendStringifiedValue() is missing an exception check.
+        https://bugs.webkit.org/show_bug.cgi?id=178386
+        <rdar://problem/35027610>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-178386.js: Added.
+
+2017-10-19  Michael Saboff  <msaboff@apple.com>
+
+        Test262: RegExp/property-escapes/generated/Emoji_Component.js fails with current RegExp Unicode Properties implementation
+        https://bugs.webkit.org/show_bug.cgi?id=178521
+
+        Reviewed by JF Bastien.
+
+        * test262.yaml: Enabled test262/test/built-ins/RegExp/property-escapes/generated/Emoji_Component.js as it
+        now passes with the current version (5.0) of the Emoji spec.
+
+2017-10-19  Robin Morisset  <rmorisset@apple.com>
+
+        Turn recursive tail calls into loops
+        https://bugs.webkit.org/show_bug.cgi?id=176601
+
+        Reviewed by Saam Barati.
+
+        Add some simple test that computes factorial in several ways, and other trivial computations.
+        They all tests the case where foo calls bar (in an inlineable way) that then does a tail call.
+        Depending on the nature of both calls, it is possible or not to turn the tail call into a loop.
+        I have no clear way of checking that the call was indeed transformed, but I can check that the code computes the right result
+        (which it doesn't if that tail call is transformed into a loop in the unsound cases).
+
+        * stress/inline-call-to-recursive-tail-call.js: Added.
+        (factorial.aux):
+        (factorial):
+        (factorial2.aux):
+        (factorial2.id):
+        (factorial2):
+        (factorial3.aux):
+        (factorial3):
+        (aux):
+        (factorial4):
+        (test):
+
+2017-10-18  Mark Lam  <mark.lam@apple.com>
+
+        RegExpObject::defineOwnProperty() does not need to compare values if no descriptor value is specified.
+        https://bugs.webkit.org/show_bug.cgi?id=177600
+        <rdar://problem/34710985>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-177600.js: Added.
+
+2017-10-18  Mark Lam  <mark.lam@apple.com>
+
+        The compiler should always register a structure when it adds its transitionWatchPointSet.
+        https://bugs.webkit.org/show_bug.cgi?id=178420
+        <rdar://problem/34814024>
+
+        Reviewed by Saam Barati and Filip Pizlo.
+
+        * stress/regress-178420.js: Added.
+        (new.Array.10000.map):
+
+2017-10-18  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] __proto__ getter should be fast
+        https://bugs.webkit.org/show_bug.cgi?id=178067
+
+        Reviewed by Saam Barati.
+
+        * stress/dfg-object-proto-accessor.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        * stress/dfg-object-proto-getter.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        * stress/dfg-object-prototype-of.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        * stress/dfg-reflect-get-prototype-of.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        * stress/intrinsic-getter-with-poly-proto.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/object-get-prototype-of-filtered.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        (i.Cocoa):
+        * stress/object-get-prototype-of-mono-proto.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/object-get-prototype-of-poly-mono-proto.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/object-get-prototype-of-poly-proto.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/object-proto-getter-filtered.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        (i.Cocoa):
+        * stress/object-proto-getter-poly-mono-proto.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/object-proto-getter-poly-proto.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/object-prototype-proto-accessors-should-throw-on-undefined-this.js:
+        * stress/string-proto.js: Added.
+        (shouldBe):
+        (target):
+
+2017-10-17  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r223523.
+
+        A test for this change is failing on debug JSC bots.
+
+        Reverted changeset:
+
+        "[JSC] __proto__ getter should be fast"
+        https://bugs.webkit.org/show_bug.cgi?id=178067
+        https://trac.webkit.org/changeset/223523
+
+2017-10-10  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] __proto__ getter should be fast
+        https://bugs.webkit.org/show_bug.cgi?id=178067
+
+        Reviewed by Saam Barati.
+
+        * stress/dfg-object-proto-accessor.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        * stress/dfg-object-proto-getter.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        * stress/dfg-object-prototype-of.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        * stress/dfg-reflect-get-prototype-of.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        * stress/object-get-prototype-of-filtered.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        (i.Cocoa):
+        * stress/object-get-prototype-of-mono-proto.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/object-get-prototype-of-poly-mono-proto.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/object-get-prototype-of-poly-proto.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/object-proto-getter-filtered.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (target):
+        (i.Cocoa):
+        * stress/object-proto-getter-poly-mono-proto.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/object-proto-getter-poly-proto.js: Added.
+        (shouldBe):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (target):
+        * stress/object-prototype-proto-accessors-should-throw-on-undefined-this.js:
+        * stress/string-proto.js: Added.
+        (shouldBe):
+        (target):
+
+2017-10-14  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Reland "Add Above/Below comparisons for UInt32 patterns"
+        https://bugs.webkit.org/show_bug.cgi?id=177281
+
+        Reviewed by Saam Barati.
+
+        * stress/uint32-comparison-jump.js: Added.
+        (shouldBe):
+        (above):
+        (aboveOrEqual):
+        (below):
+        (belowOrEqual):
+        (notAbove):
+        (notAboveOrEqual):
+        (notBelow):
+        (notBelowOrEqual):
+        * stress/uint32-comparison.js: Added.
+        (shouldBe):
+        (above):
+        (aboveOrEqual):
+        (below):
+        (belowOrEqual):
+        (aboveTest):
+        (aboveOrEqualTest):
+        (belowTest):
+        (belowOrEqualTest):
+
+2017-10-12  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        WebAssembly: Wasm functions should have either JSFunctionType or TypeOfShouldCallGetCallData
+        https://bugs.webkit.org/show_bug.cgi?id=178210
+
+        Reviewed by Saam Barati.
+
+        * wasm/function-tests/trap-from-start-async.js:
+        (async.StartTrapsAsync):
+        * wasm/function-tests/trap-from-start.js:
+        (StartTraps):
+        * wasm/js-api/web-assembly-function.js:
+        (assert.eq.Object.getPrototypeOf):
+        * wasm/js-api/wrapper-function.js:
+        (return.new.WebAssembly.Module):
+        (assert.throws.makeInstance): Deleted.
+        (assert.throws.Bar): Deleted.
+        (assert.throws): Deleted.
+
+2017-09-29  Filip Pizlo  <fpizlo@apple.com>
+
+        Enable gigacage on iOS
+        https://bugs.webkit.org/show_bug.cgi?id=177586
+
+        Reviewed by JF Bastien.
+        
+        Add tests for when Gigacage gets runtime disabled.
+
+        * stress/disable-gigacage-arrays.js: Added.
+        (foo):
+        * stress/disable-gigacage-strings.js: Added.
+        (foo):
+        * stress/disable-gigacage-typed-arrays.js: Added.
+        (foo):
+
+2017-10-11  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        import.meta should not be assignable
+        https://bugs.webkit.org/show_bug.cgi?id=178202
+
+        Reviewed by Saam Barati.
+
+        * modules/import-meta-assignment.js: Added.
+        (shouldThrow):
+        (SyntaxError.import.meta.can.shouldThrow):
+
+2017-10-11  Saam Barati  <sbarati@apple.com>
+
+        Unreviewed. Actually skip certain type profiler tests in debug.
+
+        * typeProfiler.yaml:
+        * typeProfiler/deltablue-for-of.js:
+        * typeProfiler/getter-richards.js:
+
+2017-10-11  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r223113 and r223121.
+        https://bugs.webkit.org/show_bug.cgi?id=178182
+
+        Reintroduced 20% regression on Kraken (Requested by rniwa on
+        #webkit).
+
+        Reverted changesets:
+
+        "Enable gigacage on iOS"
+        https://bugs.webkit.org/show_bug.cgi?id=177586
+        https://trac.webkit.org/changeset/223113
+
+        "Use one virtual allocation for all gigacages and their
+        runways"
+        https://bugs.webkit.org/show_bug.cgi?id=178050
+        https://trac.webkit.org/changeset/223121
+
+2017-10-11  Michael Saboff  <msaboff@apple.com>
+
+        Disable test262 named capture group tests with direct unicode names and with references before definitions
+        https://bugs.webkit.org/show_bug.cgi?id=178177
+
+        Reviewed by Keith Miller.
+
+        Bugs to track fixing these test are:
+        https://bugs.webkit.org/show_bug.cgi?id=178174 -
+            "Add support in named capture group identifiers for direct surrogate pairs"
+        https://bugs.webkit.org/show_bug.cgi?id=178175 -
+            "Test262 failure with Named Capture Groups - using a reference before the group is defined"
+
+        * test262.yaml:
+
+2017-10-11  Caio Lima  <ticaiolima@gmail.com>
+
+        Object properties are undefined in super.call() but not in this.call()
+        https://bugs.webkit.org/show_bug.cgi?id=177230
+
+        Reviewed by Saam Barati.
+
+        * stress/super-call-function-subclass.js: Added.
+        (assert):
+        (A.prototype.t):
+        (A):
+        * stress/super-dot-call-and-apply.js: Added.
+        (assert):
+        (A):
+        (A.prototype.call):
+        (A.prototype.apply):
+        (B.prototype.testSuper):
+        (B):
+        (const.obj.new.B.string_appeared_here.obj.testSuper.C):
+        (D.prototype.testSuper):
+        (D):
+
+2017-10-10  Saam Barati  <sbarati@apple.com>
+
+        The prototype cache should be aware of the Executable it generates a Structure for
+        https://bugs.webkit.org/show_bug.cgi?id=177907
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/dont-confuse-structures-from-different-executable-as-poly-proto.js: Added.
+        (assert):
+        (foo.C):
+        (foo):
+        (bar.C):
+        (bar):
+        (access):
+        (makeLongChain):
+        (accessY):
+
+2017-10-09  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        `async` should be able to be used as an imported binding name
+        https://bugs.webkit.org/show_bug.cgi?id=176573
+
+        Reviewed by Saam Barati.
+
+        * modules/import-default-async.js: Added.
+        * modules/import-named-async-as.js: Added.
+        * modules/import-named-async.js: Added.
+        * modules/import-named-async/target.js: Added.
+        * modules/import-namespace-async.js: Added.
+        * test262.yaml:
+
+2017-09-29  Filip Pizlo  <fpizlo@apple.com>
+
+        Enable gigacage on iOS
+        https://bugs.webkit.org/show_bug.cgi?id=177586
+
+        Reviewed by JF Bastien.
+        
+        Add tests for when Gigacage gets runtime disabled.
+
+        * stress/disable-gigacage-arrays.js: Added.
+        (foo):
+        * stress/disable-gigacage-strings.js: Added.
+        (foo):
+        * stress/disable-gigacage-typed-arrays.js: Added.
+        (foo):
+
+2017-10-09  Michael Saboff  <msaboff@apple.com>
+
+        Implement RegExp Unicode property escapes
+        https://bugs.webkit.org/show_bug.cgi?id=172069
+
+        Reviewed by JF Bastien.
+
+        Enabled Unicode Property tests.
+
+        * test262.yaml:
+
+2017-10-09  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r223015 and r223025.
+        https://bugs.webkit.org/show_bug.cgi?id=178093
+
+        Regressed Kraken on iOS by 20% (Requested by keith_mi_ on
+        #webkit).
+
+        Reverted changesets:
+
+        "Enable gigacage on iOS"
+        https://bugs.webkit.org/show_bug.cgi?id=177586
+        http://trac.webkit.org/changeset/223015
+
+        "Unreviewed, disable Gigacage on ARM64 Linux"
+        https://bugs.webkit.org/show_bug.cgi?id=177586
+        http://trac.webkit.org/changeset/223025
+
+2017-10-09  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Update expectations for test262 tests that pass after r223043.
+        https://bugs.webkit.org/show_bug.cgi?id=176685
+
+        Unreviewed test gardening.
+
+        * test262.yaml:
+
+2017-10-09  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r223022.
+
+        This change introduced 18 test262 failures.
+
+        Reverted changeset:
+
+        "`async` should be able to be used as an imported binding
+        name"
+        https://bugs.webkit.org/show_bug.cgi?id=176573
+        http://trac.webkit.org/changeset/223022
+
+2017-10-09  Saam Barati  <sbarati@apple.com>
+
+        3 poly-proto JSC tests timing out on debug after r222827
+        https://bugs.webkit.org/show_bug.cgi?id=177880
+        <rdar://problem/34817122>
+
+        Unreviewed.
+
+        I'm skipping these type profiler tests on debug since they are long running.
+
+        * typeProfiler/deltablue-for-of.js:
+        * typeProfiler/getter-richards.js:
+
+2017-10-09  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        Safari 10 /11 problem with if (!await get(something)).
+        https://bugs.webkit.org/show_bug.cgi?id=176685
+
+        Reviewed by Saam Barati.
+
+        * stress/async-await-basic.js:
+        (awaitEpression.async):
+        * stress/async-await-syntax.js:
+        (testTopLevelAsyncAwaitSyntaxSloppyMode.testSyntax):
+        (prototype.testTopLevelAsyncAwaitSyntaxStrictMode):
+
+2017-10-08  Saam Barati  <sbarati@apple.com>
+
+        Unreviewed. Make some type profiler tests run for less time to avoid debug timeouts.
+
+        * typeProfiler/deltablue-for-of.js:
+        * typeProfiler/getter-richards.js:
+
+2017-10-07  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        `async` should be able to be used as an imported binding name
+        https://bugs.webkit.org/show_bug.cgi?id=176573
+
+        Reviewed by Darin Adler.
+
+        * modules/import-default-async.js: Added.
+        * modules/import-named-async-as.js: Added.
+        * modules/import-named-async.js: Added.
+        * modules/import-named-async/target.js: Added.
+        * modules/import-namespace-async.js: Added.
+
+2017-09-29  Filip Pizlo  <fpizlo@apple.com>
+
+        Enable gigacage on iOS
+        https://bugs.webkit.org/show_bug.cgi?id=177586
+
+        Reviewed by JF Bastien.
+        
+        Add tests for when Gigacage gets runtime disabled.
+
+        * stress/disable-gigacage-arrays.js: Added.
+        (foo):
+        * stress/disable-gigacage-strings.js: Added.
+        (foo):
+        * stress/disable-gigacage-typed-arrays.js: Added.
+        (foo):
+
+2017-10-06  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r222791 and r222873.
+        https://bugs.webkit.org/show_bug.cgi?id=178031
+
+        Caused crashes with workers/wasm LayoutTests (Requested by
+        ryanhaddad on #webkit).
+
+        Reverted changesets:
+
+        "WebAssembly: no VM / JS version of everything but Instance"
+        https://bugs.webkit.org/show_bug.cgi?id=177473
+        http://trac.webkit.org/changeset/222791
+
+        "WebAssembly: address no VM / JS follow-ups"
+        https://bugs.webkit.org/show_bug.cgi?id=177887
+        http://trac.webkit.org/changeset/222873
+
+2017-10-05  Saam Barati  <sbarati@apple.com>
+
+        Make sure all prototypes under poly proto get added into the VM's prototype map
+        https://bugs.webkit.org/show_bug.cgi?id=177909
+
+        Reviewed by Keith Miller.
+
+        * stress/poly-proto-prototype-map-having-a-bad-time.js: Added.
+        (assert):
+        (foo.C):
+        (foo):
+        (set x):
+
+2017-09-30  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Introduce import.meta
+        https://bugs.webkit.org/show_bug.cgi?id=177703
+
+        Reviewed by Filip Pizlo.
+
+        * modules/import-meta-syntax.js: Added.
+        (shouldThrow):
+        (shouldNotThrow):
+        * modules/import-meta.js: Added.
+        * modules/import-meta/cocoa.js: Added.
+        * modules/resources/assert.js:
+        (export.shouldNotThrow):
+        * stress/import-syntax.js:
+
+2017-10-04  Saam Barati  <sbarati@apple.com>
+
+        Make pertinent AccessCases watch the poly proto watchpoint
+        https://bugs.webkit.org/show_bug.cgi?id=177765
+
+        Reviewed by Keith Miller.
+
+        * microbenchmarks/poly-proto-and-non-poly-proto-same-ic.js: Added.
+        (assert):
+        (foo.C):
+        (foo):
+        (validate):
+        * stress/poly-proto-clear-stub.js: Added.
+        (assert):
+        (foo.C):
+        (foo):
+
+2017-10-04  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Remove failure expectation for async-func-decl-dstr-obj-id-put-unresolvable-no-strict.js.
+
+        Unreviewed test gardening.
+
+        * test262.yaml:
+
+2017-10-04  Saam Barati  <sbarati@apple.com>
+
+        3 poly-proto JSC tests timing out on debug after r222827
+        https://bugs.webkit.org/show_bug.cgi?id=177880
+
+        Rubber stamped by Mark Lam.
+
+        * microbenchmarks/poly-proto-access.js:
+        * typeProfiler/deltablue-for-of.js:
+        * typeProfiler/getter-richards.js:
+
+2017-10-04  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Unreviewed, marking tco-catch.js as a failure after test262 update
+        https://bugs.webkit.org/show_bug.cgi?id=177859
+
+        * test262.yaml:
+
+2017-10-04  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, marking one async iterator test262 test failed
+        https://bugs.webkit.org/show_bug.cgi?id=177859
+
+        * test262.yaml:
+
+2017-10-04  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [Test262] Update Test262 to Oct 4 version
+        https://bugs.webkit.org/show_bug.cgi?id=177859
+
+        Reviewed by Sam Weinig.
+
+        Let's rebaseline test262. Since it includes the latest changes to ArrayIterator::next,
+        we no longer need to mark it skip/fail. Also this update includes bunch of BigInt tests.
+
+        * test262.yaml:
+        * test262/harness/promiseHelper.js: Renamed from JSTests/test262/harness/PromiseHelper.js.
+        (checkSequence):
+        * test262/harness/typeCoercion.js:
+        (testCoercibleToIndexZero):
+        (testCoercibleToIndexOne):
+        (testCoercibleToIndexFromIndex):
+        (testNotCoercibleToIndex.testPrimitiveValue):
+        (testNotCoercibleToInteger):
+        (testCoercibleToBigIntZero.testPrimitiveValue):
+        (testCoercibleToBigIntZero):
+        (testCoercibleToBigIntOne.testPrimitiveValue):
+        (testCoercibleToBigIntOne):
+        (testPrimitiveValue):
+        (testCoercibleToBigIntFromBigInt):
+        (testNotCoercibleToBigInt.testPrimitiveValue):
+        (testNotCoercibleToBigInt.testStringValue):
+        (testNotCoercibleToBigInt):
+        * test262/test/built-ins/Array/from/proto-from-ctor-realm.js:
+        * test262/test/built-ins/Array/length/define-own-prop-length-overflow-realm.js:
+        * test262/test/built-ins/Array/of/proto-from-ctor-realm.js:
+        * test262/test/built-ins/Array/proto-from-ctor-realm.js:
+        * test262/test/built-ins/Array/prototype/concat/create-proto-from-ctor-realm-array.js:
+        * test262/test/built-ins/Array/prototype/concat/create-proto-from-ctor-realm-non-array.js:
+        * test262/test/built-ins/Array/prototype/filter/create-proto-from-ctor-realm-array.js:
+        * test262/test/built-ins/Array/prototype/filter/create-proto-from-ctor-realm-non-array.js:
+        * test262/test/built-ins/Array/prototype/map/create-proto-from-ctor-realm-array.js:
+        * test262/test/built-ins/Array/prototype/map/create-proto-from-ctor-realm-non-array.js:
+        * test262/test/built-ins/Array/prototype/slice/create-proto-from-ctor-realm-array.js:
+        * test262/test/built-ins/Array/prototype/slice/create-proto-from-ctor-realm-non-array.js:
+        * test262/test/built-ins/Array/prototype/splice/create-proto-from-ctor-realm-array.js:
+        * test262/test/built-ins/Array/prototype/splice/create-proto-from-ctor-realm-non-array.js:
+        * test262/test/built-ins/ArrayBuffer/proto-from-ctor-realm.js:
+        * test262/test/built-ins/BigInt/asIntN/bigint-tobigint.js:
+        (testCoercibleToBigIntZero):
+        (testCoercibleToBigIntOne):
+        (testNotCoercibleToBigInt):
+        (MyError): Deleted.
+        (valueOf): Deleted.
+        (toString): Deleted.
+        (Symbol.toPrimitive): Deleted.
+        * test262/test/built-ins/BigInt/asIntN/bits-toindex.js:
+        (testCoercibleToIndexZero):
+        (testCoercibleToIndexOne):
+        (testNotCoercibleToIndex):
+        (MyError): Deleted.
+        (assert.sameValue.BigInt.asIntN.valueOf): Deleted.
+        (assert.sameValue.BigInt.asIntN.toString): Deleted.
+        (BigInt.asIntN.Symbol.toPrimitive): Deleted.
+        (BigInt.asIntN.valueOf): Deleted.
+        (BigInt.asIntN.toString): Deleted.
+        * test262/test/built-ins/BigInt/asUintN/arithmetic.js: Added.
+        * test262/test/built-ins/BigInt/asUintN/asUintN.js: Added.
+        * test262/test/built-ins/BigInt/asUintN/bigint-tobigint.js: Added.
+        (testCoercibleToBigIntZero):
+        (testCoercibleToBigIntOne):
+        (testNotCoercibleToBigInt):
+        * test262/test/built-ins/BigInt/asUintN/bits-toindex.js: Added.
+        (testCoercibleToIndexZero):
+        (testCoercibleToIndexOne):
+        (testNotCoercibleToIndex):
+        * test262/test/built-ins/BigInt/asUintN/length.js: Added.
+        * test262/test/built-ins/BigInt/asUintN/name.js: Added.
+        * test262/test/built-ins/BigInt/asUintN/order-of-steps.js: Added.
+        (bits.valueOf):
+        (bigint.valueOf):
+        * test262/test/built-ins/BigInt/prototype/valueOf/length.js: Added.
+        * test262/test/built-ins/BigInt/prototype/valueOf/name.js: Added.
+        * test262/test/built-ins/BigInt/prototype/valueOf/prop-desc.js: Added.
+        * test262/test/built-ins/BigInt/prototype/valueOf/return.js: Added.
+        * test262/test/built-ins/BigInt/prototype/valueOf/this-value-invalid-object-throws.js: Added.
+        * test262/test/built-ins/BigInt/prototype/valueOf/this-value-invalid-primitive-throws.js: Added.
+        * test262/test/built-ins/Boolean/proto-from-ctor-realm.js:
+        * test262/test/built-ins/DataView/proto-from-ctor-realm-sab.js:
+        * test262/test/built-ins/DataView/proto-from-ctor-realm.js:
+        * test262/test/built-ins/Date/proto-from-ctor-realm-one.js:
+        * test262/test/built-ins/Date/proto-from-ctor-realm-two.js:
+        * test262/test/built-ins/Date/proto-from-ctor-realm-zero.js:
+        * test262/test/built-ins/Error/proto-from-ctor-realm.js:
+        * test262/test/built-ins/Function/call-bind-this-realm-undef.js:
+        * test262/test/built-ins/Function/call-bind-this-realm-value.js:
+        * test262/test/built-ins/Function/internals/Call/class-ctor-realm.js:
+        * test262/test/built-ins/Function/internals/Construct/base-ctor-revoked-proxy-realm.js:
+        * test262/test/built-ins/Function/internals/Construct/derived-return-val-realm.js:
+        * test262/test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js:
+        * test262/test/built-ins/Function/proto-from-ctor-realm.js:
+        * test262/test/built-ins/Function/prototype/bind/get-fn-realm.js:
+        * test262/test/built-ins/Function/prototype/bind/proto-from-ctor-realm.js:
+        * test262/test/built-ins/GeneratorFunction/proto-from-ctor-realm.js:
+        * test262/test/built-ins/JSON/stringify/bigint-order.js: Added.
+        (replacer):
+        (BigInt.prototype.toJSON):
+        * test262/test/built-ins/JSON/stringify/bigint-replacer.js: Added.
+        (replacer):
+        * test262/test/built-ins/JSON/stringify/bigint-tojson.js: Added.
+        (BigInt.prototype.toJSON):
+        * test262/test/built-ins/JSON/stringify/bigint.js:
+        * test262/test/built-ins/Map/proto-from-ctor-realm.js:
+        * test262/test/built-ins/Number/S9.3.1_A2_U180E.js:
+        * test262/test/built-ins/Number/S9.3.1_A3_T1_U180E.js:
+        * test262/test/built-ins/Number/S9.3.1_A3_T2_U180E.js:
+        * test262/test/built-ins/Number/proto-from-ctor-realm.js:
+        * test262/test/built-ins/Object/proto-from-ctor.js:
+        * test262/test/built-ins/Promise/proto-from-ctor-realm.js:
+        * test262/test/built-ins/Proxy/apply/arguments-realm.js:
+        * test262/test/built-ins/Proxy/apply/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/construct/arguments-realm.js:
+        * test262/test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/construct/trap-is-undefined-proto-from-ctor-realm.js:
+        * test262/test/built-ins/Proxy/defineProperty/desc-realm.js:
+        * test262/test/built-ins/Proxy/defineProperty/null-handler-realm.js:
+        * test262/test/built-ins/Proxy/defineProperty/targetdesc-configurable-desc-not-configurable-realm.js:
+        * test262/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-not-configurable-target-realm.js:
+        * test262/test/built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-realm.js:
+        * test262/test/built-ins/Proxy/defineProperty/targetdesc-undefined-not-configurable-descriptor-realm.js:
+        * test262/test/built-ins/Proxy/defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js:
+        * test262/test/built-ins/Proxy/defineProperty/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/deleteProperty/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/get-fn-realm.js:
+        * test262/test/built-ins/Proxy/get/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/getOwnPropertyDescriptor/result-type-is-not-object-nor-undefined-realm.js:
+        * test262/test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/getPrototypeOf/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/has/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/isExtensible/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/ownKeys/return-not-list-object-throws-realm.js:
+        * test262/test/built-ins/Proxy/ownKeys/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/preventExtensions/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/set/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/Proxy/setPrototypeOf/trap-is-not-callable-realm.js:
+        * test262/test/built-ins/RegExp/S15.10.2.12_A1_T1.js:
+        (i6.replace):
+        (i6b.replace):
+        * test262/test/built-ins/RegExp/dotall/with-dotall-unicode.js:
+        * test262/test/built-ins/RegExp/dotall/with-dotall.js:
+        * test262/test/built-ins/RegExp/dotall/without-dotall-unicode.js:
+        * test262/test/built-ins/RegExp/dotall/without-dotall.js:
+        * test262/test/built-ins/RegExp/proto-from-ctor-realm.js:
+        * test262/test/built-ins/RegExp/prototype/Symbol.split/splitter-proto-from-ctor-realm.js:
+        * test262/test/built-ins/RegExp/u180e.js: Added.
+        * test262/test/built-ins/Set/proto-from-ctor-realm.js:
+        * test262/test/built-ins/SharedArrayBuffer/proto-from-ctor-realm.js:
+        * test262/test/built-ins/String/proto-from-ctor-realm.js:
+        * test262/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Fail.js:
+        * test262/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Fail_2.js:
+        * test262/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success.js:
+        * test262/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_2.js:
+        * test262/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_3.js:
+        * test262/test/built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_4.js:
+        * test262/test/built-ins/String/prototype/endsWith/coerced-values-of-position.js:
+        * test262/test/built-ins/String/prototype/endsWith/endsWith.js:
+        * test262/test/built-ins/String/prototype/endsWith/length.js:
+        * test262/test/built-ins/String/prototype/endsWith/name.js:
+        * test262/test/built-ins/String/prototype/endsWith/return-abrupt-from-position-as-symbol.js:
+        * test262/test/built-ins/String/prototype/endsWith/return-abrupt-from-position.js:
+        * test262/test/built-ins/String/prototype/endsWith/return-abrupt-from-searchstring-as-symbol.js:
+        * test262/test/built-ins/String/prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js:
+        * test262/test/built-ins/String/prototype/endsWith/return-abrupt-from-searchstring.js:
+        * test262/test/built-ins/String/prototype/endsWith/return-abrupt-from-this-as-symbol.js:
+        * test262/test/built-ins/String/prototype/endsWith/return-abrupt-from-this.js:
+        * test262/test/built-ins/String/prototype/endsWith/return-false-if-search-start-is-less-than-zero.js:
+        * test262/test/built-ins/String/prototype/endsWith/return-true-if-searchstring-is-empty.js:
+        * test262/test/built-ins/String/prototype/endsWith/searchstring-found-with-position.js:
+        * test262/test/built-ins/String/prototype/endsWith/searchstring-found-without-position.js:
+        * test262/test/built-ins/String/prototype/endsWith/searchstring-is-regexp-throws.js:
+        * test262/test/built-ins/String/prototype/endsWith/searchstring-not-found-with-position.js:
+        * test262/test/built-ins/String/prototype/endsWith/searchstring-not-found-without-position.js:
+        * test262/test/built-ins/String/prototype/endsWith/this-is-null-throws.js:
+        * test262/test/built-ins/String/prototype/endsWith/this-is-undefined-throws.js:
+        * test262/test/built-ins/String/prototype/includes/String.prototype.includes_FailBadLocation.js:
+        * test262/test/built-ins/String/prototype/includes/String.prototype.includes_FailLocation.js:
+        * test262/test/built-ins/String/prototype/includes/String.prototype.includes_FailMissingLetter.js:
+        * test262/test/built-ins/String/prototype/includes/String.prototype.includes_Success.js:
+        * test262/test/built-ins/String/prototype/includes/String.prototype.includes_SuccessNoLocation.js:
+        * test262/test/built-ins/String/prototype/includes/String.prototype.includes_lengthProp.js:
+        * test262/test/built-ins/String/prototype/includes/coerced-values-of-position.js:
+        * test262/test/built-ins/String/prototype/includes/includes.js:
+        * test262/test/built-ins/String/prototype/includes/length.js:
+        * test262/test/built-ins/String/prototype/includes/name.js:
+        * test262/test/built-ins/String/prototype/includes/return-abrupt-from-position-as-symbol.js:
+        * test262/test/built-ins/String/prototype/includes/return-abrupt-from-position.js:
+        * test262/test/built-ins/String/prototype/includes/return-abrupt-from-searchstring-as-symbol.js:
+        * test262/test/built-ins/String/prototype/includes/return-abrupt-from-searchstring-regexp-test.js:
+        * test262/test/built-ins/String/prototype/includes/return-abrupt-from-searchstring.js:
+        * test262/test/built-ins/String/prototype/includes/return-abrupt-from-this-as-symbol.js:
+        * test262/test/built-ins/String/prototype/includes/return-abrupt-from-this.js:
+        * test262/test/built-ins/String/prototype/includes/return-false-with-out-of-bounds-position.js:
+        * test262/test/built-ins/String/prototype/includes/return-true-if-searchstring-is-empty.js:
+        * test262/test/built-ins/String/prototype/includes/searchstring-found-with-position.js:
+        * test262/test/built-ins/String/prototype/includes/searchstring-found-without-position.js:
+        * test262/test/built-ins/String/prototype/includes/searchstring-is-regexp-throws.js:
+        * test262/test/built-ins/String/prototype/includes/searchstring-not-found-with-position.js:
+        * test262/test/built-ins/String/prototype/includes/searchstring-not-found-without-position.js:
+        * test262/test/built-ins/String/prototype/includes/this-is-null-throws.js:
+        * test262/test/built-ins/String/prototype/includes/this-is-undefined-throws.js:
+        * test262/test/built-ins/String/prototype/toLocaleLowerCase/Final_Sigma_U180E.js:
+        * test262/test/built-ins/String/prototype/toLowerCase/Final_Sigma_U180E.js:
+        * test262/test/built-ins/String/prototype/trim/u180e.js:
+        * test262/test/built-ins/Symbol/for/cross-realm.js:
+        * test262/test/built-ins/Symbol/hasInstance/cross-realm.js:
+        * test262/test/built-ins/Symbol/isConcatSpreadable/cross-realm.js:
+        * test262/test/built-ins/Symbol/iterator/cross-realm.js:
+        * test262/test/built-ins/Symbol/keyFor/cross-realm.js:
+        * test262/test/built-ins/Symbol/match/cross-realm.js:
+        * test262/test/built-ins/Symbol/replace/cross-realm.js:
+        * test262/test/built-ins/Symbol/search/cross-realm.js:
+        * test262/test/built-ins/Symbol/species/cross-realm.js:
+        * test262/test/built-ins/Symbol/split/cross-realm.js:
+        * test262/test/built-ins/Symbol/toPrimitive/cross-realm.js:
+        * test262/test/built-ins/Symbol/toStringTag/cross-realm.js:
+        * test262/test/built-ins/Symbol/unscopables/cross-realm.js:
+        * test262/test/built-ins/ThrowTypeError/distinct-cross-realm.js:
+        * test262/test/built-ins/TypedArrays/buffer-arg-proto-from-ctor-realm-sab.js:
+        * test262/test/built-ins/TypedArrays/buffer-arg-proto-from-ctor-realm.js:
+        * test262/test/built-ins/TypedArrays/internals/DefineOwnProperty/detached-buffer-realm.js:
+        * test262/test/built-ins/TypedArrays/internals/Get/detached-buffer-realm.js:
+        * test262/test/built-ins/TypedArrays/internals/GetOwnProperty/detached-buffer-realm.js:
+        * test262/test/built-ins/TypedArrays/internals/HasProperty/detached-buffer-realm.js:
+        * test262/test/built-ins/TypedArrays/internals/Set/detached-buffer-realm.js:
+        * test262/test/built-ins/TypedArrays/length-arg-proto-from-ctor-realm.js:
+        * test262/test/built-ins/TypedArrays/no-args-proto-from-ctor-realm.js:
+        * test262/test/built-ins/TypedArrays/object-arg-proto-from-ctor-realm.js:
+        * test262/test/built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js:
+        * test262/test/built-ins/TypedArrays/typedarray-arg-proto-from-ctor-realm.js:
+        * test262/test/built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js:
+        * test262/test/built-ins/WeakMap/proto-from-ctor-realm.js:
+        * test262/test/built-ins/WeakSet/proto-from-ctor-realm.js:
+        * test262/test/built-ins/parseFloat/S15.1.2.3_A2_T10_U180E.js:
+        * test262/test/built-ins/parseInt/S15.1.2.2_A2_T10_U180E.js:
+        * test262/test/intl402/NumberFormat/prototype/formatToParts/length.js:
+        * test262/test/language/comments/mongolian-vowel-separator-multi.js:
+        * test262/test/language/comments/mongolian-vowel-separator-single-eval.js:
+        * test262/test/language/comments/mongolian-vowel-separator-single.js:
+        * test262/test/language/eval-code/indirect/realm.js:
+        * test262/test/language/expressions/assignment/dstr-obj-rest-order.js: Added.
+        (o.get z):
+        (o.get a):
+        * test262/test/language/expressions/call/eval-realm-indirect.js:
+        * test262/test/language/expressions/generators/eval-body-proto-realm.js:
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-bigint.js: Added.
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-non-finite.js: Added.
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-number-extremes.js: Added.
+        * test262/test/language/expressions/greater-than-or-equal/bigint-and-number.js:
+        * test262/test/language/expressions/greater-than/bigint-and-bigint.js: Added.
+        * test262/test/language/expressions/greater-than/bigint-and-non-finite.js: Added.
+        * test262/test/language/expressions/greater-than/bigint-and-number-extremes.js: Added.
+        * test262/test/language/expressions/greater-than/bigint-and-number.js:
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-bigint.js: Added.
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-non-finite.js: Added.
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-number-extremes.js: Added.
+        * test262/test/language/expressions/less-than-or-equal/bigint-and-number.js:
+        * test262/test/language/expressions/less-than/bigint-and-bigint.js: Added.
+        * test262/test/language/expressions/less-than/bigint-and-non-finite.js: Added.
+        * test262/test/language/expressions/less-than/bigint-and-number-extremes.js: Added.
+        * test262/test/language/expressions/less-than/bigint-and-number.js:
+        * test262/test/language/expressions/new/non-ctor-err-realm.js:
+        * test262/test/language/expressions/super/realm.js:
+        * test262/test/language/expressions/tagged-template/cache-realm.js:
+        * test262/test/language/expressions/template-literal/mongolian-vowel-separator-eval.js:
+        * test262/test/language/expressions/template-literal/mongolian-vowel-separator.js:
+        * test262/test/language/literals/regexp/mongolian-vowel-separator-eval.js:
+        * test262/test/language/literals/regexp/mongolian-vowel-separator.js:
+        * test262/test/language/literals/string/mongolian-vowel-separator-eval.js:
+        * test262/test/language/literals/string/mongolian-vowel-separator.js:
+        * test262/test/language/statements/for-of/dstr-obj-rest-order.js: Added.
+        (o.get z):
+        (o.get a):
+        * test262/test/language/statements/for-of/iterator-next-reference.js:
+        (next):
+        (iterator.next): Deleted.
+        (x.of.iterable.): Deleted.
+        (x.of.iterable.get return): Deleted.
+        (x.of.iterable.iterator.next): Deleted.
+        * test262/test/language/types/reference/get-value-prop-base-primitive-realm.js:
+        * test262/test/language/types/reference/put-value-prop-base-primitive-realm.js:
+        * test262/test/language/white-space/mongolian-vowel-separator-eval.js:
+        * test262/test/language/white-space/mongolian-vowel-separator.js:
+        * test262/test262-Revision.txt:
+
+2017-10-03  Saam Barati  <sbarati@apple.com>
+
+        Implement polymorphic prototypes
+        https://bugs.webkit.org/show_bug.cgi?id=176391
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/poly-proto-access.js: Added.
+        (assert):
+        (foo.C):
+        (foo.C.prototype.get bar):
+        (foo):
+        (bar):
+        * microbenchmarks/poly-proto-put-transition-speed.js: Added.
+        (assert):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (performSet):
+        * microbenchmarks/poly-proto-setter-speed.js: Added.
+        (assert):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo.C.prototype.set p):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (performSet):
+        * stress/constructor-with-return.js:
+        (i.tests.forEach.Constructor):
+        (i.tests.forEach):
+        (tests.forEach.Constructor): Deleted.
+        (tests.forEach): Deleted.
+        * stress/dom-jit-with-poly-proto.js: Added.
+        (assert):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (validate):
+        * stress/poly-proto-custom-value-and-accessor.js: Added.
+        (assert):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (items.forEach):
+        (set get for):
+        * stress/poly-proto-intrinsic-getter-correctness.js: Added.
+        (assert):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (foo):
+        * stress/poly-proto-miss.js: Added.
+        (makePolyProtoInstanceWithNullPrototype.foo.C):
+        (makePolyProtoInstanceWithNullPrototype.foo):
+        (makePolyProtoInstanceWithNullPrototype):
+        (assert):
+        (validate):
+        * stress/poly-proto-op-in-caching.js: Added.
+        (assert):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (validate):
+        (validate2):
+        * stress/poly-proto-put-transition.js: Added.
+        (assert):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (performSet):
+        (i.obj.__proto__.set p):
+        * stress/poly-proto-set-prototype.js: Added.
+        (assert):
+        (let.alternateProto.get x):
+        (let.alternateProto2.get y):
+        (let.alternateProto2.get x):
+        (foo.C):
+        (foo):
+        (validate):
+        * stress/poly-proto-setter.js: Added.
+        (assert):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo.C.prototype.set p):
+        (makePolyProtoObject.foo.C.prototype.get p):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (performSet):
+        * stress/poly-proto-using-inheritance.js: Added.
+        (assert):
+        (foo.C):
+        (foo.C.prototype.get baz):
+        (foo):
+        (bar.C):
+        (bar):
+        (validate):
+        * stress/primitive-poly-proto.js: Added.
+        (makePolyProtoInstance.foo.C):
+        (makePolyProtoInstance.foo):
+        (makePolyProtoInstance):
+        (assert):
+        (validate):
+        * stress/prototype-is-not-js-object.js: Added.
+        (foo.bar):
+        (foo):
+        (assert):
+        (validate):
+        * stress/try-get-by-id-poly-proto.js: Added.
+        (assert):
+        (makePolyProtoObject.foo.C):
+        (makePolyProtoObject.foo):
+        (makePolyProtoObject):
+        (tryGetByIdText):
+        (x.__proto__.get bar):
+        (validate):
+        * typeProfiler/overflow.js:
+
+2017-10-03  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: no VM / JS version of everything but Instance
+        https://bugs.webkit.org/show_bug.cgi?id=177473
+
+        Reviewed by Filip Pizlo.
+
+        - Exceeding max on memory growth now returns a range error as per
+        spec. This is a (very minor) breaking change: it used to throw OOM
+        error. Update the corresponding test.
+
+        * wasm/js-api/memory-grow.js:
+        (assertEq):
+        * wasm/js-api/table.js:
+        (assert.throws):
+
+2017-10-03  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip JSC test stress/regress-159779-2.js on debug.
+        https://bugs.webkit.org/show_bug.cgi?id=177204
+
+        Unreviewed test gardening.
+
+        * stress/regress-159779-2.js:
+
+2017-10-02  Caio Lima  <ticaiolima@gmail.com>
+
+        ChakraCore/test/Function/apply3.js is resulting wrong result in x86_64
+        https://bugs.webkit.org/show_bug.cgi?id=175642
+
+        Reviewed by Darin Adler.
+
+        * ChakraCore/test/Function/apply3.baseline-jsc:
+
+2017-10-01  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r222564.
+        https://bugs.webkit.org/show_bug.cgi?id=177720
+
+        "It regressed JetStream by 2% on iOS caused by a 50%
+        regression on the bigfib subtest" (Requested by saamyjoon on
+        #webkit).
+
+        Reverted changeset:
+
+        "Add Above/Below comparisons for UInt32 patterns"
+        https://bugs.webkit.org/show_bug.cgi?id=177281
+        http://trac.webkit.org/changeset/222564
+
+2017-09-29  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Support ArrayPush with multiple args
+        https://bugs.webkit.org/show_bug.cgi?id=175823
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/array-push-0.js: Added.
+        (arrayPush0):
+        * microbenchmarks/array-push-1.js: Added.
+        (arrayPush1):
+        * microbenchmarks/array-push-2.js: Added.
+        (arrayPush2):
+        * microbenchmarks/array-push-3.js: Added.
+        (arrayPush3):
+        * stress/array-push-multiple-contiguous.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-double-nan.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-double.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-int32.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-many-contiguous.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-many-double.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-many-int32.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-many-storage.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-storage.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-with-force-exit.js: Added.
+        (target.createBuiltin):
+
+2017-09-29  Saam Barati  <sbarati@apple.com>
+
+        Custom GetterSetterAccessCase does not use the correct slotBase when making call
+        https://bugs.webkit.org/show_bug.cgi?id=177639
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/custom-get-set-inline-caching-one-level-up-proto-chain.js: Added.
+        (assert):
+        (Class):
+        (items.forEach):
+        (set get for):
+
+2017-09-29  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r222563, r222565, and r222581.
+        https://bugs.webkit.org/show_bug.cgi?id=177675
+
+        "It causes a crash when playing youtube videos" (Requested by
+        saamyjoon on #webkit).
+
+        Reverted changesets:
+
+        "[DFG] Support ArrayPush with multiple args"
+        https://bugs.webkit.org/show_bug.cgi?id=175823
+        http://trac.webkit.org/changeset/222563
+
+        "Unreviewed, build fix after r222563"
+        https://bugs.webkit.org/show_bug.cgi?id=175823
+        http://trac.webkit.org/changeset/222565
+
+        "Unreviewed, fix x86 breaking due to exhausted registers"
+        https://bugs.webkit.org/show_bug.cgi?id=175823
+        http://trac.webkit.org/changeset/222581
+
+2017-09-28  Mark Lam  <mark.lam@apple.com>
+
+        test262: Unexpected passes after r222617 and r222618.
+        https://bugs.webkit.org/show_bug.cgi?id=177622
+        <rdar://problem/34725960>
+
+        Reviewed by Saam Barati.
+
+        Update test262.yaml for tests that are now passing.
+
+        * test262.yaml:
+
+2017-09-27  Michael Saboff  <msaboff@apple.com>
+
+        REGRESSION(210837): RegExp containing failed non-zero minimum greedy groups incorrectly match
+        https://bugs.webkit.org/show_bug.cgi?id=177570
+
+        Reviewed by Filip Pizlo.
+
+        New regression test.
+
+        * stress/regress-177570.js: Added.
+
+2017-09-28  Michael Saboff  <msaboff@apple.com>
+
+        Heap out of bounds read in JSC::Yarr::Parser<JSC::Yarr::SyntaxChecker, unsigned char>::peek()
+        https://bugs.webkit.org/show_bug.cgi?id=177423
+
+        Reviewed by Mark Lam.
+
+        Updated regression test.
+
+        * stress/regress-177423.js:
+        (catch):
+
+2017-09-27  Mark Lam  <mark.lam@apple.com>
+
+        JSArray::canFastCopy() should fail if the source and destination arrays are the same.
+        https://bugs.webkit.org/show_bug.cgi?id=177584
+        <rdar://problem/34463903>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-177584.js: Added.
+        (assertEqual):
+        (Array.prototype.Symbol.species):
+
+2017-09-27  Saam Barati  <sbarati@apple.com>
+
+        Propagate hasBeenFlattenedBefore in Structure's transition constructor and fix our for-in caching to fail when the prototype chain has an object with a dictionary structure
+        https://bugs.webkit.org/show_bug.cgi?id=177523
+
+        Reviewed by Mark Lam.
+
+        * stress/prototype-chain-has-dictionary-structure-for-in-caching.js: Added.
+        (assert):
+        (Test):
+        (addMethods.Test.prototype.string_appeared_here.i.methodNumber):
+        (addMethods):
+        (i.Test.prototype.propName):
+
+2017-09-27  Mark Lam  <mark.lam@apple.com>
+
+        Yarr::Parser::tryConsumeGroupName() should check for the end of the pattern.
+        https://bugs.webkit.org/show_bug.cgi?id=177423
+        <rdar://problem/34621320>
+
+        Reviewed by Keith Miller.
+
+        * stress/regress-177423.js: Added.
+
+2017-09-27  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Add Above/Below comparisons for UInt32 patterns
+        https://bugs.webkit.org/show_bug.cgi?id=177281
+
+        Reviewed by Saam Barati.
+
+        * stress/uint32-comparison-jump.js: Added.
+        (shouldBe):
+        (above):
+        (aboveOrEqual):
+        (below):
+        (belowOrEqual):
+        (notAbove):
+        (notAboveOrEqual):
+        (notBelow):
+        (notBelowOrEqual):
+        * stress/uint32-comparison.js: Added.
+        (shouldBe):
+        (above):
+        (aboveOrEqual):
+        (below):
+        (belowOrEqual):
+        (aboveTest):
+        (aboveOrEqualTest):
+        (belowTest):
+        (belowOrEqualTest):
+
+2017-09-25  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Support ArrayPush with multiple args
+        https://bugs.webkit.org/show_bug.cgi?id=175823
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/array-push-0.js: Added.
+        (arrayPush0):
+        * microbenchmarks/array-push-1.js: Added.
+        (arrayPush1):
+        * microbenchmarks/array-push-2.js: Added.
+        (arrayPush2):
+        * microbenchmarks/array-push-3.js: Added.
+        (arrayPush3):
+        * stress/array-push-multiple-contiguous.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-double-nan.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-double.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-int32.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-many-contiguous.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-many-double.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-many-int32.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-many-storage.js: Added.
+        (shouldBe):
+        (test):
+        * stress/array-push-multiple-storage.js: Added.
+        (shouldBe):
+        (test):
+
+2017-09-26  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r222518.
+        https://bugs.webkit.org/show_bug.cgi?id=177507
+
+        Break the High Sierra build (Requested by yusukesuzuki on
+        #webkit).
+
+        Reverted changeset:
+
+        "Add Above/Below comparisons for UInt32 patterns"
+        https://bugs.webkit.org/show_bug.cgi?id=177281
+        http://trac.webkit.org/changeset/222518
+
+2017-09-26  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Add Above/Below comparisons for UInt32 patterns
+        https://bugs.webkit.org/show_bug.cgi?id=177281
+
+        Reviewed by Saam Barati.
+
+        * stress/uint32-comparison-jump.js: Added.
+        (shouldBe):
+        (above):
+        (aboveOrEqual):
+        (below):
+        (belowOrEqual):
+        (notAbove):
+        (notAboveOrEqual):
+        (notBelow):
+        (notBelowOrEqual):
+        * stress/uint32-comparison.js: Added.
+        (shouldBe):
+        (above):
+        (aboveOrEqual):
+        (below):
+        (belowOrEqual):
+        (aboveTest):
+        (aboveOrEqualTest):
+        (belowTest):
+        (belowOrEqualTest):
+
+2017-09-23  Keith Miller  <keith_miller@apple.com>
+
+        Fix infinite looping test262 test
+        https://bugs.webkit.org/show_bug.cgi?id=177412
+
+        Reviewed by Yusuke Suzuki.
+
+        This test was poorly designed since failing it would cause the vm
+        to inifinite loop. I've fixed it locally and will fix it on github pending
+        the results of next weeks tc39 meeting.
+
+        * test262.yaml:
+        * test262/test/language/statements/for-of/iterator-next-reference.js:
+
+2017-09-23  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: $.agent became $262.agent in test262 update
+        https://bugs.webkit.org/show_bug.cgi?id=177407
+
+        Reviewed by Yusuke Suzuki.
+
+        * test262.yaml:
+        ~320 tests pass now that we correctly make $262 available.
+
+2017-09-22  Keith Miller  <keith_miller@apple.com>
+
+        Speculatively change iteration protocall to use the same next function
+        https://bugs.webkit.org/show_bug.cgi?id=175653
+
+        Reviewed by Saam Barati.
+
+        Change test to match the new iteration behavior.
+
+        * stress/spread-optimized-properly.js:
+
+2017-09-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Profile array vector length for array allocation
+        https://bugs.webkit.org/show_bug.cgi?id=177051
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/new-array-buffer-vector-profile.js: Added.
+        (target):
+
+2017-09-22  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r222380.
+        https://bugs.webkit.org/show_bug.cgi?id=177352
+
+        Octane/box2d shows 8% regression (Requested by yusukesuzuki on
+        #webkit).
+
+        Reverted changeset:
+
+        "[DFG][FTL] Profile array vector length for array allocation"
+        https://bugs.webkit.org/show_bug.cgi?id=177051
+        http://trac.webkit.org/changeset/222380
+
+2017-09-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Profile array vector length for array allocation
+        https://bugs.webkit.org/show_bug.cgi?id=177051
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/new-array-buffer-vector-profile.js: Added.
+        (target):
+
+2017-09-21  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Skip new hanging test262 tests.
+        https://bugs.webkit.org/show_bug.cgi?id=177326
+
+        Unreviewed test gardening.
+
+        * test262.yaml:
+
+2017-09-21  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Mark 6 test262 tests as passing.
+        https://bugs.webkit.org/show_bug.cgi?id=177307
+
+        Unreviewed test gardening.
+
+        * test262.yaml:
+
+2017-09-20  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Unreviewed follow-up to r222311.
+
+        * test262/harness/sta.js:
+        * test262/test/built-ins/Array/from/calling-from-valid-1-noStrict.js:
+        * test262/test/built-ins/Array/from/calling-from-valid-1-onlyStrict.js:
+        * test262/test/built-ins/Array/from/calling-from-valid-2.js:
+        * test262/test/built-ins/Array/from/elements-added-after.js:
+        * test262/test/built-ins/Array/from/elements-deleted-after.js:
+        * test262/test/built-ins/Array/from/elements-updated-after.js:
+        * test262/test/built-ins/Array/from/from-array.js:
+        * test262/test/built-ins/Array/from/mapfn-is-not-callable-typeerror.js:
+        * test262/test/built-ins/Array/from/mapfn-throws-exception.js:
+        * test262/test/built-ins/Array/from/source-array-boundary.js:
+        * test262/test/built-ins/Array/from/source-object-constructor.js:
+        * test262/test/built-ins/Array/from/source-object-iterator-1.js:
+        * test262/test/built-ins/Array/from/source-object-iterator-2.js:
+        * test262/test/built-ins/Array/from/source-object-length.js:
+        * test262/test/built-ins/Array/from/source-object-missing.js:
+        * test262/test/built-ins/Array/from/source-object-without.js:
+        * test262/test/built-ins/Array/from/this-null.js:
+        * test262/test/built-ins/Function/prototype/toString/line-terminator-normalisation-CR.js:
+        * test262/test/language/line-terminators/S7.3_A3.2_T1.js:
+        * test262/test/language/literals/numeric/7.8.3-1gs.js:
+        * test262/test/language/literals/numeric/7.8.3-2gs.js:
+        * test262/test/language/literals/numeric/7.8.3-3gs.js:
+        * test262/test/language/literals/regexp/7.8.5-1gs.js:
+        * test262/test/language/literals/string/7.8.4-1gs.js:
+        Fix some files that I failed to update when I applied my patch.
+
+2017-09-20  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Update test262 tests
+        https://bugs.webkit.org/show_bug.cgi?id=177220
+
+        Reviewed by Saam Barati and Yusuke Suzuki.
+
+        * test262.yaml:
+        * test262/test262-Revision.txt:
+        New rebaselined expectations for all tests.
+
+        * test262/*:
+        Updated.
+
+2017-09-17  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Remove ToThis more aggressively
+        https://bugs.webkit.org/show_bug.cgi?id=177056
+
+        Reviewed by Saam Barati.
+
+        * stress/generator-with-this-strict.js: Added.
+        (shouldBe):
+        (generator):
+        (target):
+        * stress/generator-with-this.js: Added.
+        (shouldBe):
+        (generator):
+        (target):
+
+2017-09-17  Michael Saboff  <msaboff@apple.com>
+
+        https://bugs.webkit.org/show_bug.cgi?id=177038
+        Add an option to run-jsc-stress-tests to limit tests variations to a basic set
+
+        Reviewed by JF Bastien.
+
+        * stress/unshiftCountSlowCase-correct-postCapacity.js: Disabled this test on ARM64 iOS devices
+        as it dies using too much memory.
+
+2017-09-15  Saam Barati  <sbarati@apple.com>
+
+        Arity fixup during inlining should do a 2 phase commit so it properly recovers the frame in case of exit
+        https://bugs.webkit.org/show_bug.cgi?id=176981
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/exit-during-inlined-arity-fixup-recover-proper-frame.js: Added.
+        (assert):
+        (verify):
+        (func):
+        (const.bar.createBuiltin):
+
+2017-09-14  Saam Barati  <sbarati@apple.com>
+
+        It should be valid to exit before each set when doing arity fixup when inlining
+        https://bugs.webkit.org/show_bug.cgi?id=176948
+
+        Reviewed by Keith Miller.
+
+        * stress/arity-fixup-inlining-dont-generate-invalid-use.js: Added.
+        (baz):
+        (bar):
+        (foo):
+
+2017-09-14  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Add PrivateSymbolMode::{Include,Exclude} for PropertyNameArray
+        https://bugs.webkit.org/show_bug.cgi?id=176867
+
+        Reviewed by Sam Weinig.
+
+        * microbenchmarks/object-get-own-property-symbols.js: Added.
+        (test):
+
+2017-09-13  Mark Lam  <mark.lam@apple.com>
+
+        Rolling out r221832: Regresses Speedometer by ~4% and Dromaeo CSS YUI by ~20%.
+        https://bugs.webkit.org/show_bug.cgi?id=176888
+        <rdar://problem/34381832>
+
+        Not reviewed.
+
+        * stress/op_mod-ConstVar.js:
+        * stress/op_mod-VarConst.js:
+        * stress/op_mod-VarVar.js:
+
+2017-09-13  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip 3 op_mod tests on Debug JSC bots.
+        https://bugs.webkit.org/show_bug.cgi?id=176630
+
+        Unreviewed test gardening.
+
+        * stress/op_mod-ConstVar.js:
+        * stress/op_mod-VarConst.js:
+        * stress/op_mod-VarVar.js:
+
+2017-09-13  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Fix Array allocation in Object.keys
+        https://bugs.webkit.org/show_bug.cgi?id=176826
+
+        Reviewed by Saam Barati.
+
+        * stress/object-own-property-keys.js: Added.
+        (shouldBe):
+
+2017-09-12  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Optimize WeakMap::get by adding intrinsic and fixup
+        https://bugs.webkit.org/show_bug.cgi?id=176010
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/weak-map-key.js: Added.
+        (assert):
+        (objectKey):
+        (let.start.Date.now):
+
+2017-09-12  Mark Lam  <mark.lam@apple.com>
+
+        REGRESSION: 3 stress/op_mod (and op_div) tests timing out on Debug JSC bots.
+        https://bugs.webkit.org/show_bug.cgi?id=176630
+
+        Reviewed by JF Bastien.
+
+        Debug builds are just slow, and these tests do a lot.  They pass when I run them
+        locally on my MacBook Pro.  So, I'm bumping their timing multiplier to 2.0x as
+        a speculative fix for the bots that are seeing these fail.
+
+        I also undid the skipping of the op_mod tests for debug builds.
+
+        * stress/op_div-ConstVar.js:
+        * stress/op_div-VarConst.js:
+        * stress/op_div-VarVar.js:
+        * stress/op_mod-ConstVar.js:
+        * stress/op_mod-VarConst.js:
+        * stress/op_mod-VarVar.js:
+
+2017-09-12  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip stress/value-to-boolean.js on Debug bots.
+        https://bugs.webkit.org/show_bug.cgi?id=176787
+
+        Unreviewed test gardening.
+
+        * stress/value-to-boolean.js:
+
+2017-09-11  Mark Lam  <mark.lam@apple.com>
+
+        Change test expectation for test262/test/language/statements/try/tco-catch.js
+        https://bugs.webkit.org/show_bug.cgi?id=176749
+
+        Rubber stamped by Keith Miller.
+
+        It's been failing since at least r221821.  I'm changing the test expectation to
+        fail to green the bots while I investigate some more.
+
+        * test262.yaml:
+
+2017-09-11  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r221854.
+
+        The test added with this change fails on 32-bit JSC bots.
+
+        Reverted changeset:
+
+        "[DFG] Optimize WeakMap::get by adding intrinsic and fixup"
+        https://bugs.webkit.org/show_bug.cgi?id=176010
+        http://trac.webkit.org/changeset/221854
+
+2017-09-03  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Optimize WeakMap::get by adding intrinsic and fixup
+        https://bugs.webkit.org/show_bug.cgi?id=176010
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/weak-map-key.js: Added.
+        (assert):
+        (objectKey):
+        (let.start.Date.now):
+
+2017-09-09  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Optimize Object.keys by using careful array allocation
+        https://bugs.webkit.org/show_bug.cgi?id=176654
+
+        Reviewed by Darin Adler.
+
+        * microbenchmarks/object-keys.js: Added.
+        (test):
+
+2017-09-09  Filip Pizlo  <fpizlo@apple.com>
+
+        Error should compute .stack and friends lazily
+        https://bugs.webkit.org/show_bug.cgi?id=176645
+
+        Reviewed by Saam Barati.
+
+        * ChakraCore.yaml: Skip test that was testing non-standard behavior of these fields.
+        * microbenchmarks/new-error.js: Added.
+        * microbenchmarks/throw.js: Added.
+
+2017-09-09  Mark Lam  <mark.lam@apple.com>
+
+        [Re-landing] Use JIT probes for DFG OSR exit.
+        https://bugs.webkit.org/show_bug.cgi?id=175144
+        <rdar://problem/33437050>
+
+        Not reviewed.  Original patch reviewed by Saam Barati.
+
+        Disable these tests for debug builds because they run too slow with the new OSR exit.
+
+        * stress/op_mod-ConstVar.js:
+        * stress/op_mod-VarConst.js:
+        * stress/op_mod-VarVar.js:
+
+2017-09-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] NewArrayWithSize(size)'s size does not care negative zero
+        https://bugs.webkit.org/show_bug.cgi?id=176300
+
+        Reviewed by Saam Barati.
+
+        * stress/new-array-with-size-div.js: Added.
+        (shouldBe):
+        (test):
+        (i.i):
+
+2017-09-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] PutByVal with Array::Generic is too generic
+        https://bugs.webkit.org/show_bug.cgi?id=176345
+
+        Reviewed by Filip Pizlo.
+
+        * stress/object-assign-symbols.js: Added.
+        (shouldBe):
+        (test):
+        * stress/object-assign.js: Added.
+        (shouldBe):
+        (test):
+        (i.shouldBe.JSON.stringify.test):
+
+2017-09-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] GetByVal(ObjectUse with Array::Generic, StringUse/SymbolUse) should be supported
+        https://bugs.webkit.org/show_bug.cgi?id=176590
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/object-iterate-symbols.js: Added.
+        (test):
+        * microbenchmarks/object-iterate.js: Added.
+        (test):
+        * stress/object-iterate-symbols.js: Added.
+        (shouldBe):
+        (test):
+        * stress/object-iterate.js: Added.
+        (shouldBe):
+        (test):
+
+2017-09-07  Per Arne Vollan  <pvollan@apple.com>
+
+        [Win32] 10 JSC stress tests are failing.
+        https://bugs.webkit.org/show_bug.cgi?id=176538
+
+        Reviewed by Mark Lam.
+
+        Skip tests on Windows to make the bots green.
+
+        * ChakraCore.yaml:
+        * stress/date-relaxed.js:
+
+2017-09-06  Mark Lam  <mark.lam@apple.com>
+
+        constructGenericTypedArrayViewWithArguments() is missing an exception check.
+        https://bugs.webkit.org/show_bug.cgi?id=176485
+        <rdar://problem/33898874>
+
+        Reviewed by Keith Miller.
+
+        * stress/regress-176485.js: Added.
+
+2017-09-05  Saam Barati  <sbarati@apple.com>
+
+        isNotCellSpeculation is wrong with respect to SpecEmpty
+        https://bugs.webkit.org/show_bug.cgi?id=176429
+
+        Reviewed by Michael Saboff.
+
+        * microbenchmarks/is-not-cell-speculation-for-empty-value.js: Added.
+        (Foo):
+
+2017-09-05  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: Completion values for control flow do not match the spec
+        https://bugs.webkit.org/show_bug.cgi?id=171265
+
+        Reviewed by Saam Barati.
+
+        * stress/completion-value.js:
+        Condensed test for completion values in top level statements.
+
+        * stress/super-get-by-id.js:
+        ClassDeclaration when evaled no longer produce values. Convert
+        these to ClassExpressions so they produce the class value.
+        
+        * ChakraCore/test/GlobalFunctions/evalreturns3.baseline-jsc:
+        This is a progression for currect spec behavior.
+
+        * mozilla/mozilla-tests.yaml:
+        This test is now outdated, so mark it as failing for that reason.
+
+        * test262.yaml:
+        Passing all "cptn" completion value tests.
+
+2017-09-04  Saam Barati  <sbarati@apple.com>
+
+        typeCheckHoistingPhase may emit a CheckStructure on the empty value which leads to a dereference of zero on 64 bit platforms
+        https://bugs.webkit.org/show_bug.cgi?id=176317
+
+        Reviewed by Keith Miller.
+
+        * stress/dont-crash-when-hoist-check-structure-on-tdz.js: Added.
+        (Foo):
+
+2017-09-03  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Efficiently execute number#toString()
+        https://bugs.webkit.org/show_bug.cgi?id=170007
+
+        Reviewed by Keith Miller.
+
+        * microbenchmarks/number-to-string-strength-reduction.js: Added.
+        (test):
+        * microbenchmarks/number-to-string-with-radix-10.js: Added.
+        (test):
+        * microbenchmarks/number-to-string-with-radix-cse.js: Added.
+        (test):
+        * microbenchmarks/number-to-string-with-radix.js: Added.
+        (test):
+        * stress/number-to-string-strength-reduction.js: Added.
+        (shouldBe):
+        (test):
+        * stress/number-to-string-with-radix-10.js: Added.
+        (shouldBe):
+        (test):
+        * stress/number-to-string-with-radix-cse.js: Added.
+        (shouldBe):
+        (test):
+        * stress/number-to-string-with-radix-invalid.js: Added.
+        (shouldThrow):
+        * stress/number-to-string-with-radix-watchpoint.js: Added.
+        (shouldBe):
+        (test):
+        (i.i.1e3.Number.prototype.toString):
+        * stress/number-to-string-with-radix.js: Added.
+        (shouldBe):
+        (test):
+
+2017-09-02  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Relax arity requirement
+        https://bugs.webkit.org/show_bug.cgi?id=175523
+
+        Reviewed by Saam Barati.
+
+        * stress/arity-mismatch-arguments-length.js: Added.
+        (shouldBe):
+        (test1):
+        (test):
+        * stress/arity-mismatch-get-argument.js: Added.
+        (shouldBe):
+        (builtin.createBuiltin):
+        (test):
+        * stress/arity-mismatch-inlining-extra-slots.js: Added.
+        (shouldBe):
+        (inlineTarget):
+        (test):
+        * stress/arity-mismatch-inlining.js: Added.
+        (shouldBe):
+        (inlineTarget):
+        (test):
+        * stress/arity-mismatch-rest.js: Added.
+        (shouldBe):
+        (test2):
+        (test1):
+        (test):
+
+2017-08-31  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Fix "name" and "length" of Proxy revoke function
+        https://bugs.webkit.org/show_bug.cgi?id=176155
+
+        Reviewed by Mark Lam.
+
+        * test262.yaml:
+
+2017-08-31  Saam Barati  <sbarati@apple.com>
+
+        Graph::methodOfGettingAValueProfileFor compares NodeOrigin instead of the semantic CodeOrigin
+        https://bugs.webkit.org/show_bug.cgi?id=176206
+
+        Reviewed by Keith Miller.
+
+        * stress/compare-semantic-origin-op-negate-method-of-getting-a-value-profile.js: Added.
+        (a):
+        (b):
+        (foo):
+
+2017-08-31  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip two slow JSC tests after r221422.
+
+        Unreviewed test gardening.
+
+        * stress/regexp-prototype-match-on-too-long-rope.js:
+        * stress/regexp-prototype-test-on-too-long-rope.js:
+
+2017-08-31  Filip Pizlo  <fpizlo@apple.com>
+
+        Unreviewed, skipping slow tests.
+        
+        These tests are now timing out. They would have always been slow. The timeouts are probably because OOMs
+        work differently now.
+
+        * stress/regexp-prototype-exec-on-too-long-rope.js:
+        * stress/string-prototype-charCodeAt-on-too-long-rope.js:
+
+2017-08-31  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Use reifying system for "name" property of builtin JSFunction
+        https://bugs.webkit.org/show_bug.cgi?id=175260
+
+        Reviewed by Saam Barati.
+
+        * stress/accessors-get-set-prefix.js:
+        * stress/builtin-function-name.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (shouldBe.JSON.stringify.Object.getOwnPropertyDescriptor):
+        (shouldBe.JSON.stringify.Object.getOwnPropertyNames.Array.prototype.filter.sort):
+        * stress/private-name-as-anonymous-builtin.js: Added.
+        (shouldBe):
+        (NotPromise):
+
+2017-08-30  Saam Barati  <sbarati@apple.com>
+
+        Unreviewed. Make test stop printing.
+
+        * microbenchmarks/fake-iterators-that-throw-when-finished.js:
+
+2017-08-30  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r221327.
+
+        This change caused test262 failures.
+
+        Reverted changeset:
+
+        "[JSC] Use reifying system for "name" property of builtin
+        JSFunction"
+        https://bugs.webkit.org/show_bug.cgi?id=175260
+        http://trac.webkit.org/changeset/221327
+
+2017-08-30  Saam Barati  <sbarati@apple.com>
+
+        semicolon is being interpreted as an = in the LiteralParser
+        https://bugs.webkit.org/show_bug.cgi?id=176114
+
+        Reviewed by Oliver Hunt.
+
+        * stress/jsonp-literal-parser-semicolon-is-not-assignment.js: Added.
+        * stress/resources/literal-parser-test-case.js: Added.
+
+2017-08-30  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        [ESNext] Async iteration - Implement async iteration statement: for-await-of
+        https://bugs.webkit.org/show_bug.cgi?id=166698
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/async-iteration-for-await-of-syntax.js: Added.
+        (assert):
+        (checkSyntax):
+        (checkSyntaxError):
+        (checkSimpleAsyncGeneratorSloppyMode):
+        (checkSimpleAsyncGeneratorStrictMode):
+        (checkNestedAsyncGenerators):
+        (checkSimpleAsyncGeneratorSyntaxErrorInStrictMode):
+        * stress/async-iteration-for-await-of.js: Added.
+        (assert):
+        (async.foo):
+        (async.boo):
+        (const.boo.async):
+
+2017-08-29  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Use reifying system for "name" property of builtin JSFunction
+        https://bugs.webkit.org/show_bug.cgi?id=175260
+
+        Reviewed by Saam Barati.
+
+        * stress/accessors-get-set-prefix.js:
+        * stress/builtin-function-name.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (shouldBe.JSON.stringify.Object.getOwnPropertyDescriptor):
+        (shouldBe.JSON.stringify.Object.getOwnPropertyNames.Array.prototype.filter.sort):
+
+2017-08-25  Saam Barati  <sbarati@apple.com>
+
+        Support compiling catch in the DFG
+        https://bugs.webkit.org/show_bug.cgi?id=174590
+        <rdar://problem/34047845>
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/delta-blue-try-catch.js: Added.
+        (exception):
+        (value):
+        (OrderedCollection):
+        (OrderedCollection.prototype.add):
+        (OrderedCollection.prototype.at):
+        (OrderedCollection.prototype.size):
+        (OrderedCollection.prototype.removeFirst):
+        (OrderedCollection.prototype.remove):
+        (Strength):
+        (Strength.stronger):
+        (Strength.weaker):
+        (Strength.weakestOf):
+        (Strength.strongest):
+        (Strength.prototype.nextWeaker):
+        (Constraint):
+        (Constraint.prototype.addConstraint):
+        (Constraint.prototype.satisfy):
+        (Constraint.prototype.destroyConstraint):
+        (Constraint.prototype.isInput):
+        (UnaryConstraint):
+        (UnaryConstraint.prototype.addToGraph):
+        (UnaryConstraint.prototype.chooseMethod):
+        (UnaryConstraint.prototype.isSatisfied):
+        (UnaryConstraint.prototype.markInputs):
+        (UnaryConstraint.prototype.output):
+        (UnaryConstraint.prototype.recalculate):
+        (UnaryConstraint.prototype.markUnsatisfied):
+        (UnaryConstraint.prototype.inputsKnown):
+        (UnaryConstraint.prototype.removeFromGraph):
+        (StayConstraint):
+        (StayConstraint.prototype.execute):
+        (EditConstraint.prototype.isInput):
+        (EditConstraint.prototype.execute):
+        (BinaryConstraint):
+        (BinaryConstraint.prototype.chooseMethod):
+        (BinaryConstraint.prototype.addToGraph):
+        (BinaryConstraint.prototype.isSatisfied):
+        (BinaryConstraint.prototype.markInputs):
+        (BinaryConstraint.prototype.input):
+        (BinaryConstraint.prototype.output):
+        (BinaryConstraint.prototype.recalculate):
+        (BinaryConstraint.prototype.markUnsatisfied):
+        (BinaryConstraint.prototype.inputsKnown):
+        (BinaryConstraint.prototype.removeFromGraph):
+        (ScaleConstraint):
+        (ScaleConstraint.prototype.addToGraph):
+        (ScaleConstraint.prototype.removeFromGraph):
+        (ScaleConstraint.prototype.markInputs):
+        (ScaleConstraint.prototype.execute):
+        (ScaleConstraint.prototype.recalculate):
+        (EqualityConstraint):
+        (EqualityConstraint.prototype.execute):
+        (Variable):
+        (Variable.prototype.addConstraint):
+        (Variable.prototype.removeConstraint):
+        (Planner):
+        (Planner.prototype.incrementalAdd):
+        (Planner.prototype.incrementalRemove):
+        (Planner.prototype.newMark):
+        (Planner.prototype.makePlan):
+        (Planner.prototype.extractPlanFromConstraints):
+        (Planner.prototype.addPropagate):
+        (Planner.prototype.removePropagateFrom):
+        (Planner.prototype.addConstraintsConsumingTo):
+        (Plan):
+        (Plan.prototype.addConstraint):
+        (Plan.prototype.size):
+        (Plan.prototype.constraintAt):
+        (Plan.prototype.execute):
+        (chainTest):
+        (projectionTest):
+        (change):
+        (deltaBlue):
+        * microbenchmarks/fake-iterators-that-throw-when-finished.js: Added.
+        (assert):
+        (Numbers):
+        (Numbers.prototype.next):
+        (return.Transpose):
+        (return.Transpose.prototype.next):
+        (transpose):
+        (verifyEven):
+        (verifyString):
+        (foo):
+        (runIterators):
+        * microbenchmarks/try-catch-word-count.js: Added.
+        (let.assert):
+        (EOF):
+        (let.texts):
+        (let.o.apply):
+        (foo):
+        (bar):
+        (f):
+        (run):
+        (test1):
+        (test2):
+        (test3):
+        (fn):
+        (A):
+        (B):
+        (A.prototype.getValue):
+        (B.prototype.getParentValue):
+        (strlen):
+        (sum.0):
+        (test):
+        (result.test.o):
+        (set add.set add):
+        (set forEach):
+        (stringHash):
+        (set if):
+        (testFunction):
+        (set delete.set has.set add):
+        * stress/catch-set-argument-speculation-failure.js: Added.
+        (o):
+        (e):
+        (e2):
+        (escape):
+        (baz):
+        (noInline.run):
+        (noInline):
+        * stress/osr-enter-to-catch-with-set-local-type-check-failure.js: Added.
+        (foo):
+        (e):
+        (baz):
+        (bar):
+
+2017-08-24  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r221119, r221124, and r221143.
+        https://bugs.webkit.org/show_bug.cgi?id=175973
+
+        "I think it regressed JSBench by 20%" (Requested by saamyjoon
+        on #webkit).
+
+        Reverted changesets:
+
+        "Support compiling catch in the DFG"
+        https://bugs.webkit.org/show_bug.cgi?id=174590
+        http://trac.webkit.org/changeset/221119
+
+        "Unreviewed, build fix in GTK port"
+        https://bugs.webkit.org/show_bug.cgi?id=174590
+        http://trac.webkit.org/changeset/221124
+
+        "DFG::JITCode::osrEntry should get sorted since we perform a
+        binary search on it"
+        https://bugs.webkit.org/show_bug.cgi?id=175893
+        http://trac.webkit.org/changeset/221143
+
+2017-08-24  Michael Saboff  <msaboff@apple.com>
+
+        Add support for RegExp "dotAll" flag
+        https://bugs.webkit.org/show_bug.cgi?id=175924
+
+        Reviewed by Keith Miller.
+
+        Updated tests for new dotAll ('s' flag) changes.
+
+        * es6/Proxy_internal_get_calls_RegExp.prototype.flags.js:
+        * stress/static-getter-in-names.js:
+
+2017-08-24  Mark Lam  <mark.lam@apple.com>
+
+        Land regression test for https://bugs.webkit.org/show_bug.cgi?id=164081.
+        https://bugs.webkit.org/show_bug.cgi?id=175940
+        <rdar://problem/29003921>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-164081.js: Added.
+        (shouldEqual):
+        (testcase):
+
+2017-08-24  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip flaky JSC test stress/test-finally.js.
+        https://bugs.webkit.org/show_bug.cgi?id=160283
+
+        Unreviewed test gardening.
+
+        * stress/test-finally.js:
+
+2017-08-23  Saam Barati  <sbarati@apple.com>
+
+        Support compiling catch in the DFG
+        https://bugs.webkit.org/show_bug.cgi?id=174590
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/delta-blue-try-catch.js: Added.
+        (exception):
+        (value):
+        (OrderedCollection):
+        (OrderedCollection.prototype.add):
+        (OrderedCollection.prototype.at):
+        (OrderedCollection.prototype.size):
+        (OrderedCollection.prototype.removeFirst):
+        (OrderedCollection.prototype.remove):
+        (Strength):
+        (Strength.stronger):
+        (Strength.weaker):
+        (Strength.weakestOf):
+        (Strength.strongest):
+        (Strength.prototype.nextWeaker):
+        (Constraint):
+        (Constraint.prototype.addConstraint):
+        (Constraint.prototype.satisfy):
+        (Constraint.prototype.destroyConstraint):
+        (Constraint.prototype.isInput):
+        (UnaryConstraint):
+        (UnaryConstraint.prototype.addToGraph):
+        (UnaryConstraint.prototype.chooseMethod):
+        (UnaryConstraint.prototype.isSatisfied):
+        (UnaryConstraint.prototype.markInputs):
+        (UnaryConstraint.prototype.output):
+        (UnaryConstraint.prototype.recalculate):
+        (UnaryConstraint.prototype.markUnsatisfied):
+        (UnaryConstraint.prototype.inputsKnown):
+        (UnaryConstraint.prototype.removeFromGraph):
+        (StayConstraint):
+        (StayConstraint.prototype.execute):
+        (EditConstraint.prototype.isInput):
+        (EditConstraint.prototype.execute):
+        (BinaryConstraint):
+        (BinaryConstraint.prototype.chooseMethod):
+        (BinaryConstraint.prototype.addToGraph):
+        (BinaryConstraint.prototype.isSatisfied):
+        (BinaryConstraint.prototype.markInputs):
+        (BinaryConstraint.prototype.input):
+        (BinaryConstraint.prototype.output):
+        (BinaryConstraint.prototype.recalculate):
+        (BinaryConstraint.prototype.markUnsatisfied):
+        (BinaryConstraint.prototype.inputsKnown):
+        (BinaryConstraint.prototype.removeFromGraph):
+        (ScaleConstraint):
+        (ScaleConstraint.prototype.addToGraph):
+        (ScaleConstraint.prototype.removeFromGraph):
+        (ScaleConstraint.prototype.markInputs):
+        (ScaleConstraint.prototype.execute):
+        (ScaleConstraint.prototype.recalculate):
+        (EqualityConstraint):
+        (EqualityConstraint.prototype.execute):
+        (Variable):
+        (Variable.prototype.addConstraint):
+        (Variable.prototype.removeConstraint):
+        (Planner):
+        (Planner.prototype.incrementalAdd):
+        (Planner.prototype.incrementalRemove):
+        (Planner.prototype.newMark):
+        (Planner.prototype.makePlan):
+        (Planner.prototype.extractPlanFromConstraints):
+        (Planner.prototype.addPropagate):
+        (Planner.prototype.removePropagateFrom):
+        (Planner.prototype.addConstraintsConsumingTo):
+        (Plan):
+        (Plan.prototype.addConstraint):
+        (Plan.prototype.size):
+        (Plan.prototype.constraintAt):
+        (Plan.prototype.execute):
+        (chainTest):
+        (projectionTest):
+        (change):
+        (deltaBlue):
+        * microbenchmarks/fake-iterators-that-throw-when-finished.js: Added.
+        (assert):
+        (Numbers):
+        (Numbers.prototype.next):
+        (return.Transpose):
+        (return.Transpose.prototype.next):
+        (transpose):
+        (verifyEven):
+        (verifyString):
+        (foo):
+        (runIterators):
+        * microbenchmarks/try-catch-word-count.js: Added.
+        (let.assert):
+        (EOF):
+        (let.texts):
+        (let.o.apply):
+        (foo):
+        (bar):
+        (f):
+        (run):
+        (test1):
+        (test2):
+        (test3):
+        (fn):
+        (A):
+        (B):
+        (A.prototype.getValue):
+        (B.prototype.getParentValue):
+        (strlen):
+        (sum.0):
+        (test):
+        (result.test.o):
+        (set add.set add):
+        (set forEach):
+        (stringHash):
+        (set if):
+        (testFunction):
+        (set delete.set has.set add):
+        * stress/catch-set-argument-speculation-failure.js: Added.
+        (o):
+        (e):
+        (e2):
+        (escape):
+        (baz):
+        (noInline.run):
+        (noInline):
+        * stress/osr-enter-to-catch-with-set-local-type-check-failure.js: Added.
+        (foo):
+        (e):
+        (baz):
+        (bar):
+
+2017-08-23  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Optimize Map iteration with intrinsic
+        https://bugs.webkit.org/show_bug.cgi?id=174355
+
+        Reviewed by Saam Barati.
+
+        * stress/map-iterator-result-should-have-expected-shape.js: Added.
+        (shouldBe):
+        (throw.new.Error):
+        * stress/set-iterator-result-should-have-expected-shape.js: Added.
+        (shouldBe):
+        (throw.new.Error.let.iterator.set Symbol):
+        (throw.new.Error.set add):
+        (let.iterator.set Symbol):
+
+2017-08-23  Robin Morisset  <rmorisset@apple.com>
+
+        Add a micro-benchmark for checking that accessing a variable within a 'with'
+        block does not automatically prevent type prediction.
+        https://bugs.webkit.org/show_bug.cgi?id=175738
+
+        Reviewed by Saam Barati.
+
+        * stress/with_and_arith.js: Added.
+        (with):
+
+2017-08-23  Skachkov Oleksandr  <gskachkov@gmail.com>
+
+        [ESNext] Async iteration - Implement Async Generator - runtime
+        https://bugs.webkit.org/show_bug.cgi?id=175240
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/async-iteration-async-from-sync.js: Added.
+        (assert):
+        (const.Logger):
+        (this.fullfilled):
+        (this.fullfilledDone):
+        (this.rejected):
+        (this.catched):
+        (this.isFinal):
+        (_assertLogger):
+        (const.assertLogger):
+        (const.getPromise.promiseHolder.return.new.Promise):
+        (foo):
+        (async.boo):
+        (bar):
+        (async.baz):
+        (async.goo):
+        * stress/async-iteration-basic.js: Added.
+        (assert):
+        (const.Logger):
+        (this.fullfilled):
+        (this.fullfilledDone):
+        (this.rejected):
+        (this.catched):
+        (this.isFinal):
+        (_assertLogger):
+        (const.assertLogger):
+        (const.getPromise.promiseHolder.return.new.Promise):
+        (async.generator):
+        (iterator.next.then):
+        (async.baz):
+        (async.boo):
+        (async.foo):
+        (async.goo):
+        (A.prototype.async.foo):
+        (A.prototype.async.boo):
+        (A):
+        (asyncGenExp.async):
+        (async.joo):
+        (j.next.then):
+        (then):
+        (async.koo):
+        (async.loo):
+        (async.moo):
+        (async.noo):
+        (async.ooo):
+        (async.roo):
+        (async.poo):
+        (async.soo):
+        (async.too):
+        * stress/async-iteration-evaluation.js: Added.
+        (assert):
+        (async.foo):
+        (catch):
+        * stress/async-iteration-syntax.js:
+        * stress/async-iteration-yield-promise.js: Added.
+        (assert):
+        (const.Logger):
+        (this.fullfilled):
+        (this.fullfilledDone):
+        (this.rejected):
+        (this.catched):
+        (this.isFinal):
+        (_assertLogger):
+        (const.assertLogger):
+        (const.getPromise.promiseHolder.return.new.Promise):
+        (async.foo):
+        (async.boo):
+        (async.bar):
+        * stress/async-iteration-yield-star-interface.js: Added.
+        (assert):
+        (const.getPromise.promiseHolder.return.new.Promise):
+        (const.Logger):
+        (this.fullfilled):
+        (this.fullfilledDone):
+        (this.rejected):
+        (this.catched):
+        (this.custom):
+        (this.isFinal):
+        (_assertLogger):
+        (const.assertLogger):
+        (let.asyncIter.Symbol.asyncIterator):
+        (let.asyncIter.next):
+        (let.asyncIter.throw):
+        (let.asyncIter.return):
+        (async.foo):
+        (asyncIter.Symbol.asyncIterator):
+        (asyncIter.next):
+        (async.boo):
+        (asyncIter.return):
+        (async.bar):
+        (async.baz):
+        (async.foobar):
+        * stress/async-iteration-yield-star.js: Added.
+        (assert):
+        (const.Logger):
+        (this.fullfilled):
+        (this.fullfilledDone):
+        (this.rejected):
+        (this.catched):
+        (this.custom):
+        (this.isFinal):
+        (_assertLogger):
+        (const.assertLogger):
+        (const.getPromise.promiseHolder.return.new.Promise):
+        (async.foo):
+        (async.boo):
+        (async.bar):
+        (async.baz):
+        (async.joo):
+        (async.goo):
+        (async.koo):
+        (async.loo):
+        (let.asyncIter.Symbol.asyncIterator):
+        (let.asyncIter.next):
+        (let.asyncIter.throw):
+        (let.asyncIter.return):
+        (async.moo):
+        (async.noo):
+        * test262.yaml:
+
+2017-08-23  JF Bastien  <jfbastien@apple.com>
+
+        Fix printing in test
+
+        Unreviewed: fixing verbosity, shouldn't have been there.
+
+        * wasm/regress/175693.js:
+        (else.else):
+        (catch):
+
+2017-08-18  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip flaky JSC test microbenchmarks/generator-with-several-types.js.
+        https://bugs.webkit.org/show_bug.cgi?id=172543
+
+        Unreviewed test gardening.
+
+        * microbenchmarks/generator-with-several-types.js:
+
+2017-08-17  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: const in unreachable code decoded incorrectly, erroneously rejects binary as invalid
+        https://bugs.webkit.org/show_bug.cgi?id=175693
+        <rdar://problem/33952443>
+
+        Reviewed by Saam Barati.
+
+        Add a regression directory for WebAssembly tests.
+
+        * wasm.yaml:
+        * wasm/regress/175693.js: Added.
+        (else.else):
+        (instance.new.WebAssembly.Instance.new.WebAssembly.Module):
+        (catch):
+        * wasm/regress/175693.wasm: Added.
+
+2017-08-15  Robin Morisset  <rmorisset@apple.com>
+
+        Support the 'with' keyword in FTL.
+        https://bugs.webkit.org/show_bug.cgi?id=175585
+
+        Reviewed by Saam Barati.
+
+        Also improve the JSTest/stress/with.js file to test
+        what happens when non-objects are passed to with.
+
+        * stress/with.js:
+        (foo):
+        (i.catch):
+        (i.with): Deleted.
+
+2017-08-14  Keith Miller  <keith_miller@apple.com>
+
+        Add testing tool to lie to the DFG about profiles
+        https://bugs.webkit.org/show_bug.cgi?id=175487
+
+        Reviewed by Saam Barati.
+
+        * stress/compare-eq-incomplete-profile.js: Added.
+        (const.test.createBuiltin):
+
+2017-08-14  Robin Morisset  <rmorisset@apple.com>
+
+        Support the with keyword in DFG
+        https://bugs.webkit.org/show_bug.cgi?id=175470
+
+        Reviewed by Saam Barati.
+
+        Added a new stress-test for the 'with' keyword, that caught a bug in a
+        previous version of this code.
+
+        * stress/with.js: Added.
+        (i.with):
+
+2017-08-14  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip flaky JSC test test/fieldopts/objtypespec-newobj-invalidation.1.js
+        https://bugs.webkit.org/show_bug.cgi?id=175544
+
+        Unreviewed test gardening.
+
+        * ChakraCore.yaml:
+
+2017-08-09  Caitlin Potter  <caitp@igalia.com>
+
+        Early error on ANY operator before new.target
+        https://bugs.webkit.org/show_bug.cgi?id=157970
+
+        Reviewed by Saam Barati.
+
+        Instead of throwing if any unary operator precedes new.target, only
+        throw if the unary operator updates the reference.
+
+        The following become legal in JSC:
+
+        ```
+        !new.target
+        ~new.target
+        typeof new.target
+        delete new.target
+        void new.target
+        ```
+
+        All of which are legal in v8 and SpiderMonkey in strict and sloppy mode
+
+        * stress/new-target-syntax-errors.js:
+        * stress/new-target.js:
+
+2017-08-09  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip failing JSC tests stress/regress-169783.js and wasm.yaml/wasm/stress/oom.js.
+        https://bugs.webkit.org/show_bug.cgi?id=175255
+
+        Unreviewed test gardening.
+
+        * stress/regress-169783.js:
+        * wasm/stress/oom.js:
+
+2017-08-09  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        REGRESSION: 2 test262/test/language/statements/async-function failures
+        https://bugs.webkit.org/show_bug.cgi?id=175334
+
+        Reviewed by Yusuke Suzuki.
+
+        Add @skip parameters to tests, and remove test for async iterator from 
+        async await syntax test because it is already covered by async-iterator-syntax.js
+
+        * stress/async-await-syntax.js:
+        * stress/async-iteration-syntax.js:
+
+2017-08-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, gardening test262 for Promise resolve / reject function length
+        https://bugs.webkit.org/show_bug.cgi?id=175333
+
+        * test262.yaml:
+
+2017-08-07  Robin Morisset  <rmorisset@apple.com>
+
+        GetOwnProperty of TypedArray indexed fields is wrongly configurable
+        https://bugs.webkit.org/show_bug.cgi?id=175307
+
+        Reviewed by Saam Barati.
+
+        * stress/typedarray-getownproperty-not-configurable.js: Added.
+        (assert):
+        (foo):
+
+2017-08-06  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Promise resolve and reject function should have length = 1
+        https://bugs.webkit.org/show_bug.cgi?id=175242
+
+        Reviewed by Saam Barati.
+
+        * stress/builtin-function-length.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (shouldBe.JSON.stringify.Object.getOwnPropertyDescriptor):
+        (shouldBe.JSON.stringify.Object.getOwnPropertyNames.Array.prototype.filter.sort):
+
+2017-08-06  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        [ESNext] Async iteration - Implement Async Generator - parser
+        https://bugs.webkit.org/show_bug.cgi?id=175210
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/async-await-syntax.js:
+        (testTopLevelAsyncAwaitSyntaxSloppyMode.testSyntax):
+        * stress/async-iteration-syntax.js: Added.
+        (assert):
+        (checkSyntax):
+        (checkSyntaxError):
+        (checkSimpleAsyncGeneratorSloppyMode):
+        (checkSimpleAsyncGeneratorStrictMode):
+        (checkNestedAsyncGenerators):
+        (checkSimpleAsyncGeneratorSyntaxErrorInStrictMode):
+        * stress/generator-class-methods-syntax.js:
+
+2017-08-03  Carlos Alberto Lopez Perez  <clopez@igalia.com>
+
+        JSC test wasm/js-api/test_memory_constructor.js should be skipped on memoryLimited
+        https://bugs.webkit.org/show_bug.cgi?id=175150
+
+        Unreviewed test gardening.
+
+        * wasm/js-api/test_memory_constructor.js:
+
+2017-08-02  Carlos Alberto Lopez Perez  <clopez@igalia.com>
+
+        [Linux] JSTests/wasm/stress/oom.js should not run on Linux
+        https://bugs.webkit.org/show_bug.cgi?id=175100
+
+        Reviewed by Mark Lam.
+
+        The JSC test JSTests/wasm/stress/oom.js tries to use all the
+        available memory until an out of memory exception happens.
+
+        The Linux kernel is more tuned for server workloads than for GUI
+        responsiveness. When a process tries to use a lot of memory, Linux
+        will do its best to serve the request. This usually translates to
+        free physical RAM by writing to disk dirty pages and/or moving out
+        less recently used pages to swap (disk storage).
+        Meanwhile it does this, the system will become unresponsive and this
+        leads to freezes that can last even some minutes on the worst cases.
+
+        Therefore, let's skip this test on Linux as it will cause more harm
+        than good on the Linux bots or on the machines of Linux developers.
+
+        * wasm/stress/oom.js:
+
+2017-08-01  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        [JSC] Remove unnecessary print from stress\promise-finally.js test
+        https://bugs.webkit.org/show_bug.cgi?id=175015
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/promise-finally.js:
+        (p.finally):
+        (then):
+
+2017-07-31  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, update test262 results for optional catch binding
+
+        * test262.yaml:
+
+2017-07-31  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Support optional catch binding
+        https://bugs.webkit.org/show_bug.cgi?id=174981
+
+        Reviewed by Saam Barati.
+
+        * stress/optional-catch-binding-syntax.js: Added.
+        (testSyntax):
+        (testSyntaxError):
+        (catch.catch):
+        * stress/optional-catch-binding.js: Added.
+        (shouldBe):
+        (throwException):
+
+2017-07-28  Mark Lam  <mark.lam@apple.com>
+
+        ObjectToStringAdaptiveStructureWatchpoint should not fire if it's dying imminently.
+        https://bugs.webkit.org/show_bug.cgi?id=174948
+        <rdar://problem/33495680>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-174948.js: Added.
+
+2017-07-28  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        ASSERTION FAILED: candidate->op() == PhantomCreateRest || candidate->op() == PhantomDirectArguments || candidate->op() == PhantomClonedArguments || candidate->op() == PhantomSpread || candidate->op() == PhantomNewArrayWithSpread
+        https://bugs.webkit.org/show_bug.cgi?id=174900
+
+        Reviewed by Saam Barati.
+
+        * stress/arguments-elimination-candidate-listings-should-respect-pseudo-terminals.js: Added.
+        (sideEffect):
+        (args):
+        (test):
+
+2017-07-27  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Hoist DOM binding attribute getter prologue into JavaScriptCore taking advantage of DOMJIT / CheckSubClass
+        https://bugs.webkit.org/show_bug.cgi?id=171637
+
+        Reviewed by Darin Adler.
+
+        * stress/domjit-getter-complex-with-incorrect-object.js:
+        (i.shouldThrow):
+        * stress/domjit-getter-type-check.js: Copied from JSTests/stress/domjit-getter-complex-with-incorrect-object.js.
+        (shouldBe):
+        (i.shouldThrow):
+
+2017-07-26  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: test throwing out of the start function
+        https://bugs.webkit.org/show_bug.cgi?id=165714
+        <rdar://problem/29760251>
+
+        Reviewed by Keith Miller.
+
+        * wasm/assert.js:
+        * wasm/function-tests/trap-from-start.js: Added.
+        (StartTraps):
+        * wasm/function-tests/trap-from-start-async.js: Added.
+        (async.StartTrapsAsync):
+
+2017-07-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [FTL] Arguments elimination is suppressed by unreachable blocks
+        https://bugs.webkit.org/show_bug.cgi?id=174352
+
+        Reviewed by Filip Pizlo.
+
+        * stress/arguments-elimination-force-exit.js: Added.
+        (shouldBe):
+        (strict):
+        (sloppy):
+        * stress/arguments-elimination-throw.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (sloppy):
+        (isArguments):
+
+2017-07-13  Mark Lam  <mark.lam@apple.com>
+
+        Add some additional test cases for bug 170896.
+        https://bugs.webkit.org/show_bug.cgi?id=174491
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-170896-with-contiguous-shape-profile.js: Copied from JSTests/stress/regress-170896.js.
+        * stress/regress-170896-with-double-shape-profile.js: Added.
+        (test):
+        * stress/regress-170896-with-int32-shape-profile.js: Added.
+        (test):
+        * stress/regress-170896.js: Removed.
+
+2017-07-13  Saam Barati  <sbarati@apple.com>
+
+        Missing exception check in JSObject::hasInstance
+        https://bugs.webkit.org/show_bug.cgi?id=174455
+        <rdar://problem/31384608>
+
+        Reviewed by Mark Lam.
+
+        * stress/has-instance-exception-check.js: Added.
+        (assert):
+        (let.getter.Object.getOwnPropertyDescriptor.get foo):
+
+2017-07-13  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESnext] Implement Object Spread
+        https://bugs.webkit.org/show_bug.cgi?id=167963
+
+        Reviewed by Saam Barati.
+
+        * stress/obj-rest-destructuring-order.js: Added.
+        (assert):
+        (o.get z):
+        (o.get a):
+        * stress/obj-spread-order.js: Added.
+        (assert):
+        (o.get z):
+        (o.get a):
+        * stress/object-spread.js: Added.
+        (let.assert):
+        (assert.sameValue):
+        (let.o.get a):
+        (let.obj.get c):
+        (cthulhu.get x):
+        (let.obj.set c):
+        (calls.o.get z):
+        (calls.o.get a):
+        (try.let.obj.get foo):
+        (get calls):
+
+2017-07-12  Saam Barati  <sbarati@apple.com>
+
+        GenericArguments consults the wrong state when tracking modified argument descriptors and mapped arguments
+        https://bugs.webkit.org/show_bug.cgi?id=174411
+        <rdar://problem/31696186>
+
+        Reviewed by Mark Lam.
+
+        * stress/generic-arguments-correct-delete-behavior.js: Added.
+        (assert):
+        (makeTest):
+
+2017-07-07  Mark Lam  <mark.lam@apple.com>
+
+        \n\r is not the same as \r\n.
+        https://bugs.webkit.org/show_bug.cgi?id=173053
+
+        Reviewed by Keith Miller.
+
+        * stress/regress-173053.js: Added.
+        * stress/template-literal-line-terminators.js:
+
+2017-07-06  Saam Barati  <sbarati@apple.com>
+
+        We are missing places where we invalidate the for-in context
+        https://bugs.webkit.org/show_bug.cgi?id=174184
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/for-in-invalidate-context-weird-assignments.js: Added.
+        (assert):
+        (test):
+
+2017-07-05  Saam Barati  <sbarati@apple.com>
+
+        NewArray in FTLLowerDFGToB3 does not handle speculating on doubles when having a bad time
+        https://bugs.webkit.org/show_bug.cgi?id=174188
+        <rdar://problem/30581423>
+
+        Reviewed by Mark Lam.
+
+        * stress/new-array-having-a-bad-time-double.js: Added.
+        (assert):
+        (foo):
+
+2017-07-05  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        WTF::StringImpl::copyChars segfaults when built with GCC 7
+        https://bugs.webkit.org/show_bug.cgi?id=173407
+
+        Reviewed by Andreas Kling.
+
+        * stress/string-repeat-copy-chars-crash.js: Added.
+        (shouldBe):
+
+2017-07-03  Saam Barati  <sbarati@apple.com>
+
+        Skip unshiftCountSlowCase-correct-postCapacity.js on debug builds since it takes a long time to run.
+
+        * stress/unshiftCountSlowCase-correct-postCapacity.js:
+
+2017-07-03  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, annotate dont--reserve-huge-capacity-lexer.js with $memoryLimited
+
+        It requires too much memory.
+
+        * stress/dont-reserve-huge-capacity-lexer.js:
+
+2017-06-30  Michael Saboff  <msaboff@apple.com>
+
+        Skip a test on ARM64 platform since we run out of address space.
+
+        Rubber stamped by Saam Barati.
+
+        * stress/dont-reserve-huge-capacity-lexer.js:
+
+2017-06-30  Michael Saboff  <msaboff@apple.com>
+
+        RegExp's  anchored with .* with \g flag can return wrong match start for strings with multiple matches
+        https://bugs.webkit.org/show_bug.cgi?id=174044
+
+        Reviewed by Oliver Hunt.
+
+        New regression test.
+
+        * stress/regress-174044.js: Added.
+        (test1):
+        (test2):
+
+2017-06-30  Filip Pizlo  <fpizlo@apple.com>
+
+        RegExpCachedResult::setInput should reify left and right contexts
+        https://bugs.webkit.org/show_bug.cgi?id=173818
+
+        Reviewed by Keith Miller.
+
+        * stress/right-left-context-invalidated-by-input.js: Added.
+        (test.validateContexts):
+        (test):
+
+2017-06-29  Saam Barati  <sbarati@apple.com>
+
+        Calculating postCapacity in unshiftCountSlowCase is wrong
+        https://bugs.webkit.org/show_bug.cgi?id=173992
+        <rdar://problem/32283199>
+
+        Reviewed by Keith Miller.
+
+        * stress/unshiftCountSlowCase-correct-postCapacity.js: Added.
+        (temp):
+
+2017-06-29  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r218512.
+        https://bugs.webkit.org/show_bug.cgi?id=173981
+
+        "It changes the behavior of the JS API's JSEvaluateScript
+        which breaks TurboTax" (Requested by saamyjoon on #webkit).
+
+        Reverted changeset:
+
+        "test262: Completion values for control flow do not match the
+        spec"
+        https://bugs.webkit.org/show_bug.cgi?id=171265
+        http://trac.webkit.org/changeset/218512
+
+2017-06-27  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: running out of executable memory should throw OoM
+        https://bugs.webkit.org/show_bug.cgi?id=171537
+        <rdar://problem/32963338>
+
+        Reviewed by Saam Barati.
+
+        * wasm.yaml:
+        * wasm/lowExecutableMemory/executable-memory-oom.js: Added.
+        (const.invoke):
+        (failCount.0.catch):
+        (failCount.0.module.undefined.catch):
+        * wasm/lowExecutableMemory/exports-oom.js: Added.
+        (const.type):
+        (const.params):
+        (const.randomProgram):
+        (failCount.0.catch):
+        (failCount.0.module.undefined.catch):
+        * wasm/lowExecutableMemory/imports-oom.js: Added.
+        (const.type):
+        (const.params):
+        (const.randomProgram):
+        (f.imports.push):
+        (failCount.0.catch):
+        (failCount.0.module.undefined.catch):
+
+2017-06-27  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESnext] Implement Object Rest - Implementing Object Rest Destructuring
+        https://bugs.webkit.org/show_bug.cgi?id=167962
+
+        Reviewed by Saam Barati.
+
+        * stress/object-rest-deconstruct.js: Added.
+        (let.assert):
+        (let.assertPropDescriptor):
+        (catch):
+        (get 3):
+        (foo):
+        (let.src.get y):
+        (let.src.set y):
+        (let.gen):
+
+2017-06-27  Saam Barati  <sbarati@apple.com>
+
+        Function constructor needs to follow the spec and validate parameters and body independently
+        https://bugs.webkit.org/show_bug.cgi?id=173303
+        <rdar://problem/32732526>
+
+        Reviewed by Keith Miller.
+
+        * ChakraCore/test/Function/FuncBodyES5.baseline-jsc:
+        * stress/function-constructor-semantics.js: Added.
+        (assert):
+        (hasSyntaxError):
+        (foo):
+        (async.foo):
+        (testError):
+        (testOK.toString):
+        (toString):
+
+2017-06-26  Saam Barati  <sbarati@apple.com>
+
+        RegExpPrototype.js builtin uses for-of iteration which is almost certainly incorrect
+        https://bugs.webkit.org/show_bug.cgi?id=173740
+
+        Reviewed by Mark Lam.
+
+        * stress/regexp-prototype-replace-builtin-should-not-use-for-of.js: Added.
+        (Array.prototype.Symbol.iterator):
+
+2017-06-26  Saam Barati  <sbarati@apple.com>
+
+        Skip a test on 32-bit platforms since we run out of address space.
+
+        Rubber stamped by Mark Lam.
+
+        * stress/dont-reserve-huge-capacity-lexer.js:
+
+2017-06-26  Saam Barati  <sbarati@apple.com>
+
+        Crash in JSC::Lexer<unsigned char>::setCode
+        https://bugs.webkit.org/show_bug.cgi?id=172754
+
+        Reviewed by Mark Lam.
+
+        * stress/dont-reserve-huge-capacity-lexer.js: Added.
+        (catch):
+
+2017-06-24  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Clean up Object.entries implementation
+        https://bugs.webkit.org/show_bug.cgi?id=173759
+
+        Reviewed by Sam Weinig.
+
+        * microbenchmarks/object-entries.js: Added.
+        (test):
+
+2017-06-24  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Remove Reflect.enumerate
+        https://bugs.webkit.org/show_bug.cgi?id=173806
+
+        Reviewed by Yusuke Suzuki.
+
+        * ChakraCore.yaml:
+        * es6.yaml:
+        These tests now fail because they use Reflect.enumerate.
+
+        * test262.yaml:
+        This test now passes, it checked that Reflect.enumerate is undefined!
+
+        * stress/property-name-enumerator-should-not-look-into-indexed-values-when-it-is-a-dictionary.js:
+        Convert to for..in which presented the original issue. See bug <https://webkit.org/b/149811>
+
+        * stress/reflect-enumerate.js: Removed.
+        Remove a test solely for Reflect.enumerate.
+
+2017-06-22  Saam Barati  <sbarati@apple.com>
+
+        ValueRep(DoubleRep(@v)) can not simply convert to @v
+        https://bugs.webkit.org/show_bug.cgi?id=173687
+        <rdar://problem/32855563>
+
+        Reviewed by Mark Lam.
+
+        * stress/dont-strength-reduce-valuerep-of-doublerep.js: Added.
+        (i.catch):
+
+2017-06-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Object.values should be implemented in C++
+        https://bugs.webkit.org/show_bug.cgi?id=173703
+
+        Reviewed by Sam Weinig.
+
+        * microbenchmarks/object-keys-map-values.js: Added.
+        (test):
+        * microbenchmarks/object-values.js: Added.
+        (test):
+        * stress/object-values-changing-properties.js: Added.
+        (shouldBe):
+        (throw.new.Error.let.source.get x):
+        (throw.new.Error):
+        (shouldBe.let.handler.get order):
+        (get let):
+        (shouldBe.let.handler.get return):
+        (let.handler.get order):
+
+2017-06-21  Saam Barati  <sbarati@apple.com>
+
+        eval virtual call is incorrect in the baseline JIT
+        https://bugs.webkit.org/show_bug.cgi?id=173587
+        <rdar://problem/32867897>
+
+        Reviewed by Michael Saboff.
+
+        * stress/do-eval-virtual-call-correctly.js: Added.
+        (assert):
+        (f):
+        (i.test):
+        (catch):
+
+2017-06-20  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Update test262 test expectations after r218581.
+
+        Unreviewed test gardening.
+
+        * test262.yaml:
+
+2017-06-20  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        Revert changes in bug#160417 about extending `null` not being a derived class
+        https://bugs.webkit.org/show_bug.cgi?id=169293
+
+        Reviewed by Saam Barati.
+
+        * stress/class-derived-from-null.js:
+        (assertThrow):
+        (test1):
+        (test2):
+        (test3):
+        (test4):
+        (test5):
+        (test6):
+
+2017-06-13  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] More ArrayIndexOf fixups for various types
+        https://bugs.webkit.org/show_bug.cgi?id=173176
+
+        Reviewed by Saam Barati.
+
+        * stress/array-indexof-arraystorage.js: Added.
+        (shouldBe):
+        (indexOfInt32Other):
+        (indexOfInt32Cell):
+        (indexOfInt32Boolean):
+        (indexOfDoubleOther):
+        (indexOfDoubleCell):
+        (indexOfDoubleBoolean):
+        (indexOfInt32):
+        (indexOfDouble):
+        * stress/array-indexof-constant-folding.js: Added.
+        (shouldBe):
+        (indexOfInt32Other):
+        (indexOfInt32Cell):
+        (indexOfInt32Boolean):
+        (indexOfDoubleOther):
+        (indexOfDoubleCell):
+        (indexOfDoubleBoolean):
+        * stress/array-indexof-hole-and-other.js: Added.
+        (shouldBe):
+        (indexOf):
+        * stress/array-indexof-other.js: Added.
+        (shouldBe):
+        (indexOfInt32):
+        (indexOfDouble):
+        (indexOfString):
+        (indexOfObject):
+        * stress/array-indexof-symbol.js: Added.
+        (shouldBe):
+        (indexOfInt32):
+        (indexOfDouble):
+        (indexOfString):
+        (indexOfObject):
+
+2017-06-19  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: Completion values for control flow do not match the spec
+        https://bugs.webkit.org/show_bug.cgi?id=171265
+
+        Reviewed by Saam Barati.
+
+        * stress/completion-value.js:
+        Condensed test for completion values in top level statements.
+
+        * stress/super-get-by-id.js:
+        ClassDeclaration when evaled no longer produce values. Convert
+        these to ClassExpressions so they produce the class value.
+        
+        * ChakraCore/test/GlobalFunctions/evalreturns3.baseline-jsc:
+        This is a progression for currect spec behavior.
+
+        * mozilla/mozilla-tests.yaml:
+        This test is now outdated, so mark it as failing for that reason.
+
+        * test262.yaml:
+        Passing all "cptn" completion value tests.
+
+2017-06-17  Keith Miller  <keith_miller@apple.com>
+
+        ArrayBuffer constructor needs to create subclass structures before its buffer
+        https://bugs.webkit.org/show_bug.cgi?id=173510
+
+        Reviewed by Yusuke Suzuki.
+
+        * test262.yaml:
+
+2017-06-17  Keith Miller  <keith_miller@apple.com>
+
+        ArrayPrototype methods should use JSValue::toLength for non-Arrays.
+        https://bugs.webkit.org/show_bug.cgi?id=173506
+
+        Reviewed by Ryosuke Niwa.
+
+        Re-baseline tests.
+
+        * ChakraCore/test/Function/apply3.baseline-jsc:
+        * test262.yaml:
+
+2017-06-16  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Add fast path for Object.assign
+        https://bugs.webkit.org/show_bug.cgi?id=173416
+
+        Reviewed by Mark Lam.
+
+        * stress/object-assign-changing-properties.js: Added.
+        (shouldBe):
+        (throw.new.Error.let.source.get x):
+        (throw.new.Error):
+        (shouldBe.let.source.get x):
+        (shouldBe.let.target.set x):
+        (shouldBe.let.target.get x):
+        * stress/object-assign-proxy.js: Added.
+        (shouldBe):
+        (throw.new.Error.let.handler.get order):
+
+2017-06-15  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Implement Object.assign in C++
+        https://bugs.webkit.org/show_bug.cgi?id=173414
+
+        Reviewed by Saam Barati.
+
+        * stress/object-assign-string-first.js: Added.
+        (shouldBe):
+        (source.get Symbol):
+        (source.get 1):
+        (source.get cocoa):
+
+2017-06-14  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: remove empty test files
+        https://bugs.webkit.org/show_bug.cgi?id=173382
+
+        Reviewed by Saam Barati.
+
+        The following files:
+                JSTests/wasm/function-tests/call-indirect-params.js
+                JSTests/wasm/function-tests/call-indirect.js
+                JSTests/wasm/js-api/call-indirect-results.js
+        Were changed to empty files in https://trac.webkit.org/changeset/209771
+
+        They were testing call_indirect with the wrong semantics, before
+        we implemented tables. That change implemented tables and
+        therefore removed the erroneous tests.
+
+        We have a few tests for call_indirect which already do the right thing:
+                JSTests/wasm/function-tests/context-switch.js
+                JSTests/wasm/function-tests/exceptions.js
+                JSTests/wasm/function-tests/grow-memory-2.js
+                JSTests/wasm/function-tests/stack-overflow.js
+                JSTests/wasm/function-tests/table-basic-2.js
+                JSTests/wasm/function-tests/table-basic.js
+                JSTests/wasm/js-api/call-indirect.js
+                JSTests/wasm/js-api/table.js
+                JSTests/wasm/js-api/unique-signature.js
+                JSTests/wasm/js-api/wrapper-function.js
+
+        I also just imported the updated spec tests which, among other
+        things, test call_indirect:
+                core/br.wast
+                core/br_table.wast
+                core/call_indirect.wast
+                core/func.wast
+                core/func_ptrs.wast
+                core/imports.wast
+                core/left-to-right.wast
+                core/linking.wast
+                core/nop.wast
+                core/return.wast
+                core/typecheck.wast
+                core/unreachable.wast
+
+        So I think it's OK to just delete the tests which should just have
+        been deleted back when tables were added.
+
+        * wasm/function-tests/call-indirect-params.js: Removed.
+        * wasm/function-tests/call-indirect.js: Removed.
+        * wasm/js-api/call-indirect-results.js: Removed.
+
+2017-06-13  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: import updated spec tests
+        https://bugs.webkit.org/show_bug.cgi?id=173287
+        <rdar://problem/32725975>
+
+        Reviewed by Saam Barati.
+
+        Import spec tests as of 31c641cc15f2aedbec2fa45a5185f68416df578b,
+        with a few modifications so things work.
+
+        Fix a bunch of bugs found through this process, and punt a few tests (which I
+        marked as blocked by this bug).
+
+        Fixes:
+
+        Fix load / store alignment: r216908 erroneously implemented it as bit alignment
+        instead of byte alignment. It was also missing memory-alignment.js despite it
+        being in the ChangeLog, so add it too. This allows spec-test/align.wast.js to
+        pass.
+
+        Tables can be imported or in a section. There can be only one, but sections can
+        be empty. An Elements section can exist if there's no Table, as long as it is
+        also empty.
+
+        Memories can be imported or in a section. There can be only one, but sections
+        can be empty. A Data section can exist if there's no Memory, as long as it is
+        also empty.
+
+        Prototypes: stringify without .prototype. in the string.
+
+        WebAssembly.Table.prototype.grow was plain wrong: it takes a delta parameter,
+        not a final size, and throws a RangeError on failure, not a TypeError.
+
+        Fix compile / instantiate so the reject the promise if given an argument of the
+        wrong type (instead of failing instantly).
+
+        Fix async on neuter test.
+
+        Element section shouldn't affect any Table if any of the elements are out of
+        bounds. We need to process it in two passes.
+
+        Segment section shouldn't affect any Data if any of the segments are out of
+        bounds. We need to process it in two passes.
+
+        Empty data segments are valid, but only when there is no memory. Their index
+        still gets validated, and has to be zero.
+
+        Punts:
+
+        Error messages with context, the test seems overly restrictive but this is
+        minor.
+
+        compile/instantiate/validate property descriptors.
+
+        UTF-8 bugs.
+
+        Temporarily disable NaN tests. We need to go back and implement the following
+        semantics: https://github.com/WebAssembly/spec/pull/414 This doesn't matter as
+        much as getting all the other tests passing.
+
+        Worth noting for NaNs: f64.no_fold_mul_one (also a NaN test) as well as
+        no_fold_promote_demote (an interesting corner case which we get wrong). mul by
+        one is (assert_return (invoke \"f64.no_fold_mul_one\" (i64.const
+        0x7ff4000000000000)) (i64.const 0x7ff8000000000000)) which means converting sNaN
+        to qNaN, and promote/demote is (assert_return (invoke \"no_fold_promote_demote\"
+        (i32.const 0x7fa00000)) (i32.const 0x7fc00000)) which is the same. I'm not sure
+        why they're not allowed.
+
+        * wasm.yaml:
+        * wasm/function-tests/i32-load8-s.js:
+        * wasm/function-tests/memory-access-past-4gib.js:
+        (const.op.of.WASM.opcodes):
+        * wasm/function-tests/memory-alignment.js: Added.
+        (const.op.of.WASM.opcodes):
+        * wasm/function-tests/memory-section-and-import.js:
+        * wasm/js-api/Module-compile.js:
+        (async.testPromiseAPI):
+        * wasm/js-api/dont-mmap-zero-byte-memory.js:
+        (testMems):
+        * wasm/js-api/element.js:
+        (assert.throws.new.WebAssembly.Module.builder.WebAssembly):
+        * wasm/js-api/neutered-inputs.js:
+        (const.testFunction): Deleted.
+        (const.testConstructor): Deleted.
+        * wasm/js-api/table.js:
+        (assert.throws.new.WebAssembly.Module.builder.WebAssembly):
+        (new.WebAssembly.Module):
+        (assert.throws):
+        (assertBadTableImport):
+        (assert.throws.WebAssembly.Table.prototype.grow):
+        (assertBadTableInstance): Deleted.
+        * wasm/js-api/test_Data.js:
+        (DataSectionWithoutMemory):
+        * wasm/spec-harness/index.js:
+        (module):
+        (uniqueTest): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (register): Deleted.
+        (call): Deleted.
+        (get instance): Deleted.
+        (exports): Deleted.
+        (run): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (try.f): Deleted.
+        (catch): Deleted.
+        (assert_exhaustion): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-harness/testharness.css: Removed.
+        * wasm/spec-harness/testharness.js: Removed.
+        * wasm/spec-harness/testharnessreport.js: Removed.
+        * wasm/spec-harness/wasm-constants.js:
+        (assertTraps):
+        (assertWasmThrows):
+        * wasm/spec-harness/wasm-module-builder.js:
+        (Binary.prototype.emit_section):
+        (Binary):
+        (WasmFunctionBuilder.prototype.addBody):
+        (WasmFunctionBuilder.prototype.end):
+        (WasmFunctionBuilder):
+        (WasmModuleBuilder.prototype.stringToBytes):
+        (WasmModuleBuilder.prototype.addCustomSection):
+        (WasmModuleBuilder.prototype.addFunctionTableInit):
+        (WasmModuleBuilder.prototype.appendToTable):
+        (WasmModuleBuilder.prototype.toArray):
+        (WasmModuleBuilder.prototype.toBuffer):
+        (WasmModuleBuilder.prototype.instantiate):
+        (WasmModuleBuilder):
+        * wasm/spec-tests/address.wast.js:
+        * wasm/spec-tests/align.wast.js: Added.
+        * wasm/spec-tests/binary.wast.js:
+        * wasm/spec-tests/block.wast.js:
+        * wasm/spec-tests/br.wast.js:
+        * wasm/spec-tests/br_if.wast.js:
+        * wasm/spec-tests/br_table.wast.js:
+        * wasm/spec-tests/call.wast.js:
+        * wasm/spec-tests/call_indirect.wast.js:
+        * wasm/spec-tests/comments.wast.js:
+        * wasm/spec-tests/const.wast.js: Added.
+        * wasm/spec-tests/conversions.wast.js: Added.
+        * wasm/spec-tests/custom_section.wast.js:
+        * wasm/spec-tests/exports.wast.js:
+        * wasm/spec-tests/f32.wast.js: Added.
+        * wasm/spec-tests/f64.wast.js: Added.
+        * wasm/spec-tests/fac.wast.js:
+        * wasm/spec-tests/float_exprs.wast.js: Added.
+        * wasm/spec-tests/float_misc.wast.js: Added.
+        * wasm/spec-tests/func.wast.js:
+        * wasm/spec-tests/globals.wast.js:
+        * wasm/spec-tests/if.wast.js:
+        * wasm/spec-tests/imports.wast.js:
+        * wasm/spec-tests/inline-module.wast.js: Added.
+        * wasm/spec-tests/jsapi.js:
+        (testJSAPI.test):
+        (testJSAPI):
+        * wasm/spec-tests/labels.wast.js:
+        * wasm/spec-tests/loop.wast.js:
+        * wasm/spec-tests/memory.wast.js:
+        * wasm/spec-tests/memory_trap.wast.js: Added.
+        * wasm/spec-tests/names.wast.js:
+        * wasm/spec-tests/nop.wast.js:
+        * wasm/spec-tests/return.wast.js:
+        * wasm/spec-tests/stack.wast.js:
+        * wasm/spec-tests/token.wast.js: Added.
+        * wasm/spec-tests/type.wast.js: Added.
+        * wasm/spec-tests/typecheck.wast.js:
+        * wasm/spec-tests/unreachable.wast.js:
+        * wasm/spec-tests/unreached-invalid.wast.js:
+        * wasm/spec-tests/unwind.wast.js:
+        * wasm/spec-tests/utf8-custom-section-id.wast.js: Added.
+        * wasm/spec-tests/utf8-import-field.wast.js: Added.
+        * wasm/spec-tests/utf8-import-module.wast.js: Added.
+
+2017-06-13  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed JSC test gardening.
+
+        * stress/check-string-ident.js:
+        * stress/new-largeish-contiguous-array-with-size.js:
+
+2017-06-13  Michael Saboff  <msaboff@apple.com>
+
+        DFG doesn't properly handle a property that is change to read only in a prototype
+        https://bugs.webkit.org/show_bug.cgi?id=173321
+
+        Reviewed by Filip Pizlo.
+
+        * ChakraCore.yaml: Renabled fieldopts/objtypespec-newobj-invalidation.1.js.
+        * stress/regress-173321.js: Added new regression test.
+        (shouldBe):
+        (SimpleObject):
+        (test):
+
+2017-06-12  Saam Barati  <sbarati@apple.com>
+
+        Update test262 test expectation since r218082 makes new tests pass.
+
+        * test262.yaml:
+
+2017-06-12  Saam Barati  <sbarati@apple.com>
+
+        We should not claim that SpecEmpty is filtered out of cell checks on 64 bit platforms
+        https://bugs.webkit.org/show_bug.cgi?id=172957
+        <rdar://problem/32602704>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/spec-empty-flows-through-cell-checks.js: Added.
+        (A):
+        (B):
+        (i.catch):
+
+2017-06-12  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        We incorrectly allow escaped characters in keyword tokens
+        https://bugs.webkit.org/show_bug.cgi?id=171310
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/destructuring-assignment-syntax.js:
+        * stress/error-messages-for-in-operator-should-not-crash.js:
+        (catch):
+        * stress/reserved-word-with-escape.js:
+        (testSyntaxError.String.raw.v):
+        (String.raw.SyntaxError.Cannot.use.the.keyword.string_appeared_here.as.a.name):
+        (testSyntaxError.String.raw.a):
+        * JSTests/ChakraCore/test/Basics/IdsWithEscapes.baseline-jsc:
+
+2017-06-09  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Add ArrayIndexOf intrinsic
+        https://bugs.webkit.org/show_bug.cgi?id=172421
+
+        Reviewed by Saam Barati.
+
+        * stress/array-indexof-array-prototype-change.js: Added.
+        (shouldBe):
+        (indexOfInt32):
+        * stress/array-indexof-have-a-bad-time-getter.js: Added.
+        (shouldBe):
+        (indexOfInt32):
+        * stress/array-indexof-have-a-bad-time.js: Added.
+        (shouldBe):
+        (indexOfInt32):
+        * stress/array-indexof-hole-with-prototype.js: Added.
+        (shouldBe):
+        (indexOf):
+        * stress/array-indexof-hole.js: Added.
+        (shouldBe):
+        (indexOf):
+        * stress/array-indexof-index.js: Added.
+        (shouldBe):
+        (indexOfInt32):
+        (indexOfDouble):
+        (indexOfString):
+        (indexOfObject):
+        (indexOfValue):
+        * stress/array-indexof-negative-index.js: Added.
+        (shouldBe):
+        (indexOfInt32):
+        (indexOfDouble):
+        (indexOfString):
+        (indexOfObject):
+        (indexOfValue):
+        * stress/array-indexof-non-int32-start-index.js: Added.
+        (shouldBe):
+        (indexOf):
+        (object.valueOf):
+        * stress/array-indexof-object-prototype-change.js: Added.
+        (shouldBe):
+        (indexOfInt32):
+        * stress/array-indexof-object.js: Added.
+        (shouldBe):
+        (indexOf):
+        * stress/array-indexof-original-array.js: Added.
+        (shouldBe):
+        (indexOfInt32):
+        * stress/array-indexof-string.js: Added.
+        (shouldBe):
+        (indexOf):
+        * stress/array-indexof-structure-change-convert.js: Added.
+        (shouldBe):
+        (indexOf):
+        * stress/array-indexof-structure-change.js: Added.
+        (shouldBe):
+        (indexOf):
+        * stress/array-indexof.js: Added.
+        (shouldBe):
+        (indexOf):
+
+2017-06-11  Keith Miller  <keith_miller@apple.com>
+
+        TypedArray constructor with string shouldn't throw
+        https://bugs.webkit.org/show_bug.cgi?id=173181
+
+        Reviewed by JF Bastien.
+
+        We should be coercing primitive arguments to numbers in the various
+        TypedArray constructors.
+
+        * stress/typedarray-constructor.js:
+
+2017-06-11  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, update test results part 3
+        https://bugs.webkit.org/show_bug.cgi?id=173227
+
+        * microbenchmarks/regexp-prototype-search-observable-side-effects.js:
+
+2017-06-10  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, update test results part 2
+        https://bugs.webkit.org/show_bug.cgi?id=173227
+
+        * test262.yaml:
+
+2017-06-10  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, update test results
+        https://bugs.webkit.org/show_bug.cgi?id=173227
+
+        * microbenchmarks/string-prototype-search-observable-side-effects.js:
+        * test262.yaml:
+
+2017-06-10  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Update RegExp.prototype.[@@search]] implementation according to the latest spec
+        https://bugs.webkit.org/show_bug.cgi?id=173227
+
+        Reviewed by Mark Lam.
+
+        Update the test.
+
+        * es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.search].js:
+
+2017-06-08  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: We should only create wrappers for functions that can be exported
+        https://bugs.webkit.org/show_bug.cgi?id=173088
+
+        Reviewed by Saam Barati.
+
+        Remove a bunch of old tests that are actually duplicates of the spec-tests and rely
+        on the old testWasmModuleFunctions api, which has been removed.
+
+        * wasm/function-tests/copysign.js: Removed.
+        * wasm/function-tests/ctz.js: Removed.
+        * wasm/function-tests/drop.js: Removed.
+        * wasm/function-tests/dumb-eq-if-then-else.js: Removed.
+        * wasm/function-tests/dumb-less-than-fallthrough.js: Removed.
+        * wasm/function-tests/dumb-less-than-ite.js: Removed.
+        * wasm/function-tests/eqz.js: Removed.
+        * wasm/function-tests/i32-trunc-s-f32.js: Removed.
+        * wasm/function-tests/i32-trunc-s-f64.js: Removed.
+        * wasm/function-tests/i32-trunc-u-f32.js: Removed.
+        * wasm/function-tests/i32-trunc-u-f64.js: Removed.
+        * wasm/function-tests/i64-trunc-s-f32.js: Removed.
+        * wasm/function-tests/i64-trunc-s-f64.js: Removed.
+        * wasm/function-tests/i64-trunc-u-f32.js: Removed.
+        * wasm/function-tests/i64-trunc-u-f64.js: Removed.
+        * wasm/function-tests/if-then-else-fallthrough.js: Removed.
+        * wasm/function-tests/if-then-fallthrough.js: Removed.
+        * wasm/function-tests/int-to-floating-point.js: Removed.
+        * wasm/function-tests/loop-mult.js:
+        * wasm/function-tests/loop-sum.js:
+        * wasm/function-tests/max.js: Removed.
+        * wasm/function-tests/min.js: Removed.
+        * wasm/function-tests/nearest.js: Removed.
+        * wasm/function-tests/nop.js: Removed.
+        * wasm/function-tests/popcnt.js: Removed.
+        * wasm/function-tests/ret5.js:
+        * wasm/function-tests/select.js: Removed.
+        * wasm/function-tests/tee-local.js: Removed.
+        * wasm/function-tests/trunc.js: Removed.
+
+2017-06-07  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: test imports and exports with 16-bit characters
+        https://bugs.webkit.org/show_bug.cgi?id=165977
+        <rdar://problem/29760130>
+
+        Reviewed by Saam Barati.
+
+        The output for import failure was improved, so many tests need to
+        be updated here. Only one has new tests as noted below.
+
+        * wasm/function-tests/memory-import-and-grow.js:
+        * wasm/js-api/Instance.imports.exports.unicode.js: Added. Main new test.
+        (idxModule):
+        * wasm/js-api/global-error.js:
+        (new.Number):
+        (assert.throws):
+        * wasm/js-api/table.js:
+        (assert.throws):
+        (new.WebAssembly.Table):
+        * wasm/js-api/test_memory.js:
+        (test):
+        * wasm/js-api/wasm-to-wasm-bad-signature.js:
+        (BadSignatureDropStartParams.):
+        (BadSignatureDropStartParams):
+        (BadSignatureDropEndParams.):
+        (BadSignatureSwapParam.):
+        (BadSignatureRet.):
+        * wasm/js-api/web-assembly-instantiate.js:
+        (assert.asyncTest.async.test):
+        (assert.asyncTest):
+        * wasm/js-api/wrapper-function.js:
+        (return.new.WebAssembly.Module):
+
+2017-06-07  Mark Lam  <mark.lam@apple.com>
+
+        Restrict the regress-173035.js test to only run on Darwin x86-64.
+        https://bugs.webkit.org/show_bug.cgi?id=173075
+
+        Reviewed by Saam Barati.
+
+        This is because the 32-bit x86 build will fail to mmap the 0x3f900000 bytes that
+        this test will require to succeed.  Here's an example of this failure:
+        https://build.webkit.org/builders/Apple%20Sierra%2032-bit%20JSC%20%28BuildAndTest%29/builds/866/steps/webkit-32bit-jsc-test/logs/stdio
+
+        Since the issue is due to allocation of a very large amount of memory, the test
+        will probably fail on iOS and other platforms as well.  Hence, we should just
+        skip this test for any platforms that is not Darwin x86-64.
+
+        * stress/regress-173035.js:
+
+2017-06-07  Mark Lam  <mark.lam@apple.com>
+
+        ASSERTION failure: !masqueradesAsUndefinedWatchpointIsStillValid() || !isKnownCell(operand.node())
+        https://bugs.webkit.org/show_bug.cgi?id=168587
+
+        Not reviewed.
+
+        Unskipping the test because the issue has been fixed in https://bugs.webkit.org/show_bug.cgi?id=172673.
+
+        * stress/test-finally.js:
+
+2017-06-06  Mark Lam  <mark.lam@apple.com>
+
+        Contiguous storage butterfly length should not exceed MAX_STORAGE_VECTOR_LENGTH.
+        https://bugs.webkit.org/show_bug.cgi?id=173035
+        <rdar://problem/32554593>
+
+        Reviewed by Geoffrey Garen and Filip Pizlo.
+
+        * stress/regress-173035.js: Added.
+
+2017-06-06  Saam Barati  <sbarati@apple.com>
+
+        Make sure we restore SP when doing calls that could be to JS
+        https://bugs.webkit.org/show_bug.cgi?id=172946
+        <rdar://problem/32579026>
+
+        Reviewed by JF Bastien.
+
+        * wasm/function-tests/many-args-tail-call-sp-restored.js: Added.
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.f1):
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.end):
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.f2):
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.let.instance.new.WebAssembly.Instance.new.WebAssembly.Module.builder.WebAssembly):
+
+2017-06-06  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Unreviewed rollout r217807. Caused a test to crash.
+
+        * heapProfiler/class-names.js: Removed.
+        * heapProfiler/driver/driver.js:
+        (CheapHeapSnapshotNode):
+        (CheapHeapSnapshot):
+        (createCheapHeapSnapshot):
+        (HeapSnapshot):
+        (createHeapSnapshot):
+        * typeProfiler/inheritance.js:
+        (wrapper.A):
+        (wrapper.B):
+        (wrapper.C):
+        (wrapper):
+
+2017-06-06  Filip Pizlo  <fpizlo@apple.com>
+
+        index out of bound in bytecodebasicblock
+        https://bugs.webkit.org/show_bug.cgi?id=172963
+
+        Reviewed by Saam Barati and Mark Lam.
+
+        * stress/dfg-call-class-constructor.js: Added.
+        (Foo):
+        (i.catch):
+
+2017-06-05  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Web Inspector: Improve ES6 Class instances in Heap Snapshot instances view
+        https://bugs.webkit.org/show_bug.cgi?id=172848
+        <rdar://problem/25709212>
+
+        Reviewed by Saam Barati.
+
+        * typeProfiler/inheritance.js:
+        Rewrite the test slightly for clarity. The hoisting was confusing.
+
+        * heapProfiler/class-names.js: Added.
+        (MyES5Class):
+        (MyES6Class):
+        (MyES6Subclass):
+        Test object types and improved class names.
+
+        * heapProfiler/driver/driver.js:
+        (CheapHeapSnapshotNode):
+        (CheapHeapSnapshot):
+        (createCheapHeapSnapshot):
+        (HeapSnapshot):
+        (createHeapSnapshot):
+        Update snapshot parsing from version 1 to version 2.
+
+2017-06-02  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        ASSERTION FAILED: "We should only declare a function as a lexically scoped variable in scopes where var declarations aren't allowed. ..." for function redeclaration with async function module export
+        https://bugs.webkit.org/show_bug.cgi?id=168844
+
+        Reviewed by Saam Barati.
+
+        * modules/async-function-export.js: Added.
+        (f):
+        (export.async.f):
+
+2017-06-02  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        ES2015 modules - Export default function hoisting
+        https://bugs.webkit.org/show_bug.cgi?id=170174
+
+        Reviewed by Saam Barati.
+
+        This issue itself is solved by fixing function declaration hoisting rules.
+        This patch just adds the specific test to modules tests to ensure the bug
+        is fixed.
+
+        * modules/export-default-function-hoisting.js: Added.
+        * modules/export-default-function-hoisting/cappuccino.js: Added.
+        (import.drinkCocoa.from.string_appeared_here.export.default.drinkCappuccino):
+        * modules/export-default-function-hoisting/cocoa.js: Added.
+        (export.default.drinkCocoa):
+
+2017-06-01  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        Class Proxy can't be extended
+        https://bugs.webkit.org/show_bug.cgi?id=169040
+
+        Reviewed by Saam Barati.
+
+        Adding tests that check correctness of Proxy to ES6 `class`
+        Bug is already fixed in https://bugs.webkit.org/show_bug.cgi?id=164849
+
+        * stress/proxy-class.js: Added.
+        (assert):
+        (throw.new.Error.SuperClass):
+        (throw.new.Error.A):
+        (throw.new.Error):
+
+2017-05-31  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Implement String.prototype.concat in JS builtins
+        https://bugs.webkit.org/show_bug.cgi?id=172798
+
+        Reviewed by Sam Weinig.
+
+        * microbenchmarks/string-concat-convert.js: Added.
+        (test):
+        * microbenchmarks/string-concat-long-convert.js: Added.
+        (test):
+        * microbenchmarks/string-concat-long.js: Added.
+        (test):
+        * microbenchmarks/string-concat.js: Added.
+        (test):
+
+2017-05-31  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        Rolling out: Prevent async methods named 'function'
+        https://bugs.webkit.org/show_bug.cgi?id=172776
+
+        Reviewed by Mark Lam.
+
+        * stress/async-await-syntax.js:
+        (testTopLevelAsyncAwaitSyntaxSloppyMode.testSyntax):
+        (testTopLevelAsyncAwaitSyntaxSloppyMode):
+        (prototype.testTopLevelAsyncAwaitSyntaxStrictMode.testSyntax):
+        (prototype.testTopLevelAsyncAwaitSyntaxStrictMode):
+        (testTopLevelAsyncAwaitSyntaxSloppyMode.testSyntaxError):
+
+2017-05-31  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip flaky JSC test stress/test-finally.js
+        https://bugs.webkit.org/show_bug.cgi?id=168587
+
+        Unreviewed test gardening.
+
+        * stress/test-finally.js:
+
+2017-05-30  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        Prevent async methods named 'function' in Object literal
+        https://bugs.webkit.org/show_bug.cgi?id=172660
+
+        Reviewed by Saam Barati.
+
+        * stress/async-await-syntax.js:
+        (testTopLevelAsyncAwaitSyntaxSloppyMode.testSyntaxError):
+
+2017-05-30  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        ASSERTION FAILED: generator.isConstructor() || generator.derivedContextType() == DerivedContextType::DerivedConstructorContext
+        https://bugs.webkit.org/show_bug.cgi?id=171274
+
+        Reviewed by Saam Barati.
+
+        * stress/async-arrow-functions-lexical-binding-in-class.js:
+        (shouldBeAsync):
+        (shouldBeAsyncAndStoreBind):
+        (promise.new.Promise):
+        (ChildClass4):
+        (ChildClass4.prototype.classValue):
+        (ChildClass4.prototype.get classProperty):
+        * stress/async-arrow-functions-lexical-super-binding.js:
+        (A):
+        (const.childA1.new.prototype.var.f.async):
+        (const.childA1.new.var):
+        (const.childA1.new):
+        (const.childA2.new.prototype.var.f.async):
+        (const.childA2.new.var):
+        (const.childA2.new):
+        (const.childA3.new.prototype.var.f.async):
+        (const.childA3.new.var):
+        (const.childA3.new):
+        (try.childA4.new.prototype.var.f.async):
+        (try.childA4.new.var):
+        (try.childA4.new):
+        (catch):
+        (const.childA5.new.prototype.var.f.async):
+        (const.childA5.new.var):
+        (const.childA5.new):
+        (checkClass):
+        (checkClass.new.prototype.var.f.async):
+        (checkClass.new.var):
+        (checkClass.new):
+        (checkClass.new.prototype.method):
+        (checkClass.new.prototype.prop):
+
+2017-05-27  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Map and Set constructors should have fast path for cloning
+        https://bugs.webkit.org/show_bug.cgi?id=172413
+
+        Reviewed by Saam Barati.
+
+        * stress/map-clone-instance-iterator-change.js: Added.
+        (shouldBe):
+        (map.Symbol.iterator):
+        * stress/map-clone-iterator-change.js: Added.
+        (shouldBe):
+        (Map.prototype.Symbol.iterator):
+        * stress/map-clone-next-change.js: Added.
+        (shouldBe):
+        (map.Symbol.iterator.__proto__.next):
+        * stress/map-clone.js: Added.
+        (shouldBe):
+        (Map.prototype):
+        * stress/map-inherit-set.js: Added.
+        (shouldBe):
+        (DerivedMap):
+        (set for):
+        * stress/set-clone-instance-iterator-change.js: Added.
+        (shouldBe):
+        (set Symbol.iterator):
+        * stress/set-clone-iterator-change.js: Added.
+        (shouldBe):
+        (set Set.prototype.Symbol.iterator):
+        * stress/set-clone-next-change.js: Added.
+        (shouldBe):
+        (set Symbol.iterator.__proto__.next):
+        * stress/set-clone.js: Added.
+        (shouldBe):
+        (set Set.prototype.add):
+        * stress/set-inherit-add.js: Added.
+        (shouldBe):
+        (DerivedSet.set add):
+
+2017-05-26  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r217458.
+
+        This change caused 55 JSC test failures.
+
+        Reverted changeset:
+
+        "Date should use historical data if it's available."
+        https://bugs.webkit.org/show_bug.cgi?id=172592
+        http://trac.webkit.org/changeset/217458
+
+2017-05-26  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Give ModuleProgram the same treatment that we did for ProgramCode in bug#167725
+        https://bugs.webkit.org/show_bug.cgi?id=167805
+
+        Reviewed by Saam Barati.
+
+        * modules/module-jit-reachability.js: Added.
+
+2017-05-26  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        Prevent async methods named 'function'
+        https://bugs.webkit.org/show_bug.cgi?id=172598
+
+        Reviewed by Mark Lam.
+
+        * stress/async-await-syntax.js:
+        (testTopLevelAsyncAwaitSyntaxSloppyMode.testSyntax):
+        (testTopLevelAsyncAwaitSyntaxSloppyMode):
+        (prototype.testTopLevelAsyncAwaitSyntaxStrictMode.testSyntax):
+        (prototype.testTopLevelAsyncAwaitSyntaxStrictMode):
+        (testTopLevelAsyncAwaitSyntaxSloppyMode.testSyntaxError):
+
+2017-05-25  Keith Miller  <keith_miller@apple.com>
+
+        Date should use historical data if it's available.
+        https://bugs.webkit.org/show_bug.cgi?id=172592
+
+        Reviewed by Mark Lam.
+
+        Remove parts of the date tests that rely on the absence of
+        historical data in Date.
+
+        * mozilla/ecma/Date/15.9.5.31-1.js:
+        (getTestCases):
+        * mozilla/ecma/Date/15.9.5.35-1.js:
+        (getTestCases):
+
+2017-05-25  Saam Barati  <sbarati@apple.com>
+
+        Our for-in optimization in the bytecode generator does its static analysis incorrectly
+        https://bugs.webkit.org/show_bug.cgi?id=172532
+        <rdar://problem/32369452>
+
+        Reviewed by Mark Lam.
+
+        * stress/for-in-invalidation-for-any-write.js: Added.
+        (assert):
+        (test):
+        (test.i):
+
+2017-05-25  Mark Lam  <mark.lam@apple.com>
+
+        ObjectToStringAdaptiveInferredPropertyValueWatchpoint should not reinstall itself nor handleFire if it's dying shortly.
+        https://bugs.webkit.org/show_bug.cgi?id=172548
+        <rdar://problem/31458393>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-172548.patch: Added.
+
+2017-05-23  Saam Barati  <sbarati@apple.com>
+
+        We should not mmap zero bytes for a memory in Wasm
+        https://bugs.webkit.org/show_bug.cgi?id=172528
+        <rdar://problem/32257076>
+
+        Reviewed by Mark Lam.
+
+        * wasm/js-api/dont-mmap-zero-byte-memory.js: Added.
+        (testMems):
+
+2017-05-23  Saam Barati  <sbarati@apple.com>
+
+        CFGSimplificationPhase should not merge a block with itself
+        https://bugs.webkit.org/show_bug.cgi?id=172508
+        <rdar://problem/28424006>
+
+        Reviewed by Keith Miller.
+
+        * stress/dont-crash-in-cfg-simplification.js: Added.
+        (bar):
+        (baz):
+        (foo):
+
+2017-05-20  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [FTL] Support GetByVal with ArrayStorage and SlowPutArrayStorage
+        https://bugs.webkit.org/show_bug.cgi?id=172216
+
+        Reviewed by Saam Barati.
+
+        * stress/array-storage-get-by-val.js: Added.
+        (shouldBe):
+        (testOutOfBound):
+        (testInBound):
+        (testSlowPutOutOfBound):
+        (testSlowPutInBound):
+
+2017-05-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, fix commented out tests
+        https://bugs.webkit.org/show_bug.cgi?id=172225
+
+        * stress/get-by-val-string.js:
+        (object.43):
+        (Hello):
+        (Hello.prototype.get 42):
+        (Hello.prototype.43):
+        (Derived):
+        (shouldBe):
+        (throw.new.Error): Deleted.
+
+2017-05-21  Saam Barati  <sbarati@apple.com>
+
+        We incorrectly throw a syntax error when declaring a top level for-loop iteration variable the same as a parameter
+        https://bugs.webkit.org/show_bug.cgi?id=171041
+        <rdar://problem/32082516>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/lexical-scoping-for-loop.js: Added.
+        (assert):
+        (test1):
+        (test2):
+        (test3):
+        (test4):
+        (test5):
+        (test6):
+        (let.test7):
+        (let.test8):
+        (let.test9):
+        (let.test10):
+        (let.test11):
+        (let.test12):
+
+2017-05-19  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Make get_by_val & string "499" to number 499
+        https://bugs.webkit.org/show_bug.cgi?id=172225
+
+        Reviewed by Saam Barati.
+
+        * stress/get-by-val-string.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (object.43):
+        (Hello):
+        (Hello.prototype.get 42):
+        (Hello.prototype.43):
+        (Derived):
+
+2017-05-19  Mark Lam  <mark.lam@apple.com>
+
+        [Re-landing] DFG::SpeculativeJIT::pickCanTrample() is wrongly ignoring result registers.
+        https://bugs.webkit.org/show_bug.cgi?id=172383
+        <rdar://problem/31418651>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-172383.js: Added.
+
+2017-05-19  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r217156.
+
+        This change broke the iOS build.
+
+        Reverted changeset:
+
+        "DFG::SpeculativeJIT::pickCanTrample() is wrongly ignoring
+        result registers."
+        https://bugs.webkit.org/show_bug.cgi?id=172383
+        http://trac.webkit.org/changeset/217156
+
+2017-05-19  Mark Lam  <mark.lam@apple.com>
+
+        Add missing exception check.
+        https://bugs.webkit.org/show_bug.cgi?id=172346
+        <rdar://problem/32289640>
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/regress-172346.js: Added.
+
+2017-05-19  Mark Lam  <mark.lam@apple.com>
+
+        DFG::SpeculativeJIT::pickCanTrample() is wrongly ignoring result registers.
+        https://bugs.webkit.org/show_bug.cgi?id=172383
+        <rdar://problem/31418651>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-172383.js: Added.
+
+2017-05-19  Filip Pizlo  <fpizlo@apple.com>
+
+        arrayProtoPrivateFuncConcatMemcpy needs to be down with firstArray being undecided
+        https://bugs.webkit.org/show_bug.cgi?id=172369
+
+        Reviewed by Mark Lam.
+
+        * stress/undecided-concat.js: Added.
+
+2017-05-19  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC][DFG][DOMJIT] Extend CheckDOM to CheckSubClass
+        https://bugs.webkit.org/show_bug.cgi?id=172098
+
+        Reviewed by Saam Barati.
+
+        * stress/check-sub-class.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (calling):
+        (array.forEach):
+        (i.array.forEach):
+
+2017-05-18  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: exports is a getter
+        https://bugs.webkit.org/show_bug.cgi?id=172129
+
+        Reviewed by Saam Barati.
+
+        Update test to reflect new semantics.
+
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties.switch):
+
+2017-05-18  Saam Barati  <sbarati@apple.com>
+
+        Proxy's [[Get]] passes incorrect receiver
+        https://bugs.webkit.org/show_bug.cgi?id=164849
+        <rdar://problem/31767058>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/proxy-get-set-correct-receiver.js: Added.
+        (assert):
+        (test):
+        (test.let.target.set prop):
+        (test.let.target.get prop):
+        (test.get let):
+        * stress/proxy-set.js:
+        (let.target.get x):
+        * stress/reflect-set-proxy-set.js:
+        (let.target.get x):
+        * stress/reflect-set-receiver-proxy-set.js:
+        (let.target.get x):
+
+2017-05-18  Filip Pizlo  <fpizlo@apple.com>
+
+        Constructor calls set this too early
+        https://bugs.webkit.org/show_bug.cgi?id=172302
+
+        Reviewed by Saam Barati.
+        
+        This tests all three kinds of constructs in BytecodeGenerator. All three were previously
+        wrong.
+
+        * stress/construct-overwritten-variable.js: Added.
+        (new.x.x):
+        * stress/construct-spread-overwritten-variable-2.js: Added.
+        (new.x.x):
+        * stress/construct-spread-overwritten-variable.js: Added.
+        (new.x.x):
+
+2017-05-18  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: perform stack checks
+        https://bugs.webkit.org/show_bug.cgi?id=165546
+        <rdar://problem/29760307>
+
+        Reviewed by Filip Pizlo.
+
+        * wasm.yaml:
+        * wasm/function-tests/factorial.js:
+        * wasm/function-tests/float-sub.js:
+        * wasm/function-tests/stack-overflow.js: Added.
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.makeInstance):
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.assertOverflows):
+        (assertOverflows.makeInstance):
+        (assertOverflows.makeInstance2):
+        (assertOverflows.assertThrows):
+        (assertOverflows):
+        (assertThrows.test.makeSignature):
+        (assertThrows.test.makeInstance):
+        (assertThrows.test):
+        (assertThrows):
+
+2017-05-18  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly API: test with neutered inputs
+        https://bugs.webkit.org/show_bug.cgi?id=163899
+
+        Reviewed by JF Bastien.
+
+        * wasm/js-api/neutered-inputs.js: Added.
+        (const.testFunction):
+        (const.testConstructor):
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties.switch):
+
+2017-05-18  Filip Pizlo  <fpizlo@apple.com>
+
+        DFG inlining should be hardened for the no-result case
+        https://bugs.webkit.org/show_bug.cgi?id=172290
+
+        Reviewed by Saam Barati.
+
+        * stress/array-constructor-no-result.js: Added.
+        (foo):
+        * stress/pow-no-result.js: Added.
+        (foo):
+
+2017-05-18  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r217031, r217032, and r217037.
+        https://bugs.webkit.org/show_bug.cgi?id=172293
+
+        cause linking errors in Windows (Requested by yusukesuzuki on
+        #webkit).
+
+        Reverted changesets:
+
+        "[JSC][DFG][DOMJIT] Extend CheckDOM to CheckSubClass"
+        https://bugs.webkit.org/show_bug.cgi?id=172098
+        http://trac.webkit.org/changeset/217031
+
+        "Unreviewed, rebaseline for newly added ClassInfo"
+        https://bugs.webkit.org/show_bug.cgi?id=172098
+        http://trac.webkit.org/changeset/217032
+
+        "Unreviewed, fix debug and non-JIT build"
+        https://bugs.webkit.org/show_bug.cgi?id=172098
+        http://trac.webkit.org/changeset/217037
+
+2017-05-16  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC][DFG][DOMJIT] Extend CheckDOM to CheckSubClass
+        https://bugs.webkit.org/show_bug.cgi?id=172098
+
+        Reviewed by Saam Barati.
+
+        * stress/check-sub-class.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (calling):
+        (array.forEach):
+        (i.array.forEach):
+
+2017-05-17  Filip Pizlo  <fpizlo@apple.com>
+
+        Unreviewed, address mlam's review feedback.
+
+        * stress/arguments-elimination-varargs-too-many-args-arg-count.js:
+
+2017-05-17  Saam Barati  <sbarati@apple.com>
+
+        We don't do context switches for Wasm->Wasm call indirect
+        https://bugs.webkit.org/show_bug.cgi?id=172188
+        <rdar://problem/32231828>
+
+        Reviewed by Keith Miller.
+
+        * wasm/function-tests/context-switch.js: Added.
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.makeInstance):
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.makeInstance2):
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.const.i2.makeInstance2):
+        (makeInstance):
+        (makeInstance2):
+        (assert.eq.makeInstance):
+        (assert.eq.makeInstance2):
+        (assert.eq):
+
+2017-05-17  Filip Pizlo  <fpizlo@apple.com>
+
+        JSC: Incorrect LoadVarargs handling in ArgumentsEliminationPhase::transform
+        https://bugs.webkit.org/show_bug.cgi?id=172208
+
+        Reviewed by Saam Barati.
+
+        * stress/arguments-elimination-varargs-too-many-args-arg-count.js: Added.
+        (foo):
+        (bar):
+        (baz):
+
+2017-05-16  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Constant Folding Phase should convert MakeRope("", String) => Identity(String)
+        https://bugs.webkit.org/show_bug.cgi?id=172115
+
+        Reviewed by Saam Barati.
+
+        * stress/constant-folding-should-fold-make-rope-with-empty-strings.js: Added.
+        (shouldBe):
+        (unknown):
+        (readWord1):
+        (readWord2):
+        (readWord3):
+        (readWord4):
+
+2017-05-16  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: add memory fuzzer
+        https://bugs.webkit.org/show_bug.cgi?id=169976
+        <rdar://problem/31965328>
+
+        Reviewed by Keith Miller.
+
+        * wasm/fuzz/memory.js: Added.
+        (const.insert):
+        (const.action.string_appeared_here):
+        (const.performAction):
+        (catch):
+
+2017-05-16  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: validate load / store alignment
+        https://bugs.webkit.org/show_bug.cgi?id=168836
+        <rdar://problem/31965349>
+
+        Reviewed by Keith Miller.
+
+        * wasm/WASM.js: fix regular expression greed
+        * wasm/function-tests/memory-alignment.js: Added.
+        (const.op.of.WASM.opcodes):
+        * wasm/wasm.json: fix formatting
+
+2017-05-15  Mark Lam  <mark.lam@apple.com>
+
+        Rolling out r214038 and r213697: Crashes when using computed properties with rest destructuring and object spread.
+        https://bugs.webkit.org/show_bug.cgi?id=172147
+
+        Rubber-stamped by Saam Barati.
+
+        * stress/object-rest-deconstruct.js: Removed.
+        * stress/object-spread.js: Removed.
+
+2017-05-11  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: stop supporting 0xD
+        https://bugs.webkit.org/show_bug.cgi?id=168788
+        <rdar://problem/31880922>
+
+        Reviewed by Saam Barati.
+
+        Test that only version 1 is supported.
+
+        * wasm/js-api/version.js: Added.
+
+2017-05-10  JF Bastien  <jfbastien@apple.com>
+
+        WebAssemby: builder doesn't do Memory section maximum correctly
+        https://bugs.webkit.org/show_bug.cgi?id=171931
+
+        Reviewed by Keith Miller.
+
+        * wasm/Builder.js:
+        (export.default.Builder.prototype._registerSectionBuilders.const.section.in.WASM.description.section.switch.section.case.string_appeared_here.this.section):
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.emitters.Memory):
+        * wasm/function-tests/memory-grow-invalid.js: Added.
+
+2017-05-10  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: support name section
+        https://bugs.webkit.org/show_bug.cgi?id=171263
+
+        Reviewed by Keith Miller.
+
+        * wasm/function-tests/nameSection.js: Added.
+        (const.compile):
+        * wasm/function-tests/nameSection.wasm: Added.
+        * wasm/function-tests/stack-trace.js: Update format
+
+2017-05-10  Filip Pizlo  <fpizlo@apple.com>
+
+        Null pointer dereference in WTF::RefPtr<WTF::StringImpl>::operator!() under slow_path_get_direct_pname
+        https://bugs.webkit.org/show_bug.cgi?id=171801
+
+        Reviewed by Michael Saboff.
+        
+        These tests used to crash. The prefix and postfix tests cover different paths, except
+        postfix-ignored goes down the same path as prefix due to an optimization.
+
+        * stress/for-in-postfix-ignored-index.js: Added.
+        (foo):
+        * stress/for-in-postfix-index.js: Added.
+        (foo):
+        * stress/for-in-prefix-index.js: Added.
+        (foo):
+
+2017-05-08  Mark Lam  <mark.lam@apple.com>
+
+        op_throw_static_error's use of its first operand should be reflected in DFG BytecodeUseDef as well.
+        https://bugs.webkit.org/show_bug.cgi?id=171786
+        <rdar://problem/32051023>
+
+        Reviewed by Saam Barati.
+
+        * stress/bug-171786.js: Added.
+
+2017-05-06  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        [ES6] Arrow function. Issue in access to this after eval('super()') within constructor
+        https://bugs.webkit.org/show_bug.cgi?id=171543
+
+        Reviewed by Saam Barati.
+
+        * stress/arrowfunction-lexical-bind-supercall-4.js:
+        (J):
+        (K):
+
+2017-05-05  Saam Barati  <sbarati@apple.com>
+
+        putDirectIndex does not properly do defineOwnProperty
+        https://bugs.webkit.org/show_bug.cgi?id=171591
+        <rdar://problem/31735695>
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/array-prototype-splice-making-typed-array.js:
+        (test):
+        * stress/array-species-config-array-constructor.js:
+        (shouldThrow):
+        (test):
+        * stress/put-direct-index-broken-2.js: Added.
+        (assert):
+        (test):
+        (makeLengthWritable):
+        (set get restoreOldDesc):
+        * stress/put-direct-index-broken.js: Added.
+        (whatToTest):
+        (tryRunning):
+        (tryItOut):
+        * stress/put-indexed-getter-setter.js: Added.
+        (foo.X.prototype.set 7):
+        (foo.X.prototype.get 7):
+        (foo.X):
+        (foo):
+
+2017-05-04  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Math unary functions should be handled by DFG
+        https://bugs.webkit.org/show_bug.cgi?id=171269
+
+        Reviewed by Saam Barati.
+
+        * stress/arith-acos-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueACosNoArgument):
+        (testNoArgument):
+        (opaqueAllTypesACos):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueACosForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueACosForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueACosForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueACosWithException):
+        (testException):
+        * stress/arith-acosh-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueACoshNoArgument):
+        (testNoArgument):
+        (opaqueAllTypesACosh):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueACoshForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueACoshForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueACoshForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueACoshWithException):
+        (testException):
+        * stress/arith-asin-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueASinNoArgument):
+        (testNoArgument):
+        (opaqueAllTypesASin):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueASinForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueASinForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueASinForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueASinWithException):
+        (testException):
+        * stress/arith-asinh-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueASinhNoArgument):
+        (testNoArgument):
+        (opaqueAllTypesASinh):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueASinhForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueASinhForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueASinhForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueASinhWithException):
+        (testException):
+        * stress/arith-atan-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueATanNoArgument):
+        (testNoArgument):
+        (opaqueAllTypesATan):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueATanForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueATanForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueATanForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueATanWithException):
+        (testException):
+        * stress/arith-atanh-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueATanhNoArgument):
+        (testNoArgument):
+        (opaqueAllTypesATanh):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueATanhForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueATanhForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueATanhForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueATanhWithException):
+        (testException):
+        * stress/arith-cbrt-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueCbrtNoArgument):
+        (testNoArgument):
+        (opaqueAllTypesCbrt):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueCbrtForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueCbrtForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueCbrtForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueCbrtWithException):
+        (testException):
+        * stress/arith-cosh-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueCoshNoArgument):
+        (testNoArgument):
+        (opaqueAllTypesCosh):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueCoshForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueCoshForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueCoshForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueCoshWithException):
+        (testException):
+        * stress/arith-expm1-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueExpm1NoArgument):
+        (testNoArgument):
+        (opaqueAllTypesExpm1):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueExpm1ForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueExpm1ForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueExpm1ForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueExpm1WithException):
+        (testException):
+        * stress/arith-log10-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueLog10NoArgument):
+        (testNoArgument):
+        (opaqueAllTypesLog10):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueLog10ForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueLog10ForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueLog10ForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueLog10WithException):
+        (testException):
+        * stress/arith-log2-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueLog2NoArgument):
+        (testNoArgument):
+        (opaqueAllTypesLog2):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueLog2ForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueLog2ForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueLog2ForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueLog2WithException):
+        (testException):
+        * stress/arith-sinh-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueSinhNoArgument):
+        (testNoArgument):
+        (opaqueAllTypesSinh):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueSinhForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueSinhForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueSinhForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueSinhWithException):
+        (testException):
+        * stress/arith-tan-on-various-types.js:
+        (isIdentical):
+        * stress/arith-tanh-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueTanhNoArgument):
+        (testNoArgument):
+        (opaqueAllTypesTanh):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (testConstant):
+        (opaqueTanhForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueTanhForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueTanhForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueTanhWithException):
+        (testException):
+
+2017-05-03  Keith Miller  <keith_miller@apple.com>
+
+        Array.prototype.sort should also allow a null comparator
+        https://bugs.webkit.org/show_bug.cgi?id=171621
+
+        Reviewed by Michael Saboff.
+
+        Add test to make it less likely we revert to the incompatable behavior.
+        Also, fix now incorrect tests.
+
+        * ChakraCore/test/Array/array_sort.baseline-jsc:
+        * stress/array-sort-bad-comparator.js:
+        (test):
+        * stress/sort-null-comparator.js: Added.
+        (assertEq):
+
+2017-05-03  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] remove unneeded asyncFunctionTests.yaml
+        https://bugs.webkit.org/show_bug.cgi?id=171611
+
+        Reviewed by Yusuke Suzuki.
+
+        Async functions have shipped, and those tests are run as part of
+        JSTests/stress and JSTests/test262.yaml. The file is no longer needed.
+
+        * asyncFunctionTests.yaml: Removed.
+        * stress/async-await-long-loop.js:
+        * stress/async-await-throw-loop.js:
+
+2017-05-03  Keith Miller  <keith_miller@apple.com>
+
+        Different behaviour with the .sort(callback) method (unlike Firefox & Chrome)
+        https://bugs.webkit.org/show_bug.cgi?id=47825
+
+        Reviewed by Saam Barati.
+
+        * stress/sorting-boolean-result-comparator.js: Added.
+        (checkArray):
+
+2017-05-02  David Kilzer  <ddkilzer@apple.com>
+
+        check-webkit-style should keep JavaScript test functions in sync
+        <https://webkit.org/b/171424>
+
+        Reviewed by Joseph Pecoraro.
+
+        This change makes shouldBe(), shouldNotBe(), shouldNotThrow()
+        and shouldThrow() in sync with other copies of these methods.
+
+        * stress/resources/standalone-pre.js:
+        (shouldBe): Fix whitespace.  Prefix 'exception' and 'quiet'
+        variables with underscore.
+        (shouldThrow): Fix whitespace.
+
+2017-04-30  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        We initialize functions too early in an eval
+        https://bugs.webkit.org/show_bug.cgi?id=161099
+
+        Reviewed by Saam Barati.
+
+        * stress/eval-func-decl-with-let-const-class.js: Added.
+
+2017-04-30  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        [ES6]. Implement Annex B.3.3 function hoisting rules for eval
+        https://bugs.webkit.org/show_bug.cgi?id=163208
+
+        Reviewed by Saam Barati.
+
+        * stress/eval-func-decl-block-scoping-reassign.js: Added.
+        (assert):
+        (throw.new.Error.f):
+        (throw.new.Error):
+        * stress/eval-func-decl-block-with-remove.js: Added.
+        (assert):
+        (foo.boo):
+        (foo):
+        * stress/eval-func-decl-block-with-var-and-remove.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (joo):
+        (koo):
+        * stress/eval-func-decl-block-with-var-sinthesize.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (hoo):
+        (joo):
+        (koo):
+        * stress/eval-func-decl-in-block-scope-and-bind-to-top-eval-scope.js: Added.
+        * stress/eval-func-decl-in-eval-within-block-with-let.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (goo):
+        * stress/eval-func-decl-in-eval-within-with-scope.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (boo.let.val2):
+        (boo.let.val3):
+        * stress/eval-func-decl-in-frozen-global.js: Added.
+        (assert):
+        (assertThrow):
+        (throw.new.Error):
+        (Object.freeze):
+        * stress/eval-func-decl-in-global-of-eval.js: Added.
+        (assert):
+        (assertThrow):
+        (bar):
+        (baz):
+        (foobar):
+        * stress/eval-func-decl-in-global.js: Added.
+        (assert):
+        (assertThrow):
+        * stress/eval-func-decl-in-if.js: Added.
+        (assert):
+        * stress/eval-func-decl-within-eval-with-reassign-to-var.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (foobar):
+        (hoo):
+        (joo):
+        (koo):
+        (loo):
+        * stress/eval-func-decl-within-eval-without-reassign-to-let.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (goo):
+        * stress/variable-under-tdz-eval-tricky.js:
+        (assert):
+        * test262.yaml:
+
+2017-04-27  Mark Lam  <mark.lam@apple.com>
+
+        Fix some RELEASE_ASSERT failures caused by OutOfMemoryErrors.
+        https://bugs.webkit.org/show_bug.cgi?id=171404
+        <rdar://problem/31876178>
+
+        Reviewed by Saam Barati.
+
+        * stress/js-fixed-array-out-of-memory.js: Added.
+
+2017-04-27  David Kilzer  <ddkilzer@apple.com>
+
+        Enhance shouldBe()/shouldNotBe() to accept anonymous function arguments
+        <https://webkit.org/b/171362>
+        <rdar://problem/31867686>
+
+        Reviewed by Joseph Pecoraro.
+
+        * stress/resources/standalone-pre.js:
+        (shouldBe):
+        (shouldNotThrow):
+        (shouldThrow):
+        - Update shouldBe() to accept anonymous function arguments.
+          (The shouldNotBe() function was never copied over.)
+        - Also fix shouldThrow()/shouldNotThrow() to accept anonymous
+          function arguments (which were missed in r202609 for Bug
+          159232).
+
+2017-04-27  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Handle PhantomSpread in LoadVarargs as the same to the others
+        https://bugs.webkit.org/show_bug.cgi?id=171262
+
+        Reviewed by Saam Barati.
+
+        * stress/spread-outer-create-rest.js: Added.
+        (assert):
+        (foo):
+        (bar):
+        (baz):
+
+2017-04-26  Saam Barati  <sbarati@apple.com>
+
+        Print Wasm function index in stack trace
+        https://bugs.webkit.org/show_bug.cgi?id=171349
+
+        Reviewed by JF Bastien.
+
+        * wasm/function-tests/stack-trace.js: Added.
+        (import.Builder.from.string_appeared_here.assert):
+        (let.imp):
+        * wasm/function-tests/trap-after-cross-instance-call.js:
+        (wasmFrameCountFromError):
+        * wasm/function-tests/trap-load-2.js:
+        (wasmFrameCountFromError):
+        * wasm/function-tests/trap-load.js:
+        (wasmFrameCountFromError):
+
+2017-04-26  Saam Barati  <sbarati@apple.com>
+
+        ASSERTION FAILED: inIndex != notFound in JSC::invalidParameterInSourceAppender()
+        https://bugs.webkit.org/show_bug.cgi?id=170924
+        <rdar://problem/31721052>
+
+        Reviewed by Mark Lam.
+
+        * stress/error-message-for-function-base-not-found.js: Added.
+        (assert):
+        (throw.new.Error):
+        * stress/error-messages-for-in-operator-should-not-crash.js: Added.
+        (catch):
+
+2017-04-26  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: Implement tier up
+        https://bugs.webkit.org/show_bug.cgi?id=170134
+
+        Reviewed by Filip Pizlo.
+
+        * wasm/function-tests/trap-after-cross-instance-call.js:
+        * wasm/tier-up/js-to-wasm.js: Added.
+        (async.test):
+        * wasm/tier-up/wasm-to-wasm.js: Added.
+        (async.test):
+
+2017-04-26  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] Object.keys() must discard property names with no PropertyDescriptor
+        https://bugs.webkit.org/show_bug.cgi?id=171291
+
+        Reviewed by Yusuke Suzuki.
+
+        * es6/Proxy_ownKeys_duplicates.js:
+        * stress/proxy-own-keys.js:
+        (let.handler.getOwnPropertyDescriptor):
+        (let.handler.ownKeys):
+
+2017-04-25  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r215476.
+        https://bugs.webkit.org/show_bug.cgi?id=171304
+
+        "It broke JSBench" (Requested by saamyjoon on #webkit).
+
+        Reverted changeset:
+
+        "[ES6]. Implement Annex B.3.3 function hoisting rules for
+        eval"
+        https://bugs.webkit.org/show_bug.cgi?id=163208
+        http://trac.webkit.org/changeset/215476
+
+2017-04-25  Saam Barati  <sbarati@apple.com>
+
+        JSArray::isArrayPrototypeIteratorProtocolFastAndNonObservable is wrong because it does not do the necessary checks on the base object
+        https://bugs.webkit.org/show_bug.cgi?id=171150
+        <rdar://problem/31771880>
+
+        Reviewed by Sam Weinig.
+
+        * stress/spread-optimized-properly.js: Added.
+        (assert):
+        (test):
+        (shallowEq):
+        (makeArrayIterator):
+        (test.bar):
+        (test.callback):
+        (test.arr.__proto__.Symbol.iterator):
+        (test.arr.Symbol.iterator):
+        (test.get bar):
+        (test.hackedNext):
+        (test.test):
+        (test.):
+
+2017-04-25  Mark Lam  <mark.lam@apple.com>
+
+        [Follow up] Array.prototype.slice() should ensure that end >= begin.
+        https://bugs.webkit.org/show_bug.cgi?id=170989
+        <rdar://problem/31705652>
+
+        Not reviewed.
+
+        Follow up to rename a test file that was accidentally named wrongly.
+
+        * stress/regress-170989.js: Copied from JSTests/stress/regress-170989.patch.
+        * stress/regress-170989.patch: Removed.
+
+2017-04-25  Mark Lam  <mark.lam@apple.com>
+
+        Array.prototype.slice() should ensure that end >= begin.
+        https://bugs.webkit.org/show_bug.cgi?id=170989
+        <rdar://problem/31705652>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-170989.patch: Added.
+
+2017-04-25  Mark Lam  <mark.lam@apple.com>
+
+        Local CSE wrongly CSEs array accesses with different result types.
+        https://bugs.webkit.org/show_bug.cgi?id=170990
+        <rdar://problem/31705945>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-170990.js: Added.
+
+2017-04-25  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        WebAssembly: exporting a property with a name that's a number doesn't work
+        https://bugs.webkit.org/show_bug.cgi?id=168857
+
+        Reviewed by JF Bastien.
+
+        r213453 allows Wasm instances to expose indexed properties. We activate the tests.
+
+        * wasm/js-api/test_Instance.js:
+        (ExportedNumber):
+
+2017-04-24  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/language/expressions/object/method-definition/early-errors-object-method-duplicate-parameters.js
+        https://bugs.webkit.org/show_bug.cgi?id=171190
+
+        Reviewed by Saam Barati.
+
+        * stress/async-await-syntax.js:
+        * test262.yaml:
+
+2017-04-24  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Use JSFixedArray directly when using call_varargs
+        https://bugs.webkit.org/show_bug.cgi?id=171057
+
+        Reviewed by Saam Barati.
+
+        * stress/spread-capture-rest.js: Added.
+        (shouldBe):
+        (capture):
+        (a):
+        (b):
+        * stress/spread-multi-layers.js: Added.
+        (shouldBe):
+        (a):
+        (b):
+        (c):
+        (d):
+        * stress/spread-non-varargs.js: Added.
+        (shouldBe):
+        (a):
+        (b):
+
+2017-04-24  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/language/computed-property-names/class/static/getter-prototype.js
+        https://bugs.webkit.org/show_bug.cgi?id=170897
+
+        Reviewed by Saam Barati.
+
+        * test262.yaml:
+
+2017-04-24  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Address some FIXMEs in JavaScript tests for bugs that have been fixed
+        https://bugs.webkit.org/show_bug.cgi?id=171191
+
+        Reviewed by JF Bastien.
+
+        * stress/proxy-is-extensible.js:
+
+2017-04-24  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/language/statements/for-of/dstr-array-elem-init-fn-name-arrow.js
+        https://bugs.webkit.org/show_bug.cgi?id=171160
+
+        Reviewed by JF Bastien.
+
+        * stress/inferred-names.js:
+        * test262.yaml:
+
+2017-04-24  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/language/expressions/generators/yield-as-label.js
+        https://bugs.webkit.org/show_bug.cgi?id=170979
+
+        Reviewed by Saam Barati.
+
+        * stress/async-await-module-reserved-word.js:
+        * stress/async-await-reserved-word.js:
+        Converge on "Cannot" instead of "Can't".
+
+        * catch-parameter-syntax.js:
+        * yield-named-variable-generator.js:
+        * yield-named-variable.js:
+        * stress/yield-label-generator.js:
+        * stress/yield-label.js:
+        * stress/yield-reserved-word.js: Added.
+        More complete list of when 'yield' is allowed.
+
+        * ChakraCore/test/strict/23.reservedWords_sm.baseline-jsc:
+        * test262.yaml:
+
+2017-04-23  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r215674.
+        https://bugs.webkit.org/show_bug.cgi?id=171212
+
+        Possible unintended commit. This patch was on the wrong bug.
+        (Requested by JoePeck on #webkit).
+
+        Reverted changeset:
+
+        "test262: test262/test/language/expressions/generators/yield-
+        as-label.js"
+        https://bugs.webkit.org/show_bug.cgi?id=170979
+        http://trac.webkit.org/changeset/215674
+
+2017-04-23  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/built-ins/Number/prototype/toPrecision/nan.js
+        https://bugs.webkit.org/show_bug.cgi?id=171197
+
+        Reviewed by Saam Barati.
+
+        * test262.yaml:
+
+2017-04-23  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/language/expressions/generators/yield-as-label.js
+        https://bugs.webkit.org/show_bug.cgi?id=170979
+
+        Reviewed by Saam Barati.
+
+        * stress/async-await-module-reserved-word.js:
+        * stress/async-await-reserved-word.js:
+        Converge on "Cannot" instead of "Can't".
+
+        * catch-parameter-syntax.js:
+        * yield-named-variable-generator.js:
+        * yield-named-variable.js:
+        * stress/yield-label-generator.js:
+        * stress/yield-label.js:
+        * stress/yield-reserved-word.js: Added.
+        More complete list of when 'yield' is allowed.
+
+        * ChakraCore/test/strict/23.reservedWords_sm.baseline-jsc:
+        * test262.yaml:
+
+2017-04-23  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/built-ins/Number/parseFloat.js
+        https://bugs.webkit.org/show_bug.cgi?id=171193
+
+        Reviewed by Yusuke Suzuki.
+
+        * test262.yaml:
+
+2017-04-22  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: Module.exports, Module.imports, Module.customSections are wrong
+        https://bugs.webkit.org/show_bug.cgi?id=171078
+
+        Reviewed by Saam Barati.
+
+        They're static properties of Module, not instance properties of a module.
+        https://github.com/WebAssembly/design/blob/master/JS.md#webassemblymoduleexports
+
+        * wasm/js-api/Module.customSection.js:
+        (assert.throws.WebAssembly.Module.customSections):
+        (assert.eq):
+        (assert.throws.WebAssembly.Module.prototype.customSections): Deleted.
+        * wasm/js-api/Module.exports.js:
+        (assert.throws.WebAssembly.Module.exports):
+        (assert.truthy):
+        (assert.throws.WebAssembly.Module.prototype.exports): Deleted.
+        * wasm/js-api/Module.imports.js:
+        (assert.throws.WebAssembly.Module.imports):
+        (assert.truthy):
+        (assert.throws.WebAssembly.Module.prototype.imports): Deleted.
+
+2017-04-21  JF Bastien  <jfbastien@apple.com>
+
+        Silence noisy test
+
+        Unreviewed, Fil / Michael and I talked about it in the corridor. I
+        just forgot to set verbose to false before commit.
+
+        * wasm/stress/oom.js:
+
+2017-04-20  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC][FTL] FTL should support Arrayify
+        https://bugs.webkit.org/show_bug.cgi?id=169596
+
+        Reviewed by Saam Barati.
+
+        * stress/arrayify.js: Added.
+        (arrayifyInt32):
+        (arrayifyDouble):
+        (arrayifyContiguous):
+
+2017-04-20  Mark Lam  <mark.lam@apple.com>
+
+        virtualThunkFor() needs to materialize its of tagMaskRegister for tail calls.
+        https://bugs.webkit.org/show_bug.cgi?id=171079
+        <rdar://problem/31684756>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-171079.js: Added.
+
+2017-04-15  Filip Pizlo  <fpizlo@apple.com>
+
+        Optimize SharedArrayBuffer in the DFG+FTL
+        https://bugs.webkit.org/show_bug.cgi?id=164108
+
+        Reviewed by Saam Barati.
+        
+        Added a fairly comprehensive test of the intrinsics. This creates a function for each possible
+        combination of type and operation, and then first uses it nicely and then tries a bunch of
+        erroneous conditions like OOB.
+
+        * stress/SharedArrayBuffer-opt.js: Added.
+        (string_appeared_here.switch):
+        (string_appeared_here.str):
+        (runAtomic):
+        (shouldFail):
+        (Symbol):
+        (string_appeared_here.a.of.arrays.m.of.atomics):
+        * stress/SharedArrayBuffer.js:
+
+2017-04-19  Mark Lam  <mark.lam@apple.com>
+
+        B3StackmapSpecial should handle when stackmap values are not recoverable from a Def'ed arg.
+        https://bugs.webkit.org/show_bug.cgi?id=170973
+        <rdar://problem/30318657>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-170973.js: Added.
+
+2017-04-19  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: limit slow memories
+        https://bugs.webkit.org/show_bug.cgi?id=170825
+
+        Reviewed by Saam Barati.
+
+        * wasm.yaml:
+        * wasm/stress/oom.js: Added.
+        (try.true.WebAssemblyMemoryMode):
+        (catch):
+
+2017-04-19  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: don't expose any WebAssembly JS object if JIT is off
+        https://bugs.webkit.org/show_bug.cgi?id=170782
+
+        Reviewed by Saam Barati.
+
+        * wasm.yaml:
+        * wasm/noJIT/noJIT.js: Added.
+
+2017-04-18  Mark Lam  <mark.lam@apple.com>
+
+        r211670 broke double to int conversion.
+        https://bugs.webkit.org/show_bug.cgi?id=170961
+        <rdar://problem/31687696>
+
+        Reviewed by Yusuke Suzuki.
+
+        * microbenchmarks/double-to-int32.js: Added.
+        * stress/to-int32-sensible2.js: Added.
+
+2017-04-18  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        [ES6]. Implement Annex B.3.3 function hoisting rules for eval
+        https://bugs.webkit.org/show_bug.cgi?id=163208
+
+        Reviewed by Saam Barati.
+
+        * stress/eval-func-decl-block-scoping-reassign.js: Added.
+        (assert):
+        (throw.new.Error.f):
+        (throw.new.Error):
+        * stress/eval-func-decl-block-with-remove.js: Added.
+        (assert):
+        (foo.boo):
+        (foo):
+        * stress/eval-func-decl-block-with-var-and-remove.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (joo):
+        (koo):
+        * stress/eval-func-decl-block-with-var-sinthesize.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (hoo):
+        (joo):
+        (koo):
+        * stress/eval-func-decl-in-block-scope-and-bind-to-top-eval-scope.js: Added.
+        * stress/eval-func-decl-in-eval-within-block-with-let.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (goo):
+        * stress/eval-func-decl-in-eval-within-with-scope.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (boo.let.val2):
+        (boo.let.val3):
+        * stress/eval-func-decl-in-frozen-global.js: Added.
+        (assert):
+        (assertThrow):
+        (throw.new.Error):
+        (Object.freeze):
+        * stress/eval-func-decl-in-global-of-eval.js: Added.
+        (assert):
+        (assertThrow):
+        (bar):
+        (baz):
+        (foobar):
+        * stress/eval-func-decl-in-global.js: Added.
+        (assert):
+        (assertThrow):
+        * stress/eval-func-decl-in-if.js: Added.
+        (assert):
+        * stress/eval-func-decl-within-eval-with-reassign-to-var.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (foobar):
+        (hoo):
+        (joo):
+        (koo):
+        (loo):
+        * stress/eval-func-decl-within-eval-without-reassign-to-let.js: Added.
+        (assert):
+        (assertThrow):
+        (foo):
+        (boo):
+        (goo):
+        * stress/variable-under-tdz-eval-tricky.js:
+        (assert):
+        * test262.yaml:
+
+2017-04-18  Filip Pizlo  <fpizlo@apple.com>
+
+        wasm/function-tests/memory-multiagent times out sometimes
+        https://bugs.webkit.org/show_bug.cgi?id=170958
+
+        Reviewed by Keith Miller.
+        
+        Add the ability to skip tests easily. Skip the test.
+
+        * wasm.yaml:
+        * wasm/function-tests/memory-multiagent.js:
+
+2017-04-18  Saam Barati  <sbarati@apple.com>
+
+        Follow up to debug build stack overflow in test after r215453
+
+        Rubber stamped by Mark Lam.
+
+        * stress/call-apply-exponential-bytecode-size.js: Decrease the call
+        size to prevent stack overflow errors on debug builds.
+
+2017-04-18  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Convert ValueAdd(Int32, String) => MakeRope(ToString(Int32), String)
+        https://bugs.webkit.org/show_bug.cgi?id=170943
+
+        Reviewed by Geoffrey Garen.
+
+        * microbenchmarks/number-to-string-with-add-empty.js: Added.
+        (toStringLeft):
+        (toStringRight):
+        * microbenchmarks/number-to-string-with-add-in-loop.js: Added.
+        (toStringLeft):
+        (toStringRight):
+        * microbenchmarks/number-to-string-with-add.js: Added.
+        (toStringLeft):
+        (toStringRight):
+        * stress/number-to-string-with-add.js: Added.
+        (shouldBe):
+        (toStringRight):
+        (toStringLeftEmpty):
+        (toStringRightEmpty):
+
+2017-04-18  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Drop unknown use of CheckCell's child2 to work ObjectAllocationSinking for Array iterator object
+        https://bugs.webkit.org/show_bug.cgi?id=170940
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/for-of-array.js: Added.
+        (fn):
+
+2017-04-17  Saam Barati  <sbarati@apple.com>
+
+        BytecodeGenerator ".call" and ".apply" is exponential in nesting depth
+        https://bugs.webkit.org/show_bug.cgi?id=139847
+        <rdar://problem/19321122>
+
+        Reviewed by Oliver Hunt.
+
+        * stress/call-apply-exponential-bytecode-size.js: Added.
+        (assert):
+        (const.inc):
+        (const.inc2):
+        (bar):
+        (randomApplyOrCall):
+        (baz):
+        (jaz):
+        (haz):
+        (foo):
+
+2017-04-17  Mark Lam  <mark.lam@apple.com>
+
+        JSArray::appendMemcpy() needs to handle copying from Undecided indexing type too.
+        https://bugs.webkit.org/show_bug.cgi?id=170896
+        <rdar://problem/31651319>
+
+        Reviewed by JF Bastien and Keith Miller.
+
+        * stress/regress-170896.js: Added.
+
+2017-04-16  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/built-ins/Object/prototype/toLocaleString/primitive_this_value.js
+        https://bugs.webkit.org/show_bug.cgi?id=170882
+
+        Reviewed by Saam Barati.
+
+        * test262.yaml:
+
+2017-04-16  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/built-ins/isNaN/toprimitive-not-callable-throws.js
+        https://bugs.webkit.org/show_bug.cgi?id=170888
+
+        Reviewed by Saam Barati.
+
+        * stress/computed-accessor.js:
+        * stress/eval-in-arrow-function.js:
+        * stress/rest-elements.js:
+        * stress/string-object-define-own-property.js:
+        Remove unused shouldThrow.
+
+        * stress/symbol-toprimitive-errors.js: Added.
+        Check for ToPrimitive TypeErrors.
+
+        * test262.yaml:
+
+2017-04-16  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/language/expressions/tagged-template/template-object.js
+        https://bugs.webkit.org/show_bug.cgi?id=170878
+
+        Reviewed by Saam Barati.
+
+        * stress/array-length-not-writable.js: Added.
+        (assert):
+        * test262.yaml:
+
+2017-04-16  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/built-ins/Object/getOwnPropertyNames/15.2.3.4-4-44.js
+        https://bugs.webkit.org/show_bug.cgi?id=170879
+
+        Reviewed by Saam Barati.
+
+        * ChakraCore/test/es5/enumerable.baseline-jsc:
+        * test262.yaml:
+
+2017-04-16  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/built-ins/Date/prototype/Symbol.toPrimitive/name.js
+        https://bugs.webkit.org/show_bug.cgi?id=170884
+
+        Reviewed by Yusuke Suzuki.
+
+        * test262.yaml:
+
+2017-04-15  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/language/global-code/new.target-arrow.js
+        https://bugs.webkit.org/show_bug.cgi?id=170872
+
+        Reviewed by Saam Barati.
+
+        * stress/async-arrow-functions-lexical-new.target-binding.js:
+        (shouldThrowAsync): Deleted.
+        (shouldThrowAsync.async): Deleted.
+        This code should have thrown a SyntaxError. Instead it was throwing
+        a ReferenceError for the internal @newTargetLocal variable.
+
+        * stress/new-target-syntax-errors.js:
+        Cover the arrow function in global code cases.
+
+        * ChakraCore.yaml:
+        * ChakraCore/test/es6/globalLambdaNewTargetSyntaxError.baseline-jsc:
+        We now pass with an expected SyntaxError. Our error message is different.
+
+        * test262.yaml:
+
+2017-04-14  Saam Barati  <sbarati@apple.com>
+
+        ParseInt intrinsic in DFG backend doesn't properly flush its operands
+        https://bugs.webkit.org/show_bug.cgi?id=170865
+
+        Reviewed by Mark Lam and Geoffrey Garen.
+
+        * stress/parse-int-intrinsic-dfg-backend-flush.js: Added.
+        (assert):
+        (foo):
+
+2017-04-14  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] use ExpressionErrorClassifier for AwaitExpression operand
+        https://bugs.webkit.org/show_bug.cgi?id=170844
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-170732.js: Added.
+
+2017-04-14  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        Safari 10.1 JSON.parse returns incorrect object for numeric keys with decimal values
+        https://bugs.webkit.org/show_bug.cgi?id=170442
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/object-number-properties.js:
+
+2017-04-13  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Date.parse should accept wider range of representation
+        https://bugs.webkit.org/show_bug.cgi?id=170720
+
+        Reviewed by Darin Adler.
+
+        * stress/date-relaxed.js: Added.
+        (shouldBe):
+        (throw.new.Error):
+
+2017-04-13  Mark Lam  <mark.lam@apple.com>
+
+        Should use flushDirect() when flushing the scopeRegister due to needsScopeRegister().
+        https://bugs.webkit.org/show_bug.cgi?id=170661
+        <rdar://problem/31579046>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-170661.js: Added.
+
+2017-04-13  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: manage memory better
+        https://bugs.webkit.org/show_bug.cgi?id=170628
+
+        Reviewed by Keith Miller, Michael Saboff.
+
+        * wasm/Builder.js: move a helper out so tests can use it
+        (export.default.Builder.prototype._registerSectionBuilders.const.section.in.WASM.description.section.switch.section.case.string_appeared_here.this.section):
+        * wasm/WASM.js: add utilities to classify opcodes
+        (export.opcodes):
+        (export.const.memoryAccessInfo.op.const.sign):
+        * wasm/function-tests/memory-access-past-4gib.js: Added. This test
+        fails before this patch.
+        (const.op.of.WASM.opcodes):
+        * wasm/function-tests/memory-many.js: Added. This simple tests
+        just shouldn't crash. In verbose mode it's useful at determining
+        if the GC falls behind or not.
+        * wasm/function-tests/memory-multiagent.js: Added. Emulate postMessage.
+        (const.startAgents.numAgentsToStart.a.agent.receiveBroadcast):
+        (const.startAgents.numAgentsToStart.a.write.const.idx.Math.random):
+        (const.broadcastToAgents):
+        * wasm/js-api/extension-MemoryMode.js: verbose logging.
+        (testMemoryNoMax):
+        (testMemory):
+        (testInstanceNoMemory):
+        (testInstanceNoMax):
+        (testInstance):
+        * wasm/utilities.js: move a utility here.
+
+2017-04-12  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/built-ins/NativeErrors/EvalError/proto.js
+        https://bugs.webkit.org/show_bug.cgi?id=170668
+
+        Reviewed by Keith Miller.
+
+        * ChakraCore.yaml:
+        * ChakraCore/test/Lib/error.baseline-jsc: Added.
+        This test does not match the spec.
+
+        * test262.yaml:
+
+2017-04-12  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/language/literals/regexp/u-dec-esc.js
+        https://bugs.webkit.org/show_bug.cgi?id=170687
+
+        Reviewed by Michael Saboff.
+
+        * test262.yaml:
+
+2017-04-11  Michael Saboff  <msaboff@apple.com>
+
+        Implement Object.isFrozen() and Object.isSealed() per ECMA spec
+        https://bugs.webkit.org/show_bug.cgi?id=170753
+
+        Reviewed by Mark Lam.
+
+        Added JSC baseline and enabled defineIndexProperty test.
+
+        Note that JSC differs from Chakra in that a JSC doesn't use indexed
+        properties placed on the Array prototype when sorting the indexed 
+        properties of an Object.  This is behavior is considered undefined
+        in the standard.
+
+        * ChakraCore.yaml:
+        * ChakraCore/test/es5/defineIndexProperty.baseline-jsc: Added.
+
+2017-04-11  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/annexB/language/comments/multi-line-html-close.js
+        https://bugs.webkit.org/show_bug.cgi?id=170648
+
+        Reviewed by Keith Miller.
+
+        * test262.yaml:
+
+2017-04-11  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/built-ins/Array/S15.4.3_A2.2.js
+        https://bugs.webkit.org/show_bug.cgi?id=170652
+
+        Reviewed by Michael Saboff.
+
+        * stress/native-constructors-length.js: Added.
+        (assertLengthDescriptorAttributes):
+        Add a quick test for the length properties of all native constructors.
+
+        * ChakraCore/test/es5/enumerable.baseline-jsc:
+        Rebaseline expectations for this test.
+
+        * test262.yaml:
+
+2017-04-10  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: Update spec tests
+        https://bugs.webkit.org/show_bug.cgi?id=170683
+
+        Rubber-stamped by JF Bastien.
+
+        * wasm.yaml:
+        * wasm/spec-tests/br_table.wast.js:
+        * wasm/spec-tests/conversions.wast.js: Removed.
+        * wasm/spec-tests/f32_bitwise.wast.js: Added.
+        * wasm/spec-tests/f32_cmp.wast.js:
+        * wasm/spec-tests/f64_bitwise.wast.js: Added.
+        * wasm/spec-tests/f64_cmp.wast.js:
+        * wasm/spec-tests/i32.wast.js:
+        * wasm/spec-tests/i64.wast.js:
+        * wasm/spec-tests/int_exprs.wast.js:
+        * wasm/spec-tests/memory.wast.js:
+
+2017-04-09  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/annexB/language/expressions/object/__proto__-fn-name.js
+        https://bugs.webkit.org/show_bug.cgi?id=170650
+
+        Reviewed by Saam Barati.
+
+        * stress/inferred-names.js:
+        * test262.yaml:
+
+2017-04-09  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: test262/test/annexB/language/literals/regexp/identity-escape.js
+        https://bugs.webkit.org/show_bug.cgi?id=170651
+
+        Reviewed by Saam Barati.
+
+        * test262.yaml:
+
+2017-04-07  Michael Saboff  <msaboff@apple.com>
+
+        Fix and enable ChakraCore/test/es6/ES6Function_bugs.js after r215072
+        https://bugs.webkit.org/show_bug.cgi?id=170580
+
+        Reviewed by JF Bastien.
+
+        Commented out subtest that expects defineProperty("length") to a getter on a
+        sealed function shouldn't throw.
+
+        * ChakraCore.yaml:
+        * ChakraCore/test/es6/ES6Function_bugs.js:
+
+2017-04-06  Michael Saboff  <msaboff@apple.com>
+
+        Cannot Object.seal() or Object.freeze() global "this"
+        https://bugs.webkit.org/show_bug.cgi?id=170549
+
+        Reviewed by Mark Lam.
+
+        Enabled failing tests fixed by the corresponding code change:
+            ChakraCore/test/LetConst/delete.js
+            ChakraCore/test/LetConst/dop.js
+            ChakraCore/test/LetConst/dop1.js
+
+        * ChakraCore.yaml:
+        * ChakraCore/test/LetConst/dop.baseline-jsc: Added JSC specific expected output.
+        * ChakraCore/test/LetConst/dop1.baseline-jsc: Added JSC specific expected output.
+
+2017-04-05  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: ES2017 test progressions need updated expectations (arguments.caller removed)
+        https://bugs.webkit.org/show_bug.cgi?id=170536
+
+        Reviewed by Mark Lam.
+
+        * test262.yaml:
+        After r208867 the tests are out of date and are now expected to fail.
+
+2017-04-05  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: Final rebaseline of existing tests, a few tests have started failing
+        https://bugs.webkit.org/show_bug.cgi?id=170538
+
+        Reviewed by Mark Lam.
+
+        * test262.yaml:
+        These tests started failing a while ago. Mark them as legitmate failures.
+
+2017-04-05  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: Rebaseline expectations for now passing tests
+        https://bugs.webkit.org/show_bug.cgi?id=170532
+
+        Reviewed by Ryosuke Niwa.
+
+        * test262.yaml:
+        Update expectations for tests we are now passing.
+
+2017-04-05  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: module test progressions need updated expectations (@@iterator changes)
+        https://bugs.webkit.org/show_bug.cgi?id=170535
+
+        Reviewed by Saam Barati.
+
+        * test262.yaml:
+        After r212430 the tests are out of date and are now expected to fail.
+
+2017-04-05  Michael Saboff  <msaboff@apple.com>
+
+        Unreviewed rollout of r214642 as the test still intermittently fails.
+
+        Disabled ChakraCore/test/fieldopts/objtypespec-newobj-invalidation.1.js.
+
+        * ChakraCore.yaml:
+
+2017-04-05  Michael Saboff  <msaboff@apple.com>
+
+        REGRESSION (Safari 10.1): Inserting elements into arrays fails when array contains very large numbers
+        https://bugs.webkit.org/show_bug.cgi?id=170264
+        <rdar://problem/31375593>
+
+        Rubber-stamped by Saam Barati.
+
+        The original bug was fixed in: https://trac.webkit.org/changeset/214714
+        I'm just adding another test for good measure.
+
+        * stress/double-array-to-array-storage.js: Added.
+        (assert):
+
+2017-04-05  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: We shouldn't need to pin size registers if we have a fast memory.
+        https://bugs.webkit.org/show_bug.cgi?id=170504
+
+        Reviewed by Mark Lam.
+
+        * wasm/function-tests/trap-after-cross-instance-call.js: Added.
+        (b.new.WebAssembly.Memory):
+        (importObject.foo.bar):
+        (wasmFrameCountFromError):
+
+2017-03-16  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Generate TemplateObjects at linking time
+        https://bugs.webkit.org/show_bug.cgi?id=169743
+
+        Reviewed by Keith Miller.
+
+        * stress/template-string-tags-eval.js: Added.
+        (shouldBe):
+        (tag):
+
+2017-04-04  Mark Lam  <mark.lam@apple.com>
+
+        On ARM64, DFG::SpeculativeJIT::compileArithMod() failed to ensure result is of DataFormatInt32.
+        https://bugs.webkit.org/show_bug.cgi?id=170473
+        <rdar://problem/29912391>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-170473.js: Added.
+
+2017-04-03  Mark Lam  <mark.lam@apple.com>
+
+        Fix incorrect capacity delta calculation reported in SparseArrayValueMap::add().
+        https://bugs.webkit.org/show_bug.cgi?id=170412
+        <rdar://problem/29697336>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/regress-170412.js: Added.
+
+2017-04-03  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: Update spec tests
+        https://bugs.webkit.org/show_bug.cgi?id=170361
+
+        Rubber-stamped by Saam Barati.
+
+        Update the spec tests to run tests generated by the newer spec
+        test builder wasm-spec/test/builder.py. This patch also adds the
+        necessary harness code in spec-harness.js so we can run the tests.
+
+        * wasm.yaml:
+        * wasm/import-spec-tests.rb:
+        * wasm/spec-harness.js: Added.
+        (import.string_appeared_here.then):
+        (test):
+        (promise_test):
+        (let.assert_unreached):
+        * wasm/spec-harness/index.js: Added.
+        (let.testNum):
+        (assertThrows):
+        (_assert):
+        (ValueResult):
+        (ErrorResult):
+        (Result.prototype.isError):
+        (binary):
+        (module):
+        (uniqueTest):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (register):
+        (call):
+        (get instance):
+        (exports):
+        (run):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (try.f):
+        (catch):
+        (assert_exhaustion):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-harness/testharness.css: Added.
+        (html):
+        (#log .warning,):
+        (#log .error,):
+        (section#summary):
+        (table#results):
+        (table#results th:first-child,):
+        (table#results th:last-child,):
+        (table#results.assertions th:last-child,):
+        (table#results th):
+        (table#results td):
+        (tr.pass > td:first-child):
+        (tr.fail > td:first-child):
+        (tr.timeout > td:first-child):
+        (tr.notrun > td:first-child):
+        (.pass > td:first-child, .fail > td:first-child, .timeout > td:first-child, .notrun > td:first-child):
+        (table#results span):
+        (table#results span.expected):
+        (table#results span.actual):
+        (span.ok):
+        (tr.error):
+        (span.timeout):
+        (span.ok, span.timeout, span.error):
+        * wasm/spec-harness/testharness.js: Added.
+        (WindowTestEnvironment):
+        (WindowTestEnvironment.prototype._dispatch):
+        (WindowTestEnvironment.prototype._forEach_windows):
+        (WindowTestEnvironment.prototype.on_tests_ready):
+        (WindowTestEnvironment.prototype.setup_messages):
+        (WindowTestEnvironment.prototype.next_default_test_name):
+        (WindowTestEnvironment.prototype.on_new_harness_properties):
+        (WindowTestEnvironment.prototype.add_on_loaded_callback):
+        (WindowTestEnvironment.prototype.test_timeout):
+        (WindowTestEnvironment.prototype.global_scope):
+        (WorkerTestEnvironment):
+        (WorkerTestEnvironment.prototype._dispatch):
+        (WorkerTestEnvironment.prototype._add_message_port):
+        (WorkerTestEnvironment.prototype.next_default_test_name):
+        (WorkerTestEnvironment.prototype.on_new_harness_properties):
+        (WorkerTestEnvironment.prototype.on_tests_ready):
+        (WorkerTestEnvironment.prototype.add_on_loaded_callback):
+        (WorkerTestEnvironment.prototype.test_timeout):
+        (WorkerTestEnvironment.prototype.global_scope):
+        (DedicatedWorkerTestEnvironment):
+        (DedicatedWorkerTestEnvironment.prototype.on_tests_ready):
+        (SharedWorkerTestEnvironment):
+        (SharedWorkerTestEnvironment.prototype.on_tests_ready):
+        (ServiceWorkerTestEnvironment):
+        (ServiceWorkerTestEnvironment.prototype.add_on_loaded_callback):
+        (create_test_environment):
+        (is_shared_worker):
+        (is_service_worker):
+        (test):
+        (async_test):
+        (promise_test):
+        (this.wait_for):
+        (EventWatcher):
+        (setup):
+        (done):
+        (generate_tests):
+        (step_timeout):
+        (truncate):
+        (is_node):
+        (format_value):
+        * wasm/spec-harness/testharnessreport.js: Added.
+        * wasm/spec-harness/wasm-constants.js: Added.
+        (bytes):
+        (bytesWithHeader):
+        (makeSig):
+        (makeSig_v_x):
+        (makeSig_v_xx):
+        (makeSig_r_v):
+        (makeSig_r_x):
+        (makeSig_r_xx):
+        (assertTraps):
+        (assertWasmThrows):
+        * wasm/spec-harness/wasm-module-builder.js: Added.
+        (Binary.prototype.emit_u8):
+        (Binary.prototype.emit_u16):
+        (Binary.prototype.emit_u32):
+        (Binary.prototype.emit_u32v):
+        (Binary.prototype.emit_bytes):
+        (Binary.prototype.emit_string):
+        (Binary.prototype.emit_header):
+        (Binary.prototype.emit_section):
+        (Binary):
+        (WasmFunctionBuilder):
+        (WasmFunctionBuilder.prototype.exportAs):
+        (WasmFunctionBuilder.prototype.exportFunc):
+        (WasmFunctionBuilder.prototype.addBody):
+        (WasmFunctionBuilder.prototype.addLocals):
+        (WasmFunctionBuilder.prototype.end):
+        (WasmGlobalBuilder):
+        (WasmGlobalBuilder.prototype.exportAs):
+        (WasmModuleBuilder):
+        (WasmModuleBuilder.prototype.addStart):
+        (WasmModuleBuilder.prototype.addMemory):
+        (WasmModuleBuilder.prototype.addExplicitSection):
+        (WasmModuleBuilder.prototype.addType):
+        (WasmModuleBuilder.prototype.addGlobal):
+        (WasmModuleBuilder.prototype.addFunction):
+        (WasmModuleBuilder.prototype.addImport):
+        (WasmModuleBuilder.prototype.addImportedGlobal):
+        (WasmModuleBuilder.prototype.addImportedMemory):
+        (WasmModuleBuilder.prototype.addImportedTable):
+        (WasmModuleBuilder.prototype.addExport):
+        (WasmModuleBuilder.prototype.addExportOfKind):
+        (WasmModuleBuilder.prototype.addDataSegment):
+        (WasmModuleBuilder.prototype.exportMemoryAs):
+        (WasmModuleBuilder.prototype.addFunctionTableInit):
+        (WasmModuleBuilder.prototype.appendToTable):
+        (WasmModuleBuilder.prototype.setFunctionTableLength):
+        (WasmModuleBuilder.prototype.toArray):
+        (WasmModuleBuilder.prototype.toBuffer):
+        (WasmModuleBuilder.prototype.instantiate):
+        * wasm/spec-harness/wast.js: Added.
+        (normalize):
+        (require.else._registry.name):
+        (require):
+        (add_hex_char):
+        (add_char):
+        (string_with):
+        (list_of_opt):
+        (break_bytes.f):
+        (break_bytes):
+        (f):
+        (decls):
+        (func_type):
+        (limits):
+        (global_type):
+        (testop):
+        (relop):
+        (unop):
+        (binop):
+        (cvtop):
+        (oper):
+        (mem_size):
+        (extension):
+        (memop):
+        (storeop):
+        (var):
+        (constop):
+        (instr.else.switch.case.0.f):
+        (instr.else.switch.case.1.f.1):
+        (instr.else.switch.case.2.f.2):
+        (instr):
+        (func_with_name):
+        (func):
+        (start):
+        (table):
+        (memory):
+        (segment):
+        (elems):
+        (data):
+        (typedef):
+        (import_kind):
+        (import):
+        (export_kind):
+        (export):
+        (var_opt):
+        (is_func_import):
+        (is_table_import):
+        (is_memory_import):
+        (is_global_import):
+        (f.1):
+        (f.2):
+        (f.3):
+        (module_with_var_opt):
+        (module_):
+        (literal):
+        (definition):
+        (access):
+        (action):
+        (script):
+        (_registry.string_appeared_here):
+        (init):
+        (make_matrix):
+        (copy):
+        (append):
+        (sub):
+        (fill):
+        (blit):
+        (iter):
+        (map):
+        (iteri):
+        (mapi):
+        (to_list):
+        (list_length):
+        (of_list):
+        (fold_left):
+        (fold_right):
+        (maxson):
+        (trickle):
+        (bubble):
+        (trickleup):
+        (sort):
+        (merge):
+        (isortto):
+        (sortto):
+        (stable_sort):
+        (import_type):
+        (export_type):
+        (dims.n):
+        (dims.d.i):
+        (dims):
+        (map_file):
+        (create):
+        (of_array):
+        (slice_left):
+        (slice_right):
+        (slice_left_1):
+        (slice_right_1):
+        (slice_left_2):
+        (slice_right_2):
+        (array1_of_genarray):
+        (array2_of_genarray):
+        (array3_of_genarray):
+        (reshape_1):
+        (reshape_2):
+        (reshape_3):
+        (reshape):
+        (__):
+        (contents):
+        (to_bytes):
+        (nth):
+        (length):
+        (clear):
+        (reset):
+        (resize):
+        (add_substring):
+        (add_subbytes):
+        (add_string):
+        (add_bytes):
+        (add_buffer):
+        (add_channel):
+        (output_buffer):
+        (closing):
+        (advance_to_closing):
+        (advance_to_non_alpha):
+        (find_ident):
+        (add_substitute):
+        (make):
+        (to_string):
+        (of_string):
+        (sub_string):
+        (extend):
+        (blit_string):
+        (concat):
+        (cat):
+        (is_space):
+        (trim):
+        (escaped):
+        (uppercase):
+        (lowercase):
+        (apply1):
+        (capitalize):
+        (uncapitalize):
+        (index_rec):
+        (index):
+        (index_from):
+        (rindex_rec):
+        (rindex):
+        (rindex_from):
+        (contains_from):
+        (contains):
+        (rcontains_from):
+        (caml_array_sub):
+        (len):
+        (caml_array_concat):
+        (caml_make_vect):
+        (caml_array_blit):
+        (get if):
+        (caml_set_oo_id):
+        (get_id):
+        (caml_int32_float_of_bits):
+        (caml_int32_bits_of_float):
+        (caml_classify_float):
+        (caml_modf_float):
+        (caml_ldexp_float):
+        (caml_frexp_float):
+        (caml_copysign_float):
+        (caml_expm1_float):
+        (caml_hypot_float):
+        (caml_log10_float):
+        (caml_failwith):
+        (parse_digit):
+        (int_of_string_base):
+        (parse_sign_and_base):
+        (caml_int_of_string.aux):
+        (caml_int_of_string):
+        (caml_int64_of_string.aux):
+        (caml_int64_of_string):
+        (int_of_base):
+        (parse_format):
+        (finish_formatting):
+        (caml_format_int):
+        (caml_int64_format):
+        (caml_format_float):
+        (float_of_string):
+        (div):
+        (mod_):
+        (caml_bswap16):
+        (caml_int32_bswap):
+        (imul):
+        (neg_signed):
+        (not):
+        (eq):
+        (neg):
+        (lsl_):
+        (lsr_):
+        (asr_):
+        (is_zero):
+        (mul):
+        (swap):
+        (xor):
+        (or_):
+        (and_):
+        (ge):
+        (lt):
+        (gt):
+        (le):
+        (to_float):
+        (of_float):
+        (div_mod):
+        (compare):
+        (of_int32):
+        (to_int32):
+        (to_hex.aux):
+        (to_hex):
+        (discard_sign):
+        (float_of_bits):
+        (bits_of_float.to_nat):
+        (bits_of_float):
+        (get64):
+        (erase_rel):
+        (concat_fmtty):
+        (concat_fmt):
+        (create_char_set):
+        (add_in_char_set):
+        (rev_char_set):
+        (is_in_char_set):
+        (prec_of_prec_opt):
+        (param_format_of_ignored_format):
+        (buffer_check_size):
+        (buffer_add_char):
+        (buffer_add_string):
+        (buffer_contents):
+        (char_of_iconv):
+        (char_of_fconv):
+        (char_of_counter):
+        (print_char):
+        (set while.set var):
+        (set while.set else):
+        (set var):
+        (set else):
+        (set print_char):
+        (set if):
+        (bprint_padty):
+        (bprint_ignored_flag):
+        (bprint_pad_opt):
+        (bprint_padding):
+        (bprint_precision):
+        (bprint_iconv_flag):
+        (bprint_int_fmt):
+        (bprint_altint_fmt):
+        (bprint_fconv_flag):
+        (bprint_float_fmt):
+        (string_of_formatting_lit):
+        (string_of_formatting_gen):
+        (bprint_char_literal):
+        (bprint_string_literal):
+        (bprint_fmtty):
+        (int_of_custom_arity):
+        (bprint_fmt):
+        (string_of_fmt):
+        (symm):
+        (fmtty_rel_det):
+        (trans):
+        (fmtty_of_formatting_gen):
+        (fmtty_of_fmt):
+        (fmtty_of_custom):
+        (fmtty_of_padding_fmtty):
+        (fmtty_of_precision_fmtty):
+        (type_padding):
+        (type_padprec):
+        (type_ignored_param_one):
+        (type_format_gen):
+        (type_ignored_format_substitution):
+        (type_format):
+        (recast):
+        (fix_padding):
+        (fix_int_precision):
+        (string_to_caml_string):
+        (format_of_iconv):
+        (format_of_aconv):
+        (format_of_fconv):
+        (convert_int):
+        (convert_int32):
+        (convert_nativeint):
+        (convert_int64):
+        (else.is_valid):
+        (convert_float):
+        (format_caml_char):
+        (string_of_fmtty):
+        (else.switch.):
+        (else.switch.k.prime):
+        (else.switch.else.):
+        (else.switch.else.k.prime.1):
+        (make_printf):
+        (make_from_fmtty):
+        (make_invalid_arg):
+        (make_string_padding):
+        (make_int_padding_precision):
+        (make_custom):
+        (output_acc):
+        (bufput_acc):
+        (strput_acc):
+        (failwith_message.k):
+        (failwith_message):
+        (open_box_of_string.else.invalid_box):
+        (open_box_of_string.else.parse_spaces):
+        (open_box_of_string.else.parse_lword):
+        (open_box_of_string.else.parse_int):
+        (open_box_of_string):
+        (make_padding_fmt_ebb):
+        (make_precision_fmt_ebb):
+        (make_padprec_fmt_ebb):
+        (invalid_format_message):
+        (invalid_format_without):
+        (expected_character):
+        (compute_int_conv):
+        (incompatible_flag):
+        (parse_positive):
+        (parse_conv):
+        (parse_after_precision):
+        (else.parse_literal):
+        (parse_after_padding):
+        (parse_literal):
+        (parse_after_at):
+        (add_literal):
+        (parse_spaces):
+        (parse_integer):
+        (compute_float_conv):
+        (search_subformat_end):
+        (check_no_0):
+        (opt_of_pad):
+        (get_prec_opt):
+        (else.switch.case.99.char_format):
+        (else.switch.scan_format):
+        (parse_conversion):
+        (set_flag):
+        (parse_flags):
+        (is_int_base):
+        (counter_of_char):
+        (add_range):
+        (fail_single_percent):
+        (parse_char_set_after_char):
+        (parse_char_set_content):
+        (parse_char_set_start):
+        (parse_char_set):
+        (check_open_box):
+        (parse_tag):
+        (fmt_ebb_of_string):
+        (format_of_string_fmtty):
+        (format_of_string_format):
+        (caret):
+        (caml_ml_open_descriptor_in):
+        (caml_ml_open_descriptor_out):
+        (caml_ml_flush):
+        (node_std_output):
+        (caml_ml_output_char):
+        (caml_ml_input):
+        (caml_ml_input_char):
+        (caml_ml_out_channels_list):
+        (fail):
+        (caml_lex_array):
+        (caml_lex_engine):
+        (caml_lex_run_mem):
+        (caml_lex_run_tag):
+        (caml_new_lex_engine):
+        (caml_obj_dup):
+        (caml_obj_truncate):
+        (caml_lazy_make_forward):
+        (caml_update_dummy):
+        (caml_int_compare):
+        (caml_compare):
+        (caml_equal):
+        (caml_notequal):
+        (caml_greaterequal):
+        (caml_lessequal):
+        (else.aux):
+        (caml_get_public_method):
+        (caml_parse_engine):
+        (caml_set_parser_trace):
+        (js_string_of_char):
+        (caml_string_get):
+        (caml_create_string):
+        (caml_string_compare):
+        (caml_fill_string):
+        (caml_blit_string):
+        (caml_blit_bytes):
+        (bytes_of_string):
+        (bytes_to_string):
+        (caml_string_of_char_array):
+        (caml_is_printable):
+        (caml_string_get16):
+        (caml_string_get32):
+        (repeat):
+        (chr):
+        (app):
+        (js):
+        (curry_1):
+        (_1):
+        (js1):
+        (__1):
+        (curry_2):
+        (_2):
+        (js2):
+        (__2):
+        (curry_3):
+        (_3):
+        (js3):
+        (__3):
+        (curry_4):
+        (_4):
+        (js4):
+        (__4):
+        (curry_5):
+        (_5):
+        (js5):
+        (__5):
+        (curry_6):
+        (_6):
+        (js6):
+        (__6):
+        (curry_7):
+        (_7):
+        (js7):
+        (__7):
+        (curry_8):
+        (_8):
+        (js8):
+        (__8):
+        (stream):
+        (eos):
+        (skip):
+        (read):
+        (peek):
+        (string_of_byte):
+        (position):
+        (region):
+        (error):
+        (guard):
+        (get 1):
+        (get expect):
+        (get illegal):
+        (at):
+        (u32):
+        (u64):
+        (get require):
+        (vuN):
+        (get var):
+        (vsN):
+        (vu32):
+        (vs32):
+        (vs64):
+        (f32):
+        (f64):
+        (len32):
+        (string):
+        (opt):
+        (vec):
+        (sized):
+        (value_type):
+        (elem_type):
+        (stack_type):
+        (table_type):
+        (memory_type):
+        (mutability.get if):
+        (mutability):
+        (instr.get if):
+        (instr_block):
+        (const):
+        (id):
+        (section):
+        (type_section):
+        (import_kind.get if):
+        (import_section):
+        (func_section):
+        (table_section):
+        (memory_section):
+        (global):
+        (global_section):
+        (export_kind.get if):
+        (export_section):
+        (start_section):
+        (local):
+        (code):
+        (code_section):
+        (table_segment):
+        (elem_section):
+        (memory_segment):
+        (data_section):
+        (partial_arg.1):
+        (custom):
+        (custom_section):
+        (iterate):
+        (decode):
+        (patch):
+        (encode.u8):
+        (encode.u16):
+        (encode.u32):
+        (encode.vu64):
+        (encode.vs64):
+        (encode.vu32):
+        (encode.len):
+        (encode.bool):
+        (encode.string):
+        (encode.vec):
+        (encode.gap32):
+        (encode.patch_gap32):
+        (encode.value_type):
+        (encode.stack_type):
+        (encode.func_type):
+        (encode.limits):
+        (encode.table_type):
+        (encode.memory_type):
+        (encode.global_type):
+        (encode.memop):
+        (encode):
+        (encode.instr):
+        (encode.const):
+        (encode.section):
+        (encode.type_section):
+        (encode.import):
+        (encode.import_section):
+        (encode.func):
+        (encode.func_section):
+        (encode.table):
+        (encode.table_section):
+        (encode.memory):
+        (encode.memory_section):
+        (encode.global):
+        (encode.global_section):
+        (encode.export_kind):
+        (encode.export):
+        (encode.export_section):
+        (encode.start_section):
+        (encode.combine):
+        (encode.compress):
+        (encode.local):
+        (encode.code):
+        (encode.code_section):
+        (encode.segment):
+        (encode.table_segment):
+        (encode.elem_section):
+        (encode.memory_segment):
+        (encode.module_):
+        (Make.warn):
+        (Make.error):
+        (Make):
+        (print_nan_significand_digits):
+        (Make.of_bits):
+        (Make.to_bits):
+        (Make.is_nan):
+        (Make.canonicalize_nan):
+        (Make.determine_binary_nan):
+        (Make.determine_unary_nan):
+        (Make.binary):
+        (Make.unary):
+        (Make.add):
+        (Make.sub):
+        (Make.mul):
+        (Make.div):
+        (Make.sqrt):
+        (Make.ceil):
+        (Make.floor):
+        (Make.trunc):
+        (Make.nearest):
+        (Make.min):
+        (Make.max):
+        (Make.abs):
+        (Make.neg):
+        (Make.copysign):
+        (Make.eq):
+        (Make.ne):
+        (Make.lt):
+        (Make.gt):
+        (Make.le):
+        (Make.ge):
+        (Make.of_signless_string):
+        (Make.of_string):
+        (Make.to_string):
+        (add_queue):
+        (peek_queue):
+        (take_queue):
+        (pp_enqueue):
+        (pp_clear_queue):
+        (pp_output_string):
+        (break_new_line):
+        (break_same_line):
+        (pp_force_break_line):
+        (switch.add_tab):
+        (else.switch.find):
+        (format_pp_token):
+        (advance_left):
+        (enqueue_advance):
+        (enqueue_string_as):
+        (set_size):
+        (scan_push):
+        (pp_open_box_gen):
+        (pp_close_box):
+        (pp_open_tag):
+        (pp_close_tag):
+        (pp_set_print_tags):
+        (pp_set_mark_tags):
+        (pp_get_print_tags):
+        (pp_get_mark_tags):
+        (pp_set_tags):
+        (pp_get_formatter_tag_functions):
+        (pp_set_formatter_tag_functions):
+        (pp_rinit):
+        (pp_flush_queue):
+        (pp_print_as_size):
+        (pp_print_string):
+        (pp_print_int):
+        (pp_print_float):
+        (pp_print_bool):
+        (pp_open_hbox):
+        (pp_open_vbox):
+        (pp_open_hvbox):
+        (pp_open_hovbox):
+        (pp_open_box):
+        (pp_print_newline):
+        (pp_print_flush):
+        (pp_force_newline):
+        (pp_print_if_newline):
+        (pp_print_break):
+        (pp_print_space):
+        (pp_print_cut):
+        (pp_open_tbox):
+        (pp_close_tbox):
+        (pp_print_tbreak):
+        (pp_print_tab):
+        (pp_set_tab):
+        (pp_print_list):
+        (flush):
+        (pp_print_text):
+        (pp_set_max_boxes):
+        (pp_get_max_boxes):
+        (pp_over_max_boxes):
+        (pp_get_ellipsis_text):
+        (pp_limit):
+        (pp_set_max_indent):
+        (pp_get_max_indent):
+        (pp_set_margin):
+        (pp_get_margin):
+        (pp_set_formatter_out_functions):
+        (pp_get_formatter_out_functions):
+        (pp_set_formatter_output_functions):
+        (pp_get_formatter_output_functions):
+        (pp_set_all_formatter_output_functions):
+        (pp_get_all_formatter_output_functions):
+        (display_newline):
+        (display_blanks):
+        (state.16):
+        (state.17):
+        (state.18):
+        (state.19):
+        (pp_set_formatter_out_channel):
+        (default_pp_mark_open_tag):
+        (default_pp_mark_close_tag):
+        (default_pp_print_open_tag):
+        (default_pp_print_close_tag):
+        (pp_make_formatter):
+        (ppf.18):
+        (ppf.19):
+        (make_formatter):
+        (formatter_of_out_channel):
+        (formatter_of_buffer):
+        (flush_str_formatter):
+        (flush_buf_formatter):
+        (open_hbox):
+        (open_vbox):
+        (open_hvbox):
+        (open_hovbox):
+        (open_box):
+        (close_box):
+        (open_tag):
+        (close_tag):
+        (print_as):
+        (print_string):
+        (print_int):
+        (print_float):
+        (print_bool):
+        (print_cut):
+        (print_space):
+        (force_newline):
+        (print_flush):
+        (print_newline):
+        (print_if_newline):
+        (open_tbox):
+        (close_tbox):
+        (print_tbreak):
+        (set_tab):
+        (print_tab):
+        (set_margin):
+        (get_margin):
+        (set_max_indent):
+        (get_max_indent):
+        (set_max_boxes):
+        (get_max_boxes):
+        (over_max_boxes):
+        (set_ellipsis_text):
+        (get_ellipsis_text):
+        (set_formatter_out_channel):
+        (set_formatter_out_functions):
+        (get_formatter_out_functions):
+        (set_formatter_output_functions):
+        (get_formatter_output_functions):
+        (set_all_formatter_output_functions):
+        (get_all_formatter_output_functions):
+        (set_formatter_tag_functions):
+        (get_formatter_tag_functions):
+        (set_print_tags):
+        (get_print_tags):
+        (set_mark_tags):
+        (get_mark_tags):
+        (set_tags):
+        (compute_tag):
+        (output_formatting_lit):
+        (kfprintf):
+        (ikfprintf):
+        (fprintf):
+        (ifprintf):
+        (printf):
+        (eprintf):
+        (k.prime):
+        (ksprintf):
+        (sprintf):
+        (asprintf.k.prime):
+        (asprintf):
+        (k):
+        (bprintf):
+        (succ):
+        (pred):
+        (abs):
+        (lognot):
+        (Make.cmp_u):
+        (Make.divrem_u):
+        (Make.div_s):
+        (Make.div_u):
+        (Make.rem_s):
+        (Make.rem_u):
+        (Make.shift):
+        (Make.shl):
+        (Make.shr_s):
+        (Make.shr_u):
+        (Make.clamp_rotate_count):
+        (Make.rotl):
+        (Make.rotr):
+        (Make.loop):
+        (Make.clz):
+        (Make.ctz):
+        (Make.popcnt):
+        (Make.eqz):
+        (Make.lt_u):
+        (Make.le_u):
+        (Make.gt_u):
+        (Make.ge_u):
+        (Make.of_int_u):
+        (Make.to_string_u):
+        (Make.require):
+        (Make.dec_digit):
+        (Make.hex_digit):
+        (Make.parse_int):
+        (Make.of_string_s):
+        (Make.of_string_u):
+        (convert_pos):
+        (error_nest):
+        (text):
+        (intop):
+        (floatop):
+        (numop):
+        (memsz):
+        (ext):
+        (token.else.switch):
+        (token.else.switch.):
+        (token):
+        (__ocaml_lex_comment_rec):
+        (engine):
+        (new_engine):
+        (from_function):
+        (from_channel):
+        (from_string):
+        (lexeme):
+        (sub_lexeme):
+        (sub_lexeme_opt):
+        (sub_lexeme_char):
+        (sub_lexeme_char_opt):
+        (lexeme_char):
+        (lexeme_start):
+        (lexeme_end):
+        (lexeme_start_p):
+        (lexeme_end_p):
+        (new_line):
+        (flush_input):
+        (take):
+        (drop):
+        (last):
+        (split_last):
+        (index_of):
+        (index_of_int32):
+        (dim):
+        (set 1):
+        (get 2):
+        (log2):
+        (is_power_of_two):
+        (loop):
+        (breakup):
+        (hd):
+        (tl):
+        (rev_append):
+        (rev):
+        (flatten):
+        (rev_map):
+        (map2):
+        (rev_map2):
+        (iter2):
+        (fold_left2):
+        (fold_right2):
+        (for_all):
+        (exists):
+        (for_all2):
+        (exists2):
+        (mem):
+        (memq):
+        (assoc):
+        (assq):
+        (mem_assoc):
+        (mem_assq):
+        (remove_assoc):
+        (remove_assq):
+        (find):
+        (find_all):
+        (partition):
+        (split):
+        (combine):
+        (chop):
+        (rev_sort):
+        (sort_uniq):
+        (Make.height):
+        (Make.create):
+        (Make.singleton):
+        (Make.bal):
+        (Make.is_empty):
+        (Make.find):
+        (Make.mem):
+        (Make.min_binding):
+        (Make.max_binding):
+        (Make.remove_min_binding):
+        (Make.remove):
+        (Make.iter):
+        (Make.map):
+        (Make.mapi):
+        (Make.fold):
+        (Make.for_all):
+        (Make.exists):
+        (Make.add_min_binding):
+        (Make.add_max_binding):
+        (Make.join):
+        (Make.concat):
+        (Make.concat_or_join):
+        (Make.split):
+        (Make.merge):
+        (Make.filter):
+        (Make.partition):
+        (Make.cons_enum):
+        (Make.compare):
+        (Make.equal):
+        (Make.cardinal):
+        (Make.bindings_aux):
+        (Make.bindings):
+        (double_field):
+        (set_double_field):
+        (marshal):
+        (unmarshal):
+        (extension_slot):
+        (extension_name):
+        (extension_id):
+        (i32_const):
+        (i64_const):
+        (f32_const):
+        (f64_const):
+        (block):
+        (br):
+        (br_if):
+        (br_table):
+        (if_):
+        (call):
+        (call_indirect):
+        (get_local):
+        (set_local):
+        (tee_local):
+        (get_global):
+        (set_global):
+        (i32_load):
+        (i64_load):
+        (f32_load):
+        (f64_load):
+        (i32_load8_s):
+        (i32_load8_u):
+        (i32_load16_s):
+        (i32_load16_u):
+        (i64_load8_s):
+        (i64_load8_u):
+        (i64_load16_s):
+        (i64_load16_u):
+        (i64_load32_s):
+        (i64_load32_u):
+        (i32_store):
+        (i64_store):
+        (f32_store):
+        (f64_store):
+        (i32_store8):
+        (i32_store16):
+        (i64_store8):
+        (i64_store16):
+        (i64_store32):
+        (parse):
+        (string_to):
+        (string_to_script):
+        (string_to_module):
+        (parse_error):
+        (position_to_pos):
+        (positions_to_region):
+        (ati):
+        (nat):
+        (nat32):
+        (empty_context):
+        (enter_func):
+        (type_):
+        (lookup):
+        (label):
+        (anon_type):
+        (bind):
+        (bind_func):
+        (bind_local):
+        (bind_global):
+        (bind_table):
+        (bind_memory):
+        (anon):
+        (anon_func):
+        (anon_locals):
+        (anon_global):
+        (anon_table):
+        (anon_memory):
+        (anon_label):
+        (explicit_sig):
+        (inline_type):
+        (yyact):
+        (script1):
+        (module1):
+        (grow_stacks):
+        (clear_parser):
+        (current_lookahead_fun):
+        (catch.else.current_lookahead_fun.0):
+        (yyparse):
+        (peek_val):
+        (symbol_start_pos):
+        (symbol_end_pos):
+        (rhs_start_pos):
+        (rhs_end_pos):
+        (symbol_start):
+        (symbol_end):
+        (rhs_start):
+        (rhs_end):
+        (is_current_lookahead):
+        (failwith):
+        (invalid_arg):
+        (min):
+        (max):
+        (lnot):
+        (char_of_int):
+        (string_of_bool):
+        (bool_of_string):
+        (string_of_int):
+        (valid_float_lexem):
+        (string_of_float):
+        (open_out_gen):
+        (open_out):
+        (open_out_bin):
+        (flush_all):
+        (output_bytes):
+        (output_string):
+        (output):
+        (output_substring):
+        (output_value):
+        (close_out):
+        (close_out_noerr):
+        (open_in_gen):
+        (open_in):
+        (open_in_bin):
+        (input):
+        (else.r):
+        (unsafe_really_input):
+        (really_input):
+        (really_input_string):
+        (input_line.build_result):
+        (input_line.n):
+        (input_line.scan):
+        (input_line):
+        (close_in_noerr):
+        (print_bytes):
+        (print_endline):
+        (prerr_char):
+        (prerr_string):
+        (prerr_bytes):
+        (prerr_int):
+        (prerr_float):
+        (prerr_endline):
+        (prerr_newline):
+        (read_line):
+        (read_int):
+        (read_float):
+        (string_of_format):
+        (at_exit.exit_function.0):
+        (at_exit):
+        (do_at_exit):
+        (exit):
+        (output_binary_int):
+        (seek_out):
+        (pos_out):
+        (out_channel_length):
+        (set_binary_mode_out):
+        (input_binary_int):
+        (input_value):
+        (seek_in):
+        (pos_in):
+        (in_channel_length):
+        (close_in):
+        (set_binary_mode_in):
+        (LargeFile_000):
+        (LargeFile_001):
+        (LargeFile_002):
+        (LargeFile_003):
+        (LargeFile_004):
+        (LargeFile_005):
+        (kbprintf):
+        (plus):
+        (pp):
+        (print):
+        (string_of_pos):
+        (string_of_region):
+        (escaped.needs_escape):
+        (set_signal):
+        (catch_break):
+        (size):
+        (string_of_value_type):
+        (string_of_value_types):
+        (string_of_elem_type):
+        (string_of_limits):
+        (string_of_table_type):
+        (string_of_global_type):
+        (string_of_stack_type):
+        (string_of_func_type):
+        (type_of):
+        (default_value):
+        (value_of_bool):
+        (string_of_values):
+        (to_value):
+        (of_value):
+        (g):
+        (binary):
+        (bytes):
+        * wasm/spec-tests/address.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/binary.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/block.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/br.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/br_if.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/br_table.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/break-drop.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/call.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/call_indirect.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/comments.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/conversions.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/custom_section.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/endianness.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/exports.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/f32.wast.js: Removed.
+        * wasm/spec-tests/f32_cmp.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/f64.wast.js: Removed.
+        * wasm/spec-tests/f64_cmp.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/fac.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/float_exprs.wast.js: Removed.
+        * wasm/spec-tests/float_literals.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/float_memory.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/float_misc.wast.js: Removed.
+        * wasm/spec-tests/forward.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/func.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/func_ptrs.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/get_local.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/globals.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/i32.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/i64.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/if.wast.js: Added.
+        * wasm/spec-tests/imports.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/int_exprs.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/int_literals.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/jsapi.js: Added.
+        (testJSAPI.get test):
+        (testJSAPI.test):
+        (testJSAPI.set test):
+        (testJSAPI.assertCompileError):
+        (testJSAPI.assertCompileSuccess):
+        (testJSAPI):
+        * wasm/spec-tests/labels.wast.js: Added.
+        * wasm/spec-tests/left-to-right.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/linking.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/loop.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/memory.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/memory_redundancy.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/memory_trap.wast.js: Removed.
+        * wasm/spec-tests/names.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/nop.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/resizing.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/return.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/select.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/set_local.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/skip-stack-guard-page.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/stack.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/start.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/store_retval.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/switch.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/tee_local.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/traps.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/typecheck.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/unreachable.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+        * wasm/spec-tests/unreached-invalid.wast.js: Added.
+        * wasm/spec-tests/unwind.wast.js:
+        (register): Deleted.
+        (module): Deleted.
+        (instance): Deleted.
+        (assert_malformed): Deleted.
+        (assert_invalid): Deleted.
+        (assert_soft_invalid): Deleted.
+        (assert_unlinkable): Deleted.
+        (assert_uninstantiable): Deleted.
+        (assert_trap): Deleted.
+        (assert_return): Deleted.
+        (assert_return_nan): Deleted.
+
+2017-04-01  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        Object with numerical keys with gaps gets filled by NaN values
+        https://bugs.webkit.org/show_bug.cgi?id=164412
+
+        Reviewed by Merk Lam.
+
+        * stress/object-number-properties.js: Added.
+        (assert):
+        (boo):
+
+2017-03-30  Michael Saboff  <msaboff@apple.com>
+
+        Turning ChakraCore/test/fieldopts/objtypespec-newobj-invalidation.1.js back as it appears to always work
+        https://bugs.webkit.org/show_bug.cgi?id=170313
+
+        Reviewed by Saam Barati.
+
+        Enable ChakraCore/test/fieldopts/objtypespec-newobj-invalidation.1.js as it seems solid.
+
+        * ChakraCore.yaml:
+
+2017-03-30  Michael Saboff  <msaboff@apple.com>
+
+        Enable ChakraCore/Function/FuncBody.js test as it now works
+        https://bugs.webkit.org/show_bug.cgi?id=170301
+
+        Reviewed by Mark Lam.
+
+        This test no longer crashes, so enable it and create a JSC specific
+        expected file.
+
+        * ChakraCore.yaml:
+        * ChakraCore/test/Function/FuncBodyES5.baseline-jsc: Added.
+
+2017-03-30  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: fix misc JS API implementation inconsistencies
+        https://bugs.webkit.org/show_bug.cgi?id=170187
+
+        Reviewed by Keith Miller.
+
+        Verify that WebAssembly function are on the object's __proto__.
+
+        * wasm/js-api/Module-compile.js:
+        * wasm/js-api/validate.js:
+        * wasm/js-api/web-assembly-instantiate.js:
+
+2017-03-29  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: add shell-only Memory mode helper
+        https://bugs.webkit.org/show_bug.cgi?id=170227
+
+        Reviewed by Mark Lam.
+
+        * wasm/assert.js: fix a prior debug thing I forgot to remove
+        * wasm/function-tests/memory-section-and-import.js: the assert
+        issue was hiding a failure in error message here
+        * wasm/js-api/element.js: the assert issue was hiding a failure in
+        error message here
+        (badInstantiation.test):
+        (badInstantiation):
+        * wasm/js-api/extension-MemoryMode.js: Added.
+        (const.validateMode.what.switch):
+        (testMemoryNoMax):
+        (testMemory):
+        (testInstanceNoMemory):
+        (testInstanceNoMax):
+        (testInstance):
+        * wasm/js-api/test_memory.js: the assert issue was hiding a
+        failure in error message here
+        (test):
+
+2017-03-28  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: Make WebAssembly.instantiate/compile truly asynchronous
+        https://bugs.webkit.org/show_bug.cgi?id=169187
+
+        Reviewed by Saam Barati.
+
+        * wasm/assert.js:
+        * wasm/js-api/Module-compile.js:
+        (async.testPromiseAPI):
+        * wasm/js-api/web-assembly-compile-parallel.js: Added.
+        (async.throwExn):
+        (async.test):
+        * wasm/js-api/web-assembly-instantiate-parallel.js: Added.
+        (async.test):
+        * wasm/js-api/web-assembly-instantiate.js:
+        (assert.eq.async.test):
+        (assert.eq):
+        (assert.asyncTest.async.test):
+        (assert.asyncTest):
+        (assert.truthy.async.test): Deleted.
+        (assert.truthy): Deleted.
+
+2017-03-28  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: implement Module imports/exports
+        https://bugs.webkit.org/show_bug.cgi?id=166982
+
+        Reviewed by Saam Barati.
+
+        * wasm/js-api/Module.exports.js: Added.
+        (assert.throws.WebAssembly.Module.prototype.exports):
+        (assert.eq):
+        * wasm/js-api/Module.imports.js: Added.
+        (assert.throws.WebAssembly.Module.prototype.imports):
+        (assert.eq):
+
+2017-03-27  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: misc memory testing
+        https://bugs.webkit.org/show_bug.cgi?id=170137
+
+        Reviewed by Keith Miller.
+
+        * wasm/assert.js: handle newlines in code we print out, avoid regex
+        * wasm/function-tests/memory-import-and-grow.js: Added.
+        (const.instantiate):
+        (const.test):
+        * wasm/function-tests/memory-section-and-import.js: Added.
+        (const.instantiate):
+
+2017-03-23  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Use jsNontrivialString agressively for ToString(Int52)
+        https://bugs.webkit.org/show_bug.cgi?id=170002
+
+        Reviewed by Sam Weinig.
+
+        * stress/to-string-int52.js: Added.
+        (shouldBe):
+        (toString10):
+        (expected):
+
+2017-03-23  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC][DFG] Make addShouldSpeculateAnyInt more conservative to avoid regression caused by Double <-> Int52 conversions
+        https://bugs.webkit.org/show_bug.cgi?id=169998
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/int52-back-and-forth.js: Added.
+        (shouldBe):
+        (num):
+
+2017-03-23  Mark Lam  <mark.lam@apple.com>
+
+        Clients of JSArray::tryCreateForInitializationPrivate() should do their own null checks.
+        https://bugs.webkit.org/show_bug.cgi?id=169783
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-169783.js: Added.
+
+2017-03-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC][DFG] Propagate AnyIntAsDouble information carefully to utilize it in fixup
+        https://bugs.webkit.org/show_bug.cgi?id=169914
+
+        Reviewed by Saam Barati.
+
+        * stress/any-int-as-double-add.js: Added.
+        (shouldBe):
+        (test):
+        * stress/to-this-numbers.js: Added.
+        (shouldBe):
+        (Number.prototype.toThis):
+
+2017-03-22  Mark Lam  <mark.lam@apple.com>
+
+        Add support for Error.stackTraceLimit.
+        https://bugs.webkit.org/show_bug.cgi?id=169904
+
+        Reviewed by Saam Barati.
+
+        * stress/error-stack-trace-limit.js: Added.
+
+2017-03-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Use jsNontrivialString for Number toString operations
+        https://bugs.webkit.org/show_bug.cgi?id=169965
+
+        Reviewed by Mark Lam.
+
+        * stress/to-string-int32.js: Added.
+        (shouldBe):
+        (toString10):
+        (expected):
+
+2017-03-22  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: test module namespace object for WebAssembly.Instance
+        https://bugs.webkit.org/show_bug.cgi?id=169951
+
+        Reviewed by Saam Barati.
+
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties.switch):
+
+2017-03-22  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: constructors without new don't throw
+        https://bugs.webkit.org/show_bug.cgi?id=165995
+
+        Reviewed by Saam Barati.
+
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties.switch):
+
+2017-03-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Optimize Number.prototype.toString on Int32 / Int52 / Double
+        https://bugs.webkit.org/show_bug.cgi?id=167454
+
+        Reviewed by Saam Barati.
+
+        * stress/number-to-string-abstract-operation.js: Added.
+        (shouldBe):
+        (int32ToString):
+        (shouldBe.int32ToString.new.Number.int52ToString):
+        (shouldBe.int32ToString.new.Number):
+        (shouldBe.doubleToString):
+        * stress/number-to-string-radix.js: Added.
+        (shouldBe):
+        (int32ToString):
+        (shouldBe.int32ToString.new.Number.int52ToString):
+        (shouldBe.int32ToString.new.Number):
+        (shouldBe.doubleToString):
+        * stress/number-to-string.js: Added.
+        (shouldBe):
+        (int32ToString):
+        (shouldBe.int32ToString.new.Number.int52ToString):
+        (shouldBe.int32ToString.new.Number):
+        (shouldBe.doubleToString):
+
+2017-03-19  Chris Dumez  <cdumez@apple.com>
+
+        `const location = "foo"` throws in a worker
+        https://bugs.webkit.org/show_bug.cgi?id=169839
+
+        Reviewed by Mark Lam.
+
+        * ChakraCore/test/es6/letconst_global_shadow_builtins_nonconfigurable.baseline-jsc:
+        Update expected jsc result now that we throw a SyntaxError when trying to shadow undefined
+        with a let variable. We used not to throw because the value is undefined but this was not
+        as per EcmaScript. Both Firefox and Chrome throw in this case.
+
+        * stress/global-lexical-redeclare-variable.js:
+        (catch):
+        Update test that defines a non-configurable 'zoo' property on the global object and then
+        expected shadowing it with a 'let zoo' variable to work because its value was undefined.
+        This was not as per EcmaScript spec and both Firefox and Chrome throw in this case.
+
+2017-03-19  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        import(arg) crashes when ToString(arg) throws
+        https://bugs.webkit.org/show_bug.cgi?id=169778
+
+        Reviewed by Saam Barati.
+
+        * stress/import-reject-with-exception.js: Added.
+        (shouldBe):
+        (let.x.get toString):
+
+2017-03-16  Filip Pizlo  <fpizlo@apple.com>
+
+        FTL should support global and eval code
+        https://bugs.webkit.org/show_bug.cgi?id=169656
+
+        Reviewed by Geoffrey Garen and Saam Barati.
+        
+        Added basic performance tests of global and eval code. These tests will run a lot faster in with
+        the FTL because of the object allocation.
+
+        * microbenchmarks/eval-code-ftl-reentry.js: Added.
+        * microbenchmarks/eval-code-ftl.js: Added.
+        * microbenchmarks/global-code-ftl.js: Added.
+        * stress/arith-log-on-various-types.js: This was a flaky fail with concurrent JIT, so I stopped running it with concurrent JIT. The failure was its assertion about how many times something gets compiled.
+
+2017-03-16  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESnext] Implement Object Spread
+        https://bugs.webkit.org/show_bug.cgi?id=167963
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/object-spread.js: Added.
+        (let.assert):
+        (assert.sameValue):
+        (let.o.get a):
+        (let.obj.get c):
+        (cthulhu.get x):
+        (let.obj.set c):
+        (calls.o.get z):
+        (calls.o.get a):
+        (try.let.obj.get foo):
+        (get calls):
+
+2017-03-15  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Default parameter part should be retrieved by op_get_argument opcode instead of changing arity
+        https://bugs.webkit.org/show_bug.cgi?id=164582
+
+        Reviewed by Saam Barati.
+
+        * stress/function-with-defaults-inlining.js: Added.
+        (shouldBe):
+        (ok):
+        (a):
+        * stress/function-with-defaults-non-inlining.js: Added.
+        (shouldBe):
+        (ok):
+        (a):
+
+2017-03-15  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] ToString operation should have fixup for primitives to say this node does not have side effects
+        https://bugs.webkit.org/show_bug.cgi?id=169544
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/template-string-array.js: Added.
+        (test):
+        * stress/to-string-non-cell-use.js: Added.
+        (shouldBe):
+        (shouldThrow):
+
+2017-03-13  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r213856.
+        https://bugs.webkit.org/show_bug.cgi?id=169562
+
+        Breaks JSC stress test stress/super-property-access.js.ftl-
+        eager failing (Requested by mlam|g on #webkit).
+
+        Reverted changeset:
+
+        "FTL should not flush strict arguments unless it really needs
+        to"
+        https://bugs.webkit.org/show_bug.cgi?id=169519
+        http://trac.webkit.org/changeset/213856
+
+2017-03-11  Filip Pizlo  <fpizlo@apple.com>
+
+        FTL should not flush strict arguments unless it really needs to
+        https://bugs.webkit.org/show_bug.cgi?id=169519
+
+        Reviewed by Mark Lam.
+        
+        This benchmark runs 3.5x faster thanks to this patch.
+
+        * microbenchmarks/strict-arguments-no-escape.js: Added.
+        (foo):
+        (bar):
+        (baz):
+
+2017-03-13  Caio Lima  <ticaiolima@gmail.com>
+
+        [JSC] It should be possible create a label named let when parsing Statement in non strict mode
+        https://bugs.webkit.org/show_bug.cgi?id=168684
+
+        Reviewed by Saam Barati.
+
+        * ChakraCore/test/LetConst/DeclOutofBlock.baseline-jsc:
+
+2017-03-10  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Make more demos run
+        https://bugs.webkit.org/show_bug.cgi?id=165510
+        <rdar://problem/29760310>
+
+        Reviewed by Keith Miller.
+
+        * wasm/Builder.js:
+        (export.default.Builder.prototype._registerSectionBuilders.const.section.in.WASM.description.section.switch.section.case.string_appeared_here.this.section):
+        * wasm/js-api/wrapper-function.js: Added.
+        (exportImport):
+        (return.new.WebAssembly.Module):
+        (assert.throws.makeInstance):
+        (assert.throws.Bar):
+        (assert.throws):
+
+2017-03-10  Mark Lam  <mark.lam@apple.com>
+
+        JSC: BindingNode::bindValue doesn't increase the scope's reference count.
+        https://bugs.webkit.org/show_bug.cgi?id=168546
+        <rdar://problem/30589551>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-168546.js: Added.
+
+2017-03-09  Caio Lima  <ticaiolima@gmail.com>
+
+        [ESnext] Implement Object Rest - Implementing Object Rest Destructuring
+        https://bugs.webkit.org/show_bug.cgi?id=167962
+
+        Reviewed by Keith Miller.
+
+        * stress/object-rest-deconstruct.js: Added.
+        (let.assert):
+        (let.assertPropDescriptor):
+        (catch):
+        (get 3):
+        (foo):
+        (let.src.get y):
+        (let.src.set y):
+        (let.gen):
+
+2017-03-09  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Make the Unity AngryBots demo run
+        https://bugs.webkit.org/show_bug.cgi?id=169268
+
+        Reviewed by Keith Miller.
+
+        * wasm/function-tests/many-arguments-to-function.js: Added.
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.I32Const.0.I32Const.1.I32Const.2.I32Const.3.I32Const.4.I32Const.5.I32Const.6.I32Const.7.I32Const.8.I32Const.9.I32Const.10.I32Const.11.I32Const.12.I32Const.13.I32Const.14.I32Const.15.I32Const.16.I32Const.17.Call.0.Return.End.End.foo):
+        (i.instance.exports.f0.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.F32Const.Call.Return.End.End.foo):
+        (i.instance.exports.f0):
+        (instance.exports.f0.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.GetLocal.Call.Return.End.End.foo):
+        (instance.exports.f0):
+
+2017-03-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [GTK] JSC test stress/arity-check-ftl-throw.js.ftl-no-cjit-validate-sampling-profiler crashing on GTK bot
+        https://bugs.webkit.org/show_bug.cgi?id=160124
+
+        Reviewed by Mark Lam.
+
+        * stress/spread-forward-call-varargs-stack-overflow.js:
+
+2017-03-06  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Implement the WebAssembly.instantiate API
+        https://bugs.webkit.org/show_bug.cgi?id=165982
+        <rdar://problem/29760110>
+
+        Reviewed by Keith Miller.
+
+        * wasm/js-api/web-assembly-instantiate.js: Added.
+        (assert.eq.async.test):
+        (assert.eq):
+        (assert.truthy.async.test):
+        (assert.truthy):
+
+2017-03-06  Saam Barati  <sbarati@apple.com>
+
+        Unreviewed. Fix test expected error message.
+
+        * wasm/js-api/element.js:
+        (assert.throws):
+
+2017-03-06  Caio Lima  <ticaiolima@gmail.com>
+
+        op_get_by_id_with_this should use inline caching
+        https://bugs.webkit.org/show_bug.cgi?id=162124
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/super-getter.js: Added.
+        (A.prototype.get f):
+        (A):
+        (B.prototype.get f):
+        (B):
+        * stress/super-force-ic-fail.js: Added.
+        (let.assert):
+        (let.aObj.get foo):
+        (let.obj.jaz):
+        (let.bObj.get foo):
+        (let.obj2.foo):
+        * stress/super-get-by-id.js: Added.
+        (assert):
+        (Base):
+        (Base.prototype.get name):
+        (Base.prototype.set name):
+        (Subclass.prototype.get name):
+        (Subclass):
+        (getterName):
+        (getterValue):
+        (PolymorphicSubclass.prototype.get value):
+        (PolymorphicSubclass):
+        (i.let.BaseCode):
+        (i.get value):
+        (MegamorphicSubclass.prototype.get value):
+        (MegamorphicSubclass):
+        (let.subObj.get value):
+        (i.catch):
+        (subObj.get value):
+        (BaseException):
+        (BaseException.prototype.get name):
+        (SubclassException.prototype.get name):
+        (SubclassException):
+        (prototype.foo):
+        (prototype.get name):
+        (SubclassExceptionComplex.prototype.get name):
+        (SubclassExceptionComplex):
+        * stress/super-getter-reset-ic.js: Added.
+        (let.assert):
+        (let.B.f):
+
+2017-03-06  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: implement init_expr for Element
+        https://bugs.webkit.org/show_bug.cgi?id=165888
+        <rdar://problem/29760199>
+
+        Reviewed by Keith Miller.
+
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.emitters.Element):
+        * wasm/assert.js:
+        * wasm/js-api/element.js:
+        (assert.throws):
+        (badInstantiation.makeModule):
+        (badInstantiation.test):
+        (badInstantiation):
+        * wasm/js-api/global-error.js:
+
+2017-03-06  Carlos Alberto Lopez Perez  <clopez@igalia.com>
+
+        [JSC] [Linux] Test stress/spread-forward-call-varargs-stack-overflow.js fails
+        https://bugs.webkit.org/show_bug.cgi?id=169206
+
+        Unreviewed test gardening.
+
+        * stress/spread-forward-call-varargs-stack-overflow.js: Skip on Linux platforms.
+
+2017-03-06  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Allow indexed module namespace object fields
+        https://bugs.webkit.org/show_bug.cgi?id=168870
+
+        Reviewed by Saam Barati.
+
+        * wasm/spec-tests/names.wast.js:
+
+2017-03-06  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Null pointer crash when loading module with unresolved import also as a script file
+        https://bugs.webkit.org/show_bug.cgi?id=168971
+
+        Reviewed by Saam Barati.
+
+        * stress/re-execute-error-module.js: Added.
+        (shouldBe):
+        (async):
+        * stress/resources/error-module.js: Added.
+
+2017-03-02  Keith Miller  <keith_miller@apple.com>
+
+        WebAssemblyFunction should have Function.prototype as its prototype
+        https://bugs.webkit.org/show_bug.cgi?id=169101
+
+        Reviewed by Filip Pizlo.
+
+        * wasm/js-api/web-assembly-function.js: Added.
+
+2017-02-28  Oleksandr Skachkov  <gskachkov@gmail.com>
+
+        Use of arguments in arrow function is slow
+        https://bugs.webkit.org/show_bug.cgi?id=168829
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/arrowfunciton-direct-arguments.js: Added.
+        (fn):
+        * microbenchmarks/arrowfunciton-reference-arguments.js: Added.
+        (fn):
+
+2017-02-27  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r213019.
+        https://bugs.webkit.org/show_bug.cgi?id=168925
+
+        "It broke 32-bit jsc tests in debug builds" (Requested by
+        saamyjoon on #webkit).
+
+        Reverted changeset:
+
+        "op_get_by_id_with_this should use inline caching"
+        https://bugs.webkit.org/show_bug.cgi?id=162124
+        http://trac.webkit.org/changeset/213019
+
+2017-02-27  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: miscellaneous spec fixes part deux
+        https://bugs.webkit.org/show_bug.cgi?id=168861
+
+        Reviewed by Keith Miller.
+
+        * wasm.yaml: more passing tests
+        * wasm/Builder.js: use a Map instead of an Object for the function
+        index space, because Number entries such as 0 were colliding with
+        string entries such as "0". This in turn requires some hashing of
+        objects which are inserted, because Map uses Object's insertion
+        order when comparing.
+        (export.default.Builder):
+        (export.default.Builder.prototype._functionIndexSpaceKeyHash):
+        (export.default.Builder.prototype._registerFunctionToIndexSpace):
+        (export.default.Builder.prototype._getFunctionFromIndexSpace):
+        * wasm/js-api/test_Instance.js: add a FIXME test
+        * wasm/spec-tests/memory.wast.js:
+        (assert_unlinkable):
+        * wasm/spec-tests/names.wast.js:
+
+2017-02-26  Caio Lima  <ticaiolima@gmail.com>
+
+        op_get_by_id_with_this should use inline caching
+        https://bugs.webkit.org/show_bug.cgi?id=162124
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/super-getter.js: Added.
+        (A.prototype.get f):
+        (A):
+        (B.prototype.get f):
+        (B):
+        * stress/super-force-ic-fail.js: Added.
+        (let.assert):
+        (let.aObj.get foo):
+        (let.obj.jaz):
+        (let.bObj.get foo):
+        (let.obj2.foo):
+        * stress/super-get-by-id.js: Added.
+        (assert):
+        (Base):
+        (Base.prototype.get name):
+        (Base.prototype.set name):
+        (Subclass.prototype.get name):
+        (Subclass):
+        (getterName):
+        (getterValue):
+        (PolymorphicSubclass.prototype.get value):
+        (PolymorphicSubclass):
+        (i.let.BaseCode):
+        (i.get value):
+        (MegamorphicSubclass.prototype.get value):
+        (MegamorphicSubclass):
+        (let.subObj.get value):
+        (i.catch):
+        (subObj.get value):
+        (BaseException):
+        (BaseException.prototype.get name):
+        (SubclassException.prototype.get name):
+        (SubclassException):
+        (prototype.foo):
+        (prototype.get name):
+        (SubclassExceptionComplex.prototype.get name):
+        (SubclassExceptionComplex):
+        * stress/super-getter-reset-ic.js: Added.
+        (let.assert):
+        (let.B.f):
+
+2017-02-24  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: miscellaneous spec fixes
+        https://bugs.webkit.org/show_bug.cgi?id=168822
+
+        Reviewed by Saam Barati.
+
+        * wasm.yaml: mark some skip tests as normal, now that they pass
+        * wasm/Builder.js: error message was wrong, causing extra error if hit
+        * wasm/js-api/global-error.js: new tests
+        (assert.throws):
+        * wasm/spec-tests/call.wast.js: comment out stack check tests
+        * wasm/spec-tests/call_indirect.wast.js: comment out stack check tests
+        * wasm/spec-tests/fac.wast.js: comment out stack check tests
+        * wasm/spec-tests/float_exprs.wast.js: wabt is wrong, bug reported, we should update
+        * wasm/spec-tests/imports.wast.js: bug in old wabt, fixed in recent wabt
+        (assert_unlinkable):
+
+2017-02-23  Saam Barati  <sbarati@apple.com>
+
+        Intrinsicify parseInt
+        https://bugs.webkit.org/show_bug.cgi?id=168627
+
+        Reviewed by Filip Pizlo.
+
+        * stress/parse-int-intrinsic.js: Added.
+        (assert):
+        (testIntrinsic.let.s):
+        (testIntrinsic):
+        (testIntrinsic2.baz):
+        (testIntrinsic2):
+        (testIntrinsic3.foo):
+        (testIntrinsic3):
+        (testIntrinsic4.foo):
+        (testIntrinsic4):
+        (testIntrinsic5.foo):
+        (testIntrinsic5):
+        (testIntrinsic6.foo):
+        (testIntrinsic6):
+        (testIntrinsic7.foo):
+        (testIntrinsic7):
+
+2017-02-23  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: support 0x1 version
+        https://bugs.webkit.org/show_bug.cgi?id=168672
+
+        Reviewed by Keith Miller.
+
+        Update the version number for all the tests. Note that the spec
+        tests are only updated with a new version number because spec+wabt
+        aren't ready for 0x1 yet. This is tracked by bug #168784.
+
+        * wasm/import-spec-tests.rb: use the new spec repository layout
+        * wasm/js-api/test_basic_api.js:
+        * wasm/self-test/test_BuilderWebAssembly.js:
+        (EmptyModule):
+        (CustomSection):
+        * wasm/spec-tests/address.wast.js:
+        * wasm/spec-tests/binary.wast.js:
+        * wasm/spec-tests/block.wast.js:
+        * wasm/spec-tests/br.wast.js:
+        * wasm/spec-tests/br_if.wast.js:
+        * wasm/spec-tests/br_table.wast.js:
+        * wasm/spec-tests/break-drop.wast.js:
+        * wasm/spec-tests/call.wast.js:
+        * wasm/spec-tests/call_indirect.wast.js:
+        * wasm/spec-tests/comments.wast.js:
+        * wasm/spec-tests/conversions.wast.js:
+        * wasm/spec-tests/custom_section.wast.js:
+        * wasm/spec-tests/endianness.wast.js:
+        * wasm/spec-tests/exports.wast.js:
+        * wasm/spec-tests/f32.wast.js:
+        * wasm/spec-tests/f32_cmp.wast.js:
+        * wasm/spec-tests/f64.wast.js:
+        * wasm/spec-tests/f64_cmp.wast.js:
+        * wasm/spec-tests/fac.wast.js:
+        * wasm/spec-tests/float_exprs.wast.js:
+        * wasm/spec-tests/float_literals.wast.js:
+        * wasm/spec-tests/float_memory.wast.js:
+        * wasm/spec-tests/float_misc.wast.js:
+        * wasm/spec-tests/forward.wast.js:
+        * wasm/spec-tests/func.wast.js:
+        * wasm/spec-tests/func_ptrs.wast.js:
+        * wasm/spec-tests/get_local.wast.js:
+        * wasm/spec-tests/globals.wast.js:
+        * wasm/spec-tests/i32.wast.js:
+        * wasm/spec-tests/i64.wast.js:
+        * wasm/spec-tests/imports.wast.js:
+        * wasm/spec-tests/int_exprs.wast.js:
+        * wasm/spec-tests/int_literals.wast.js:
+        * wasm/spec-tests/left-to-right.wast.js:
+        * wasm/spec-tests/linking.wast.js:
+        * wasm/spec-tests/loop.wast.js:
+        * wasm/spec-tests/memory.wast.js:
+        * wasm/spec-tests/memory_redundancy.wast.js:
+        * wasm/spec-tests/memory_trap.wast.js:
+        * wasm/spec-tests/names.wast.js:
+        * wasm/spec-tests/nop.wast.js:
+        * wasm/spec-tests/resizing.wast.js:
+        * wasm/spec-tests/return.wast.js:
+        * wasm/spec-tests/select.wast.js:
+        * wasm/spec-tests/set_local.wast.js:
+        * wasm/spec-tests/skip-stack-guard-page.wast.js:
+        * wasm/spec-tests/stack.wast.js:
+        * wasm/spec-tests/start.wast.js:
+        * wasm/spec-tests/store_retval.wast.js:
+        * wasm/spec-tests/switch.wast.js:
+        * wasm/spec-tests/tee_local.wast.js:
+        * wasm/spec-tests/traps.wast.js:
+        * wasm/spec-tests/typecheck.wast.js:
+        * wasm/spec-tests/unreachable.wast.js:
+        * wasm/spec-tests/unwind.wast.js:
+        * wasm/wasm.json:
+
+2017-02-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        JSModuleNamespace object should have IC
+        https://bugs.webkit.org/show_bug.cgi?id=160590
+
+        Reviewed by Saam Barati.
+
+        * modules/module-assert-access-binding.js: Added.
+        * modules/module-assert-access-namespace.js: Added.
+        * modules/namespace-empty.js: Added.
+        (from.string_appeared_here.access):
+        (i.shouldThrow):
+        * stress/module-namespace-access-change.js: Added.
+        (shouldBe):
+        (access):
+        (import.string_appeared_here.then):
+        * stress/module-namespace-access-non-constant.js: Added.
+        (shouldBe):
+        (import.string_appeared_here.then):
+        * stress/module-namespace-access-poly.js: Added.
+        (shouldBe):
+        (access):
+        (import.string_appeared_here.then):
+        * stress/module-namespace-access-transitive-exports.js: Added.
+        (shouldBe):
+        (import.string_appeared_here.then):
+        * stress/module-namespace-access.js: Added.
+        (shouldBe):
+        (import.string_appeared_here.then):
+        * stress/resources/module-namespace-access-transitive-exports-2.js: Added.
+        (export.cocoa):
+        (export.change):
+        * stress/resources/module-namespace-access-transitive-exports.js: Added.
+        * stress/resources/module-namespace-access.js: Added.
+        (export.cocoa):
+        (export.change):
+
+2017-02-20  Filip Pizlo  <fpizlo@apple.com>
+
+        The collector thread should only start when the mutator doesn't have heap access
+        https://bugs.webkit.org/show_bug.cgi?id=167737
+
+        Reviewed by Keith Miller.
+        
+        Add versions of splay that flash heap access, to simulate what might happen if a third-party app
+        was running concurrent GC. In this case, we might actually start the collector thread.
+
+        * stress/splay-flash-access-1ms.js: Added.
+        (performance.now):
+        (this.Setup.setup.setup):
+        (this.TearDown.tearDown.tearDown):
+        (Benchmark):
+        (BenchmarkResult):
+        (BenchmarkResult.prototype.valueOf):
+        (BenchmarkSuite):
+        (alert):
+        (Math.random):
+        (BenchmarkSuite.ResetRNG):
+        (RunStep):
+        (BenchmarkSuite.RunSuites):
+        (BenchmarkSuite.CountBenchmarks):
+        (BenchmarkSuite.GeometricMean):
+        (BenchmarkSuite.GeometricMeanTime):
+        (BenchmarkSuite.AverageAbovePercentile):
+        (BenchmarkSuite.GeometricMeanLatency):
+        (BenchmarkSuite.FormatScore):
+        (BenchmarkSuite.prototype.NotifyStep):
+        (BenchmarkSuite.prototype.NotifyResult):
+        (BenchmarkSuite.prototype.NotifyError):
+        (BenchmarkSuite.prototype.RunSingleBenchmark):
+        (RunNextSetup):
+        (RunNextBenchmark):
+        (RunNextTearDown):
+        (BenchmarkSuite.prototype.RunStep):
+        (GeneratePayloadTree):
+        (GenerateKey):
+        (SplayUpdateStats):
+        (InsertNewNode):
+        (SplaySetup):
+        (SplayTearDown):
+        (SplayRun):
+        (SplayTree):
+        (SplayTree.prototype.isEmpty):
+        (SplayTree.prototype.insert):
+        (SplayTree.prototype.remove):
+        (SplayTree.prototype.find):
+        (SplayTree.prototype.findMax):
+        (SplayTree.prototype.findGreatestLessThan):
+        (SplayTree.prototype.exportKeys):
+        (SplayTree.prototype.splay_):
+        (SplayTree.Node):
+        (SplayTree.Node.prototype.traverse_):
+        (jscSetUp):
+        (jscTearDown):
+        (jscRun):
+        (averageAbovePercentile):
+        (printPercentile):
+        * stress/splay-flash-access.js: Added.
+        (performance.now):
+        (this.Setup.setup.setup):
+        (this.TearDown.tearDown.tearDown):
+        (Benchmark):
+        (BenchmarkResult):
+        (BenchmarkResult.prototype.valueOf):
+        (BenchmarkSuite):
+        (alert):
+        (Math.random):
+        (BenchmarkSuite.ResetRNG):
+        (RunStep):
+        (BenchmarkSuite.RunSuites):
+        (BenchmarkSuite.CountBenchmarks):
+        (BenchmarkSuite.GeometricMean):
+        (BenchmarkSuite.GeometricMeanTime):
+        (BenchmarkSuite.AverageAbovePercentile):
+        (BenchmarkSuite.GeometricMeanLatency):
+        (BenchmarkSuite.FormatScore):
+        (BenchmarkSuite.prototype.NotifyStep):
+        (BenchmarkSuite.prototype.NotifyResult):
+        (BenchmarkSuite.prototype.NotifyError):
+        (BenchmarkSuite.prototype.RunSingleBenchmark):
+        (RunNextSetup):
+        (RunNextBenchmark):
+        (RunNextTearDown):
+        (BenchmarkSuite.prototype.RunStep):
+        (GeneratePayloadTree):
+        (GenerateKey):
+        (SplayUpdateStats):
+        (InsertNewNode):
+        (SplaySetup):
+        (SplayTearDown):
+        (SplayRun):
+        (SplayTree):
+        (SplayTree.prototype.isEmpty):
+        (SplayTree.prototype.insert):
+        (SplayTree.prototype.remove):
+        (SplayTree.prototype.find):
+        (SplayTree.prototype.findMax):
+        (SplayTree.prototype.findGreatestLessThan):
+        (SplayTree.prototype.exportKeys):
+        (SplayTree.prototype.splay_):
+        (SplayTree.Node):
+        (SplayTree.Node.prototype.traverse_):
+        (jscSetUp):
+        (jscTearDown):
+        (jscRun):
+        (averageAbovePercentile):
+        (printPercentile):
+
+2017-02-21  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r212712.
+
+        This change broke the CLoop build.
+
+        Reverted changeset:
+
+        "JSModuleNamespace object should have IC"
+        https://bugs.webkit.org/show_bug.cgi?id=160590
+        http://trac.webkit.org/changeset/212712
+
+2017-02-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        JSModuleNamespace object should have IC
+        https://bugs.webkit.org/show_bug.cgi?id=160590
+
+        Reviewed by Saam Barati.
+
+        * modules/module-assert-access-binding.js: Added.
+        * modules/module-assert-access-namespace.js: Added.
+        * modules/namespace-empty.js: Added.
+        (from.string_appeared_here.access):
+        (i.shouldThrow):
+        * stress/module-namespace-access-change.js: Added.
+        (shouldBe):
+        (access):
+        (import.string_appeared_here.then):
+        * stress/module-namespace-access-non-constant.js: Added.
+        (shouldBe):
+        (import.string_appeared_here.then):
+        * stress/module-namespace-access-poly.js: Added.
+        (shouldBe):
+        (access):
+        (import.string_appeared_here.then):
+        * stress/module-namespace-access-transitive-exports.js: Added.
+        (shouldBe):
+        (import.string_appeared_here.then):
+        * stress/module-namespace-access.js: Added.
+        (shouldBe):
+        (import.string_appeared_here.then):
+        * stress/resources/module-namespace-access-transitive-exports-2.js: Added.
+        (export.cocoa):
+        (export.change):
+        * stress/resources/module-namespace-access-transitive-exports.js: Added.
+        * stress/resources/module-namespace-access.js: Added.
+        (export.cocoa):
+        (export.change):
+
+2017-02-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        ASSERTION FAILED: "!scope.exception()" with Object.isSealed/isFrozen and uninitialized module bindings
+        https://bugs.webkit.org/show_bug.cgi?id=168605
+
+        Reviewed by Saam Barati.
+
+        * modules/module-namespace-is-frozen.js: Added.
+        (from.string_appeared_here.shouldThrow):
+        (export.b):
+        * modules/module-namespace-is-sealed.js: Added.
+        (from.string_appeared_here.shouldThrow):
+        (export.b):
+
+2017-02-19  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r212466.
+        https://bugs.webkit.org/show_bug.cgi?id=168577
+
+        causes crashes on AArch64 on linux, maybe it's causing crashes
+        on iOS too (Requested by pizlo on #webkit).
+
+        Reverted changeset:
+
+        "The collector thread should only start when the mutator
+        doesn't have heap access"
+        https://bugs.webkit.org/show_bug.cgi?id=167737
+        http://trac.webkit.org/changeset/212466
+
+2017-02-10  Filip Pizlo  <fpizlo@apple.com>
+
+        The collector thread should only start when the mutator doesn't have heap access
+        https://bugs.webkit.org/show_bug.cgi?id=167737
+
+        Reviewed by Keith Miller.
+        
+        Add versions of splay that flash heap access, to simulate what might happen if a third-party app
+        was running concurrent GC. In this case, we might actually start the collector thread.
+
+        * stress/splay-flash-access-1ms.js: Added.
+        (performance.now):
+        (this.Setup.setup.setup):
+        (this.TearDown.tearDown.tearDown):
+        (Benchmark):
+        (BenchmarkResult):
+        (BenchmarkResult.prototype.valueOf):
+        (BenchmarkSuite):
+        (alert):
+        (Math.random):
+        (BenchmarkSuite.ResetRNG):
+        (RunStep):
+        (BenchmarkSuite.RunSuites):
+        (BenchmarkSuite.CountBenchmarks):
+        (BenchmarkSuite.GeometricMean):
+        (BenchmarkSuite.GeometricMeanTime):
+        (BenchmarkSuite.AverageAbovePercentile):
+        (BenchmarkSuite.GeometricMeanLatency):
+        (BenchmarkSuite.FormatScore):
+        (BenchmarkSuite.prototype.NotifyStep):
+        (BenchmarkSuite.prototype.NotifyResult):
+        (BenchmarkSuite.prototype.NotifyError):
+        (BenchmarkSuite.prototype.RunSingleBenchmark):
+        (RunNextSetup):
+        (RunNextBenchmark):
+        (RunNextTearDown):
+        (BenchmarkSuite.prototype.RunStep):
+        (GeneratePayloadTree):
+        (GenerateKey):
+        (SplayUpdateStats):
+        (InsertNewNode):
+        (SplaySetup):
+        (SplayTearDown):
+        (SplayRun):
+        (SplayTree):
+        (SplayTree.prototype.isEmpty):
+        (SplayTree.prototype.insert):
+        (SplayTree.prototype.remove):
+        (SplayTree.prototype.find):
+        (SplayTree.prototype.findMax):
+        (SplayTree.prototype.findGreatestLessThan):
+        (SplayTree.prototype.exportKeys):
+        (SplayTree.prototype.splay_):
+        (SplayTree.Node):
+        (SplayTree.Node.prototype.traverse_):
+        (jscSetUp):
+        (jscTearDown):
+        (jscRun):
+        (averageAbovePercentile):
+        (printPercentile):
+        * stress/splay-flash-access.js: Added.
+        (performance.now):
+        (this.Setup.setup.setup):
+        (this.TearDown.tearDown.tearDown):
+        (Benchmark):
+        (BenchmarkResult):
+        (BenchmarkResult.prototype.valueOf):
+        (BenchmarkSuite):
+        (alert):
+        (Math.random):
+        (BenchmarkSuite.ResetRNG):
+        (RunStep):
+        (BenchmarkSuite.RunSuites):
+        (BenchmarkSuite.CountBenchmarks):
+        (BenchmarkSuite.GeometricMean):
+        (BenchmarkSuite.GeometricMeanTime):
+        (BenchmarkSuite.AverageAbovePercentile):
+        (BenchmarkSuite.GeometricMeanLatency):
+        (BenchmarkSuite.FormatScore):
+        (BenchmarkSuite.prototype.NotifyStep):
+        (BenchmarkSuite.prototype.NotifyResult):
+        (BenchmarkSuite.prototype.NotifyError):
+        (BenchmarkSuite.prototype.RunSingleBenchmark):
+        (RunNextSetup):
+        (RunNextBenchmark):
+        (RunNextTearDown):
+        (BenchmarkSuite.prototype.RunStep):
+        (GeneratePayloadTree):
+        (GenerateKey):
+        (SplayUpdateStats):
+        (InsertNewNode):
+        (SplaySetup):
+        (SplayTearDown):
+        (SplayRun):
+        (SplayTree):
+        (SplayTree.prototype.isEmpty):
+        (SplayTree.prototype.insert):
+        (SplayTree.prototype.remove):
+        (SplayTree.prototype.find):
+        (SplayTree.prototype.findMax):
+        (SplayTree.prototype.findGreatestLessThan):
+        (SplayTree.prototype.exportKeys):
+        (SplayTree.prototype.splay_):
+        (SplayTree.Node):
+        (SplayTree.Node.prototype.traverse_):
+        (jscSetUp):
+        (jscTearDown):
+        (jscRun):
+        (averageAbovePercentile):
+        (printPercentile):
+
+2017-02-16  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Update module namespace object according to the latest ECMA262
+        https://bugs.webkit.org/show_bug.cgi?id=168280
+
+        Reviewed by Saam Barati.
+
+        * modules/namespace-object-symbol-iterator-name.js:
+        * modules/namespace-object-typed-array-fast-path.js:
+        * modules/namespace.js:
+        (shouldBe.JSON.stringify.Reflect.getOwnPropertyDescriptor):
+        (shouldThrow):
+
+2017-02-11  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Implement (Shared)ArrayBuffer.prototype.byteLength
+        https://bugs.webkit.org/show_bug.cgi?id=166476
+
+        Reviewed by Saam Barati.
+
+        * ChakraCore/test/typedarray/arraybufferType.baseline-jsc:
+        * stress/array-buffer-byte-length.js: Added.
+        (shouldBe):
+        (shouldThrow):
+        (Symbol):
+        * stress/reflect-set.js:
+
+2017-02-10  Saam Barati  <sbarati@apple.com>
+
+        Object allocation sinking phase doesn't properly handle control flow when emitting a PutHint of a materialized object into a PromotedHeapLocation of a still sunken object
+        https://bugs.webkit.org/show_bug.cgi?id=168140
+        <rdar://problem/30205880>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/allocation-sinking-puthint-control-flow.js: Added.
+        (e):
+        (bar):
+        (let.y):
+        (else.let.y):
+        (baz):
+        (foo):
+        (catch):
+
+2017-02-09  Mark Lam  <mark.lam@apple.com>
+
+        B3::Procedure::deleteOrphans() should neutralize upsilons with dead phis.
+        https://bugs.webkit.org/show_bug.cgi?id=167437
+        <rdar://problem/30198083>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/b3-delete-orphans-should-neutralize-upsilons-with-dead-phis.js: Added.
+
+2017-02-09  Saam Barati  <sbarati@apple.com>
+
+        Sloppy mode: We don't properly hoist functions names "arguments" when we have a non-simple parameter list
+        https://bugs.webkit.org/show_bug.cgi?id=167319
+        <rdar://problem/30149432>
+
+        Reviewed by Mark Lam.
+
+        * stress/sloppy-mode-hoist-arguments-function-non-simple-parameter-list.js: Added.
+        (assert):
+        (assert.arguments):
+        (assert.b):
+        (x.arguments):
+        (x.b):
+        (x):
+
+2017-02-09  Mark Lam  <mark.lam@apple.com>
+
+        Fix max length check in ArrayPrototype.js' concatSlowPath().
+        https://bugs.webkit.org/show_bug.cgi?id=167270
+        <rdar://problem/30128133>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/array-prototype-concat-of-long-spliced-arrays.js: Added.
+        * stress/array-prototype-concat-of-long-spliced-arrays2.js: Added.
+
+2017-02-09  Keith Miller  <keith_miller@apple.com>
+
+        We should not allow Function.caller to be used on native functions
+        https://bugs.webkit.org/show_bug.cgi?id=165628
+
+        Reviewed by Mark Lam.
+
+        * stress/caller-native-code.js: Added.
+        (f):
+
+2017-02-04  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Add operationToInt32SensibleSlow to optimize kraken pbkdf2 and sha256
+        https://bugs.webkit.org/show_bug.cgi?id=167736
+
+        Reviewed by Saam Barati.
+
+        * stress/to-int32-sensible.js: Added.
+        (shouldBe):
+        (toInt32):
+        (test):
+
+2017-02-01  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, remove loop
+        https://bugs.webkit.org/show_bug.cgi?id=167694
+
+        It causes timeout.
+        Original bug can be tested even without this loop.
+
+        * stress/arity-fixup-should-not-touch-stack-area-below-sp.js:
+
+2017-02-01  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        ArityFixup should adjust SP first
+        https://bugs.webkit.org/show_bug.cgi?id=167239
+
+        Reviewed by Michael Saboff.
+
+        Significantly large arity fixup reliably causes this crash.
+
+        * stress/arity-fixup-should-not-touch-stack-area-below-sp.js: Added.
+
+2017-01-31  Filip Pizlo  <fpizlo@apple.com>
+
+        Move slow-running microbenchmarks out of JSTests/microbenchmarks
+        https://bugs.webkit.org/show_bug.cgi?id=167676
+
+        Reviewed by Saam Barati.
+        
+        The microbenchmarks directory is profitable when it's cheap to run. This change moves very slow
+        tests (>=200ms running time on my machine) and puts them in JSTests/slowMicrobenchmarks instead.
+        That directory is run only through `slow!; defaultQuickRun` and is not run by run-jsc-benchmarks.
+        This is a big progression in test running time. But because it frontloads more slow tests, the
+        tests will seem to run more slowly when you first start the test runner.
+
+        * microbenchmarks/default-derived-constructor.js: Removed.
+        * microbenchmarks/dense-set.js: Removed.
+        * microbenchmarks/ftl-polymorphic-div.js: Removed.
+        * microbenchmarks/ftl-polymorphic-mul.js: Removed.
+        * microbenchmarks/function-bind-inlining.js: Removed.
+        * microbenchmarks/function-bind-no-inlining.js: Removed.
+        * microbenchmarks/large-map-iteration-with-additions.js: Removed.
+        * microbenchmarks/large-map-iteration-with-mutation.js: Removed.
+        * microbenchmarks/map-get-get-cse.js: Removed.
+        * microbenchmarks/misc-bugs-847389-jpeg2000.js: Removed.
+        * microbenchmarks/spread-small-array.js: Removed.
+        * microbenchmarks/v8-raytrace-with-try-catch-high-frequency-throws.js: Removed.
+        * slowMicrobenchmarks: Added.
+        * slowMicrobenchmarks.yaml: Added.
+        * slowMicrobenchmarks/README: Added.
+        * slowMicrobenchmarks/default-derived-constructor.js: Copied from JSTests/microbenchmarks/default-derived-constructor.js.
+        * slowMicrobenchmarks/dense-set.js: Copied from JSTests/microbenchmarks/dense-set.js.
+        * slowMicrobenchmarks/ftl-polymorphic-div.js: Copied from JSTests/microbenchmarks/ftl-polymorphic-div.js.
+        * slowMicrobenchmarks/ftl-polymorphic-mul.js: Copied from JSTests/microbenchmarks/ftl-polymorphic-mul.js.
+        * slowMicrobenchmarks/function-bind-inlining.js: Copied from JSTests/microbenchmarks/function-bind-inlining.js.
+        * slowMicrobenchmarks/function-bind-no-inlining.js: Copied from JSTests/microbenchmarks/function-bind-no-inlining.js.
+        * slowMicrobenchmarks/large-map-iteration-with-additions.js: Copied from JSTests/microbenchmarks/large-map-iteration-with-additions.js.
+        * slowMicrobenchmarks/large-map-iteration-with-mutation.js: Copied from JSTests/microbenchmarks/large-map-iteration-with-mutation.js.
+        * slowMicrobenchmarks/map-get-get-cse.js: Copied from JSTests/microbenchmarks/map-get-get-cse.js.
+        * slowMicrobenchmarks/misc-bugs-847389-jpeg2000.js: Copied from JSTests/microbenchmarks/misc-bugs-847389-jpeg2000.js.
+        * slowMicrobenchmarks/spread-small-array.js: Copied from JSTests/microbenchmarks/spread-small-array.js.
+        * slowMicrobenchmarks/v8-raytrace-with-try-catch-high-frequency-throws.js: Copied from JSTests/microbenchmarks/v8-raytrace-with-try-catch-high-frequency-throws.js.
+
+2017-01-30  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Do not reject WebAssembly.compile() with Exception
+        https://bugs.webkit.org/show_bug.cgi?id=167585
+
+        Reviewed by Mark Lam.
+
+        * wasm/js-api/Module-compile.js:
+        (async.testPromiseAPI):
+
+2017-01-27  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Lift template escape sequence restrictions in tagged templates
+        https://bugs.webkit.org/show_bug.cgi?id=166871
+
+        Reviewed by Saam Barati.
+
+        Update the error messages and add new tests.
+
+        * ChakraCore/test/es6/unicode_6_identifier_Blue524737.baseline-jsc:
+        * stress/lift-template-literal.js: Added.
+        (dump):
+        (testTag.return.tag):
+        (testTag):
+        * stress/template-literal-syntax.js:
+
+2017-01-26  Mark Lam  <mark.lam@apple.com>
+
+        Fix missing exception check in genericTypedArrayViewProtoFuncSet().
+        https://bugs.webkit.org/show_bug.cgi?id=166812
+        <rdar://problem/29916672>
+
+        Reviewed by Saam Barati.
+
+        * stress/regress-166812.js: Added.
+
+2017-01-26  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r211224.
+        https://bugs.webkit.org/show_bug.cgi?id=167479
+
+        "It was a Kraken performance regression" (Requested by
+        saamyjoon on #webkit).
+
+        Reverted changeset:
+
+        "OSR entry: delay outer-loop compilation when at inner-loop"
+        https://bugs.webkit.org/show_bug.cgi?id=167149
+        http://trac.webkit.org/changeset/211224
+
+2017-01-26  JF Bastien  <jfbastien@apple.com>
+
+        OSR entry: delay outer-loop compilation when at inner-loop
+        https://bugs.webkit.org/show_bug.cgi?id=167149
+
+        Reviewed by Filip Pizlo.
+
+        Try to be mean to OSR entry by using nested loops, and having
+        non-int32 types or truly varying types.
+
+        Mandelbrot currently never tiers up to FTL because it exits too
+        many times before this. That shouldn't happen because it's just
+        numbers and int32s. I'll file a bug to fix this.
+
+        * microbenchmarks/mandelbrot.js: Added.
+        (mandelbrot):
+        (printable):
+        * microbenchmarks/nonude.js: Added.
+        (Array.prototype.remove):
+        (const.u):
+        (const.load):
+        (const.scan):
+        (const.main):
+
+2017-01-25  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly JS API: coerce return values from imports
+        https://bugs.webkit.org/show_bug.cgi?id=165480
+        <rdar://problem/29760318>
+
+        Reviewed by Yusuke Suzuki.
+
+        * wasm/function-tests/function-import-return-value.js: Added.
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.const.tests.x.assert.eq):
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.const.tests.Math.fround):
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.let.type.of.Reflect.ownKeys):
+        (test.1):
+        (assert.truthy):
+        (assert.throws):
+
+2017-01-25  Filip Pizlo  <fpizlo@apple.com>
+
+        jsc.cpp should have the $.agent stuff for testing SAB
+        https://bugs.webkit.org/show_bug.cgi?id=167431
+
+        Reviewed by Saam Barati.
+        
+        Add a very basic test of Atomics using $.agent. This is based on
+        LayoutTests/workers/sab/simple.html.
+
+        * stress/lars-sab-workers.js: Added.
+        (startWorker):
+        (resources):
+        (wake):
+        (else):
+
+2017-01-24  Filip Pizlo  <fpizlo@apple.com>
+
+        Atomics.store should return the int-converted value according to toInteger
+        https://bugs.webkit.org/show_bug.cgi?id=167399
+
+        Reviewed by Saam Barati.
+
+        * stress/atomics-add-uint32.js: Added.
+        * stress/atomics-store-return.js: Fix the test to match what the spec wants.
+
+2017-01-24  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Optimize Number#toString with Int52
+        https://bugs.webkit.org/show_bug.cgi?id=167303
+
+        Reviewed by Sam Weinig.
+
+        * stress/to-string-with-int52.js: Added.
+        (shouldBe):
+
+2017-01-24  Filip Pizlo  <fpizlo@apple.com>
+
+        Atomics.store should return the int-converted value, not the value that it stored
+        https://bugs.webkit.org/show_bug.cgi?id=167395
+
+        Reviewed by Saam Barati.
+
+        * stress/atomics-store-return.js: Added.
+
+2017-01-24  Filip Pizlo  <fpizlo@apple.com>
+
+        -0 is a valid array index and AtomicsObject should know this
+        https://bugs.webkit.org/show_bug.cgi?id=167386
+
+        Reviewed by Mark Lam.
+
+        * stress/atomics-neg-zero.js: Added.
+
+2017-01-23  Saam Barati  <sbarati@apple.com>
+
+        https://bugs.webkit.org/show_bug.cgi?id=167247
+        JSC: operationSpreadGeneric uses the wrong global object for the builtin function and slow_path_spread consults the wrong global object to prove if the iterator protocol is unobservable
+        <rdar://problem/30121809>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/spread-consults-correct-global-object.js: Added.
+        (assert):
+        (spread):
+        * stress/spread-correct-global-object-on-exception.js: Added.
+        (assert):
+        (spread):
+        (const.objectText.let.o.Symbol.iterator):
+        (catch):
+
+2017-01-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        dynamic import is ambiguous with import declaration at module code
+        https://bugs.webkit.org/show_bug.cgi?id=167098
+
+        Reviewed by Darin Adler.
+
+        * modules/import-call.js: Added.
+        (from.string_appeared_here.import.string_appeared_here.then):
+        * modules/import-call/main.js: Added.
+        * stress/import-syntax.js:
+        (async):
+
+2017-01-19  Skachkov Oleksandr  <gskachkov@gmail.com>
+
+        "this" missing after await in async arrow function
+        https://bugs.webkit.org/show_bug.cgi?id=166919
+
+        Reviewed by Saam Barati.
+
+        * stress/async-arrow-functions-lexical-binding-in-class.js:
+        (ChildClass.prototype.asyncThisPropWithAwaitBody):
+        (ChildClass.prototype.asyncThisPropInEvalWithAwaitBody):
+        (ChildClass.prototype.asyncThisValueBodyWithAwait):
+        (ChildClass.prototype.asyncThisValueInEvalWithAwaitBody):
+        (ChildClass):
+        (ChildClass3):
+        (ChildClass3.prototype.classValue):
+        (ChildClass3.prototype.get classProperty):
+        * stress/async-arrow-functions-lexical-new.target-binding.js:
+        (C2WithAwait):
+
+2017-01-16  Filip Pizlo  <fpizlo@apple.com>
+
+        Make opaque root scanning truly constraint-based
+        https://bugs.webkit.org/show_bug.cgi?id=165760
+
+        Reviewed by Geoffrey Garen.
+        
+        Added this test, which demonstrates the benefit of having a dedicated string subspace.
+
+        * microbenchmarks/stringalloc.js: Added.
+
+2017-01-17  Michael Saboff  <msaboff@apple.com>
+
+        Nested parenthesized regular expressions with non-zero minimum counts appear to hang and use lots of memory
+        https://bugs.webkit.org/show_bug.cgi?id=167125
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/regexp-nested-nonzero-min-counted-parens.js: Added.
+        New test with limits that run slow and take a reasonable amount of memory
+        before the change and run fast, using little memory with the change.
+
+2017-01-14  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Annotate large string tests with largeHeap
+        https://bugs.webkit.org/show_bug.cgi?id=167054
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/dense-set.js:
+        * microbenchmarks/lots-of-fields.js:
+        * stress/joined-strings-should-not-exceed-max-string-length.js:
+        * stress/make-large-string-jit-strcat.js:
+        * stress/make-large-string-jit.js:
+        * stress/make-large-string-strcat.js:
+        * stress/make-large-string.js:
+        * stress/string-joining-long-strings-should-not-crash.js:
+        * stress/string-prototype-replace-should-throw-out-of-memory-error-when-using-too-much-memory.js:
+
+2017-01-14  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Reserve capacity for StringBuilder in unescape
+        https://bugs.webkit.org/show_bug.cgi?id=167008
+
+        Reviewed by Sam Weinig.
+
+        * stress/unescape.js: Added.
+        (shouldBe):
+
+2017-01-12  Saam Barati  <sbarati@apple.com>
+
+        Add a slice intrinsic to the DFG/FTL
+        https://bugs.webkit.org/show_bug.cgi?id=166707
+        <rdar://problem/29913445>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/array-slice-intrinsic.js: Added.
+        (assert):
+        (shallowEq):
+        (runTest1):
+        (runTest2):
+        * stress/array-slice-jettison-on-constructor-change.js: Added.
+        (assert):
+        (runTest1):
+        (runTest2):
+        (addRandomProperties):
+        (runTests):
+        * stress/array-slice-osr-exit-2.js: Added.
+        (assert):
+        (Foo):
+        (shallowEq):
+        (runTest1):
+        (runTest2):
+        (addRandomProperties):
+        (runTests):
+        * stress/array-slice-osr-exit.js: Added.
+        (assert):
+        (Foo):
+        (shallowEq):
+        (runTest1):
+        (runTest2):
+        (addRandomProperties):
+        (runTests):
+
+2017-01-11  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Mark es6/typed_arrays_correct_prototype_chains.js as failing after r210570.
+        https://bugs.webkit.org/show_bug.cgi?id=166931i
+
+        Unreviewed test gardening.
+
+        * es6.yaml:
+
+2017-01-10  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r210052.
+        https://bugs.webkit.org/show_bug.cgi?id=166915
+
+        "breaks web compatability" (Requested by keith_miller on
+        #webkit).
+
+        Reverted changeset:
+
+        "Add support for global"
+        https://bugs.webkit.org/show_bug.cgi?id=165171
+        http://trac.webkit.org/changeset/210052
+
+2017-01-10  Mark Lam  <mark.lam@apple.com>
+
+        Property setters should not be called for bound arguments list entries.
+        https://bugs.webkit.org/show_bug.cgi?id=165631
+
+        Reviewed by Filip Pizlo.
+
+        * stress/property-setters-should-not-be-called-for-bound-arguments-list-entries.js: Added.
+
+2017-01-10  Skachkov Oleksandr  <gskachkov@gmail.com>
+
+        Calling async arrow function which is in a class's member function will cause error
+        https://bugs.webkit.org/show_bug.cgi?id=166879
+
+        Reviewed by Saam Barati.
+
+        * stress/async-arrow-functions-lexical-binding-in-class.js: Added.
+        (shouldBe):
+        (shouldBeAsync):
+        (BaseClass.prototype.baseClassValue):
+        (BaseClass.prototype.get property):
+        (BaseClass):
+        (runSomething):
+        (ChildClass.prototype.classValue):
+        (ChildClass.prototype.get classProperty):
+        (ChildClass.prototype.asyncValueExp):
+        (ChildClass.prototype.asyncValueBody):
+        (ChildClass.prototype.asyncThisPropExp):
+        (ChildClass.prototype.asyncThisPropBody):
+        (ChildClass.prototype.asyncThisPropInEvalExp):
+        (ChildClass.prototype.asyncThisPropInEvalBody):
+        (ChildClass.prototype.asyncThisValueExp):
+        (ChildClass.prototype.asyncThisValueBody):
+        (ChildClass.prototype.asyncThisValueInEvalExp):
+        (ChildClass.prototype.asyncThisValueInEvalBody):
+        (ChildClass):
+        (ChildClass2):
+        (ChildClass2.prototype.classValue):
+        (ChildClass2.prototype.get classProperty):
+        * stress/async-arrow-functions-lexical-super-binding.js:
+
+2017-01-09  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Prototype dynamic-import
+        https://bugs.webkit.org/show_bug.cgi?id=165724
+
+        Reviewed by Saam Barati.
+
+        * stress/import-basic.js: Added.
+        (async.async.load):
+        (async):
+        (catch):
+        * stress/import-from-eval.js: Added.
+        (async):
+        (catch):
+        * stress/import-syntax.js: Added.
+        (testSyntaxError):
+        * stress/import-tests/cocoa.js: Added.
+        (export.Cocoa):
+        (export.hello):
+        * stress/import-tests/multiple.js: Added.
+        (export.result):
+        * stress/import-tests/multiple2.js: Added.
+        (export.ok):
+        * stress/import-tests/should.js: Added.
+        (export.shouldBe):
+        (export.shouldThrow):
+        * stress/modules-syntax-error.js:
+
+2017-01-09  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r210476.
+        https://bugs.webkit.org/show_bug.cgi?id=166859
+
+        "4% JSBench regression" (Requested by keith_mi_ on #webkit).
+
+        Reverted changeset:
+
+        "Add a slice intrinsic to the DFG/FTL"
+        https://bugs.webkit.org/show_bug.cgi?id=166707
+        http://trac.webkit.org/changeset/210476
+
+2017-01-06  Saam Barati  <sbarati@apple.com>
+
+        Add a slice intrinsic to the DFG/FTL
+        https://bugs.webkit.org/show_bug.cgi?id=166707
+
+        Reviewed by Filip Pizlo.
+
+        * stress/array-slice-intrinsic.js: Added.
+        (assert):
+        (shallowEq):
+        (runTest1):
+        (runTest2):
+        * stress/array-slice-jettison-on-constructor-change.js: Added.
+        (assert):
+        (runTest1):
+        (runTest2):
+        (addRandomProperties):
+        (runTests):
+        * stress/array-slice-osr-exit-2.js: Added.
+        (assert):
+        (Foo):
+        (shallowEq):
+        (runTest1):
+        (runTest2):
+        (addRandomProperties):
+        (runTests):
+        * stress/array-slice-osr-exit.js: Added.
+        (assert):
+        (Foo):
+        (shallowEq):
+        (runTest1):
+        (runTest2):
+        (addRandomProperties):
+        (runTests):
+
+2017-01-06  Michael Saboff  <msaboff@apple.com>
+
+        @putByValDirect in Array.of and Array.from overwrites non-writable/configurable properties
+        https://bugs.webkit.org/show_bug.cgi?id=153486
+
+        Reviewed by Saam Barati.
+
+        New regression test.
+
+        * stress/regress-153486.js: Added.
+        (shouldEqual):
+        (makeUnwriteableUnconfigurableObject):
+        (testArrayOf):
+        (testArrayFrom):
+        (runTest):
+
+2016-12-30  Filip Pizlo  <fpizlo@apple.com>
+
+        DeferGC::~DeferGC should be super cheap
+        https://bugs.webkit.org/show_bug.cgi?id=166626
+
+        Reviewed by Saam Barati.
+
+        * stress/slow-path-generator-updating-current-node-dfg.js:
+        * stress/unshift-array-storage.js:
+
+2017-01-04  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: sections with the same name are allowed
+        https://bugs.webkit.org/show_bug.cgi?id=166708
+
+        Reviewed by Saam Barati.
+
+        * wasm/self-test/test_BuilderJSON.js:
+        (SectionsWithSameCustomName):
+
+2017-01-04  Saam Barati  <sbarati@apple.com>
+
+        stress/spread-calling.js timing out on the bots
+        https://bugs.webkit.org/show_bug.cgi?id=166689
+        <rdar://problem/29779182>
+
+        Reviewed by Mark Lam.
+
+        * stress/spread-calling.js:
+
+2017-01-04  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly JS API: add Module.sections
+        https://bugs.webkit.org/show_bug.cgi?id=165159
+        <rdar://problem/29760326>
+
+        Reviewed by Mark Lam.
+
+        As described here: https://github.com/WebAssembly/design/blob/master/JS.md#webassemblymodulecustomsections
+
+        * wasm/Builder.js: allow custom sections to be duplicated
+        * wasm/js-api/Module.customSection.js: Added.
+        (assert.throws.WebAssembly.Module.prototype.customSections):
+        (assert.eq):
+
+2017-01-04  Saam Barati  <sbarati@apple.com>
+
+        We don't properly handle exceptions inside the nativeCallTrampoline macro in the LLInt
+        https://bugs.webkit.org/show_bug.cgi?id=163720
+
+        Reviewed by Mark Lam.
+
+        * stress/bound-function-tail-call-with-exception.js: Added.
+        (bar):
+        (foo):
+        (catch):
+
+2017-01-03  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly JS API: check and test in-call / out-call values
+        https://bugs.webkit.org/show_bug.cgi?id=164876
+        <rdar://problem/29844107>
+
+        Reviewed by Saam Barati.
+
+        * wasm.yaml:
+        * wasm/assert.js: add an assert for NaN comparison
+        * wasm/fuzz/export-function.js: Added. Generate random wasm export
+        signatures, and call them with random parameters.
+        (const.paramExporter):
+        (const.setBuffer):
+        (const.types.generate):
+        (generate):
+        * wasm/js-api/export-arity.js: Added.
+        (const.paramExporter): Test that mismatched arities when JS calls
+        wasm follow the defined semantics: i32 is 0, f32 / f64 are NaN.
+        https://github.com/WebAssembly/design/blob/master/JS.md#exported-function-exotic-objects
+        * wasm/js-api/export-void-is-undef.js: Added. Test that "void"
+        wasm functions return "undefined" in JS.
+
+2017-01-02  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: handle and optimize wasm export → wasm import calls
+        https://bugs.webkit.org/show_bug.cgi?id=165282
+
+        Reviewed by Saam Barati.
+
+        * wasm/Builder.js: Add a Proxy to Builder.js, which intercepts
+        unknown property lookups. This creates way better error messages
+        on typos than 'undefined is not a function', which happens
+        semi-frequently as I typo opcode names (and which one is a typo is
+        hard to find because we chain builders).
+        (const._isValidValue):
+        (get target):
+        (const._importFunctionContinuation):
+        (const._importMemoryContinuation):
+        (const._importTableContinuation):
+        (const._exportFunctionContinuation):
+        (export.default.Builder.prototype._registerSectionBuilders.const.section.in.WASM.description.section.switch.section.case.string_appeared_here.this.section):
+        (export.default.Builder.prototype._registerSectionBuilders.this.Unknown):
+        * wasm/LowLevelBinary.js: Add limited support for var{u}int64 (only the 32-bit values)
+        (export.default.LowLevelBinary.prototype.varint32):
+        (export.default.LowLevelBinary.prototype.varuint64):
+        (export.default.LowLevelBinary.prototype.varint64):
+        * wasm/function-tests/exceptions.js: update error message
+        * wasm/function-tests/trap-load.js: update error message
+        * wasm/function-tests/trap-store.js: update error message
+        * wasm/js-api/wasm-to-wasm-bad-signature.js: Added. Test a bunch of bad wasm->wasm import signatures
+        (const.makeImportee.signature.switch):
+        (BadSignatureDropStartParams):
+        * wasm/js-api/wasm-to-wasm.js: Added. Test 64-bit wasm->wasm import calls
+        (const.callerModule):
+        (const.calleeModule):
+        (WasmToWasm):
+
+2017-01-02  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Some loads don't take into account the offset
+        https://bugs.webkit.org/show_bug.cgi?id=166616
+        <rdar://problem/29841541>
+
+        Reviewed by Keith Miller.
+
+        * wasm/function-tests/load-offset.js: Added.
+
+2016-12-29  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Rebase spec-tests now that wabt has been updated to produce certain kinds of invalid modules
+        https://bugs.webkit.org/show_bug.cgi?id=166491
+        <rdar://problem/29814999>
+
+        Reviewed by Yusuke Suzuki.
+
+        Based off these revisions:
+        - spec: b055d01ea1dfdd7a5231ae779095435f836de97f
+        - wabt: d0d44702c753f851b094615298a2f4d4e3c21035
+
+        The reason for the rebase is that wabt was updated to stop
+        silently rejecting invalid modules. This was needed because
+        some of the spec tests check to make sure that the module
+        is invalid, but wabt was silently ignoring the errors and
+        generating valid modules:
+        https://github.com/WebAssembly/wabt/issues/256
+
+        * wasm.yaml:
+        * wasm/spec-tests/address.wast.js:
+        * wasm/spec-tests/binary.wast.js:
+        * wasm/spec-tests/block.wast.js:
+        * wasm/spec-tests/br.wast.js:
+        * wasm/spec-tests/br_if.wast.js:
+        * wasm/spec-tests/br_table.wast.js:
+        * wasm/spec-tests/break-drop.wast.js:
+        * wasm/spec-tests/call.wast.js:
+        * wasm/spec-tests/call_indirect.wast.js:
+        * wasm/spec-tests/comments.wast.js:
+        * wasm/spec-tests/conversions.wast.js:
+        * wasm/spec-tests/custom_section.wast.js:
+        * wasm/spec-tests/endianness.wast.js:
+        * wasm/spec-tests/exports.wast.js:
+        * wasm/spec-tests/f32.wast.js:
+        * wasm/spec-tests/f32_cmp.wast.js:
+        * wasm/spec-tests/f64.wast.js:
+        * wasm/spec-tests/f64_cmp.wast.js:
+        * wasm/spec-tests/fac.wast.js:
+        * wasm/spec-tests/float_exprs.wast.js:
+        * wasm/spec-tests/float_literals.wast.js:
+        * wasm/spec-tests/float_memory.wast.js:
+        * wasm/spec-tests/float_misc.wast.js:
+        * wasm/spec-tests/forward.wast.js:
+        * wasm/spec-tests/func.wast.js:
+        * wasm/spec-tests/func_ptrs.wast.js:
+        * wasm/spec-tests/get_local.wast.js:
+        * wasm/spec-tests/globals.wast.js:
+        * wasm/spec-tests/i32.wast.js:
+        * wasm/spec-tests/i64.wast.js:
+        * wasm/spec-tests/imports.wast.js:
+        * wasm/spec-tests/int_exprs.wast.js:
+        * wasm/spec-tests/int_literals.wast.js:
+        * wasm/spec-tests/left-to-right.wast.js:
+        * wasm/spec-tests/linking.wast.js:
+        * wasm/spec-tests/loop.wast.js:
+        * wasm/spec-tests/memory.wast.js:
+        * wasm/spec-tests/memory_redundancy.wast.js:
+        * wasm/spec-tests/memory_trap.wast.js:
+        * wasm/spec-tests/names.wast.js:
+        * wasm/spec-tests/nop.wast.js:
+        * wasm/spec-tests/resizing.wast.js:
+        * wasm/spec-tests/return.wast.js:
+        * wasm/spec-tests/select.wast.js:
+        * wasm/spec-tests/set_local.wast.js:
+        * wasm/spec-tests/skip-stack-guard-page.wast.js:
+        * wasm/spec-tests/stack.wast.js:
+        * wasm/spec-tests/start.wast.js:
+        * wasm/spec-tests/store_retval.wast.js:
+        * wasm/spec-tests/switch.wast.js:
+        * wasm/spec-tests/tee_local.wast.js:
+        * wasm/spec-tests/traps.wast.js:
+        * wasm/spec-tests/typecheck.wast.js:
+        * wasm/spec-tests/unreachable.wast.js:
+        * wasm/spec-tests/unwind.wast.js:
+
+2016-12-28  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Don't allow duplicate export names
+        https://bugs.webkit.org/show_bug.cgi?id=166490
+        <rdar://problem/29815000>
+
+        Reviewed by Keith Miller.
+
+        * wasm.yaml:
+        * wasm/function-tests/invalid-duplicate-export.js: Added.
+
+2016-12-28  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Implement grow_memory and current_memory
+        https://bugs.webkit.org/show_bug.cgi?id=166448
+        <rdar://problem/29803676>
+
+        Reviewed by Keith Miller.
+
+        I rewrote some of the testWasmModuleFunctions that used Memory to use
+        the JS API since the jsc.cpp version can no longer use memory.
+
+        * wasm.yaml:
+        * wasm/function-tests/add-12.js:
+        (testWasmModuleFunctions):
+        * wasm/function-tests/br-if-loop-less-than.js:
+        (testWasmModuleFunctions):
+        * wasm/function-tests/brTableAsIf.js:
+        (testWasmModuleFunctions):
+        * wasm/function-tests/brTableManyValues.js:
+        (testWasmModuleFunctions):
+        * wasm/function-tests/brTableWithLoop.js:
+        (testWasmModuleFunctions):
+        * wasm/function-tests/dumb-eq-if-then-else.js:
+        * wasm/function-tests/eqz.js:
+        * wasm/function-tests/grow-memory-2.js: Added.
+        (const.func):
+        (assert.eq.instance.exports.foo):
+        * wasm/function-tests/grow-memory-3.js: Added.
+        * wasm/function-tests/grow-memory-4.js: Added.
+        (const.func):
+        * wasm/function-tests/grow-memory.js: Added.
+        (binaryShouldNotParse):
+        (assert.truthy):
+        (assert.eq):
+        (memory.grow):
+        * wasm/function-tests/i32-load.js:
+        (testWasmModuleFunctions):
+        * wasm/function-tests/i32-load8-s.js:
+        * wasm/function-tests/max.js:
+        * wasm/function-tests/min.js:
+        * wasm/js-api/memory-grow.js: Added.
+        (i.i):
+        (assertEq):
+        * wasm/js-api/test_memory.js:
+        * wasm/wasm.json:
+
+2016-12-25  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Propagate the source origin as much as possible
+        https://bugs.webkit.org/show_bug.cgi?id=166348
+
+        Reviewed by Darin Adler.
+
+        * stress/source-origin.js: Added.
+        (shouldBe):
+
+2016-12-24  Caio Lima  <ticaiolima@gmail.com>
+
+        [test262] Fixing mapped arguments object property test case
+        https://bugs.webkit.org/show_bug.cgi?id=159398
+
+        Reviewed by Saam Barati.
+
+        * stress/arguments-bizarre-behaviour-disable-enumerability.js:
+        * stress/arguments-define-property.js: Added.
+        (assert):
+        (testProperties):
+        * stress/arguments-non-configurable.js: Added.
+        (assert):
+        (tryChangeNonConfigurableDescriptor):
+        (set tryChangeNonConfigurableDescriptor):
+        (tryChangeWritableOfNonConfigurableDescriptor):
+        * test262.yaml:
+
+016-12-20  Caio Lima  <ticaiolima@gmail.com>
+
+        [test262] Fixing mapped arguments object property test case
+        https://bugs.webkit.org/show_bug.cgi?id=159398
+
+        Reviewed by .
+
+        * stress/arguments-bizarre-behaviour-disable-enumerability.js:
+        * stress/arguments-define-property.js: Added.
+        (assert):
+        (testProperties):
+        * stress/arguments-non-configurable.js: Added.
+        (assert):
+        (tryChangeNonConfigurableDescriptor):
+        (set tryChangeNonConfigurableDescriptor):
+        (tryChangeWritableOfNonConfigurableDescriptor):
+        * test262.yaml:
+
+2016-12-23  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: trap on bad division.
+        https://bugs.webkit.org/show_bug.cgi?id=164786
+
+        Reviewed by Mark Lam.
+
+        Also, mark conversions as passing.
+
+        * wasm.yaml:
+        * wasm/wasm.json:
+
+2016-12-22  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: Make spec-tests/f32.wast.js and spec-tests/f64.wast.js pass
+        https://bugs.webkit.org/show_bug.cgi?id=166447
+
+        Reviewed by Saam Barati.
+
+        * wasm.yaml:
+        * wasm/wasm.json:
+
+2016-12-22  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Make calling Wasm functions that returns or takes an i64 as a parameter an early exception
+        https://bugs.webkit.org/show_bug.cgi?id=166437
+        <rdar://problem/29793949>
+
+        Reviewed by Keith Miller.
+
+        * wasm.yaml:
+        * wasm/function-tests/i64-from-js-exceptions.js: Added.
+        (const.imp.import.sideEffects):
+        (assert.throws.instance.exports.foo.valueOf):
+
+2016-12-22  Mark Lam  <mark.lam@apple.com>
+
+        De-duplicate finally blocks.
+        https://bugs.webkit.org/show_bug.cgi?id=160168
+
+        Reviewed by Saam Barati.
+
+        Re-landing r209952 with a few new tests added in test-finally.js.
+
+        * stress/deeply-nested-finallys.js: Copied from JSTests/stress/deeply-nested-finallys.js.
+        - Tests many levels of finally nesting.  This causes the old code to hang (and
+          crashes eventually) while trying to generate bytecode for the exponentially
+          duplicated finally blocks.  The new code completes this test almost instantly.
+
+        * stress/test-finally.js: Copied from JSTests/stress/test-finally.js.
+        - Tests control flow through various permutations of finally blocks.
+
+2016-12-22  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Make the spec-tests/address.wast.js test pass
+        https://bugs.webkit.org/show_bug.cgi?id=166429
+        <rdar://problem/29793220>
+
+        Reviewed by Keith Miller.
+
+        * wasm.yaml:
+
+2016-12-22  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: The validator should not allow unused stack entries at the end of a block
+        https://bugs.webkit.org/show_bug.cgi?id=166411
+
+        Reviewed by Saam Barati.
+
+        Test cleanup and enable new passing tests.
+
+        * wasm.yaml:
+        * wasm/function-tests/br-if-as-return.js:
+
+2016-12-22  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Make the spec-tests/start.wast.js test pass
+        https://bugs.webkit.org/show_bug.cgi?id=166416
+        <rdar://problem/29784532>
+
+        Reviewed by Yusuke Suzuki.
+
+        * wasm.yaml:
+
+2016-12-21  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: Fix decode floating point constants in unreachable code
+        https://bugs.webkit.org/show_bug.cgi?id=166400
+
+        Reviewed by Saam Barati.
+
+        * wasm.yaml:
+
+2016-12-21  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: Allow br, br_if, and br_table to act as a return
+        https://bugs.webkit.org/show_bug.cgi?id=166393
+
+        Reviewed by Saam Barati.
+
+        Add tests for breaks acting as returns and fix tests that
+        validate error messages.
+
+        * wasm/function-tests/br-as-return.js: Added.
+        * wasm/function-tests/br-if-as-return.js: Added.
+        * wasm/function-tests/br-table-as-return.js: Added.
+        * wasm/function-tests/if-no-else-non-void.js:
+        * wasm/function-tests/struct.js: Added.
+        * wasm/js-api/global-error.js:
+        (assert.throws):
+        * wasm/js-api/table.js:
+        (assert.throws):
+
+2016-12-21  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Import spec tests
+        https://bugs.webkit.org/show_bug.cgi?id=166395
+
+        Rubber stamped by Keith Miller.
+
+        This patch implements the Wasm spec's tests found here:
+        https://github.com/WebAssembly/spec/tree/master/interpreter/test
+        
+        These tests are in .wast s-epxression format. To convert
+        them to JS, I use a script from the wabt library, found here:
+        https://github.com/WebAssembly/wabt/blob/master/test/run-gen-spec-js.py
+        
+        I also added a script that automatically imports the tests as
+        JS files. The inputs to the script is the path to the Wasm spec
+        git repo and the path to the wabt git repo. This will make importing
+        new tests easy in the future.
+
+        The wasm spec imported is at commit: b055d01ea1dfdd7a5231ae779095435f836de97f
+        The wabt used to do the import is at commit: 622b42dced6d793e9d49e9b1fd1d1524defd1387
+
+        * wasm.yaml:
+        * wasm/import-spec-tests.rb: Added.
+        * wasm/spec-tests: Added.
+        * wasm/spec-tests/address.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/binary.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/block.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/br.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/br_if.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/br_table.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/break-drop.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/call.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/call_indirect.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/comments.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/conversions.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/custom_section.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/endianness.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/exports.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/f32.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/f32_cmp.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/f64.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/f64_cmp.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/fac.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/float_exprs.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/float_literals.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/float_memory.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/float_misc.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/forward.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/func.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/func_ptrs.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/get_local.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/globals.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/i32.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/i64.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/imports.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/int_exprs.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/int_literals.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/left-to-right.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/linking.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/loop.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/memory.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/memory_redundancy.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/memory_trap.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/names.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/nop.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/resizing.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/return.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/select.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/set_local.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/skip-stack-guard-page.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/stack.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/start.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/store_retval.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/switch.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/tee_local.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/traps.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/typecheck.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/unreachable.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+        * wasm/spec-tests/unwind.wast.js: Added.
+        (register):
+        (module):
+        (instance):
+        (assert_malformed):
+        (assert_invalid):
+        (assert_soft_invalid):
+        (assert_unlinkable):
+        (assert_uninstantiable):
+        (assert_trap):
+        (assert_return):
+        (assert_return_nan):
+
+2016-12-20  Keith Miller  <keith_miller@apple.com>
+
+        Add support for global
+        https://bugs.webkit.org/show_bug.cgi?id=165171
+
+        Reviewed by Filip Pizlo.
+
+        * stress/global.js: Added.
+
+2016-12-20  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly API: implement WebAssembly.LinkError
+        https://bugs.webkit.org/show_bug.cgi?id=165805
+        <rdar://problem/29747874>
+
+        Reviewed by Mark lam.
+
+        Update all exception sites which now throw WebAssembly.LinkError.
+
+        * wasm/js-api/element-data.js:
+        * wasm/js-api/element.js:
+        (assert.throws):
+        * wasm/js-api/global-error.js:
+        (new.Number):
+        * wasm/js-api/table.js:
+        (assert.throws):
+        (new.WebAssembly.Table):
+        * wasm/js-api/test_Data.js:
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties.switch):
+        * wasm/js-api/test_memory.js:
+        (test):
+        (test.testMemImportError): Deleted.
+
+2016-12-20  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: unique function signatures
+        https://bugs.webkit.org/show_bug.cgi?id=165957
+        <rdar://problem/29735737>
+
+        Reviewed by Saam Barati.
+
+        * wasm/function-tests/table-basic.js: FIXME is now addressed,
+        though instance to instance calls still need work which bug
+        #165282 will address
+        (i.assert.eq.foo):
+        * wasm/js-api/unique-signature.js: Added.
+        (CallIndirectWithDuplicateSignatures):
+
+2016-12-19  Mark Lam  <mark.lam@apple.com>
+
+        Rolling out r209974 and r209952. They break some websites in mysterious ways. Step 2: Rollout r209952.
+        https://bugs.webkit.org/show_bug.cgi?id=166049
+
+        Not reviewed.
+
+        * stress/deeply-nested-finallys.js: Removed.
+        * stress/test-finally.js: Removed.
+
+2016-12-19  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Make running Wasm tests take less time by reducing some tests' iteration count and by splitting some tests into different files
+        https://bugs.webkit.org/show_bug.cgi?id=166017
+
+        Reviewed by Yusuke Suzuki.
+
+        * wasm/function-tests/trap-load-2.js: Added.
+        (assert):
+        (wasmFrameCountFromError):
+        (continuation):
+        (i.catch):
+        * wasm/function-tests/trap-load.js:
+        (assert.continuation): Deleted.
+        * wasm/function-tests/trap-store-2.js: Added.
+        (import.Builder.from.string_appeared_here.assert):
+        (continuation):
+        (i.catch):
+        * wasm/function-tests/trap-store.js:
+        (assert.continuation): Deleted.
+        (assert): Deleted.
+        * wasm/js-api/test_memory.js:
+        (test):
+
+2016-12-18  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Implement the WebAssembly.compile and WebAssembly.validate
+        https://bugs.webkit.org/show_bug.cgi?id=165936
+
+        Reviewed by Mark Lam.
+
+        * wasm/js-api/Module-compile.js: Added.
+        (async.testPromiseAPI):
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties.switch):
+        * wasm/js-api/validate.js: Added.
+        (assert.truthy.WebAssembly.validate.builder.WebAssembly):
+
+2016-12-16  Mark Lam  <mark.lam@apple.com>
+
+        De-duplicate finally blocks.
+        https://bugs.webkit.org/show_bug.cgi?id=160168
+
+        Reviewed by Keith Miller.
+
+        * stress/deeply-nested-finallys.js: Added.
+        - Tests many levels of finally nesting.  This causes the old code to hang (and
+          crashes eventually) while trying to generate bytecode for the exponentially
+          duplicated finally blocks.  The new code completes this test almost instantly.
+
+        * stress/test-finally.js: Added.
+        - Tests control flow through various permutations of finally blocks.
+
+2016-12-16  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: WasmB3IRGenerator should throw exceptions instead of crash
+        https://bugs.webkit.org/show_bug.cgi?id=165834
+
+        Reviewed by Keith Miller.
+
+        * wasm/function-tests/exceptions.js: Added.
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.makeInstance):
+        * wasm/function-tests/table-basic.js:
+        (i.i.42.throw.new.Error):
+
+2016-12-16  Keith Miller  <keith_miller@apple.com>
+
+        i64.eqz should use an Int64 zero
+        https://bugs.webkit.org/show_bug.cgi?id=165942
+
+        Reviewed by Mark Lam.
+
+        * wasm/wasm.json:
+
+2016-12-15  Keith Miller  <keith_miller@apple.com>
+
+        Fix validation of non-void if blocks with no else
+        https://bugs.webkit.org/show_bug.cgi?id=165938
+
+        Reviewed by Saam Barati.
+
+        Add a new failing test and a fix an existing one.
+
+        * wasm/function-tests/dead-call.js:
+        * wasm/function-tests/if-no-else-non-void.js: Added.
+
+2016-12-15  Keith Miller  <keith_miller@apple.com>
+
+        Wasm should not create empty unlinked callsites
+        https://bugs.webkit.org/show_bug.cgi?id=165933
+
+        Reviewed by Mark Lam.
+
+        * wasm/function-tests/dead-call.js: Added.
+
+2016-12-15  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: improve compilation error messages
+        https://bugs.webkit.org/show_bug.cgi?id=163919
+
+        Reviewed by Saam Barati.
+
+        Update error messages in these tests.
+        Use the assert.throws facility in many of them which weren't already.
+
+        * wasm/js-api/element.js:
+        (assert.throws.new.WebAssembly.Module.builder.WebAssembly):
+        (assert.throws):
+        * wasm/js-api/global-error.js:
+        (assert.throws.new.WebAssembly.Module.bin):
+        (assert.throws):
+        (new.Number):
+        * wasm/js-api/table.js:
+        (assert.throws.new.WebAssembly.Module.builder.WebAssembly):
+        (assert.throws):
+        (assertBadTableImport):
+        * wasm/js-api/test_Data.js:
+        (DataSectionWithoutMemory):
+        * wasm/js-api/test_Start.js:
+        (InvalidStartFunctionIndex):
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties.switch):
+
+2016-12-15  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly API: improve data section errors
+        https://bugs.webkit.org/show_bug.cgi?id=165733
+
+        Reviewed by Keith Miller.
+
+        * wasm/js-api/element-data.js: Added.
+        (ElementBeforeData.set const):
+        (ElementBeforeData): check the order of initialization, which is observable on failure
+        * wasm/js-api/test_Data.js:
+        (DataSectionWithoutMemory):
+        (DataSectionOffTheEnd): Deleted.
+        (DataSectionPartlyOffTheEnd): Deleted.
+        (DataSectionEmptyOffTheEnd): Deleted.
+        (DataSectionSeenByStart): Deleted.
+
+2016-12-15  Keith Miller  <keith_miller@apple.com>
+
+        Fix 64-bit shift family Wasm opcodes
+        https://bugs.webkit.org/show_bug.cgi?id=165902
+
+        Reviewed by Geoffrey Garen.
+
+        Add tests for shift family of instructions. Since
+        we can't generate i64 values to pass to wasm we only compile
+        the code for those functions. Attempting to generate any i64
+        code using these instructions would have been enough to cause
+        the B3 Validation error anyway.
+
+        * wasm/assert.js:
+        * wasm/function-tests/rotl.js: Added.
+        * wasm/function-tests/rotr.js: Added.
+        * wasm/function-tests/shl.js: Added.
+        * wasm/function-tests/shr-s.js: Added.
+        * wasm/function-tests/shr-u.js: Added.
+        * wasm/wasm.json:
+
+2016-12-14  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly: test_BuilderJSON.js is broken
+        https://bugs.webkit.org/show_bug.cgi?id=165893
+
+        Reviewed by Michael Saboff.
+
+        * wasm/Builder.js:
+        (const._isValidValue):
+        * wasm/self-test/test_BuilderJSON.js:
+
+2016-12-14  Keith Miller  <keith_miller@apple.com>
+
+        Unreviewed, fix test.
+
+        * wasm/function-tests/i32-const.js:
+
+2016-12-14  Keith Miller  <keith_miller@apple.com>
+
+        Wasm should decode constants correctly
+        https://bugs.webkit.org/show_bug.cgi?id=165886
+
+        Reviewed by Saam Barati.
+
+        * wasm/Builder.js:
+        (const._isValidValue):
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.putOp):
+        * wasm/LowLevelBinary.js:
+        (export.default.LowLevelBinary.prototype.float):
+        (export.default.LowLevelBinary.prototype.double):
+        * wasm/function-tests/f32-const.js: Added.
+        * wasm/function-tests/f64-const.js: Added.
+        * wasm/function-tests/i32-const.js: Added.
+        * wasm/wasm.json:
+
+2016-12-14  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: Add various low hanging fruit that will allow us to run the LLVM torture tests in Wasm
+        https://bugs.webkit.org/show_bug.cgi?id=165883
+
+        Reviewed by Keith Miller.
+
+        * wasm/Builder.js:
+        (export.default.Builder.prototype._registerSectionBuilders.switch.case.string_appeared_here.this.section):
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.emitters.Export):
+        * wasm/js-api/table.js:
+        (assertBadBinary):
+        (assertBadTable):
+        (assert.truthy):
+        * wasm/js-api/test_memory.js:
+        (binaryShouldNotParse):
+        (test):
+        (test.testMemImportError):
+        (assert.truthy):
+        (assert): Deleted.
+
+2016-12-14  Filip Pizlo  <fpizlo@apple.com>
+
+        DirectTailCall implementation needs to tell the shuffler what to put into the ArgumentCount explicitly
+        https://bugs.webkit.org/show_bug.cgi?id=165882
+
+        Reviewed by Mark Lam.
+
+        * stress/direct-tail-call-arity-mismatch-count-args.js: Added.
+        (foo):
+        (bar):
+
+2016-12-14  Keith Miller  <keith_miller@apple.com>
+
+        WebAssembly JS API: implement Global
+        https://bugs.webkit.org/show_bug.cgi?id=164133
+
+        Reviewed by Saam Barati.
+
+        * wasm/Builder.js:
+        (export.default.Builder.prototype._registerSectionBuilders.switch.case.string_appeared_here.this.section):
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.valueType.WASM.description.type.i32.type.const.putGlobalType):
+        (const.putOp):
+        (const.putInitExpr):
+        (const.emitters.Import):
+        (const.emitters.Global):
+        (const.emitters.Export):
+        (const.emitters.Code):
+        * wasm/LowLevelBinary.js:
+        (export.default.LowLevelBinary.prototype.varuint32):
+        (export.default.LowLevelBinary.prototype.varint32):
+        * wasm/js-api/global-error.js: Added.
+        (catch):
+        (assert.truthy):
+        * wasm/js-api/global-external-init-from-import.js: Added.
+        * wasm/js-api/global-internal-init-from-import.js: Added.
+        * wasm/js-api/global-mutate.js: Added.
+        (createInternalGlobalModule):
+        * wasm/js-api/globals-export.js: Added.
+        * wasm/js-api/globals-import.js: Added.
+        * wasm/wasm.json:
+
+2016-12-13  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: implement the elements section
+        https://bugs.webkit.org/show_bug.cgi?id=165715
+
+        Reviewed by Keith Miller.
+
+        * wasm/Builder.js:
+        (export.default.Builder.prototype._registerSectionBuilders.switch.case.string_appeared_here.this.section):
+        (export.default.Builder.prototype._registerSectionBuilders.switch):
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.emitters.Element):
+        * wasm/function-tests/basic-element.js: Added.
+        * wasm/js-api/element.js: Added.
+        (assertBadBinary):
+        (assertBadBinary.badInstantiation):
+
+2016-12-13  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly: implement the table section and table import
+        https://bugs.webkit.org/show_bug.cgi?id=165716
+
+        Reviewed by Keith Miller.
+
+        * wasm/Builder.js:
+        (const._importMemoryContinuation):
+        (const._importTableContinuation):
+        (export.default.Builder.prototype._registerSectionBuilders.switch.case.string_appeared_here.this.section):
+        (const._importMemoryContinuation.section): Deleted.
+        (const): Deleted.
+        (const._importMemoryContinuation.assert): Deleted.
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.putResizableLimits):
+        (const.putTable):
+        (const.emitters.Import):
+        (const.emitters.Table):
+        * wasm/function-tests/call-indirect-params.js:
+        * wasm/function-tests/call-indirect.js:
+        * wasm/function-tests/table-basic-2.js: Added.
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.makeInstance):
+        (func):
+        * wasm/function-tests/table-basic.js: Added.
+        (import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.makeInstance):
+        * wasm/js-api/call-indirect-results.js:
+        (const.wasmModuleWhichImportJS): Deleted.
+        (MonomorphicImport): Deleted.
+        * wasm/js-api/call-indirect.js:
+        (const.wasmModuleWhichImportJS):
+        (const.makeTable):
+        (Polyphic2Import):
+        (VirtualImport):
+        (MonomorphicImport): Deleted.
+        * wasm/js-api/table.js: Added.
+        (assertBadBinary):
+        (assert.truthy):
+        (assertBadTable):
+        (assertBadTableImport):
+        (assertBadBinary.assertBadTableInstance):
+        (assertBadTableInstance):
+        (new.WebAssembly.Table):
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties.switch):
+
+2016-12-13  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r209725.
+        https://bugs.webkit.org/show_bug.cgi?id=165811
+
+        "Broke ARMv7 builds" (Requested by msaboff on #webkit).
+
+        Reverted changeset:
+
+        "REGRESSION(r209653): speedometer crashes making virtual slow
+        path tailcalls"
+        https://bugs.webkit.org/show_bug.cgi?id=165748
+        http://trac.webkit.org/changeset/209725
+
+2016-12-12  Michael Saboff  <msaboff@apple.com>
+
+        REGRESSION(r209653): speedometer crashes making virtual slow path tailcalls
+        https://bugs.webkit.org/show_bug.cgi?id=165748
+
+        Reviewed by Filip Pizlo.
+
+        New regression test.
+
+        * stress/regress-165748.js: Added.
+        (sum1):
+        (sum2):
+        (sum3):
+        (sum4):
+        (sum5):
+        (sum6):
+        (tailCaller):
+        (test):
+
+2016-12-12  Mark Lam  <mark.lam@apple.com>
+
+        Debug JSC test timeout: stress/string-prototype-replace-should-throw-out-of-memory-error-when-using-too-much-memory.js.ftl-no-cjit.
+        https://bugs.webkit.org/show_bug.cgi?id=164630
+
+        Reviewed by Keith Miller.
+
+        Speculative fix for timeout issue.  It looks like this test just runs a bit
+        slower on debug builds.  So, we'll give it a little more time to run.
+
+        * stress/string-prototype-replace-should-throw-out-of-memory-error-when-using-too-much-memory.js:
+
+2016-12-11  Saam Barati  <sbarati@apple.com>
+
+        We should be able to throw exceptions from Wasm code and when Wasm frames are on the stack
+        https://bugs.webkit.org/show_bug.cgi?id=165429
+
+        Reviewed by Keith Miller.
+
+        * wasm/function-tests/trap-load.js: Added.
+        (assert):
+        (wasmFrameCountFromError):
+        (i.catch):
+        (assert.continuation):
+        * wasm/function-tests/trap-store.js: Added.
+        (import.Builder.from.string_appeared_here.assert):
+        (i.catch):
+        (assert.continuation):
+        (assert):
+        * wasm/js-api/test_memory_constructor.js:
+        (assert):
+
+2016-12-10  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r209653, r209654, r209663, and
+        r209673.
+        https://bugs.webkit.org/show_bug.cgi?id=165739
+
+        speedometer crashes (Requested by pizlo on #webkit).
+
+        Reverted changesets:
+
+        "JSVALUE64: Pass arguments in platform argument registers when
+        making JavaScript calls"
+        https://bugs.webkit.org/show_bug.cgi?id=160355
+        http://trac.webkit.org/changeset/209653
+
+        "Unreviewed build fix for 32 bit builds."
+        http://trac.webkit.org/changeset/209654
+
+        "Unreviewed build fix for the CLOOP after r209653"
+        http://trac.webkit.org/changeset/209663
+
+        "REGRESSION(r209653) Crash in CallFrameShuffler::snapshot()"
+        https://bugs.webkit.org/show_bug.cgi?id=165728
+        http://trac.webkit.org/changeset/209673
+
+2016-12-10  Michael Saboff  <msaboff@apple.com>
+
+        REGRESSION(r209653) Crash in CallFrameShuffler::snapshot()
+        https://bugs.webkit.org/show_bug.cgi?id=165728
+
+        Reviewed by Filip Pizlo.
+
+        New regression test.
+
+        * stress/regress-165728.js: Added.
+        (sum1):
+        (sum2):
+        (tailCaller):
+        (test):
+
+2016-12-10  Keith Miller  <keith_miller@apple.com>
+
+        Fix indirect_call if the result type is used.
+        https://bugs.webkit.org/show_bug.cgi?id=165727
+
+        Reviewed by Michael Saboff.
+
+        * wasm/js-api/call-indirect-results.js: Added.
+        (const.wasmModuleWhichImportJS):
+        (MonomorphicImport):
+
+2016-12-10  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Module namespace object behaves like immutable prototype exotic object
+        https://bugs.webkit.org/show_bug.cgi?id=165598
+
+        Reviewed by Mark Lam.
+
+        * modules/namespace-prototype-assignment.js: Added.
+        (else):
+        (reportError):
+        (shouldEqual):
+        (shouldThrow):
+        (stringify):
+        (makeTestID):
+        (doInternalSetPrototypeOf):
+        (ordinarySetPrototypeOf):
+        (setImmutablePrototype):
+        (windowProxySetPrototypeOf):
+        (initSetterExpectation):
+        (throwIfNoExceptionPending):
+        (objectSetPrototypeOf):
+        (setUnderscoreProto):
+        (reflectSetPrototypeOf):
+        (setPrototypeOf):
+        (newObjectProto.toString):
+        (Symbol):
+        (test):
+        (runTests):
+        * modules/namespace-set-prototype-of.js: Added.
+        (shouldThrow):
+        (TypeError.Cannot.set prototype):
+
+2016-12-09  Michael Saboff  <msaboff@apple.com>
+
+        JSVALUE64: Pass arguments in platform argument registers when making JavaScript calls
+        https://bugs.webkit.org/show_bug.cgi?id=160355
+
+        Reviewed by Filip Pizlo.
+
+        New microbenchmarks to measure call type performance.
+
+        * microbenchmarks/calling-computed-args.js: Added.
+        * microbenchmarks/calling-many-callees.js: Added.
+        * microbenchmarks/calling-one-callee-fixed.js: Added.
+        * microbenchmarks/calling-one-callee.js: Added.
+        * microbenchmarks/calling-poly-callees.js: Added.
+        * microbenchmarks/calling-poly-extra-arity-callees.js: Added.
+        * microbenchmarks/calling-tailcall.js: Added.
+        * microbenchmarks/calling-virtual-arity-fixup-callees.js: Added.
+        * microbenchmarks/calling-virtual-arity-fixup-stackargs.js: Added.
+        * microbenchmarks/calling-virtual-callees.js: Added.
+        * microbenchmarks/calling-virtual-extra-arity-callees.js: Added.
+
+2016-12-09  Keith Miller  <keith_miller@apple.com>
+
+        Wasm should support call_indirect
+        https://bugs.webkit.org/show_bug.cgi?id=165718
+
+        Reviewed by Filip Pizlo.
+
+        * wasm/Builder.js:
+        * wasm/function-tests/call-indirect-params.js: Added.
+        * wasm/function-tests/call-indirect.js: Added.
+        * wasm/js-api/call-indirect.js: Added.
+        (const.wasmModuleWhichImportJS):
+        (MonomorphicImport):
+        (Polyphic2Import):
+        (VirtualImport):
+        * wasm/wasm.json:
+
+2016-12-09  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: implement data section
+        https://bugs.webkit.org/show_bug.cgi?id=165696
+
+        Reviewed by Keith Miller.
+
+        As specified in https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#data-section
+        Note that some of the interesting corner cases are ill-defined by the spec: https://github.com/WebAssembly/design/issues/897
+
+        * wasm/Builder.js: create a data section from JavaScript
+        * wasm/Builder_WebAssemblyBinary.js: assemble the data section into the proper binary encoding
+        (const.emitters.Data):
+        * wasm/js-api/test_Data.js: Added.
+        (DataSection):
+        (DataSectionOffTheEnd):
+        (DataSectionPartlyOffTheEnd):
+        (DataSectionEmptyOffTheEnd):
+        (DataSectionSeenByStart):
+        * wasm/self-test/test_BuilderJSON.js: make sure the JSON structure is fine (this sanity checks before going to binary)
+
+2016-12-09  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly JS API: implement start function
+        https://bugs.webkit.org/show_bug.cgi?id=165150
+
+        Reviewed by Saam Barati.
+
+        * wasm/Builder.js: allow building a .Start()
+        * wasm/Builder_WebAssemblyBinary.js:
+        * wasm/js-api/test_Start.js: Added.
+        (const.emitters.Start): serialize a start section
+        * wasm/self-test/test_BuilderJSON.js: validate the start section's content
+
+2016-12-09  Saam Barati  <sbarati@apple.com>
+
+        WebAssembly JS API: implement importing and defining Memory
+        https://bugs.webkit.org/show_bug.cgi?id=164134
+
+        Reviewed by Keith Miller.
+
+        * wasm/Builder.js:
+        (const._importMemoryContinuation.section):
+        (const._importMemoryContinuation.assert):
+        (const._importMemoryContinuation):
+        (const._exportFunctionContinuation.const): Deleted.
+        (const._exportFunctionContinuation): Deleted.
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.emitters.Import):
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties.switch):
+        * wasm/js-api/test_memory.js: Added.
+        (assert):
+        (binaryShouldNotParse):
+        (test):
+        (test.testMemImportError):
+        * wasm/js-api/test_memory_constructor.js: Added.
+        (assert):
+        (throw.new.Error):
+        (testInvalidSize):
+        (assert.testInvalidInitial):
+        (testInvalidInitial.testInvalidMaximum):
+        (testInvalidInitial):
+        (testInvalidMaximum):
+        * wasm/self-test/test_BuilderJSON.js:
+
+2016-12-08  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: JSC::link* shouldn't need a CodeBlock
+        https://bugs.webkit.org/show_bug.cgi?id=165591
+
+        Reviewed by Keith Miller.
+
+        test that wasm -> JS works, including the IC
+
+        * wasm/js-api/test_Instance.js:
+        (const.wasmModuleWhichImportJS):
+        (MonomorphicImport):
+        (Polyphic2Import):
+        (Polyphic3Import):
+        (VirtualImport):
+
+2016-12-08  Filip Pizlo  <fpizlo@apple.com>
+
+        Green the cloop bot by raising this threshold.
+
+        * mozilla/js1_5/Array/regress-101964.js:
+
+2016-12-08  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly JS API: wire up Instance imports
+        https://bugs.webkit.org/show_bug.cgi?id=165118
+
+        Reviewed by Saam Barati.
+
+        * wasm/js-api/test_Instance.js: add the test, disabled for now
+
+2016-12-07  Keith Miller  <keith_miller@apple.com>
+
+        Add more missing trivial wasm ops.
+        https://bugs.webkit.org/show_bug.cgi?id=165564
+
+        Add tests for drop and tee_local.
+
+        Reviewed by Geoffrey Garen.
+
+        * wasm/function-tests/drop.js: Added.
+        * wasm/function-tests/nop.js: Added.
+        * wasm/function-tests/tee-local.js: Added.
+
+2016-12-06  Keith Miller  <keith_miller@apple.com>
+
+        Add support for truncation operators
+        https://bugs.webkit.org/show_bug.cgi?id=165519
+
+        Reviewed by Geoffrey Garen.
+
+        * wasm/function-tests/i32-trunc-s-f32.js: Added.
+        * wasm/function-tests/i32-trunc-s-f64.js: Added.
+        * wasm/function-tests/i32-trunc-u-f32.js: Added.
+        * wasm/function-tests/i32-trunc-u-f64.js: Added.
+        * wasm/function-tests/i64-trunc-s-f32.js: Added.
+        * wasm/function-tests/i64-trunc-s-f64.js: Added.
+        * wasm/function-tests/i64-trunc-u-f32.js: Added.
+        * wasm/function-tests/i64-trunc-u-f64.js: Added.
+
+2016-12-06  Mark Lam  <mark.lam@apple.com>
+
+        Introduce the concept of Immutable Prototype Exotic Objects to comply with the spec.
+        https://bugs.webkit.org/show_bug.cgi?id=165227
+        <rdar://problem/29442665>
+
+        Reviewed by Saam Barati.
+
+        * stress/get-from-scope-dynamic-onto-proxy.js:
+        - Updated error message.
+
+        * stress/proxy-dont-infinite-loop.js: Removed.
+        * stress/proxy-json-path.js: Removed.
+        * stress/rest-parameter-allocation-elimination-watchpoints-6.js: Removed.
+        - Removed these tests because the issue they are testing relies on being able to
+          set Object.prototype.__proto__ to something else (which is now not possible).
+
+2016-12-05  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] report unexpected token when "async" is followed by identifier 
+        https://bugs.webkit.org/show_bug.cgi?id=165091
+
+        Reviewed by Mark Lam.
+
+        * stress/bug-165091.js:
+
+2016-12-05  Keith Miller  <keith_miller@apple.com>
+
+        Add Wasm i64 to i32 conversion.
+        https://bugs.webkit.org/show_bug.cgi?id=165378
+
+        Reviewed by Filip Pizlo.
+
+        It turns out the wrap operation is just B3's Trunc.
+
+        * wasm/wasm.json:
+
+2016-12-04  Keith Miller  <keith_miller@apple.com>
+
+        Add support for Wasm ctz and popcnt
+        https://bugs.webkit.org/show_bug.cgi?id=165369
+
+        Reviewed by Saam Barati.
+
+        * wasm/function-tests/ctz.js: Added.
+        * wasm/function-tests/popcnt.js: Added.
+
+2016-12-03  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: update binary format to 0xD version
+        https://bugs.webkit.org/show_bug.cgi?id=165345
+
+        Reviewed by Keith Miller.
+
+        As described in the following PR: https://github.com/WebAssembly/design/pull/836
+        Originally committed in r209175, reverted in r209242, and fixed in r209284.
+
+        * wasm/Builder.js:
+        (const._normalizeFunctionSignature):
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.emitters.Type):
+        (const.emitters.Code):
+        * wasm/LowLevelBinary.js:
+        (export.default.LowLevelBinary.prototype.block_type):
+        (export.default.LowLevelBinary.prototype.inline_signature_type): Deleted.
+        * wasm/WASM.js:
+        * wasm/js-api/test_basic_api.js:
+        * wasm/self-test/test_BuilderWebAssembly.js:
+        (EmptyModule):
+        (CustomSection):
+        * wasm/self-test/test_WASM.js:
+        * wasm/wasm.json:
+
+2016-12-02  Keith Miller  <keith_miller@apple.com>
+
+        Add Wasm copysign
+        https://bugs.webkit.org/show_bug.cgi?id=165355
+
+        Reviewed by Filip Pizlo.
+
+        * wasm/function-tests/copysign.js: Added.
+
+2016-12-03  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r209298.
+        https://bugs.webkit.org/show_bug.cgi?id=165359
+
+        broke the build (Requested by smfr on #webkit).
+
+        Reverted changeset:
+
+        "Add Wasm copysign"
+        https://bugs.webkit.org/show_bug.cgi?id=165355
+        http://trac.webkit.org/changeset/209298
+
+2016-12-02  Keith Miller  <keith_miller@apple.com>
+
+        Add Wasm copysign
+        https://bugs.webkit.org/show_bug.cgi?id=165355
+
+        Reviewed by Filip Pizlo.
+
+        * wasm/function-tests/copysign.js: Added.
+
+2016-12-02  Keith Miller  <keith_miller@apple.com>
+
+        Unreviewed, fix git having a breakdown over trying to reland a rollout.
+
+2016-12-02  Keith Miller  <keith_miller@apple.com>
+
+        Add Wasm floating point nearest and trunc
+        https://bugs.webkit.org/show_bug.cgi?id=165339
+
+        Reviewed by Saam Barati.
+
+        * wasm/function-tests/nearest.js: Added.
+        * wasm/function-tests/trunc.js: Added.
+
+2016-12-02  Caitlin Potter  <caitp@igalia.com>
+
+[JSC] add additional bit to JSTokenType bitfield
+        https://bugs.webkit.org/show_bug.cgi?id=165091
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/bug-165091.js: Added.
+        (shouldThrowSyntaxError):
+
+2016-12-02  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r209275 and r209276.
+        https://bugs.webkit.org/show_bug.cgi?id=165348
+
+        "broke the arm build" (Requested by keith_miller on #webkit).
+
+        Reverted changesets:
+
+        "Add Wasm floating point nearest and trunc"
+        https://bugs.webkit.org/show_bug.cgi?id=165339
+        http://trac.webkit.org/changeset/209275
+
+        "Unreviewed, forgot to change instruction after renaming."
+        http://trac.webkit.org/changeset/209276
+
+2016-12-02  Keith Miller  <keith_miller@apple.com>
+
+        Add Wasm floating point nearest and trunc
+        https://bugs.webkit.org/show_bug.cgi?id=165339
+
+        Reviewed by Filip Pizlo.
+
+        * wasm/function-tests/nearest.js: Added.
+        * wasm/function-tests/trunc.js: Added.
+
+2016-12-02  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: revert patch causing odd breakage
+        https://bugs.webkit.org/show_bug.cgi?id=165308
+
+        Unreviewed.
+
+        Bug #164724 seems to cause build issues which I haven't tracked down yet. WasmOps.h can't be found:
+        ./Source/JavaScriptCore/wasm/WasmFormat.h:34:10: fatal error: 'WasmOps.h' file not found
+
+        It's weird since the file is auto-generated and has been for a while. #164724 merely includes it in WasmFormat.h.
+
+        * wasm/Builder.js:
+        (const._normalizeFunctionSignature):
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.emitters.Type):
+        (const.emitters.Code):
+        * wasm/LowLevelBinary.js:
+        (export.default.LowLevelBinary.prototype.inline_signature_type):
+        (export.default.LowLevelBinary.prototype.block_type): Deleted.
+        * wasm/WASM.js:
+        * wasm/js-api/test_basic_api.js:
+        * wasm/self-test/test_BuilderWebAssembly.js:
+        (EmptyModule):
+        (CustomSection):
+        * wasm/self-test/test_WASM.js:
+        * wasm/wasm.json:
+
+2016-12-01  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip flaky test ChakraCore/test/fieldopts/objtypespec-newobj-invalidation.1.js
+        https://bugs.webkit.org/show_bug.cgi?id=162567
+
+        Reviewed by Saam Barati.
+
+        * ChakraCore.yaml:
+
+2016-12-01  Keith Miller  <keith_miller@apple.com>
+
+        Add wasm int to floating point opcodes
+        https://bugs.webkit.org/show_bug.cgi?id=165252
+
+        Reviewed by Geoffrey Garen.
+
+        Add tests for Wasm integral to floating point conversion opcodes.
+
+        * wasm/function-tests/int-to-floating-point.js: Added.
+        * wasm/wasm.json:
+
+2016-12-01  Geoffrey Garen  <ggaren@apple.com>
+
+        Land a test case for <rdar://problem/27889416>
+        https://bugs.webkit.org/show_bug.cgi?id=165272
+
+        Reviewed by Saam Barati.
+
+        * stress/marked-argument-buffer.js: Added.
+        (allocate):
+        (test.o.toString):
+        (test):
+
+2016-11-29  Per Arne Vollan  <pvollan@apple.com>
+
+        [Win] Skip failing JSC tests.
+        https://bugs.webkit.org/show_bug.cgi?id=165140
+
+        Reviewed by Mark Lam.
+
+        * ChakraCore.yaml:
+        * microbenchmarks/tan.js:
+
+2016-11-30  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly builder: don't throw when checker not implemented
+        https://bugs.webkit.org/show_bug.cgi?id=165219
+
+        Reviewed by Mark Lam.
+
+        We should perform whichever checks we've implemented, and assume the rest are OK until bug #163421 is fixed.
+
+        * wasm/Builder.js:
+        * wasm/README.md:
+        * wasm/function-tests/add-12.js:
+        * wasm/function-tests/br-if-loop-less-than.js:
+        * wasm/function-tests/brTableAsIf.js:
+        * wasm/function-tests/brTableManyValues.js:
+        * wasm/function-tests/brTableWithLoop.js:
+        * wasm/function-tests/dumb-eq-if-then-else.js:
+        * wasm/function-tests/dumb-less-than-fallthrough.js:
+        * wasm/function-tests/dumb-less-than-ite.js:
+        * wasm/function-tests/eqz.js:
+        * wasm/function-tests/factorial.js:
+        * wasm/function-tests/float-sub.js:
+        * wasm/function-tests/i32-load.js:
+        * wasm/function-tests/i32-load8-s.js:
+        * wasm/function-tests/if-then-else-fallthrough.js:
+        * wasm/function-tests/if-then-fallthrough.js:
+        * wasm/function-tests/loop-mult.js:
+        * wasm/function-tests/loop-sum.js:
+        * wasm/function-tests/max.js:
+        * wasm/function-tests/min.js:
+        * wasm/function-tests/ret5.js:
+        * wasm/function-tests/select.js:
+        * wasm/self-test/test_BuilderJSON.js:
+
+2016-11-29  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly JS API: improve Instance
+        https://bugs.webkit.org/show_bug.cgi?id=164757
+
+        Reviewed by Keith Miller.
+
+        An Instance's `exports` property wasn't populated with exports.
+
+        A follow-up patch will do imports.
+
+        A few things of note:
+
+         - LowLevelBinary: support 3-byte integers.
+         - LowLevelBinary: support proper UTF-8 2003 code points (instead of UTF-16).
+
+        * wasm/Builder.js:
+        * wasm/Builder_WebAssemblyBinary.js: wire up exports, stub other things out some more
+        (const.emitters.Export):
+        * wasm/LowLevelBinary.js:
+        (export.default.LowLevelBinary.prototype.uint24): add, used for UTF-8
+        (export.default.LowLevelBinary.prototype.string): support UTF-8
+        (export.default.LowLevelBinary.prototype.getUint24): add, used for UTF-8
+        (export.default.LowLevelBinary.prototype.getVaruint1): was missing
+        (export.default.LowLevelBinary.prototype.getString): support UTF-8
+        (export.default.LowLevelBinary):
+        * wasm/js-api/test_Instance.js: instance.exports.answer() // <-- this is where the magic of this entire patch is
+        (ExportedAnswerI32):
+        * wasm/js-api/test_basic_api.js: punt test to later
+        (const.c.in.constructorProperties.switch):
+        * wasm/self-test/test_BuilderWebAssembly.js: UTF-8
+        (CustomSection):
+        * wasm/self-test/test_LowLevelBinary_string.js: UTF-8 now works
+        * wasm/self-test/test_LowLevelBinary_uint16.js: was missing one value
+        * wasm/self-test/test_LowLevelBinary_uint24.js: Copied from JSTests/wasm/self-test/test_LowLevelBinary_uint8.js.
+        * wasm/self-test/test_LowLevelBinary_uint8.js: was missing one value
+        * wasm/self-test/test_LowLevelBinary_varuint1.js: Added.
+        * wasm/utilities.js: this `dump` thing was useful
+        (const._dump):
+
+2016-11-29  Saam Barati  <sbarati@apple.com>
+
+        We should be able optimize the pattern where we spread a function's rest parameter to another call
+        https://bugs.webkit.org/show_bug.cgi?id=163865
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/default-derived-constructor.js: Added.
+        (createClassHierarchy.let.currentClass):
+        (createClassHierarchy):
+        * stress/call-varargs-spread.js: Added.
+        (assert):
+        (bar):
+        (foo):
+        * stress/load-varargs-on-new-array-with-spread-convert-to-static-loads.js: Added.
+        (assert):
+        (baz):
+        (bar):
+        (foo):
+        * stress/new-array-with-spread-with-normal-spread-and-phantom-spread.js: Added.
+        (assert):
+        (foo):
+        (escape):
+        (bar):
+        * stress/phantom-new-array-with-spread-osr-exit.js: Added.
+        (assert):
+        (baz):
+        (bar):
+        (effects):
+        (foo):
+        * stress/phantom-spread-forward-varargs.js: Added.
+        (assert):
+        (test1.bar):
+        (test1.foo):
+        (test1):
+        (test2.bar):
+        (test2.foo):
+        (test3.baz):
+        (test3.bar):
+        (test3.foo):
+        (test4.baz):
+        (test4.bar):
+        (test4.foo):
+        (test5.baz):
+        (test5.bar):
+        (test5.foo):
+        * stress/phantom-spread-osr-exit.js: Added.
+        (assert):
+        (baz):
+        (bar):
+        (effects):
+        (foo):
+        * stress/spread-call-convert-to-static-call.js: Added.
+        (assert):
+        (baz):
+        (bar):
+        (foo):
+        * stress/spread-forward-call-varargs-stack-overflow.js: Added.
+        (assert):
+        (identity):
+        (bar):
+        (foo):
+        * stress/spread-forward-varargs-rest-parameter-change-iterator-protocol-2.js: Added.
+        (assert):
+        (baz.Array.prototype.Symbol.iterator):
+        (baz):
+        (bar):
+        (foo):
+        (test):
+        * stress/spread-forward-varargs-rest-parameter-change-iterator-protocol.js: Added.
+        (assert):
+        (baz.Array.prototype.Symbol.iterator):
+        (baz):
+        (bar):
+        (foo):
+        * stress/spread-forward-varargs-stack-overflow.js: Added.
+        (assert):
+        (bar):
+        (foo):
+
+2016-11-29  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] always wrap AwaitExpression operand in a new Promise
+        https://bugs.webkit.org/show_bug.cgi?id=165181
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/async-await-basic.js:
+        (async.awaitedPromisesAreWrapped):
+
+2016-11-29  Keith Miller  <keith_miller@apple.com>
+
+        Add simple way to implement Wasm ops that require more than one B3 opcode
+        https://bugs.webkit.org/show_bug.cgi?id=165129
+
+        Reviewed by Geoffrey Garen.
+
+        * wasm/function-tests/eqz.js: Added.
+        * wasm/function-tests/max.js: Added.
+        * wasm/function-tests/min.js: Added.
+        * wasm/wasm.json:
+
+2016-11-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Crash in com.apple.JavaScriptCore: WTF::ThreadSpecific<WTF::WTFThreadData, + 142
+        https://bugs.webkit.org/show_bug.cgi?id=164898
+
+        Reviewed by Darin Adler.
+
+        * stress/tagged-template-registry-key-collect.js: Added.
+        (shouldBe):
+        (tag):
+        (i.eval):
+        * stress/tagged-template-registry-key.js: Added.
+        (shouldBe):
+        (tag):
+        (a):
+        (b):
+
+2016-11-20  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] speed up parsing of async functions
+        https://bugs.webkit.org/show_bug.cgi?id=164808
+
+        Reviewed by Yusuke Suzuki.
+
+        Add tests for line terminator following "async" keyword in async
+        function syntax.
+
+        * stress/async-await-syntax.js:
+        (shouldBe):
+
+2016-11-19  Mark Lam  <mark.lam@apple.com>
+
+        op_mod-* JSC tests needs a longer timeout too.
+        https://bugs.webkit.org/show_bug.cgi?id=164994
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/op_mod-ConstVar.js:
+        * stress/op_mod-VarConst.js:
+        * stress/op_mod-VarVar.js:
+
+2016-11-19  Mark Lam  <mark.lam@apple.com>
+
+        Add --timeoutMultiplier option to allow some tests more time to run.
+        https://bugs.webkit.org/show_bug.cgi?id=164951
+
+        Reviewed by Yusuke Suzuki.
+
+        Extended the timeout for these tests by 50% more because they run quite slow on
+        low-end machines.
+
+        * stress/op_div-ConstVar.js:
+        * stress/op_div-VarConst.js:
+        * stress/op_div-VarVar.js:
+
+2016-11-18  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        REGRESSION(r208867): JSC test failure: ChakraCore.yaml/ChakraCore/test/strict/05.arguments_sm.js.default
+        https://bugs.webkit.org/show_bug.cgi?id=164929
+
+        Reviewed by Mark Lam.
+
+        ES2017 drops arguments.caller and JavaScriptCore is updated to meet the spec.
+        This patch rebaselines the result of ChakraCore test for JSC.
+
+        * ChakraCore/test/strict/05.arguments_sm.baseline-jsc:
+
+2016-11-18  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Web Inspector: Generator functions should have a displayable name when shown in stack traces
+        https://bugs.webkit.org/show_bug.cgi?id=164844
+        <rdar://problem/29300697>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/generator-function-name.js:
+        Add another test now that we name the inner generator function
+        that we do not break the lexical resolution of names.
+
+2016-11-17  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Drop arguments.caller
+        https://bugs.webkit.org/show_bug.cgi?id=164859
+
+        Reviewed by Saam Barati.
+
+        * stress/strict-mode-arguments-caller.js: Added.
+        (strictArguments):
+        (shouldBe):
+
+2016-11-17  Keith Miller  <keith_miller@apple.com>
+
+        Add rotate to Wasm
+        https://bugs.webkit.org/show_bug.cgi?id=164871
+
+        Reviewed by Filip Pizlo.
+
+        * wasm/wasm.json:
+
+2016-11-17  Keith Miller  <keith_miller@apple.com>
+
+        Add sqrt to Wasm
+        https://bugs.webkit.org/show_bug.cgi?id=164877
+
+        Reviewed by Mark Lam.
+
+        B3 already has a Sqrt opcode we just need to map Wasm to it.
+
+        * wasm/wasm.json:
+
+2016-11-17  Saam Barati  <sbarati@apple.com>
+
+        Remove async/await compile time flag and enable tests
+        https://bugs.webkit.org/show_bug.cgi?id=164828
+        <rdar://problem/28639334>
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/async-arrow-functions-lexical-arguments-binding.js:
+        * stress/async-arrow-functions-lexical-new.target-binding.js:
+        * stress/async-arrow-functions-lexical-super-binding.js:
+        * stress/async-arrow-functions-lexical-this-binding.js:
+        * stress/async-await-basic.js:
+        * stress/async-await-long-loop.js:
+        * stress/async-await-module-reserved-word.js:
+        * stress/async-await-mozilla.js:
+        (mozSyntaxErrors):
+        * stress/async-await-reserved-word.js:
+        * stress/async-await-syntax.js:
+        * stress/async-await-throw-loop.js:
+        * stress/async-function-create-nobaseline.js:
+        * stress/async-function-create-optimized.js:
+        * stress/async-function-declaration-sinking-no-double-allocate.js:
+        * stress/async-function-declaration-sinking-osrexit.js:
+        * stress/async-function-declaration-sinking-put.js:
+        * stress/async-function-expression-sinking-no-double-allocate.js:
+        * stress/async-function-expression-sinking-osrexit.js:
+        * stress/async-function-expression-sinking-put.js:
+        * test262.yaml:
+
+2016-11-15  Mark Lam  <mark.lam@apple.com>
+
+        Make JSC test functions more robust.
+        https://bugs.webkit.org/show_bug.cgi?id=164807
+
+        Reviewed by Keith Miller.
+
+        * stress/jsc-test-functions-should-be-more-robust.js: Added.
+
+2016-11-15  Keith Miller  <keith_miller@apple.com>
+
+        B3 should support UDiv/UMod
+        https://bugs.webkit.org/show_bug.cgi?id=164811
+
+        Reviewed by Filip Pizlo.
+
+        Link new instructions to wasm.
+
+        * wasm/wasm.json:
+
+2016-11-15  Saam Barati  <sbarati@apple.com>
+
+        Debug JSC test timeout: stress/has-own-property-name-cache-symbols-and-strings.js.ftl-no-cjit-small-pool
+        https://bugs.webkit.org/show_bug.cgi?id=163012
+
+        Unreviewed. This patch makes a test run for less time because it's timing out on the bots.
+
+        * stress/has-own-property-name-cache-symbols-and-strings.js:
+
+2016-11-15  Mark Lam  <mark.lam@apple.com>
+
+        The jsc shell's setImpureGetterDelegate() should ensure that the set value is an ImpureGetter.
+        https://bugs.webkit.org/show_bug.cgi?id=164781
+        <rdar://problem/28418590>
+
+        Reviewed by Geoffrey Garen and Michael Saboff.
+
+        * stress/jsc-setImpureGetterDelegate-on-bad-type.js: Added.
+
+2016-11-15  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DOMJIT] Allow using macro assembler scratches in FTL CheckDOM
+        https://bugs.webkit.org/show_bug.cgi?id=164727
+
+        Reviewed by Filip Pizlo.
+
+        * stress/check-dom-with-signature.js: Added.
+        (shouldBe):
+        (calling):
+        (i.array.forEach):
+
+2016-11-14  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] do not reference AwaitExpression Promises in async function Promise chain
+        https://bugs.webkit.org/show_bug.cgi?id=164753
+
+        Reviewed by Yusuke Suzuki.
+
+        * asyncFunctionTests.yaml:
+        * stress/async-await-long-loop.js: Added.
+        (shouldBe):
+        (async.longLoop):
+        * stress/async-await-throw-loop.js: Added.
+        (shouldBe):
+        (async.thrower):
+        (async.throwLoop):
+
+2016-11-14  Keith Miller  <keith_miller@apple.com>
+
+        Add Wasm select
+        https://bugs.webkit.org/show_bug.cgi?id=164743
+
+        Reviewed by Saam Barati.
+
+        * wasm/function-tests/select.js: Added.
+
+2016-11-14  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] Handle new_async_func / new_async_func_exp in DFG / FTL
+        https://bugs.webkit.org/show_bug.cgi?id=164037
+
+        Reviewed by Yusuke Suzuki.
+
+        Add tests based on tests from https://trac.webkit.org/changeset/194216.
+
+        * asyncFunctionTests.yaml:
+        * stress/async-function-create-nobaseline.js: Added.
+        * stress/async-function-create-optimized.js: Added.
+        * stress/async-function-declaration-sinking-no-double-allocate.js: Added.
+        * stress/async-function-declaration-sinking-osrexit.js: Added.
+        * stress/async-function-declaration-sinking-put.js: Added.
+        * stress/async-function-expression-sinking-no-double-allocate.js: Added.
+        * stress/async-function-expression-sinking-osrexit.js: Added.
+        * stress/async-function-expression-sinking-put.js: Added.
+
+2016-11-14  Mark Lam  <mark.lam@apple.com>
+
+        Some of JSStringView::SafeView methods are not idiomatically safe for JSString to StringView conversions.
+        https://bugs.webkit.org/show_bug.cgi?id=164701
+        <rdar://problem/27462104>
+
+        Reviewed by Darin Adler.
+
+        * stress/string-prototype-charCodeAt-on-too-long-rope.js: Added.
+
+2016-11-14  Mark Lam  <mark.lam@apple.com>
+
+        RegExpObject::exec/match should handle errors gracefully.
+        https://bugs.webkit.org/show_bug.cgi?id=155145
+        <rdar://problem/27435934>
+
+        Reviewed by Keith Miller.
+
+        * stress/regexp-prototype-exec-on-too-long-rope.js: Added.
+        * stress/regexp-prototype-match-on-too-long-rope.js: Added.
+        * stress/regexp-prototype-test-on-too-long-rope.js: Added.
+
+2016-11-14  Mark Lam  <mark.lam@apple.com>
+
+        Enhance run-jsc-stress-test script to allow optional test specific options to be added for all test run configurations.
+        https://bugs.webkit.org/show_bug.cgi?id=164695
+
+        Reviewed by Keith Miller.
+
+        Replace use of runMisc* test run configurations with equivalents.
+
+        * stress/licm-no-pre-header-nested.js:
+        * stress/licm-no-pre-header.js:
+        * stress/licm-pre-header-cannot-exit-nested.js:
+        * stress/licm-pre-header-cannot-exit.js:
+        * stress/make-dictionary-repatch.js:
+        * stress/retry-cache-later.js:
+        * stress/shadow-chicken-reading-from-scope-after-ftl-osr-exit-bytecode-liveness.js:
+        * stress/slow-path-generator-updating-current-node-dfg.js:
+        * stress/unshift-array-storage.js:
+
+2016-11-11  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: DataView with explicit undefined byteLength should be the same as it not being present
+        https://bugs.webkit.org/show_bug.cgi?id=164453
+
+        Reviewed by Darin Adler.
+
+        * stress/dataview-construct.js: Added.
+        (assert):
+        (shouldThrow):
+        * test262.yaml:
+
+2016-11-11  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: DataView get methods should allow for missing offset, set methods should allow for missing value
+        https://bugs.webkit.org/show_bug.cgi?id=164451
+
+        Reviewed by Darin Adler.
+
+        * test262.yaml:
+
+2016-11-11  Saam Barati  <sbarati@apple.com>
+
+        We should have a more concise way of determining when we're varargs calling a function using rest parameters
+        https://bugs.webkit.org/show_bug.cgi?id=164258
+
+        Reviewed by Yusuke Suzuki.
+
+        * microbenchmarks/call-using-spread.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/spread-large-array.js: Added.
+        (foo):
+        (arrays.push):
+        * microbenchmarks/spread-small-array.js: Added.
+        (foo):
+        * stress/spread-array-iterator-watchpoint-2.js: Added.
+        (foo):
+        (arrayIterator.next):
+        * stress/spread-array-iterator-watchpoint.js: Added.
+        (foo):
+        (Array.prototype.Symbol.iterator):
+        * stress/spread-non-array.js: Added.
+        (assert):
+        (foo):
+        (let.customIterator.Symbol.iterator):
+        (bar):
+
+2016-11-11  Keith Miller  <keith_miller@apple.com>
+
+        Relocate wasm tests and actually add them to the test runner
+        https://bugs.webkit.org/show_bug.cgi?id=164668
+
+        Reviewed by Yusuke Suzuki.
+
+        This moves the Wasm tests from their current location down a level.
+        Without relocating, the tests cannot properly be run by the wasm test runner.
+
+        * wasm.yaml:
+        * wasm/Builder.js: Fix typos, yay lazy synatx checking!
+        * wasm/LowLevelBinary.js: Fix typos, yay lazy synatx checking!
+        (export.default.LowLevelBinary.prototype.get return):
+        * wasm/function-tests/add-12.js: Renamed from JSTests/wasm/js-api/function-tests/add-12.js.
+        * wasm/function-tests/br-if-loop-less-than.js: Renamed from JSTests/wasm/js-api/function-tests/br-if-loop-less-than.js.
+        * wasm/function-tests/brTableAsIf.js: Renamed from JSTests/wasm/js-api/function-tests/brTableAsIf.js.
+        * wasm/function-tests/brTableManyValues.js: Renamed from JSTests/wasm/js-api/function-tests/brTableManyValues.js.
+        * wasm/function-tests/brTableWithLoop.js: Renamed from JSTests/wasm/js-api/function-tests/brTableWithLoop.js.
+        * wasm/function-tests/dumb-eq-if-then-else.js: Renamed from JSTests/wasm/js-api/function-tests/dumb-eq-if-then-else.js.
+        * wasm/function-tests/dumb-less-than-fallthrough.js: Renamed from JSTests/wasm/js-api/function-tests/dumb-less-than-fallthrough.js.
+        * wasm/function-tests/dumb-less-than-ite.js: Renamed from JSTests/wasm/js-api/function-tests/dumb-less-than-ite.js.
+        * wasm/function-tests/factorial.js: Renamed from JSTests/wasm/js-api/function-tests/factorial.js.
+        * wasm/function-tests/float-sub.js: Renamed from JSTests/wasm/js-api/function-tests/float-sub.js.
+        * wasm/function-tests/i32-load.js: Renamed from JSTests/wasm/js-api/function-tests/i32-load.js.
+        * wasm/function-tests/i32-load8-s.js: Renamed from JSTests/wasm/js-api/function-tests/i32-load8-s.js.
+        * wasm/function-tests/if-then-else-fallthrough.js: Renamed from JSTests/wasm/js-api/function-tests/if-then-else-fallthrough.js.
+        * wasm/function-tests/if-then-fallthrough.js: Renamed from JSTests/wasm/js-api/function-tests/if-then-fallthrough.js.
+        * wasm/function-tests/loop-mult.js: Renamed from JSTests/wasm/js-api/function-tests/loop-mult.js.
+        * wasm/function-tests/loop-sum.js: Renamed from JSTests/wasm/js-api/function-tests/loop-sum.js.
+        * wasm/function-tests/ret5.js: Renamed from JSTests/wasm/js-api/function-tests/ret5.js.
+        * wasm/self-test/test_BuilderJSON.js: Rebasline
+
+2016-11-11  Keith Miller  <keith_miller@apple.com>
+
+        Move Wasm tests to JS
+        https://bugs.webkit.org/show_bug.cgi?id=164611
+
+        Reviewed by Geoffrey Garen.
+
+        This patch translates most of the tests from testWasm.cpp to the JS testing api. Most of the
+        ommited tests were earliest tests, which tested trivial things, like adding two
+        constants. Some tests are ommited for other reasons, however. These are:
+
+        1) Tests using I64 since the testing api does not yet know how to handle 64-bit numbers.  2)
+        Tests that would validate the memory of the module once wasm was done with it since that's
+        not really possible in JS.
+
+        In order to make such a translation easier this patch also adds some features to the JS
+        testing api:
+
+        1) Blocks can now be done lexically by adding a lambda as the last argument of the block
+        opcode. For example one can do:
+            ...
+            .Block("i32", b => b.I32Const(1) )
+
+        and the nested lambda will automatically have an end attached.
+
+        2) The JS testing api can now handle inline signature types.
+
+        3) Relocate some code to make it easier to follow and prevent 44 space indentation.
+
+        4) Rename varuint/varint to varuint32/varint32, this lets them be directly called from the
+        wasm.json without being remapped.
+
+        5) Add support for Memory and Function sections to the Builder.
+
+        6) Add support for local variables.
+
+        On the JSC side, we needed to expose a new function to validate the compiled wasm code
+        behaves the way we expect. At least until the JS Wasm API is finished. The new validation
+        function, testWasmModuleFunctions, takes an array buffer containing the wasm binary, the
+        number of functions in the blob and tests for each of those functions.
+
+        * wasm/Builder.js:
+        (const._maybeRegisterType):
+        (const): Deleted.
+        (switch.typeof): Deleted.
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.emitters.Type):
+        (const.emitters.Import):
+        (const.emitters.Function):
+        (const.emitters.Memory):
+        (const.emitters.Code):
+        (export.const.Binary):
+        * wasm/LowLevelBinary.js:
+        (export.default.LowLevelBinary.prototype.get return):
+        (export.default.LowLevelBinary.prototype.varuint32):
+        (export.default.LowLevelBinary.prototype.varint32):
+        (export.default.LowLevelBinary.prototype.varuint1):
+        (export.default.LowLevelBinary.prototype.varint7):
+        (export.default.LowLevelBinary.prototype.varuint7):
+        (export.default.LowLevelBinary.prototype.inline_signature_type):
+        (export.default.LowLevelBinary.prototype.string):
+        (export.default.LowLevelBinary.prototype.getVaruint32):
+        (export.default.LowLevelBinary.prototype.getVarint32):
+        (export.default.LowLevelBinary.prototype.getVaruint7):
+        (export.default.LowLevelBinary.prototype.getString):
+        (export.default.LowLevelBinary):
+        (export.default.LowLevelBinary.prototype.varuint): Deleted.
+        (export.default.LowLevelBinary.prototype.varint): Deleted.
+        (export.default.LowLevelBinary.prototype.getVaruint): Deleted.
+        (export.default.LowLevelBinary.prototype.getVarint): Deleted.
+        * wasm/js-api/test_old_tests.js: Added.
+        (ret5):
+        (brTableWithLoop):
+        (brTableManyValues):
+        (run.brTableManyValues.brTableAsIf):
+        (ifThenFallthrough):
+        (ifThenElseFallthrough):
+        (dumbLessThanFallthrough):
+        (run.dumbLessThanFallthrough.floatSub):
+        (run.floatSub.add12):
+        (run.add12.factorial):
+        (i32load):
+        (run.i32load.i32load8s):
+        (run.i32load8s.dumbEqIfThenElse):
+        (run.dumbEqIfThenElse.dumbEqIfThenElse):
+        (run.dumbEqIfThenElse.dumbLessThanIfThenElse):
+        (run.dumbLessThanIfThenElse.loopSum):
+        (run.loopSum.loopMult):
+        (brIfLoopLessThan):
+        (run.brIfLoopLessThan.run):
+        * wasm/self-test/test_LowLevelBinary_varint32.js: Renamed from JSTests/wasm/self-test/test_LowLevelBinary_varint.js.
+        * wasm/self-test/test_LowLevelBinary_varuint32.js: Renamed from JSTests/wasm/self-test/test_LowLevelBinary_varuint.js.
+
+        * wasm/Builder.js:
+        (const._maybeRegisterType):
+        (const): Deleted.
+        (switch.typeof): Deleted.
+        * wasm/Builder_WebAssemblyBinary.js:
+        (const.emitters.Type):
+        (const.emitters.Import):
+        (const.emitters.Function):
+        (const.emitters.Memory):
+        (const.emitters.Code):
+        (export.const.Binary):
+        * wasm/LowLevelBinary.js:
+        (export.default.LowLevelBinary.prototype.get return):
+        (export.default.LowLevelBinary.prototype.varuint32):
+        (export.default.LowLevelBinary.prototype.varint32):
+        (export.default.LowLevelBinary.prototype.varuint1):
+        (export.default.LowLevelBinary.prototype.varint7):
+        (export.default.LowLevelBinary.prototype.varuint7):
+        (export.default.LowLevelBinary.prototype.inline_signature_type):
+        (export.default.LowLevelBinary.prototype.string):
+        (export.default.LowLevelBinary.prototype.getVaruint32):
+        (export.default.LowLevelBinary.prototype.getVarint32):
+        (export.default.LowLevelBinary.prototype.getVaruint7):
+        (export.default.LowLevelBinary.prototype.getString):
+        (export.default.LowLevelBinary):
+        (export.default.LowLevelBinary.prototype.varuint): Deleted.
+        (export.default.LowLevelBinary.prototype.varint): Deleted.
+        (export.default.LowLevelBinary.prototype.getVaruint): Deleted.
+        (export.default.LowLevelBinary.prototype.getVarint): Deleted.
+        * wasm/js-api/function-tests/add-12.js: Added.
+        * wasm/js-api/function-tests/br-if-loop-less-than.js: Added.
+        * wasm/js-api/function-tests/brTableAsIf.js: Added.
+        * wasm/js-api/function-tests/brTableManyValues.js: Added.
+        * wasm/js-api/function-tests/brTableWithLoop.js: Added.
+        * wasm/js-api/function-tests/dumb-eq-if-then-else.js: Added.
+        * wasm/js-api/function-tests/dumb-less-than-fallthrough.js: Added.
+        * wasm/js-api/function-tests/dumb-less-than-ite.js: Added.
+        * wasm/js-api/function-tests/factorial.js: Added.
+        * wasm/js-api/function-tests/float-sub.js: Added.
+        * wasm/js-api/function-tests/i32-load.js: Added.
+        * wasm/js-api/function-tests/i32-load8-s.js: Added.
+        * wasm/js-api/function-tests/if-then-else-fallthrough.js: Added.
+        * wasm/js-api/function-tests/if-then-fallthrough.js: Added.
+        * wasm/js-api/function-tests/loop-mult.js: Added.
+        * wasm/js-api/function-tests/loop-sum.js: Added.
+        * wasm/js-api/function-tests/ret5.js: Added.
+        * wasm/self-test/test_LowLevelBinary_varint32.js: Renamed from JSTests/wasm/self-test/test_LowLevelBinary_varint.js.
+        * wasm/self-test/test_LowLevelBinary_varuint32.js: Renamed from JSTests/wasm/self-test/test_LowLevelBinary_varuint.js.
+
+2016-11-11  Saam Barati  <sbarati@apple.com>
+
+        We recursively grab a lock in the DFGBytecodeParser causing us to deadlock
+        https://bugs.webkit.org/show_bug.cgi?id=164650
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/dont-dead-lock-put-by-val-as-put-by-id.js: Added.
+        (ident):
+        (let.o.set foo):
+        (foo):
+
+2016-11-11  Chris Dumez  <cdumez@apple.com>
+
+        Unreviewed, rolling out r208584.
+
+        Seems to have regressed Speedometer by 1% on Mac
+
+        Reverted changeset:
+
+        "We should have a more concise way of determining when we're
+        varargs calling a function using rest parameters"
+        https://bugs.webkit.org/show_bug.cgi?id=164258
+        http://trac.webkit.org/changeset/208584
+
+2016-11-11  Chris Dumez  <cdumez@apple.com>
+
+        Unreviewed, rolling out r208117 and r208160.
+
+        Regressed Speedometer by >1.5%
+
+        Reverted changesets:
+
+        "We should have a way of profiling when a get_by_id is pure
+        and to emit a PureGetById in the DFG/FTL"
+        https://bugs.webkit.org/show_bug.cgi?id=163305
+        http://trac.webkit.org/changeset/208117
+
+        "Debug JSC test microbenchmarks/pure-get-by-id-cse-2.js timing
+        out"
+        https://bugs.webkit.org/show_bug.cgi?id=164227
+        http://trac.webkit.org/changeset/208160
+
+2016-11-11  Saam Barati  <sbarati@apple.com>
+
+        We should have a more concise way of determining when we're varargs calling a function using rest parameters
+        https://bugs.webkit.org/show_bug.cgi?id=164258
+
+        Reviewed by Yusuke Suzuki.
+
+        * microbenchmarks/call-using-spread.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/spread-large-array.js: Added.
+        (foo):
+        (arrays.push):
+        * microbenchmarks/spread-small-array.js: Added.
+        (foo):
+        * stress/spread-array-iterator-watchpoint-2.js: Added.
+        (foo):
+        (arrayIterator.next):
+        * stress/spread-array-iterator-watchpoint.js: Added.
+        (foo):
+        (Array.prototype.Symbol.iterator):
+        * stress/spread-non-array.js: Added.
+        (assert):
+        (foo):
+        (let.customIterator.Symbol.iterator):
+        (bar):
+
+2016-11-10  Mark Lam  <mark.lam@apple.com>
+
+        Fix broken have-a-bad-time-with-arguments.js test.
+        https://bugs.webkit.org/show_bug.cgi?id=164626
+
+        Reviewed by Filip Pizlo.
+
+        But also saved a copy of the broken one as broken-have-a-bad-time-with-arguments-for-gc-testing.js
+        because coincidentally, it stresses the GC in ways that help reveal bugs.
+
+        * stress/broken-have-a-bad-time-with-arguments-for-gc-testing.js: Added.
+        (testFunction):
+        (warmupFunction):
+        (let.argsDeclIndex.in.argumentsDecls.let.indexToReturnIndex.in.indicesToReturn.let.insertElementActionIndex.in.insertElementActions.let.tierWarmupCountIndex.in.tierWarmupCounts.let.testArgsIndex.in.testArgsList.catch):
+        * stress/have-a-bad-time-with-arguments.js:
+
+2016-11-10  JF Bastien  <jfbastien@apple.com>
+
+        ASSERTION FAILED: length > offset encountered with wasm.yaml/wasm/js-api/test_Module.js.default-wasm
+        https://bugs.webkit.org/show_bug.cgi?id=164597
+
+        Reviewed by Keith Miller.
+
+        Trim the array buffer before returning it: it's optimistically
+        over-allocated to avoid growing all the time, but when parsed it
+        can't have extra content.
+
+        * wasm/Builder_WebAssemblyBinary.js:
+        (export.const.Binary):
+        * wasm/LowLevelBinary.js:
+        (export.default.LowLevelBinary.prototype.get return):
+
+2016-11-10  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: DataView / TypedArray methods should throw RangeErrors for negative numbers (ToIndex)
+        https://bugs.webkit.org/show_bug.cgi?id=164450
+
+        Reviewed by Darin Adler.
+
+        * stress/dataview-typedarray-toindex.js: Added.
+        Tests for all cases where ToIndex should be used.
+
+        * test262.yaml:
+        New passing tests.
+
+2016-11-10  Mark Lam  <mark.lam@apple.com>
+
+        Graph::methodOfGettingAValueProfileFor() should be returning the profile for the operand node.
+        https://bugs.webkit.org/show_bug.cgi?id=164600
+        <rdar://problem/28828676>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/osr-exit-on-op-negate-should-no-fail-assertions.js: Added.
+
+2016-11-08  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Avoid cloned arguments allocation in ArrayPrototype methods
+        https://bugs.webkit.org/show_bug.cgi?id=164502
+
+        Reviewed by Saam Barati.
+
+        * stress/argument-intrinsic-basic.js: Added.
+        (shouldBe):
+        (builtin.createBuiltin):
+        * stress/argument-intrinsic-inlining-with-result-escape.js: Added.
+        (shouldBe):
+        (builtin.createBuiltin):
+        (escape):
+        * stress/argument-intrinsic-nested-inlining.js: Added.
+        (shouldBe):
+        (builtin.createBuiltin):
+        (builtinCaller1):
+        (builtinCaller2):
+        (escape):
+        * stress/argument-intrinsic-not-convert-to-get-argument.js: Added.
+        (shouldBe):
+        (builtin.createBuiltin):
+        * stress/argument-intrinsic-with-stack-write.js: Added.
+        (shouldBe):
+        (builtin.createBuiltin):
+
+2016-11-09  Saam Barati  <sbarati@apple.com>
+
+        Math.min()/Math.max() with no arguments is lowered incorrectly in the BytecodeParser
+        https://bugs.webkit.org/show_bug.cgi?id=164464
+        <rdar://problem/29131452>
+
+        Reviewed by Darin Adler.
+
+        * stress/math-max-min-no-arguments.js: Added.
+        (assert):
+        (min):
+        (max):
+        (test):
+
+2016-11-09  Saam Barati  <sbarati@apple.com>
+
+        TypeProfiler and running GC collection on another thread don't play nicely with each other
+        https://bugs.webkit.org/show_bug.cgi?id=164441
+        <rdar://problem/29132174>
+
+        Reviewed by Geoffrey Garen.
+
+        * typeProfiler/type-profiler-gc.js: Added.
+        (bar):
+        (foo):
+
+2016-11-04  Mark Lam  <mark.lam@apple.com>
+
+        Error description code should be able to handle Symbol values.
+        https://bugs.webkit.org/show_bug.cgi?id=164436
+        <rdar://problem/29115583>
+
+        Reviewed by Filip Pizlo and Saam Barati.
+
+        * stress/error-description-on-symbols-should-not-crash.js: Added.
+
+2016-11-03  Geoffrey Garen  <ggaren@apple.com>
+
+        EvalCodeCache should not give up in strict mode and other cases
+        https://bugs.webkit.org/show_bug.cgi?id=164357
+
+        Reviewed by Michael Saboff.
+
+        * microbenchmarks/eval-cached.js: Added. 45x faster now.
+        * stress/eval-cached.js: Added. Try running the same eval text in a bunch
+        of different scopes and verify that we access the right scope.
+
+2016-11-04  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly JS API: implement more sections
+        https://bugs.webkit.org/show_bug.cgi?id=164023
+
+        Reviewed by Keith Miller.
+
+        On the JSC side:
+
+         - Put in parser stubs for all WebAssembly sections.
+         - Parse Import, Export sections.
+         - Use tryReserveCapacity instead of reserve, and bail out of the parser if it fails. This prevents the parser from bringing everything down when faced with a malicious input.
+         - Encapsulate all parsed module information into its own structure, making it easier to pass around (from parser to Plan to Module to Instance).
+         - Create WasmFormat.cpp to hold parsed module information's dtor to avoid including WasmMemory.h needlessly.
+         - parseCode: avoid overflow through function size.
+         - Remove all remainders of polyfill-prototype-1, and update license.
+         - Add missing WasmOps.h and WasmValidateInlines.h auto-generation for cmake build.
+
+        On the Builder.js testing side:
+
+         - Implement Type, Import (function only), Export (function only) sections.
+         - Check section order and uniqueness.
+         - Optionally auto-generate the Type section from subsequent Export / Import / Code entries.
+         - Allow re-exporting an import.
+
+        * wasm/Builder.js: build type, import, and export sections
+        (const._normalizeFunctionSignature):
+        * wasm/Builder_WebAssemblyBinary.js: Added. Forked from Builder.js
+        (const.emitters.Type):
+        (const.emitters.Import):
+        (const.emitters.Function):
+        (const.emitters.Table):
+        (const.emitters.Memory):
+        (const.emitters.Global):
+        (const.emitters.Export):
+        (const.emitters.Start):
+        (const.emitters.Element):
+        (const.emitters.Code):
+        (const.emitters.Data):
+        (export.const.Binary):
+        * wasm/LowLevelBinary.js: Add a few useful outputs
+        (export.default.LowLevelBinary.prototype.varuint1):
+        (export.default.LowLevelBinary.prototype.varint7):
+        * wasm/WASM.js: value type and external kind helpers
+        * wasm/assert.js: array element-wise equality comparison
+        (const._eq):
+        * wasm/js-api/test_Module.js:
+        (ModuleWithImports):
+        * wasm/self-test/test_BuilderJSON.js: many more tests for all the new Builder APIs, and update to some older tests which now require a Type section or rejiggered Function signature
+        (const.assertOpThrows):
+        (SectionsWithSameCustomName):
+        (TwoTypeSections):
+        (EmptyImportSection):
+        (ImportBeforeTypeSections):
+        * wasm/self-test/test_BuilderWebAssembly.js: remove a test which wasn't helpful and is now obsolete
+        (CustomSection):
+
+2016-11-03  Mark Lam  <mark.lam@apple.com>
+
+        ClonedArguments need to also support haveABadTime mode.
+        https://bugs.webkit.org/show_bug.cgi?id=164200
+        <rdar://problem/27211336>
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/have-a-bad-time-with-arguments.js: Added.
+
+2016-11-03  Filip Pizlo  <fpizlo@apple.com>
+
+        DFG plays fast and loose with the shadow values of a Phi
+        https://bugs.webkit.org/show_bug.cgi?id=164309
+
+        Reviewed by Saam Barati.
+        
+        This test demonstrates why the DFG needs to recognize the shadow value of a Phi.
+
+        * stress/dfg-ssa-swap.js: Added.
+        (foo):
+
+2016-11-03  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r208364.
+        https://bugs.webkit.org/show_bug.cgi?id=164402
+
+        broke the build (Requested by smfr on #webkit).
+
+        Reverted changeset:
+
+        "DFG plays fast and loose with the shadow values of a Phi"
+        https://bugs.webkit.org/show_bug.cgi?id=164309
+        http://trac.webkit.org/changeset/208364
+
+2016-11-03  Filip Pizlo  <fpizlo@apple.com>
+
+        DFG plays fast and loose with the shadow values of a Phi
+        https://bugs.webkit.org/show_bug.cgi?id=164309
+
+        Reviewed by Saam Barati.
+        
+        This test demonstrates why the DFG needs to recognize the shadow value of a Phi.
+
+        * stress/dfg-ssa-swap.js: Added.
+        (foo):
+
+2016-11-03  Saam Barati  <sbarati@apple.com>
+
+        Asking for a value profile prediction should be defensive against not finding a value profile
+        https://bugs.webkit.org/show_bug.cgi?id=164306
+
+        Reviewed by Mark Lam.
+
+        * stress/inlined-tail-call-in-inlined-setter-should-not-crash-when-getting-value-profile.js: Added.
+        (let.o.set foo):
+        (bar):
+
+2016-11-02  Saam Barati  <sbarati@apple.com>
+
+        Allocation elimination of rest parameter doesn't take into account indexed properties on Array.prototype/Object.prototype
+        https://bugs.webkit.org/show_bug.cgi?id=164301
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/rest-parameter-allocation-elimination-watchpoints-2.js: Added.
+        (assert):
+        (foo):
+        * stress/rest-parameter-allocation-elimination-watchpoints-3.js: Added.
+        (assert):
+        (foo):
+        * stress/rest-parameter-allocation-elimination-watchpoints-4.js: Added.
+        (assert):
+        (foo):
+        * stress/rest-parameter-allocation-elimination-watchpoints-5.js: Added.
+        (assert):
+        (foo):
+        * stress/rest-parameter-allocation-elimination-watchpoints-6.js: Added.
+        (assert):
+        (foo):
+        * stress/rest-parameter-allocation-elimination-watchpoints.js: Added.
+        (assert):
+        (foo):
+
+2016-11-01  Saam Barati  <sbarati@apple.com>
+
+        We should be able to eliminate rest parameter allocations
+        https://bugs.webkit.org/show_bug.cgi?id=163925
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/rest-parameter-allocation-elimination.js: Added.
+        (assert):
+        (test1.bar):
+        (test1):
+        (test2.jaz):
+        (test2.jaz2.kaz):
+        (test2.jaz2):
+        (test2):
+        (test3.foo):
+        (test3.baz):
+        (test3.jaz):
+        (test3):
+        (test4.baz):
+        (test4.jaz):
+        (test4):
+        (test5.baz):
+        (test5.jaz):
+        (test5):
+        (test6.baz):
+        (test6.jaz):
+        (test6):
+        (test7.baz):
+        (test7.jaz):
+        (test7.check):
+        (test7):
+        (test8.baz):
+        (test8.jaz):
+        (test8.check):
+        (test8):
+        (test9.baz):
+        (test9.jaz):
+        (test9.check):
+        (test9):
+        (test10.baz):
+        (test10.jaz):
+        (test10):
+        (test11.bar):
+        (test11.foo):
+        (test11.makeArguments):
+        (test11.):
+        (test12):
+        (test12.bar):
+        (test12.foo):
+        (test12.makeArguments):
+        (test12.):
+        (test13.bar):
+        (test13.top):
+        (test13.foo):
+        (test13.makeArguments):
+        (test13.):
+        (test13):
+        (test14.bar):
+        (test14.top):
+        (test14.foo):
+        (test14.makeArguments):
+        (test14.):
+        (test14):
+        (test15.bar):
+        (test15.top):
+        (test15.foo):
+        (test15.makeArguments):
+        (test15.):
+        (test15):
+
+2016-11-01  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r208208 and r208210.
+        https://bugs.webkit.org/show_bug.cgi?id=164276
+
+        This change caused 28 JSC test failures. (Requested by
+        ryanhaddad on #webkit).
+
+        Reverted changesets:
+
+        "We should be able to eliminate rest parameter allocations"
+        https://bugs.webkit.org/show_bug.cgi?id=163925
+        http://trac.webkit.org/changeset/208208
+
+        "Fix the EFL build."
+        http://trac.webkit.org/changeset/208210
+
+2016-10-31  Filip Pizlo  <fpizlo@apple.com>
+
+        JSC should support SharedArrayBuffer
+        https://bugs.webkit.org/show_bug.cgi?id=163986
+
+        Reviewed by Keith Miller.
+        
+        This adds our own test for the various corner cases of SharedArrayBuffer. This test is meant to
+        check all of the things that don't require concurrency.
+
+        * stress/SharedArrayBuffer.js: Added.
+        (checkAtomics):
+        (shouldFail):
+        (Symbol):
+        (runAtomic):
+
+2016-10-31  Saam Barati  <sbarati@apple.com>
+
+        We should be able to eliminate rest parameter allocations
+        https://bugs.webkit.org/show_bug.cgi?id=163925
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/rest-parameter-allocation-elimination.js: Added.
+        (assert):
+        (test1.bar):
+        (test1):
+        (test2.jaz):
+        (test2.jaz2.kaz):
+        (test2.jaz2):
+        (test2):
+        (test3.foo):
+        (test3.baz):
+        (test3.jaz):
+        (test3):
+        (test4.baz):
+        (test4.jaz):
+        (test4):
+        (test5.baz):
+        (test5.jaz):
+        (test5):
+        (test6.baz):
+        (test6.jaz):
+        (test6):
+        (test7.baz):
+        (test7.jaz):
+        (test7.check):
+        (test7):
+        (test8.baz):
+        (test8.jaz):
+        (test8.check):
+        (test8):
+        (test9.baz):
+        (test9.jaz):
+        (test9.check):
+        (test9):
+        (test10.baz):
+        (test10.jaz):
+        (test10):
+        (test11.bar):
+        (test11.foo):
+        (test11.makeArguments):
+        (test11.):
+        (test12):
+        (test12.bar):
+        (test12.foo):
+        (test12.makeArguments):
+        (test12.):
+        (test13.bar):
+        (test13.top):
+        (test13.foo):
+        (test13.makeArguments):
+        (test13.):
+        (test13):
+        (test14.bar):
+        (test14.top):
+        (test14.foo):
+        (test14.makeArguments):
+        (test14.):
+        (test14):
+        (test15.bar):
+        (test15.top):
+        (test15.foo):
+        (test15.makeArguments):
+        (test15.):
+        (test15):
+
+2016-10-31  Saam Barati  <sbarati@apple.com>
+
+        Debug JSC test microbenchmarks/pure-get-by-id-cse-2.js timing out
+        https://bugs.webkit.org/show_bug.cgi?id=164227
+
+        Unreviewed timeout fix.
+
+        * microbenchmarks/pure-get-by-id-cse-2.js:
+
+2016-10-31  Keith Miller  <keith_miller@apple.com>
+
+        autogenerated files from wasm.json should be in derived sources.
+        https://bugs.webkit.org/show_bug.cgi?id=164152
+
+        Reviewed by Filip Pizlo.
+
+        Delete generation script since it is no longer used.
+
+        * wasm/generate-wasmops-header.js: Removed.
+
+2016-10-29  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] JSON.stringify should handle Proxy which is non JSArray but isArray is true
+        https://bugs.webkit.org/show_bug.cgi?id=164123
+
+        Reviewed by Mark Lam.
+
+        * stress/json-stringify-with-non-jsarray-array.js: Added.
+        (shouldBe):
+        (shouldBe.JSON.stringify.new.Proxy):
+
+2016-10-29  Saam Barati  <sbarati@apple.com>
+
+        We should have a way of profiling when a get_by_id is pure and to emit a PureGetById in the DFG/FTL
+        https://bugs.webkit.org/show_bug.cgi?id=163305
+
+        Reviewed by Keith Miller.
+
+        * microbenchmarks/pure-get-by-id-cse-2.js: Added.
+        (foo):
+        * microbenchmarks/pure-get-by-id-cse.js: Added.
+        (foo):
+        * stress/pure-get-by-id-cse-correctness.js: Added.
+        (assert):
+        (foo):
+        * stress/pure-get-by-id-on-non-object.js: Added.
+        (assert):
+        (foo):
+
+2016-10-28  Csaba Osztrogonác  <ossy@webkit.org>
+
+        Skip JSTests/microbenchmarks/dense-set.js on memory limited devices
+        https://bugs.webkit.org/show_bug.cgi?id=164128
+
+        Reviewed by Mark Lam.
+
+        * microbenchmarks/dense-set.js:
+
+2016-10-20  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] implement runtime for async functions
+        https://bugs.webkit.org/show_bug.cgi?id=163760
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/async-await-basic.js: Added.
+        (shouldBe):
+        (shouldBeAsync):
+        (shouldThrow):
+        (shouldThrowAsync):
+        (shouldThrowSyntaxError):
+        (let.AsyncFunction.async):
+        (async.asyncFunctionForProto):
+        (Object.getPrototypeOf.async):
+        (Object.getPrototypeOf.async.method):
+        (async):
+        (async.method):
+        (async.asyncNonConstructorDecl):
+        (shouldThrow.new.async):
+        (shouldThrow.new.async.nonConstructor):
+        (async.asyncDecl):
+        (async.f):
+        (MyError):
+        (async.asyncDeclThrower):
+        (shouldThrowAsync.async):
+        (resolveLater):
+        (rejectLater):
+        (async.resumeAfterNormal):
+        (O.async.resumeAfterNormal):
+        (resumeAfterNormalArrow.async):
+        (async.resumeAfterThrow):
+        (O.async.resumeAfterThrow):
+        (resumeAfterThrowArrow.async):
+        (catch):
+        * stress/async-await-module-reserved-word.js: Added.
+        (shouldThrow):
+        (SyntaxError.Canstring_appeared_hereawait.checkModuleSyntaxError.String.raw.await):
+        (checkModuleSyntaxError.String.raw.await):
+        (checkModuleSyntaxError.String.raw.async.await):
+        (SyntaxError.Cannot.declare.named):
+        * stress/async-await-mozilla.js: Added.
+        (shouldBe):
+        (shouldBeAsync):
+        (shouldThrow):
+        (shouldThrowAsync):
+        (assert):
+        (shouldThrowSyntaxError):
+        (mozSemantics.async.empty):
+        (mozSemantics.async.simpleReturn):
+        (mozSemantics.async.simpleAwait):
+        (mozSemantics.async.simpleAwaitAsync):
+        (mozSemantics.async.returnOtherAsync):
+        (mozSemantics.async.simpleThrower):
+        (mozSemantics.async.delegatedThrower):
+        (mozSemantics.async.tryCatch):
+        (mozSemantics.async.tryCatchThrow):
+        (mozSemantics.async.wellFinally):
+        (mozSemantics.async.finallyMayFail):
+        (mozSemantics.async.embedded.async.inner):
+        (mozSemantics.async.embedded):
+        (mozSemantics.async.fib):
+        (mozSemantics.async.isOdd.async.isEven):
+        (mozSemantics.async.isOdd):
+        (mozSemantics.hardcoreFib.async.fib2):
+        (mozSemantics.namedAsyncExpr.async.simple):
+        (mozSemantics.async.executionOrder.async.first):
+        (mozSemantics.async.executionOrder.async.second):
+        (mozSemantics.async.executionOrder.async.third):
+        (mozSemantics.async.executionOrder):
+        (mozSemantics.async.miscellaneous):
+        (mozSemantics.thrower):
+        (mozSemantics.async.defaultArgs):
+        (mozSemantics.shouldThrow):
+        (mozSemantics):
+        (mozMethods.X):
+        (mozMethods.X.prototype.async.getValue):
+        (mozMethods.X.prototype.setValue):
+        (mozMethods.X.prototype.async.increment):
+        (mozMethods.X.prototype.async.getBaseClassName):
+        (mozMethods.X.async.getStaticValue):
+        (mozMethods.Y.prototype.async.getBaseClassName):
+        (mozMethods.Y):
+        (mozFunctionNameInferrence.async.test):
+        (mozSyntaxErrors):
+        * stress/async-await-reserved-word.js: Added.
+        (assert):
+        (shouldThrowSyntaxError):
+        (AsyncFunction.async):
+        * stress/async_arrow_functions_lexical_arguments_binding.js: Added.
+        (shouldBe):
+        (shouldBeAsync):
+        (shouldThrowAsync):
+        (noArgumentsArrow2.async):
+        * stress/async_arrow_functions_lexical_new.target_binding.js: Added.
+        (shouldBe):
+        (shouldBeAsync):
+        (shouldThrowAsync):
+        (C1):
+        (C2):
+        (shouldThrowAsync.async):
+        * stress/async_arrow_functions_lexical_super_binding.js: Added.
+        (shouldBe):
+        (shouldBeAsync):
+        (BaseClass.prototype.baseClassValue):
+        (BaseClass.prototype.get property):
+        (BaseClass):
+        (ChildClass.prototype.asyncSuperProp):
+        (ChildClass.prototype.asyncSuperProp2):
+        (ChildClass):
+        (ChildClass2):
+        * stress/async_arrow_functions_lexical_this_binding.js: Added.
+        (shouldBe):
+        (shouldBeAsync):
+        (d.y):
+
+2016-10-28  Csaba Osztrogonác  <ossy@webkit.org>
+
+        Skip 2 JS stress tests on memory limited devices
+        https://bugs.webkit.org/show_bug.cgi?id=164125
+
+        Unreviewed quick fix to unbreak JSCOnly ARM bots as soon as possible.
+
+        * stress/joined-strings-should-not-exceed-max-string-length.js:
+        * stress/string-prototype-replace-should-throw-out-of-memory-error-when-using-too-much-memory.js:
+
+2016-10-27  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] forbid lexical redeclaration of generator formal parameters
+        https://bugs.webkit.org/show_bug.cgi?id=163930
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/async-await-syntax.js:
+        * stress/generator-syntax.js:
+        (testSyntaxError.gen):
+        (testSyntaxError.arguments):
+        (testSyntaxError.eval):
+        * test262.yaml:
+
+2016-10-26  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly API: implement Instance
+
+        As described in: https://github.com/WebAssembly/design/blob/master/JS.md#webassemblyinstance-objects
+
+         - Take ownership of Wasm::Plan's compilation result when successfully creating a JSWebAssemblyModule object.
+         - Construct a basic Instance with a Module.
+         - Handle second argument (importObject) of WebAssembly.Instance.
+         - Add reference text from the spec to WebAssembly.Module's code.
+         - Expose and test an empty 'exports' ModuleNamespaceObject on WebAssembly.Instance.
+
+        The implementation isn't complete yet: it relies on further work for which I've filed bugs.
+
+        WebAssembly API: implement Instance
+        https://bugs.webkit.org/show_bug.cgi?id=163998
+
+        Reviewed by Keith Miller.
+
+        * wasm/js-api/test_Instance.js: Added.
+        (EmptyModule): use the Builder, create the simplest Module possible, and create an Instance from it
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties.switch): basic tests of the API
+
+2016-10-26  Mark Lam  <mark.lam@apple.com>
+
+        JSGenericTypedArrayView::set() should check for exceptions.
+        https://bugs.webkit.org/show_bug.cgi?id=164007
+        <rdar://problem/28853775>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/typed-array-view-set-should-not-crash-on-exception.js: Added.
+
+2016-10-25  Mark Lam  <mark.lam@apple.com>
+
+        String.prototype.replace() should throw an OutOfMemoryError when using too much memory.
+        https://bugs.webkit.org/show_bug.cgi?id=163996
+        <rdar://problem/28263117>
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/string-prototype-replace-should-throw-out-of-memory-error-when-using-too-much-memory.js: Added.
+
+2016-10-25  Mark Lam  <mark.lam@apple.com>
+
+        JSStringJoiner::joinedLength() should limit joined string lengths to INT_MAX.
+        https://bugs.webkit.org/show_bug.cgi?id=163937
+        <rdar://problem/28642990>
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/joined-strings-should-not-exceed-max-string-length.js: Added.
+
+2016-10-25  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly JS API: simple Module test
+        https://bugs.webkit.org/show_bug.cgi?id=163963
+
+        Reviewed by Filip Pizlo.
+
+        * wasm/LowLevelBinary.js:
+        (export.default.LowLevelBinary.prototype.get return): get the ArrayBuffer
+        (export.default.LowLevelBinary.prototype.hexdump): Deleted.
+        (export.default.LowLevelBinary.prototype._maybeGrow): Deleted.
+        * wasm/js-api/test_Module.js: Added.
+        (EmptyModule): The most basic module possible
+
+2016-10-25  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly JS API: implement Module
+
+        This implementation allows us to:
+         - Syncrhonously create a WebAssembly.Module with a typed array.
+         - Creates a compilation plan.
+         - Parse the Module and creates corresponding code.
+         - Throw WebAssembly.CompileError with mildly helpful [*] error messages on
+           failure.
+
+        Consult the API documentation for expected behavior: https://github.com/WebAssembly/design/blob/master/JS.md#webassemblymodule-constructor
+
+        For now the implementation discards the generated code.
+
+        The next steps will be:
+         - Expose a Module's exports.
+         - Implement WebAssembly.Instance, which allows instantiating and running a
+           compiled Module.
+         - Beef up the testing infrastructure under JSTests/wasm so that more complex
+           modules can be created and tested (instead of writing the bits by hand).
+
+        This patch also:
+         - Adds assert.instanceof in assert.js.
+         - Refactors Wasm::Parser and friends to accept const uint8_t* as well as a
+           Vector, to avoid copying when invoked synchronously.
+         - Remove useless Structure from some of the wasm constructors: they're already
+           on the JSGlobalObject, visited properly and all.
+         - Fix off-by-one error in parsing: Parser::parseUInt32 failed if the integer
+           was exactly at end of file.
+
+         [*] On error messages while parsing: I filed https://bugs.webkit.org/show_bug.cgi?id=163919
+
+        WebAssembly JS API: implement Module
+        https://bugs.webkit.org/show_bug.cgi?id=163903
+
+        Reviewed by Keith Miller.
+
+        * wasm/assert.js: use underscore in name, and remove when exporting to avoid clasing with builtin names
+        (const._notUndef):
+        (const._isUndef):
+        (const._eq):
+        (const._ge):
+        (const._throws):
+        * wasm/js-api/test_basic_api.js: test the WebAssembly.Module API
+        (const.c.in.constructorProperties.switch):
+
+2016-10-25  Keith Miller  <keith_miller@apple.com>
+
+        Add trivial Wasm conversion opcodes
+        https://bugs.webkit.org/show_bug.cgi?id=163950
+
+        Reviewed by Filip Pizlo.
+
+        This patch differentiates between Wasm opcodes that are trivially mapped to a B3 opcode and
+        those that are not.  Some of the Wasm opcodes that are currently a non-simple opcode will
+        become simple as we add B3 opcodes for Wasm operations.  The remaining opcodes will need to
+        be added via patchpoints in a later patch.
+
+        * wasm/generate-wasmops-header.js:
+        (const.template.pragma.once.ENABLE.WEBASSEMBLY.include.cstdint.namespace.JSC.namespace.Wasm.inline.bool.isSimple):
+        * wasm/wasm.json:
+
+2016-10-24  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Arrow functions with concise bodies cannot return regular expressions
+        https://bugs.webkit.org/show_bug.cgi?id=163162
+
+        Reviewed by Filip Pizlo.
+
+        * ChakraCore/test/Operators/instanceof.baseline-jsc:
+        * ChakraCore/test/Regex/nul_character.baseline-jsc:
+        * ChakraCore/test/es5/Lex_u3.baseline-jsc:
+        * stress/parse-regexp-as-token.js: Added.
+        (shouldBe):
+
+2016-10-24  Keith Miller  <keith_miller@apple.com>
+
+        Wasm should support floating point operations.
+        https://bugs.webkit.org/show_bug.cgi?id=163770
+
+        Reviewed by Michael Saboff.
+
+        Add appropriate b3op names for floating point wasm bytecodes, where they exist.
+        Also, fix some WASM => Wasm in WasmOps.h generator script that I missed
+        the first time I made the change.
+
+        * wasm/generate-wasmops-header.js:
+        (const.template.pragma.once.ENABLE.WEBASSEMBLY.include.cstdint.namespace.JSC.namespace.WASM.template.typename.Int.inline.bool.isValidOpType): Deleted.
+        (const.template.pragma.once.ENABLE.WEBASSEMBLY.include.cstdint.namespace.JSC.namespace.WASM.enum.BinaryOpType): Deleted.
+        (const.template.pragma.once.ENABLE.WEBASSEMBLY.include.cstdint.namespace.JSC.namespace.WASM.enum.UnaryOpType): Deleted.
+        (const.template.pragma.once.ENABLE.WEBASSEMBLY.include.cstdint.namespace.JSC.namespace.WASM.enum.LoadOpType): Deleted.
+        (const.template.pragma.once.ENABLE.WEBASSEMBLY.include.cstdint.namespace.JSC.namespace.WASM.enum.StoreOpType): Deleted.
+        (const.template.pragma.once.ENABLE.WEBASSEMBLY.include.cstdint.namespace.JSC.namespace.WASM.undef.CREATE_ENUM_VALUE.inline.bool.isControlOp): Deleted.
+        * wasm/wasm.json:
+
+2016-10-21  Saam Barati  <sbarati@apple.com>
+
+        SpeculativeJIT::compileTryGetById needs to pass in NeedsToSpill along both the cell speculation and untyped speculation path
+        https://bugs.webkit.org/show_bug.cgi?id=163622
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/try-get-by-id-should-spill-registers-dfg.js: Added.
+        (let.f.createBuiltin):
+
+2016-10-21  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] don't crash when arguments to `new Function()` produce unexpected AST
+        https://bugs.webkit.org/show_bug.cgi?id=163748
+
+        Reviewed by Mark Lam.
+
+        * stress/regress-163748.js: Added.
+        (assert):
+        (shouldThrowSyntaxError):
+        (GeneratorFunction):
+
+2016-10-20  Keith Miller  <keith_miller@apple.com>
+
+        Add support for WASM calls
+        https://bugs.webkit.org/show_bug.cgi?id=161727
+
+        Reviewed by Filip Pizlo and Michael Saboff.
+
+        Add members of the Call category to the WASMOps special group.
+
+        * wasm/generate-wasmops-header.js:
+
+2016-10-20  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Drop isEnvironmentRecord type info flag and use JSType information instead
+        https://bugs.webkit.org/show_bug.cgi?id=163761
+
+        Reviewed by Keith Miller.
+
+        * modules/string-prototype-module-scope.js: Added.
+        (shouldBe):
+        (catch):
+        (refer):
+        * stress/string-prototype-scopes-global-lexical-environment-strict.js: Added.
+        (shouldBe):
+        (catch):
+        * stress/string-prototype-scopes-global-lexical-environment.js: Added.
+        (shouldBe):
+        (catch):
+        * stress/string-prototype-scopes-strict.js: Added.
+        (shouldBe):
+        (catch):
+        (try.refer):
+        (refer):
+        * stress/string-prototype-scopes.js: Added.
+        (shouldBe):
+        (catch):
+        (try.refer):
+        (refer):
+        (object.toString):
+        (with):
+
+2016-10-20  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly API: implement exception constructors properly
+
+         - Rename WebAssemblyObject to JSWebAssembly for consistency.
+         - WebAssembly object now has its own prototype: add WebAssemblyPrototype, and
+           use it to register JSWebAssembly's function properties through auto-generated
+           .lut.h, instead of manually.
+         - The error constructors used to throw (e.g. `new WebAssembly.CompileError()`).
+         - Register WebAssembly's constructors from the global object, and hold a
+           reference to their structure and prototype so that invoking the constructor
+           can use the structure directly from the global object.
+         - Add a prototype base field to global object creation. Previous ones all had
+           Object's prototype as their base, but WebAssembly's error constructors have
+           Error as their base.
+         - Test for the error object's correctness.
+         - Add missing #if ENABLE(WEBASSEMBLY)
+
+        WebAssembly API: implement exception constructors properly
+        https://bugs.webkit.org/show_bug.cgi?id=163699
+
+        Reviewed by Keith Miller.
+
+        * wasm/js-api/test_basic_api.js:
+        (const.c.in.constructorProperties): more tests
+
+2016-10-20  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] disallow references to `await` in AsyncFunction formal parameters
+        https://bugs.webkit.org/show_bug.cgi?id=163694
+
+        Reviewed by Saam Barati.
+
+        * stress/async-await-syntax.js:
+
+2016-10-20  Keith Miller  <keith_miller@apple.com>
+
+        Invalid assertion in arguments elimination
+        https://bugs.webkit.org/show_bug.cgi?id=163740
+        <rdar://problem/27911462>
+
+        Reviewed by Michael Saboff.
+
+        * stress/direct-arguments-osr-entry.js: Added.
+        (foo.):
+        (foo):
+
+2016-10-20  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] throw TypeError when constructing dynamically created JSGeneratorFunction
+        https://bugs.webkit.org/show_bug.cgi?id=163714
+
+        Reviewed by Mark Lam.
+
+        Add missing test coverage that dynamically created
+        JSGeneratorFunctions can not be constructed.
+
+        * stress/generator-function-constructor.js:
+        (shouldThrow):
+
+2016-10-19  JF Bastien  <jfbastien@apple.com>
+
+        JavaScript WebAssembly API: baby steps
+
+         - Expand WebAssembly constructors into their own files. This requires a lot of
+           boilerplate, as well as adding the .lut.h files. All of the
+           JSWebAssembly*.{h,cpp}, as well as Constructor and Prototype files, are
+           currently the same between the 4 specified WebAssembly constructors. It'll be
+           easy to implement individual functions on constructed objects as per the
+           spec, and have each of these files diverge. The error constructors are also
+           similar, except that their instance derives from ErrorInstance.
+         - Use constructor macro when initializing the global object.
+         - Dramatically improve testing of the WebAssembly API by checking for
+           properties specified in the spec [*].
+         - Clean up assert.js' exception testing.
+         - Fix a copy-paste bug in wasm.json: floating-point const return values were
+           swapped.
+
+        [*] https://github.com/WebAssembly/design/blob/master/JS.md
+
+        Implement more of the JavaScript WebAssembly API
+        https://bugs.webkit.org/show_bug.cgi?id=163571
+
+        Reviewed by Keith Miller.
+
+        * wasm/assert.js:
+        (export.const.isUndef): add this useful helper
+        (export.const.throws): fold other throw checks into this one, and check message as well
+        * wasm/js-api/test_basic_api.js:
+        (const.checkOwnPropertyDescriptor): check own property descriptor follows the spec
+        * wasm/self-test/test_BuilderJSON.js:
+        (const.assertOpThrows): use new assert API
+        (CheckedOpcodeArgumentsTooMany): ditto
+        (CheckedOpcodeArgumentsNotEnough): ditto
+        (CallInvalid): ditto
+        (I32ConstInvalid): ditto
+        (F32ConstInvalid): ditto (and this caugth the JSON copy-paste bug)
+        (F64ConstInvalid): ditto
+        * wasm/self-test/test_LowLevelBinary_varint.js: use new assert API
+        * wasm/self-test/test_LowLevelBinary_varuint.js: use new assert API
+        * wasm/utilities.js: add "global" object, used in basic API test (to access global.WebAssembly).
+        * wasm/wasm.json: fix copy-paste
+
+2016-10-19  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] forbid "use strict" directive in generator functions with non-simple parameters
+        https://bugs.webkit.org/show_bug.cgi?id=163683
+
+        Reviewed by Geoffrey Garen.
+
+        Update various generator*-non-simple-param.js tests to be passing.
+
+        * test262.yaml:
+
+2016-10-18  Mark Lam  <mark.lam@apple.com>
+
+        Invoking Object.prototype.__proto__ accessors directly should throw a TypeError.
+        https://bugs.webkit.org/show_bug.cgi?id=154377
+        <rdar://problem/27330808>
+
+        Reviewed by Filip Pizlo and Saam Barati.
+
+        * stress/object-prototype-proto-accessors-should-throw-on-undefined-this.js: Added.
+
+2016-10-18  Keith Miller  <keith_miller@apple.com>
+
+        GetByVal to GetById conversion in the DFG is incorrect for getters with control flow
+        https://bugs.webkit.org/show_bug.cgi?id=163629
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/get-by-val-to-id-with-getter.js: Added.
+        (foo):
+        (o.get hello):
+
+2016-10-15  Filip Pizlo  <fpizlo@apple.com>
+
+        DFG and FTL should be able to use DirectCall ICs when they proved the callee or its executable
+        https://bugs.webkit.org/show_bug.cgi?id=163371
+
+        Reviewed by Geoffrey Garen and Saam Barati.
+        
+        Add microbenchmarks for all of the cases that this patch optimizes.
+
+        * microbenchmarks/direct-call-arity-mismatch.js: Added.
+        (foo):
+        (bar):
+        * microbenchmarks/direct-call.js: Added.
+        (foo):
+        (bar):
+        * microbenchmarks/direct-construct-arity-mismatch.js: Added.
+        (Foo):
+        (bar):
+        * microbenchmarks/direct-construct.js: Added.
+        (Foo):
+        (bar):
+        * microbenchmarks/direct-tail-call-arity-mismatch.js: Added.
+        (foo):
+        (bar):
+        * microbenchmarks/direct-tail-call-inlined-caller-arity-mismatch.js: Added.
+        (foo):
+        (bar):
+        (baz):
+        * microbenchmarks/direct-tail-call-inlined-caller.js: Added.
+        (foo):
+        (bar):
+        (baz):
+        * microbenchmarks/direct-tail-call.js: Added.
+        (foo):
+        (bar):
+
+2016-10-18  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] ES6 Method functions should not have prototype
+        https://bugs.webkit.org/show_bug.cgi?id=162530
+
+        Reviewed by Saam Barati.
+
+        Fix test262 expectations about MethodDefinitions
+
+        * ChakraCore/test/strict/05.arguments_sm.baseline-jsc:
+        * stress/reflect-set.js:
+        * test262.yaml:
+
+2016-10-17  Keith Miller  <keith_miller@apple.com>
+
+        Add support for WASM Memory.
+        https://bugs.webkit.org/show_bug.cgi?id=161710
+
+        Reviewed by Geoffrey Garen.
+
+        Add store and load opcodes to wasm.json. Additionally, add new
+        enums for those opcodes in the generator.
+
+        * stress/wasm/generate-wasmops-header.js:
+        (const.template.pragma.once.ENABLE.WEBASSEMBLY.include.cstdint.namespace.JSC.namespace.WASM.enum.LoadOpType):
+        (const.template.pragma.once.ENABLE.WEBASSEMBLY.include.cstdint.namespace.JSC.namespace.WASM.enum.StoreOpType):
+
+2016-10-17  Saam Barati  <sbarati@apple.com>
+
+        Add more tests for the double->String conversion in ValueAdd constant folding
+        https://bugs.webkit.org/show_bug.cgi?id=163517
+
+        Reviewed by Yusuke Suzuki.
+
+        * microbenchmarks/string-add-constant-folding.js:
+        (test):
+
+2016-10-17  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly JS API: implement basic stub
+
+        Implement the global WebAssembly JavaScript object, and its constructor +
+        function properties as described in:
+          https://github.com/WebAssembly/design/blob/master/JS.md
+
+        These don't do anything at the moment, the parent bug will take care of adding
+        more functionality and associated tests.
+
+        WebAssembly JS API: implement basic stub
+        https://bugs.webkit.org/show_bug.cgi?id=163404
+
+        Reviewed by Keith Miller.
+
+        * wasm.yaml:
+        * wasm/js-api/test_basic_api.js: Added.
+        (const.f.of.functionProperties.WebAssembly.f.undefined.throw.new.Error.Couldn.const.c.of.constructorProperties.WebAssembly.c.undefined.throw.new.Error.Couldn):
+        (const.c.of.constructorProperties.catch):
+
+2016-10-17  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DOMJIT] Use DOMJIT::Patchpoint in IC
+        https://bugs.webkit.org/show_bug.cgi?id=163223
+
+        Reviewed by Saam Barati.
+
+        * stress/domjit-exception-ic.js: Added.
+        (shouldBe):
+        (access):
+        * stress/domjit-exception.js: Added.
+        (shouldBe):
+        (access):
+        * stress/domjit-getter-complex-with-incorrect-object.js: Added.
+        (shouldThrow):
+        (access):
+        (i.shouldThrow):
+        * stress/domjit-getter-complex.js: Added.
+        (shouldBe):
+        (access):
+        * stress/domjit-getter-try-catch-getter-as-get-by-id-register-restoration.js: Added.
+        (assert):
+        (bar):
+        (foo):
+
+2016-10-15  Saam Barati  <sbarati@apple.com>
+
+        Assertion failed under operationToLowerCase with a rope with zero length
+        https://bugs.webkit.org/show_bug.cgi?id=163314
+
+        Reviewed by Mark Lam.
+
+        * stress/to-lower-case-intrinsic-on-empty-rope.js: Added.
+        (assert):
+        (returnRope.helper):
+        (returnRope):
+        (lower):
+
+2016-10-14  Benjamin Poulain  <bpoulain@apple.com>
+
+        [JSC] op_negate should with any type
+        https://bugs.webkit.org/show_bug.cgi?id=162587
+
+        Reviewed by Saam Barati.
+
+        * stress/arith-abs-to-arith-negate-range-optimizaton.js: Added.
+        Cover OSR Exits when converting Math.abs() into ArithNegate.
+
+        * stress/arith-negate-on-various-types.js: Added.
+        Cover ArithNegate with all types.
+
+2016-10-14  JF Bastien  <jfbastien@apple.com>
+
+        Basic WebAssembly testing
+
+        Create a small DSL in JavaScript which can build WebAssembly binary modules based on the JSON description of the format as described in:
+        https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md
+
+        This DSL can then be used to write small text description of valid and invalid WebAssembly binaries, making testing the JSC implementation much easier.
+
+        Details and example in README.md.
+
+        Basic WebAssembly testing
+        https://bugs.webkit.org/show_bug.cgi?id=163267
+
+        Reviewed by Keith Miller.
+
+        * stress/wasm/wasm.json: Removed.
+        * wasm.yaml: Added.
+        * wasm/Builder.js: Added.
+        (const._isValidValue):
+        (const._BuildWebAssemblyBinary):
+        (export.default.Builder):
+        (export.default.Builder.prototype.setChecked):
+        (export.default.Builder.prototype.setPreamble):
+        (export.default.Builder.prototype._registerSectionBuilders.switch.case.string_appeared_here.this.section):
+        (export.default.Builder.prototype._registerSectionBuilders.this.Unknown):
+        (export.default.Builder.prototype._registerSectionBuilders):
+        (export.default.Builder.prototype._addSection):
+        (export.default.Builder.prototype.optimize):
+        (export.default.Builder.prototype.json):
+        (export.default.Builder.prototype.AsmJS):
+        (export.default.Builder.prototype.WebAssembly):
+        * wasm/LowLevelBinary.js: Added.
+        (const._getterRangeCheck):
+        (const._hexdump):
+        (export.default.LowLevelBinary):
+        (export.default.LowLevelBinary.prototype.newPatchable):
+        (export.default.LowLevelBinary.prototype.hexdump):
+        (export.default.LowLevelBinary.prototype._maybeGrow):
+        (export.default.LowLevelBinary.prototype._push8):
+        (export.default.LowLevelBinary.prototype.uint8):
+        (export.default.LowLevelBinary.prototype.uint16):
+        (export.default.LowLevelBinary.prototype.uint32):
+        (export.default.LowLevelBinary.prototype.varuint):
+        (export.default.LowLevelBinary.prototype.varint):
+        (export.default.LowLevelBinary.prototype.varuint7):
+        (export.default.LowLevelBinary.prototype.string):
+        (export.default.LowLevelBinary.prototype.getSize):
+        (export.default.LowLevelBinary.prototype.getUint8):
+        (export.default.LowLevelBinary.prototype.getUint16):
+        (export.default.LowLevelBinary.prototype.getUint32):
+        (export.default.LowLevelBinary.prototype.getVaruint):
+        (export.default.LowLevelBinary.prototype.getVarint):
+        (export.default.LowLevelBinary.prototype.getVaruint7):
+        (export.default.LowLevelBinary.prototype.getString):
+        (PatchableLowLevelBinary):
+        (PatchableLowLevelBinary.prototype._push8):
+        (PatchableLowLevelBinary.prototype.apply):
+        * wasm/README.md: Added.
+        * wasm/WASM.js: Added.
+        * wasm/assert.js: Added.
+        (export.const.notUndef):
+        (export.const.eq):
+        (export.const.ge):
+        (export.const.throwsError):
+        (export.const.throwsRangeError):
+        * wasm/generate-wasmops-header.js: Renamed from JSTests/stress/wasm/generate-wasmops-header.js.
+        * wasm/self-test/test_BuilderJSON.js: Added.
+        (const.assertOpThrows):
+        (EmptyModule):
+        (CustomMagicNumber):
+        (CustomVersion):
+        (CustomSection):
+        (CustomSectionAllBytes):
+        (CustomSectionInvalidByte):
+        (TwoCustomSections):
+        (EmptyCodeSection):
+        (CodeSectionWithEmptyFunction):
+        (CodeSectionWithEmptyFunctionWithParameters):
+        (InvalidFunctionParameters):
+        (SimpleFunction):
+        (TwoSimpleFunctions):
+        (TwoBuildersAtTheSameTime):
+        (CheckedOpcodeArgumentsTooMany):
+        (CheckedOpcodeArgumentsNotEnough):
+        (CallNoArguments):
+        (CallInvalid):
+        (I32ConstInvalid):
+        (F32ConstInvalid):
+        (F64ConstInvalid):
+        (CallManyFromStack):
+        (OpcodeAdd):
+        (OpcodeUnreachable):
+        (OpcodeUnreachableCombinations):
+        (OpcodeSelect):
+        * wasm/self-test/test_BuilderWebAssembly.js: Added.
+        (EmptyModule):
+        (CustomSection):
+        (Basic):
+        * wasm/self-test/test_LowLevelBinary_encode.js: Added.
+        * wasm/self-test/test_LowLevelBinary_string.js: Added.
+        * wasm/self-test/test_LowLevelBinary_uint16.js: Added.
+        * wasm/self-test/test_LowLevelBinary_uint32.js: Added.
+        * wasm/self-test/test_LowLevelBinary_uint8.js: Added.
+        * wasm/self-test/test_LowLevelBinary_varint.js: Added.
+        * wasm/self-test/test_LowLevelBinary_varuint.js: Added.
+        * wasm/self-test/test_LowLevelBinary_varuint7.js: Added.
+        * wasm/self-test/test_WASM.js: Added.
+        * wasm/test.sh: Added.
+        * wasm/utilities.js: Added.
+        (const._read.filename.switch):
+        (const._load.filename.switch):
+        (const._json.filename.switch):
+        * wasm/wasm.json: Added.
+
+2016-10-14  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: @isConstructor incorrectly thinks Math.cos is a constructor
+        https://bugs.webkit.org/show_bug.cgi?id=163437
+
+        Reviewed by Saam Barati.
+
+        * stress/is-constructor.js: Added.
+        (assert):
+        (prototype.assert):
+        New test to cover the @isConstructor builtin.
+
+        * test262.yaml:
+        Test now passes.
+
+2016-10-14  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r207322.
+
+        This change caused JSC test failures
+
+        Reverted changeset:
+
+        "Fix Array.prototype.splice ES6 compliance."
+        https://bugs.webkit.org/show_bug.cgi?id=163372
+        http://trac.webkit.org/changeset/207322
+
+2016-10-14  Mark Lam  <mark.lam@apple.com>
+
+        JSON.parse should not modify frozen objects.
+        https://bugs.webkit.org/show_bug.cgi?id=163430
+
+        Reviewed by Saam Barati.
+
+        * stress/json-parse-on-frozen-object.js: Added.
+
+2016-10-14  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: Failure with RegExp.prototype.compile when pattern is undefined
+        https://bugs.webkit.org/show_bug.cgi?id=163431
+
+        Reviewed by Yusuke Suzuki.
+
+        * test262.yaml:
+
+2016-10-13  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Exception message for expressions with multiple bracket accesses is inconsistent / incorrect
+        https://bugs.webkit.org/show_bug.cgi?id=163426
+
+        Reviewed by Geoffrey Garen.
+
+        * ChakraCore/test/Error/CallNonFunction_3.baseline-jsc:
+        * ChakraCore/test/Object/null.baseline-jsc:
+        * stress/exception-in-to-property-key-should-be-handled-early.js:
+        Better exception messages.
+
+2016-10-13  Mark Lam  <mark.lam@apple.com>
+
+        Fix Array.prototype.splice ES6 compliance.
+        https://bugs.webkit.org/show_bug.cgi?id=163372
+
+        Reviewed by Geoffrey Garen and Yusuke Suzuki.
+
+        * stress/array-splice-on-frozen-object.js: Added.
+
+2016-10-12  Keith Miller  <keith_miller@apple.com>
+
+        Handle non-function, non-undefined comparator in Array.prototype.sort
+        https://bugs.webkit.org/show_bug.cgi?id=163085
+
+        Reviewed by Yusuke Suzuki.
+
+        * ChakraCore/test/Array/array_sort.baseline-jsc:
+        * stress/array-sort-bad-comparator.js: Added.
+        (test):
+
+2016-10-12  Mark Lam  <mark.lam@apple.com>
+
+        Array.prototype.slice should not modify frozen objects.
+        https://bugs.webkit.org/show_bug.cgi?id=163338
+
+        Reviewed by Filip Pizlo.
+
+        * stress/array-slice-on-frozen-object.js: Added.
+
+2016-10-11  Mark Lam  <mark.lam@apple.com>
+
+        Array.prototype.concat should not modify frozen objects.
+        https://bugs.webkit.org/show_bug.cgi?id=163302
+
+        Reviewed by Filip Pizlo.
+
+        * stress/array-concat-on-frozen-object.js: Added.
+
+2016-10-11  Saam Barati  <sbarati@apple.com>
+
+        ValueAdd should be constant folded if the operands are constant String,Primitive or Primitive,String
+        https://bugs.webkit.org/show_bug.cgi?id=163182
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/string-add-constant-folding.js: Added.
+        (assert):
+        (runTests):
+        (add):
+        (test):
+
+2016-10-07  Mark Lam  <mark.lam@apple.com>
+
+        Object.freeze() and seal() should throw if [[PreventExtensions]]() fails.
+        https://bugs.webkit.org/show_bug.cgi?id=163160
+
+        Reviewed by Saam Barati.
+
+        * stress/object-freeze-with-proxy-preventExtensions.js: Added.
+        * stress/object-seal-with-proxy-preventExtensions.js: Added.
+
+2016-10-05  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DOMJIT] Add initial CheckDOM and CallDOM implementations
+        https://bugs.webkit.org/show_bug.cgi?id=162941
+
+        Reviewed by Filip Pizlo.
+
+        * stress/domjit-getter-poly.js: Added.
+        (shouldBe):
+        (access):
+        * stress/domjit-getter-proto.js: Added.
+        (shouldBe):
+        (access):
+        * stress/domjit-getter-super-poly.js: Added.
+        (shouldBe):
+        (access):
+        * stress/domjit-getter.js: Added.
+        (shouldBe):
+        (access):
+
+2016-10-04  Saam Barati  <sbarati@apple.com>
+
+        String.prototype.toLowerCase should be a DFG/FTL intrinsic
+        https://bugs.webkit.org/show_bug.cgi?id=162887
+
+        Reviewed by Filip Pizlo and Yusuke Suzuki.
+
+        * microbenchmarks/to-lower-case.js: Added.
+        (assert):
+        (foo):
+        (bar):
+        * stress/to-lower-case.js: Added.
+        (assert):
+        (foo):
+
+2016-10-04  JF Bastien  <jfbastien@apple.com>
+
+        WebAssembly: handle a few corner cases
+        https://bugs.webkit.org/show_bug.cgi?id=162884
+
+        Reviewed by Keith Miller.
+
+        * stress/wasm/generate-wasmops-header.js:
+        (const.opcodeIterator): max opcode value
+
+2016-10-03  JF Bastien  <jfbastien@apple.com>
+
+        Auto-generate WASMOps.h, share with testing JSON file
+        https://bugs.webkit.org/show_bug.cgi?id=162870
+
+        Reviewed by Keith Miller.
+
+        * stress/wasm/to-c++.js: Added. Generates WASMOps.h, siilar to the current one but with more data.
+        (const.opcode_iterator):
+        (opcode_macroizer):
+        * stress/wasm/wasm.json: Added. Data from 0xC binary format version.
+
+2016-10-03  Saam Barati  <sbarati@apple.com>
+
+        MapHash should speculate on the type of its child node
+        https://bugs.webkit.org/show_bug.cgi?id=161922
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/map-key-well-typed.js: Added.
+        (assert):
+        (intKey):
+        (doubleKey):
+        (objectKey):
+        (stringKey):
+        (booleanKey):
+        (symbolKey):
+        (cellKey):
+        (assert.doubleKey):
+        (assert.booleanKey):
+
+2016-10-03  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [ES6] GeneratorFunction (a.k.a. GeneratorWrapperFunction)'s prototype object does not have constructor property
+        https://bugs.webkit.org/show_bug.cgi?id=162849
+
+        Reviewed by Geoffrey Garen.
+
+        * test262.yaml:
+
+2016-10-01  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [ES6] Align attributes of Generator related properties to spec
+        https://bugs.webkit.org/show_bug.cgi?id=162839
+
+        Reviewed by Saam Barati.
+
+        * test262.yaml:
+
+2016-10-01  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [ES6] GeneratorFunction constructor should instantiate generator function
+        https://bugs.webkit.org/show_bug.cgi?id=162838
+
+        Reviewed by Saam Barati.
+
+        * stress/generator-function-constructor-is-subclassible.js: Added.
+        (shouldBe):
+        (GeneratorFunction):
+        (prototype.hello):
+        * stress/generator-function-constructor.js:
+        * test262.yaml:
+
+2016-09-30  Saam Barati  <sbarati@apple.com>
+
+        Arrow functions should not allow duplicate parameter names
+        https://bugs.webkit.org/show_bug.cgi?id=162741
+
+        Reviewed by Filip Pizlo.
+
+        * test262.yaml:
+
+2016-09-30  Saam Barati  <sbarati@apple.com>
+
+        Make some microbenchmarks run for less time.
+
+        Rubber stamped by Filip Pizlo.
+
+        * microbenchmarks/bound-function-construction-performance.js:
+        (foo):
+        * microbenchmarks/getter-richards-try-catch.js:
+
+2016-09-29  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Arrow functions do not infer name from computed property but normal functions do
+        https://bugs.webkit.org/show_bug.cgi?id=162720
+
+        Reviewed by Saam Barati.
+
+        * stress/inferred-names.js:
+
+2016-09-29  Mark Lam  <mark.lam@apple.com>
+
+        Break some slow running tests into smaller bits so they don't time out.
+        https://bugs.webkit.org/show_bug.cgi?id=162743
+
+        Reviewed by Keith Miller.
+
+        The following tests have shown to be slow running:
+            op_div.js
+            op_lshift.js
+            op_mod.js
+            op_mul.js
+            op_rshift.js
+            op_sub.js
+            op_urshift
+
+        These tests auto-generate permutations of values to apply to binary operations.
+        They also test the operations with 3 permutations of value types:
+            1. VarVar - both operands variables
+            2. VarConst - variable operand 1, constant / literal operand 2
+            3. ConstVar - constant / literal operand 1, variable operand 2
+
+        We can prevent these tests from timing out by breaking each up to only run 1 of
+        the 3 permutations of value types.
+
+        * stress/op_div-ConstVar.js: Added.
+        * stress/op_div-VarConst.js: Added.
+        * stress/op_div-VarVar.js: Copied from JSTests/stress/op_div.js.
+        (o1.valueOf): Deleted.
+        * stress/op_div.js: Removed.
+        * stress/op_lshift-ConstVar.js: Added.
+        * stress/op_lshift-VarConst.js: Added.
+        * stress/op_lshift-VarVar.js: Copied from JSTests/stress/op_lshift.js.
+        (o1.valueOf): Deleted.
+        * stress/op_lshift.js: Removed.
+        * stress/op_mod-ConstVar.js: Added.
+        * stress/op_mod-VarConst.js: Added.
+        * stress/op_mod-VarVar.js: Copied from JSTests/stress/op_mod.js.
+        (o1.valueOf): Deleted.
+        * stress/op_mod.js: Removed.
+        * stress/op_mul-ConstVar.js: Added.
+        * stress/op_mul-VarConst.js: Added.
+        * stress/op_mul-VarVar.js: Copied from JSTests/stress/op_mul.js.
+        (o1.valueOf): Deleted.
+        * stress/op_mul.js: Removed.
+        * stress/op_rshift-ConstVar.js: Added.
+        * stress/op_rshift-VarConst.js: Added.
+        * stress/op_rshift-VarVar.js: Copied from JSTests/stress/op_rshift.js.
+        (o1.valueOf): Deleted.
+        * stress/op_rshift.js: Removed.
+        * stress/op_sub-ConstVar.js: Added.
+        * stress/op_sub-VarConst.js: Added.
+        * stress/op_sub-VarVar.js: Copied from JSTests/stress/op_sub.js.
+        (o1.valueOf): Deleted.
+        * stress/op_sub.js: Removed.
+        * stress/op_urshift-ConstVar.js: Added.
+        * stress/op_urshift-VarConst.js: Added.
+        * stress/op_urshift-VarVar.js: Copied from JSTests/stress/op_urshift.js.
+        (o1.valueOf): Deleted.
+        * stress/op_urshift.js: Removed.
+        * stress/resources/binary-op-values.js: Added.
+        (o1.valueOf):
+
+2016-09-29  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: class and function names should be inferred in assignment
+        https://bugs.webkit.org/show_bug.cgi?id=146262
+
+        Reviewed by Saam Barati.
+
+        * stress/arrowfunction-name.js: Added.
+        Quick tests for arrow function names.
+
+        * stress/inferred-names.js: Added.
+        General test for inferred function names.
+
+        * test262.yaml:
+        Pass many tests checking inferred function names.
+
+2016-09-29  Saam Barati  <sbarati@apple.com>
+
+        We don't properly propagate non-simple-parameter-list when parsing a setter
+        https://bugs.webkit.org/show_bug.cgi?id=160483
+
+        Reviewed by Joseph Pecoraro.
+
+        * test262.yaml:
+
+2016-09-28  Saam Barati  <sbarati@apple.com>
+
+        stringProtoFuncRepeatCharacter will return `null` when it should not
+        https://bugs.webkit.org/show_bug.cgi?id=161944
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/pad-start-calls-repeat-character-with-double.js: Added.
+        (logLinesWithContext):
+
+2016-09-27  Filip Pizlo  <fpizlo@apple.com>
+
+        B3::lowerMacros forgets to before->updatePredecessorsAfter() when lowering ChillMod on ARM64
+        https://bugs.webkit.org/show_bug.cgi?id=162644
+
+        Reviewed by Keith Miller.
+
+        * stress/chill-mod-chill-mod.js: Added.
+        (foo):
+
+2016-09-26  Csaba Osztrogonác  <oszi@inf.u-szeged.hu>
+
+        Skip stress/string-joining-long-strings-should-not-crash.js on memory limited devices
+        https://bugs.webkit.org/show_bug.cgi?id=162386
+
+        Unreviewed, relanding r206317 after typo fix.
+
+        * stress/string-joining-long-strings-should-not-crash.js:
+
+2016-09-24  Caitlin Potter  <caitp@igalia.com>
+
+        [JSTests] fix test262 expectations following r206333
+        https://bugs.webkit.org/show_bug.cgi?id=162533
+
+        Reviewed by Yusuke Suzuki.
+
+        * test262.yaml:
+
+2016-09-23  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] Implement parsing of Async Functions
+        https://bugs.webkit.org/show_bug.cgi?id=161409
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/async-await-syntax.js: Added.
+        (testSyntax):
+        (testSyntaxError):
+        (testTopLevelAsyncAwaitSyntaxSloppyMode.testSyntax):
+        (testTopLevelAsyncAwaitSyntaxSloppyMode):
+        (testTopLevelAsyncAwaitSyntaxStrictMode):
+        (testTopLevelAsyncAwaitSyntaxStrictMode.testSyntax):
+        (testNestedAsyncAwaitSyntax.async):
+        (testNestedAsyncAwaitSyntax.foo):
+        (testTopLevelAsyncAwaitSyntaxSloppyMode.testSyntaxError):
+
+2016-09-23  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r206317.
+
+        This change caused timeouts on El Capitan Release JSC tests
+
+        Reverted changeset:
+
+        "Skip stress/string-joining-long-strings-should-not-crash.js
+        on memory limited devices"
+        https://bugs.webkit.org/show_bug.cgi?id=162386
+        http://trac.webkit.org/changeset/206317
+
+2016-09-23  Csaba Osztrogonác  <ossy@webkit.org>
+
+        Skip mozilla-tests.yaml/js1_5/Array/regress-157652 on memory limited devices
+        https://bugs.webkit.org/show_bug.cgi?id=162381
+
+        Reviewed by Mark Lam.
+
+        * mozilla/mozilla-tests.yaml:
+
+2016-09-23  Csaba Osztrogonác  <ossy@webkit.org>
+
+        Skip stress/string-joining-long-strings-should-not-crash.js on memory limited devices
+        https://bugs.webkit.org/show_bug.cgi?id=162386
+
+        Reviewed by Mark Lam.
+
+        * stress/string-joining-long-strings-should-not-crash.js:
+
+2016-09-22  Benjamin Poulain  <bpoulain@apple.com>
+
+        [JSC] Use an inline cache to generate op_negate
+        https://bugs.webkit.org/show_bug.cgi?id=162371
+
+        Reviewed by Saam Barati.
+
+        * stress/op-negate-inline-cache.js: Added.
+
+2016-09-22  Mark Lam  <mark.lam@apple.com>
+
+        Array.prototype.join should do overflow checks on string joins.
+        https://bugs.webkit.org/show_bug.cgi?id=162459
+
+        Reviewed by Saam Barati.
+
+        * stress/array-join-on-strings-need-overflow-checks.js: Added.
+        (assert):
+        (catch):
+
+2016-09-22  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: Function length should be number of parameters before parameters with default values
+        https://bugs.webkit.org/show_bug.cgi?id=162377
+
+        Reviewed by Saam Barati.
+
+        * stress/es6-default-parameters.js:
+        Add our own tests for function lengths with default parameters.
+
+        * test262.yaml:
+        We now pass all dflt-length tests.
+
+2016-09-20  Benjamin Poulain  <bpoulain@apple.com>
+
+        [JSC] Do not use EagerRun on tests counting recompilation
+        https://bugs.webkit.org/show_bug.cgi?id=162248
+
+        Reviewed by Geoffrey Garen.
+
+        This patch adds defaultNoEagerRun to all the tests
+        for which recompilation is the symptom of a bug.
+        The reason is that an OSR Exit can be unrelated to the tested
+        nodes when we are running in Eager mode.
+
+        * stress/arith-abs-on-various-types.js:
+        * stress/arith-ceil-on-various-types.js:
+        * stress/arith-clz32-on-various-types.js:
+        * stress/arith-cos-on-various-types.js:
+        * stress/arith-floor-on-various-types.js:
+        * stress/arith-fround-on-various-types.js:
+        * stress/arith-log-on-various-types.js:
+        * stress/arith-round-on-various-types.js:
+        * stress/arith-sin-on-various-types.js:
+        * stress/arith-sqrt-on-various-types.js:
+        * stress/arith-tan-on-various-types.js:
+        * stress/arith-trunc-on-various-types.js:
+
+        * stress/compare-strict-eq-on-various-types.js:
+        (testAllTypesCall):
+        The value 2 came from the other tests.
+        CompareStrictEq supports many more cases, the worst case
+        is bool->int->int52->number->polymorphic.
+
+2016-09-20  Filip Pizlo  <fpizlo@apple.com>
+
+        Make MarkedBlock state tracking support overlapped allocation and marking state
+        https://bugs.webkit.org/show_bug.cgi?id=161581
+
+        Reviewed by Geoffrey Garen.
+        
+        Add a microbenchmark for why we want to reclaim empty blocks from other allocators.
+
+        * microbenchmarks/switching-size-classes.js: Added.
+
+2016-09-20  Saam Barati  <sbarati@apple.com>
+
+        Unreviewed, added test for x86 32-bit failure for HasOwnProperty node in DFG.
+
+        * stress/has-own-property-called-on-non-object.js: Added.
+        (let.objs):
+        (new.String):
+        (foo):
+
+2016-09-20  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Add `typeof value === "symbol"` handling to bytecode compiler
+        https://bugs.webkit.org/show_bug.cgi?id=162253
+
+        Reviewed by Sam Weinig.
+
+        * microbenchmarks/is-symbol-mixed.js: Added.
+        (isSymbol):
+        (i.let.pair.of.list.String):
+        * microbenchmarks/is-symbol.js: Added.
+        (isSymbol):
+
+2016-09-19  Saam Barati  <sbarati@apple.com>
+
+        Make HasOwnProperty faster
+        https://bugs.webkit.org/show_bug.cgi?id=161708
+
+        Reviewed by Geoffrey Garen.
+
+        * microbenchmarks/has-own-property-name-cache.js: Added.
+        (foo):
+        * stress/has-own-property-cache-basics.js: Added.
+        (assert):
+        (foo):
+        * stress/has-own-property-name-cache-string-keys.js: Added.
+        (assert):
+        (foo):
+        * stress/has-own-property-name-cache-symbol-keys.js: Added.
+        (assert):
+        (foo):
+        * stress/has-own-property-name-cache-symbols-and-strings.js: Added.
+        (assert):
+        (foo):
+
+2016-09-19  Benjamin Poulain  <bpoulain@apple.com>
+
+        [JSC] Make the rounding-related nodes support any type
+        https://bugs.webkit.org/show_bug.cgi?id=161895
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/arith-ceil-on-various-types.js: Added.
+        * stress/arith-floor-on-various-types.js: Added.
+        * stress/arith-round-on-various-types.js: Added.
+        * stress/arith-trunc-on-various-types.js: Added.
+
+2016-09-18  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [JSC] Do not need to use defineProperty to define methods for object literals
+        https://bugs.webkit.org/show_bug.cgi?id=162111
+
+        Reviewed by Saam Barati.
+
+        * stress/object-literal-methods.js: Added.
+        (shouldBe):
+        (throw.new.Error.let.object.get name):
+        (throw.new.Error):
+        (shouldBe.let.object.get name):
+        (shouldBe.let.object.get prototype):
+        (shouldBe.let.object.get 42):
+
+2016-09-16  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Introduce IsCellWithType node and unify IsJSArray, IsRegExpObject and newly added IsProxyObject
+        https://bugs.webkit.org/show_bug.cgi?id=162000
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/is-array-for-array.js: Added.
+        (isArray):
+        * microbenchmarks/is-array-for-mixed-case.js: Added.
+        (isArray):
+        * microbenchmarks/is-array-for-non-array-object.js: Added.
+        (isArray):
+        * microbenchmarks/is-array-for-proxy.js: Added.
+        (isArray):
+        (isArray.proxy.throw.new.Error.isArray):
+        (isArray.proxy.throw.new.Error):
+
+2016-09-16  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, gardening test262 results
+
+        Some tests are now passed with JSC, but marked as failed.
+
+        * test262.yaml:
+
+2016-09-16  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: Various Constructors length properties should be configurable
+        https://bugs.webkit.org/show_bug.cgi?id=161998
+
+        Reviewed by Saam Barati.
+
+        * test262.yaml:
+
+2016-09-15  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r205931.
+        https://bugs.webkit.org/show_bug.cgi?id=162021
+
+        Tests for this change fail on 32-bit JSC bots (Requested by
+        ryanhaddad on #webkit).
+
+        Reverted changeset:
+
+        "[JSC] Make the rounding-related nodes support any type"
+        https://bugs.webkit.org/show_bug.cgi?id=161895
+        http://trac.webkit.org/changeset/205931
+
+2016-09-15  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: Should be a SyntaxError for duplicate parameter names in function with default parameters
+        https://bugs.webkit.org/show_bug.cgi?id=162013
+
+        Reviewed by Saam Barati.
+
+        * stress/es6-default-parameters.js:
+        * test262.yaml:
+
+2016-09-14  Joseph Pecoraro  <pecoraro@apple.com>
+
+        ASSERT_NOT_REACHED when using spread inside an array literal with Function.prototype.apply
+        https://bugs.webkit.org/show_bug.cgi?id=162003
+
+        Reviewed by Saam Barati.
+
+        * stress/spread-calling.js:
+        * test262.yaml:
+
+2016-09-14  Michael Saboff  <msaboff@apple.com>
+
+        YARR doesn't check for invalid flags for literal regular expressions
+        https://bugs.webkit.org/show_bug.cgi?id=161995
+
+        Reviewed by Mark Lam.
+
+        New test.
+
+        * stress/regress-161995.js: Added.
+        (testStatic):
+        (catch):
+
+2016-09-14  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: TypedArray constructors length should be 3 and configurable
+        https://bugs.webkit.org/show_bug.cgi?id=161955
+
+        Reviewed by Mark Lam.
+
+        * test262.yaml:
+
+2016-09-14  Benjamin Poulain  <bpoulain@apple.com>
+
+        [JSC] Make the rounding-related nodes support any type
+        https://bugs.webkit.org/show_bug.cgi?id=161895
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/arith-ceil-on-various-types.js: Added.
+        * stress/arith-floor-on-various-types.js: Added.
+        * stress/arith-round-on-various-types.js: Added.
+        * stress/arith-trunc-on-various-types.js: Added.
+
+2016-09-14  Joseph Pecoraro  <pecoraro@apple.com>
+
+        TaggedTemplateString function calls should emit tail position calls
+        https://bugs.webkit.org/show_bug.cgi?id=161948
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/tail-call-recognize.js:
+        (runTests):
+        Ensure a tagged template string function call is tail call.
+
+        * test262.yaml:
+        These now pass.
+
+2016-09-14  Joseph Pecoraro  <pecoraro@apple.com>
+
+        test262: Array.prototype.slice should always set length
+        https://bugs.webkit.org/show_bug.cgi?id=161953
+
+        Reviewed by Mark Lam.
+
+        * test262.yaml:
+
+2016-09-13  JF Bastien  <jfbastien@apple.com>
+
+        Support jsc shell builtin `read`
+        https://bugs.webkit.org/show_bug.cgi?id=161662
+
+        Reviewed by Keith Miller.
+
+        * stress/jsc-read.js: Added.
+        (test): test `read` and `readFile` shell builtins, in string and binary mode.
+
+2016-09-12  Skachkov Oleksandr  <gskachkov@gmail.com>
+
+        ES6: Classes: Should be allowed to create a static method with name "arguments"
+        https://bugs.webkit.org/show_bug.cgi?id=152985
+
+        Reviewed by Keith Miller.
+
+        * test262.yaml:
+
+2016-09-12  Saam Barati  <sbarati@apple.com>
+
+        Speed up Function.prototype.bind a bit by making it a builtin
+        https://bugs.webkit.org/show_bug.cgi?id=161879
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/function-bind-inlining.js: Added.
+        (assert):
+        (test):
+        (test2):
+        (foo):
+        * microbenchmarks/function-bind-no-inlining.js: Added.
+        (assert):
+        (test):
+        (test2):
+        (foo):
+
+2016-09-12  Saam Barati  <sbarati@apple.com>
+
+        HashMapImpl should take into account m_deleteCount in its load factor and it should be able to rehash the table to be smaller
+        https://bugs.webkit.org/show_bug.cgi?id=161640
+
+        Reviewed by Geoffrey Garen.
+
+        * microbenchmarks/map-rehash.js: Added.
+        * stress/map-delete.js: Added.
+        (assert):
+        * stress/map-rehash-2.js: Added.
+        (assert):
+        * stress/map-rehash.js: Added.
+        (assert):
+
+2016-09-12  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, fix tests for different libm environments
+        https://bugs.webkit.org/show_bug.cgi?id=161857
+
+        * stress/ftl-arithtan.js:
+
+2016-09-12  Benjamin Poulain  <bpoulain@apple.com>
+
+        [JSC] Use GetArrayLength for JSArray.length even when the array type is undecided
+        https://bugs.webkit.org/show_bug.cgi?id=161671
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/get-array-length-on-undecided.js: Added.
+
+2016-09-12  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Add ArithTan
+        https://bugs.webkit.org/show_bug.cgi?id=161857
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/tan.js: Added.
+        * stress/arith-tan-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueTanNoArgument):
+        (testNoArgument):
+        (opaqueAllTypesTan):
+        (testAllTypesCall):
+        (testTangleTypeCall):
+        (testConstant):
+        (opaqueTanForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueTanForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (opaqueTanForDCE):
+        (testDCE.let.testObject.valueOf):
+        (testDCE):
+        (testException.opaqueTanWithException):
+        (testException):
+        * stress/ftl-arithtan.js: Added.
+        (foo):
+
+2016-09-12  Saam Barati  <sbarati@apple.com>
+
+        MapHash should do constant folding when it has a constant argument and its legal to hash that value
+        https://bugs.webkit.org/show_bug.cgi?id=161639
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/map-constant-key.js: Added.
+        (assert):
+        (test):
+        (foo):
+
+2016-09-12  Michael Saboff  <msaboff@apple.com>
+
+        JSC test timeout: ChakraCore.yaml/ChakraCore/test/Bugs/bug56026_trycatch.js.default
+        https://bugs.webkit.org/show_bug.cgi?id=161863
+
+        Reviewed by Saam Barati.
+
+        * ChakraCore.yaml:
+        Disabled Bugs/bug56026_trycatch.js.
+
+2016-09-09  Michael Saboff  <msaboff@apple.com>
+
+        Unreviewed, rolling r205759 back in with a fix.
+
+        The expectation file, JSTests/ChakraCore/test/Lib/tostring.baseline-jsc,
+        should be named "toString.baseline-jsc".
+
+        * ChakraCore/test/Lib/toString.baseline-jsc: Copied from JSTests/ChakraCore/test/Lib/tostring.baseline-jsc.
+        * ChakraCore/test/Lib/tostring.baseline-jsc: Removed.
+
+2016-09-09  Michael Saboff  <msaboff@apple.com>
+
+        Disable three flakey Chakra Tests
+        https://bugs.webkit.org/show_bug.cgi?id=161807
+
+        Reviewed by Saam Barati.
+
+        * ChakraCore.yaml: Disabled the flakey tests
+        ChakraCore/test/Array/protoLookup_native.js
+        ChakraCore/test/LetConst/delete.js
+        ChakraCore/test/fieldopts/fieldhoist_sideeffect.js
+
+2016-09-08  Saam Barati  <sbarati@apple.com>
+
+        We should inline operationConvertJSValueToBoolean into JIT code
+        https://bugs.webkit.org/show_bug.cgi?id=161729
+
+        Reviewed by Filip Pizlo.
+
+        * stress/value-to-boolean.js: Added.
+        (assert):
+        (test1):
+        (test2):
+        (test3):
+
+2016-09-08  Mark Lam  <mark.lam@apple.com>
+
+        REGRESSION (r205569?): 32-bit JSC test timeout: stress/rest-parameter-many-arguments.js.dfg-maximal-flush-validate-no-cjit
+        https://bugs.webkit.org/show_bug.cgi?id=161756
+
+        Reviewed by Saam Barati.
+
+        It looks like the 32-bit JSC bot is just too slow at running this test with the
+        dfg-maximal-flush-validate-no-cjit configuration.  We'll try excluding that
+        configuration.
+
+        * stress/rest-parameter-many-arguments.js:
+
+2016-09-08  JF Bastien  <jfbastien@apple.com>
+
+        Delete older WebAssembly tests
+        https://bugs.webkit.org/show_bug.cgi?id=161758
+
+        Reviewed by Filip Pizlo.
+
+        They're not running, rely on the older polyfill prototype, and the older code was deleted in: https://trac.webkit.org/changeset/204180
+
+        * stress/wasm-arithmetic-float32.js: Removed.
+        * stress/wasm-arithmetic-float64.js: Removed.
+        * stress/wasm-arithmetic-int32.js: Removed.
+        * stress/wasm-calls.js: Removed.
+        * stress/wasm-comma.js: Removed.
+        * stress/wasm-control-flow.js: Removed.
+        * stress/wasm-globals.js: Removed.
+        * stress/wasm-linear-memory.js: Removed.
+        * stress/wasm-locals.js: Removed.
+        * stress/wasm-relational.js: Removed.
+        * stress/wasm-type-conversion.js: Removed.
+        * stress/wasm/arithmetic-float32.wasm: Removed.
+        * stress/wasm/arithmetic-float64.wasm: Removed.
+        * stress/wasm/arithmetic-int32.wasm: Removed.
+        * stress/wasm/calls.wasm: Removed.
+        * stress/wasm/comma.wasm: Removed.
+        * stress/wasm/control-flow.wasm: Removed.
+        * stress/wasm/globals.wasm: Removed.
+        * stress/wasm/linear-memory.wasm: Removed.
+        * stress/wasm/locals.wasm: Removed.
+        * stress/wasm/relational.wasm: Removed.
+        * stress/wasm/type-conversion.wasm: Removed.
+
+2016-09-08  Per Arne Vollan  <pvollan@apple.com>
+
+        [Win] Exception fuzz tests fail
+        https://bugs.webkit.org/show_bug.cgi?id=140928
+
+        Reviewed by Mark Lam.
+
+        Unskip tests.
+
+        * exceptionFuzz.yaml:
+
+2016-09-06  Saam Barati  <sbarati@apple.com>
+
+        ProxyObject's structure should not have ObjectPrototype as its prototype and it should not have special behavior for intercepting "__proto__"
+        https://bugs.webkit.org/show_bug.cgi?id=161558
+
+        Reviewed by Benjamin Poulain.
+
+        * stress/proxy-get-prototype-of.js:
+        * stress/proxy-set-prototype-of.js:
+        (let.handler.setPrototypeOf): Deleted.
+        * stress/proxy-underscore-proto.js: Added.
+        (assert):
+
+2016-09-06  Saam Barati  <sbarati@apple.com>
+
+        Make JSMap and JSSet faster
+        https://bugs.webkit.org/show_bug.cgi?id=160989
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/dense-set.js: Added.
+        (bench):
+        * microbenchmarks/large-map-iteration-with-additions.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/large-map-iteration-with-mutation.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/large-map-iteration.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/map-get-get-cse.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/map-has-get-cse-opportunity.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/sparse-set.js: Added.
+        (bench):
+        * stress/map-cse-correctness.js: Added.
+        (assert):
+        (testHas):
+        (testGet):
+        (foo):
+        * stress/map-iteration.js: Added.
+        (assert):
+        (test1):
+        (test2):
+        (test3):
+        (test4):
+        (test5):
+        (test6):
+        (test7):
+        (test8):
+        (test9):
+        (test10):
+        (test11):
+        (test12):
+        (test13):
+        (test14):
+        (test15):
+        (test16):
+        (test17):
+        (test18):
+
+2016-09-06  Benjamin Poulain  <bpoulain@apple.com>
+
+        [JSC] Make ArithClz32 work with Cell arguments
+        https://bugs.webkit.org/show_bug.cgi?id=161369
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/arith-clz32-on-various-types.js: Added.
+
+2016-09-06  Commit Queue  <commit-queue@webkit.org>
+
+        Unreviewed, rolling out r205504.
+        https://bugs.webkit.org/show_bug.cgi?id=161645
+
+        Broke the iOS device build (Requested by ryanhaddad on
+        #webkit).
+
+        Reverted changeset:
+
+        "Make JSMap and JSSet faster"
+        https://bugs.webkit.org/show_bug.cgi?id=160989
+        http://trac.webkit.org/changeset/205504
+
+2016-09-06  Saam Barati  <sbarati@apple.com>
+
+        Make JSMap and JSSet faster
+        https://bugs.webkit.org/show_bug.cgi?id=160989
+
+        Reviewed by Filip Pizlo.
+
+        * microbenchmarks/dense-set.js: Added.
+        (bench):
+        * microbenchmarks/large-map-iteration-with-additions.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/large-map-iteration-with-mutation.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/large-map-iteration.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/map-get-get-cse.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/map-has-get-cse-opportunity.js: Added.
+        (bar):
+        (foo):
+        * microbenchmarks/sparse-set.js: Added.
+        (bench):
+        * stress/map-cse-correctness.js: Added.
+        (assert):
+        (testHas):
+        (testGet):
+        (foo):
+        * stress/map-iteration.js: Added.
+        (assert):
+        (test1):
+        (test2):
+        (test3):
+        (test4):
+        (test5):
+        (test6):
+        (test7):
+        (test8):
+        (test9):
+        (test10):
+        (test11):
+        (test12):
+        (test13):
+        (test14):
+        (test15):
+        (test16):
+        (test17):
+        (test18):
+
+2016-08-31  Filip Pizlo  <fpizlo@apple.com>
+
+        Butterflies should be allocated in Auxiliary MarkedSpace instead of CopiedSpace and we should rewrite as much of the GC as needed to make this not a regression
+        https://bugs.webkit.org/show_bug.cgi?id=160125
+
+        Reviewed by Geoffrey Garen and Keith Miller.
+        
+        Most of the things I did properly covered by existing tests, but I found some simple cases of
+        unshifting that had sketchy coverage.
+
+        * stress/array-storage-array-unshift.js: Added.
+        * stress/contiguous-array-unshift.js: Added.
+        * stress/double-array-unshift.js: Added.
+        * stress/int32-array-unshift.js: Added.
+
+2016-09-02  Michael Saboff  <msaboff@apple.com>
+
+        Unreviewed fix after importing Chakra test
+
+        * ChakraCore.yaml: Skipped ChakraCore/test/UnifiedRegex/crazy.js because the original
+        test contained tab characters.  I removed the tabs before landing.  This test depended
+        on the tab characters and now fails after they were removed.
+        test.
+
+2016-09-01  Michael Saboff  <msaboff@apple.com>
+
+        Import Chakra tests to JSC
+        https://bugs.webkit.org/show_bug.cgi?id=154697
+
+        Reviewed by Saam Barati.
+
+        Added Chakra tests.  All these tests are under Chakra/test.  This is the same layout
+        for tests in the Chakra tree.
+
+        Created a ChakraCore.yaml file to be used with run-jsc-stress-tests.  This file contains
+        the tests that are run when the original Chakra runtests.py script is run.  That script
+        is the test driver for *nix platforms and does not attempt to run all tests or all
+        variations of tests.  The runtest.py driver consults rlexe.xml files in each test
+        subdirectory to determine the test to run, the options to pass to the test and how to
+        determine pass/fail of the test.  With runtests.py as the start, tests that didn't
+        pass directly where either skipped, with a message describing why or through 
+        adjustments to the test infrastructure, as described below, where made to pass.
+        
+        The only modification to the test infrastrucutre are:
+
+         1) Added simple mapping of Chakra expected exception text to JSC expected text in
+            test/UnitTestFramework/UnitTestFramework.js.  It would make sense to also
+            map some JSC specific exception text to more generic text for the cases where
+            that text contains indetifier names or other source specific strings and the
+            Chakra equivolent exception texts are generic.  
+ 
+         2) Created JSC specific expected text files where it is clear that the text work
+            as expected on JSC but the test output is different.  Typically the differences
+            fall into three categories, different exception output, different output from
+            toString() of a function, slight numeric differences, and test that rely on
+            iteration order.
+
+         3) Stripped the CR's from the CR-LF line terminations of the files.  
+
+        No actual test .js files were modified.
+
+        * ChakraCore: Added.
+        * ChakraCore.yaml: Added.
+        * ChakraCore/CONTRIBUTING.md: Added.
+        * ChakraCore/LICENSE.txt: Added.
+        * ChakraCore/README.md: Added.
+        * ChakraCore/THIRD-PARTY-NOTICES.txt: Added.
+        * ChakraCore/test: Added this directory and the tests included therein.
+
+2016-09-01  JF Bastien  <jfbastien@apple.com>
+
+        GetByIdWithThis/GetByValWithThis should have ValueProfiles so that they can predict their result types
+        https://bugs.webkit.org/show_bug.cgi?id=160922
+
+        Reviewed by Keith Miller.
+
+        Benchmark GetBy{Id,Val}WithThis in monomorphic and polymorphic uses.
+        The value profile is used by the calc functions, which do some mild math with the result.
+        These benchmarks get ~4% faster with value profiling.
+
+        * microbenchmarks/super-get-by-id-with-this-monomorphic.js: Added.
+        (A):
+        (A.prototype.set value):
+        (A.prototype.get value):
+        (B.prototype.set value):
+        (B.prototype.get value):
+        (B):
+        (const.bench):
+        * microbenchmarks/super-get-by-id-with-this-polymorphic.js: Added.
+        (A):
+        (A.prototype.set value):
+        (A.prototype.get value):
+        (B.prototype.set value):
+        (B.prototype.get value):
+        (B):
+        (const.bench):
+        * microbenchmarks/super-get-by-val-with-this-monomorphic.js: Added.
+        (value):
+        (A):
+        (A.prototype.set v):
+        (A.prototype.get v):
+        (B.prototype.set v):
+        (B.prototype.get v):
+        (B):
+        (const.bench):
+        * microbenchmarks/super-get-by-val-with-this-polymorphic.js: Added.
+        (value):
+        (A):
+        (A.prototype.set v):
+        (A.prototype.get v):
+        (B.prototype.set v):
+        (B.prototype.get v):
+        (B):
+        (const.bench):
+
+2016-09-01  Benjamin Poulain  <bpoulain@apple.com>
+
+        arith-abs-on-various-types.js is flaky
+
+        Unreviewed.
+
+        * stress/arith-abs-on-various-types.js:
+        Two compilation is too small for the worst case.
+        Math.abs() can be typed integer->number->untyped if we are very unlucky.
+
+2016-09-01  Filip Pizlo  <fpizlo@apple.com>
+
+        ObjectAllocationSinkingPhase::insertOSRHintsForUpdate() fails to emit updated hints in some cases
+        https://bugs.webkit.org/show_bug.cgi?id=161492
+
+        Reviewed by Mark Lam.
+        
+        This bug affected function->activation references but not object->object field references,
+        because object->object field references are !neededForMaterialization(). So, the object
+        test always passed but the activation/function test used to always fail. It passes now.
+
+        * stress/materialize-activation-referenced-from-phantom-function.js: Added.
+        (bar):
+        (inc):
+        (dec):
+        (foo):
+        (test):
+        * stress/materialize-object-referenced-from-phantom-object.js: Added.
+        (bar):
+        (foo):
+        (test):
+
+2016-08-31  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        stress/random-53bit.js.ftl-no-cjit-no-inline-validate sometimes fails
+        https://bugs.webkit.org/show_bug.cgi?id=161436
+
+        Reviewed by Filip Pizlo.
+
+        The test checks Math.random() correctly produces 53bit random values.
+        The test can fail by design, but this should be fairly rare.
+
+        However, when introducing, we wrap the `test()` with 1e4 to ensure the FTL compilation, and this
+        increases the failure rate. By increasing the MAX in the test, we make the failures much more rare case.
+
+        And we also add getRandomSeed() and setRandomSeed(seed) JSC shell helpers to dump more useful information
+        and reproduce the situation easily.
+
+        * stress/random-53bit.js:
+        (test):
+
+2016-08-29  Benjamin Poulain  <bpoulain@apple.com>
+
+        [JSC] Improve ArithAbs with polymorphic input
+        https://bugs.webkit.org/show_bug.cgi?id=161286
+
+        Reviewed by Saam Barati.
+
+        * stress/arith-abs-on-various-types.js: Added.
+        New tests.
+
+        * stress/arith-cos-on-various-types.js:
+        * stress/arith-fround-on-various-types.js:
+        * stress/arith-log-on-various-types.js:
+        * stress/arith-sin-on-various-types.js:
+        * stress/arith-sqrt-on-various-types.js:
+        Extend the existing tests to cover the DCE case.
+
+2016-08-26  Benjamin Poulain  <benjamin@webkit.org>
+
+        [JSC] Implement CompareStrictEq(String, Untyped) in FTL
+        https://bugs.webkit.org/show_bug.cgi?id=161229
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/compare-strict-eq-on-various-types.js: Added.
+
+2016-08-26  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [ES6] newPromiseCapabilities should check the given argument is constructor
+        https://bugs.webkit.org/show_bug.cgi?id=161226
+
+        Reviewed by Mark Lam.
+
+        The arrow function should not be a constructor. So the error should be raised.
+
+        * stress/new-promise-capabilities-requires-constructor.js: Added.
+        (shouldThrow):
+
+2016-08-25  Benjamin Poulain  <bpoulain@apple.com>
+
+        [JSC] Clean up the abstract interpreter for cos/sin/sqrt/fround/log
+        https://bugs.webkit.org/show_bug.cgi?id=161181
+
+        Reviewed by Geoffrey Garen.
+
+        Extend the tests to constants.
+        Add no-argument cases where needed.
+
+        * stress/arith-cos-on-various-types.js:
+        * stress/arith-fround-on-various-types.js:
+        * stress/arith-log-on-various-types.js:
+        * stress/arith-sin-on-various-types.js:
+        * stress/arith-sqrt-on-various-types.js:
+
+2016-08-25  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG][FTL] Implement ES6 Generators in DFG / FTL
+        https://bugs.webkit.org/show_bug.cgi?id=152723
+
+        Reviewed by Filip Pizlo.
+
+        * stress/generator-fib-ftl-and-array.js: Added.
+        (fib):
+        * stress/generator-fib-ftl-and-object.js: Added.
+        (fib):
+        * stress/generator-fib-ftl-and-string.js: Added.
+        (fib):
+        * stress/generator-fib-ftl.js: Added.
+        (fib):
+        * stress/generator-frame-empty.js: Added.
+        (shouldThrow):
+        (shouldThrow.fib):
+        * stress/generator-reduced-save-point-put-to-scope.js: Added.
+        (shouldBe):
+        (gen):
+        * stress/generator-transfer-register-beyond-mutiple-yields.js: Added.
+        (shouldBe):
+        (gen):
+
+2016-08-25  JF Bastien  <jfbastien@apple.com>
+
+        TryGetById should have a ValueProfile so that it can predict its output type
+        https://bugs.webkit.org/show_bug.cgi?id=160921
+
+        Reviewed by Saam Barati.
+
+        * microbenchmarks/try-get-by-id-basic.js: Added.
+        (const.check):
+        (const.bench.f.const.fooPlusBar.createBuiltin):
+        * microbenchmarks/try-get-by-id-polymorphic.js: Added.
+        (const.check):
+        (fooPlusBar.createBuiltin):
+        (bench):
+
+2016-08-25  Caio Lima  <ticaiolima@gmail.com>
+
+        NewRegexp should not prevent inlining
+        https://bugs.webkit.org/show_bug.cgi?id=154808
+
+        Reviewed by Geoffrey Garen.
+
+        Added test where functions with NewRegExp can be inlined right now.
+
+        * stress/new-regex-inline.js: Added.
+        (assert):
+        (testRegexpInline):
+        (toInlineGlobal):
+        (withRegexp):
+        (inlineRegexpNotGlobal):
+        (toInlineRecursive):
+        (regexpContainsRecursive):
+
+2016-08-24  Benjamin Poulain  <benjamin@webkit.org>
+
+        [JSC] Make FRound work with any type
+        https://bugs.webkit.org/show_bug.cgi?id=161129
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/arith-fround-on-various-types.js: Added.
+
+2016-08-24  Filip Pizlo  <fpizlo@apple.com>
+
+        Unreviewed, roll out r204901, r204897, r204866, r204856, r204854.
+
+        * stress/array-storage-array-unshift.js: Removed.
+        * stress/contiguous-array-unshift.js: Removed.
+        * stress/double-array-unshift.js: Removed.
+        * stress/int32-array-unshift.js: Removed.
+
+2016-08-24  Skachkov Oleksandr  <gskachkov@gmail.com>
+
+        [ES2016] Allow assignment in for-in head in not-strict mode
+        https://bugs.webkit.org/show_bug.cgi?id=160955
+
+        Reviewed by Saam Barati.
+
+        * stress/for-in-tests.js:
+        (foo):
+        (boo):
+        (catch):
+
+2016-08-23  Benjamin Poulain  <benjamin@webkit.org>
+
+        [JSC] Make ArithLog works with any type
+        https://bugs.webkit.org/show_bug.cgi?id=161110
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/arith-log-on-various-types.js: Added.
+
+2016-08-23  Saam Barati  <sbarati@apple.com>
+
+        JSC should have a "microbenchmarks" directory instead of "regress" directory
+        https://bugs.webkit.org/show_bug.cgi?id=161096
+
+        Rubber stamped by Mark Lam.
+
+        * microbenchmarks: Copied from LayoutTests/js/regress/script-tests.
+
+2016-08-23  Keith Miller  <keith_miller@apple.com>
+
+        %TypedArray%.prototype.slice needs to check that the source and destination have not been detached.
+        https://bugs.webkit.org/show_bug.cgi?id=161031
+        <rdar://problem/27937019>
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/typedarray-slice.js:
+        (get let):
+        (get try):
+        (testSpeciesWithTransferring):
+
+2016-08-22  Filip Pizlo  <fpizlo@apple.com>
+
+        Butterflies should be allocated in Auxiliary MarkedSpace instead of CopiedSpace and we should rewrite as much of the GC as needed to make this not a regression
+        https://bugs.webkit.org/show_bug.cgi?id=160125
+
+        Reviewed by Geoffrey Garen.
+        
+        Most of the things I did properly covered by existing tests, but I found some simple cases of
+        unshifting that had sketchy coverage.
+
+        * stress/array-storage-array-unshift.js: Added.
+        * stress/contiguous-array-unshift.js: Added.
+        * stress/double-array-unshift.js: Added.
+        * stress/int32-array-unshift.js: Added.
+
+2016-08-23  Keith Miller  <keith_miller@apple.com>
+
+        Update/add new test262 tests
+        https://bugs.webkit.org/show_bug.cgi?id=161098
+
+        Reviewed by Saam Barati.
+
+        * test262.yaml:
+        * test262/test/annexB/language/statements/for-in/bare-initializer.js: Added.
+        * test262/test/annexB/language/statements/for-in/const-initializer.js: Added.
+        * test262/test/annexB/language/statements/for-in/let-initializer.js: Added.
+        * test262/test/annexB/language/statements/for-in/nonstrict-initializer.js: Added.
+        (a):
+        * test262/test/annenxB/language/statements/for-in/strict-initializer.js: Added.
+        * test262/test/annexB/language/statements/for-in/var-arraybindingpattern-initializer.js: Added.
+        * test262/test/annexB/language/statements/for-in/var-objectbindingpattern-initializer.js: Added.
+        * test262/test/built-ins/AsyncFunction/AsyncFunction-construct.js: Added.
+        (AsyncFunction.async.foo):
+        * test262/test/built-ins/AsyncFunction/AsyncFunction-is-extensible.js: Added.
+        (AsyncFunction.async):
+        * test262/test/built-ins/AsyncFunction/AsyncFunction-is-subclass.js: Added.
+        (async.foo):
+        * test262/test/built-ins/AsyncFunction/AsyncFunction-length.js: Added.
+        (AsyncFunction.async.foo):
+        * test262/test/built-ins/AsyncFunction/AsyncFunction-name.js: Added.
+        (AsyncFunction.async.foo):
+        * test262/test/built-ins/AsyncFunction/AsyncFunction-prototype.js: Added.
+        (AsyncFunction.async.foo):
+        * test262/test/built-ins/AsyncFunction/AsyncFunction.js: Added.
+        (AsyncFunction.async.foo):
+        * test262/test/built-ins/AsyncFunction/AsyncFunctionPrototype-is-extensible.js: Added.
+        (AsyncFunction.async.foo):
+        * test262/test/built-ins/AsyncFunction/AsyncFunctionPrototype-prototype.js: Added.
+        (AsyncFunction.async.foo):
+        * test262/test/built-ins/AsyncFunction/AsyncFunctionPrototype-to-string.js: Added.
+        (AsyncFunction.async.foo):
+        * test262/test/built-ins/AsyncFunction/instance-construct.js: Added.
+        (async.foo):
+        * test262/test/built-ins/AsyncFunction/instance-has-name.js: Added.
+        (async.foo):
+        * test262/test/built-ins/AsyncFunction/instance-length.js: Added.
+        (async.l0):
+        (async.l1):
+        (async.l2):
+        * test262/test/built-ins/AsyncFunction/instance-prototype-property.js: Added.
+        (async.foo):
+        * test262/test/built-ins/AsyncFunction/is-not-a-global.js: Added.
+        * test262/test/built-ins/DataView/prototype/getFloat32/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/getFloat32/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/getFloat64/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/getFloat64/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/getFloat64/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/getInt16/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/getInt16/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/getInt16/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/getInt32/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/getInt32/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/getInt32/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/getInt8/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/getInt8/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/getInt8/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/getUint16/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/getUint16/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/getUint16/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/getUint32/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/getUint32/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/getUint32/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/getUint8/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/getUint8/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/getUint8/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/setFloat32/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/setFloat32/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/setFloat32/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/setFloat32/index-check-before-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setFloat32/range-check-after-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setFloat64/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/setFloat64/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/setFloat64/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/setFloat64/index-check-before-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setFloat64/range-check-after-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setInt16/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/setInt16/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/setInt16/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/setInt16/index-check-before-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setInt16/range-check-after-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setInt32/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/setInt32/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/setInt32/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/setInt32/index-check-before-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setInt32/range-check-after-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setInt8/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/setInt8/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/setInt8/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/setInt8/index-check-before-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setInt8/range-check-after-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setUint16/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/setUint16/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/setUint16/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/setUint16/index-check-before-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setUint16/range-check-after-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setUint32/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/setUint32/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/setUint32/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/setUint32/index-check-before-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setUint32/range-check-after-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setUint8/detached-buffer-after-toindex-byteoffset.js: Renamed from JSTests/test262/test/built-ins/DataView/prototype/setUint8/detached-buffer-after-integer-byteoffset.js.
+        * test262/test/built-ins/DataView/prototype/setUint8/detached-buffer-before-outofrange-byteoffset.js:
+        * test262/test/built-ins/DataView/prototype/setUint8/index-check-before-value-conversion.js:
+        * test262/test/built-ins/DataView/prototype/setUint8/range-check-after-value-conversion.js:
+        * test262/test/built-ins/Function/prototype/bind/instance-construct-newtarget-boundtarget-bound.js: Added.
+        (A):
+        * test262/test/built-ins/Function/prototype/bind/instance-construct-newtarget-boundtarget.js: Added.
+        (A):
+        * test262/test/built-ins/Function/prototype/bind/instance-construct-newtarget-self-new.js: Added.
+        (A):
+        * test262/test/built-ins/Function/prototype/bind/instance-construct-newtarget-self-reflect.js: Added.
+        (A):
+        * test262/test/built-ins/Function/prototype/toString/AsyncFunction.js: Added.
+        (async.f):
+        * test262/test/built-ins/Function/prototype/toString/async-function-declaration.js: Added.
+        (async.f):
+        * test262/test/built-ins/Function/prototype/toString/async-function-expression.js: Added.
+        (let.f.async.f):
+        * test262/test/built-ins/Function/prototype/toString/async-method.js: Added.
+        (let.f.async.f):
+        (let.g.async.string_appeared_here):
+        * test262/test/built-ins/JSON/parse/reviver-array-define-prop-err.js: Added.
+        (defineProperty):
+        * test262/test/built-ins/JSON/parse/reviver-array-delete-err.js: Added.
+        (deleteProperty):
+        * test262/test/built-ins/JSON/parse/reviver-array-length-coerce-err.js: Added.
+        (uncoercible.valueOf):
+        (get if):
+        * test262/test/built-ins/JSON/parse/reviver-array-length-get-err.js: Added.
+        (get if):
+        * test262/test/built-ins/JSON/parse/reviver-call-err.js: Added.
+        * test262/test/built-ins/JSON/parse/reviver-get-name-err.js: Added.
+        (thrower):
+        * test262/test/built-ins/JSON/parse/reviver-object-define-prop-err.js: Added.
+        (defineProperty):
+        * test262/test/built-ins/JSON/parse/reviver-object-delete-err.js: Added.
+        (deleteProperty):
+        * test262/test/built-ins/JSON/parse/reviver-object-own-keys-err.js: Added.
+        (ownKeys):
+        * test262/test/built-ins/Number/prototype/toExponential/infinity.js: Added.
+        * test262/test/built-ins/Number/prototype/toExponential/nan.js: Added.
+        * test262/test/built-ins/Number/prototype/toExponential/prop-desc.js: Added.
+        * test262/test/built-ins/Number/prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js: Added.
+        * test262/test/built-ins/Number/prototype/toExponential/return-abrupt-tointeger-fractiondigits.js: Added.
+        (fd1.valueOf):
+        (fd2.toString):
+        * test262/test/built-ins/Number/prototype/toExponential/return-values.js: Added.
+        * test262/test/built-ins/Number/prototype/toExponential/this-is-0-fractiondigits-is-0.js: Added.
+        * test262/test/built-ins/Number/prototype/toExponential/this-is-0-fractiondigits-is-not-0.js: Added.
+        * test262/test/built-ins/Number/prototype/toExponential/this-type-not-number-or-number-object.js: Added.
+        * test262/test/built-ins/Number/prototype/toExponential/tointeger-fractiondigits.js: Added.
+        * test262/test/built-ins/Number/prototype/toExponential/undefined-fractiondigits.js: Added.
+        * test262/test/built-ins/Object/getOwnPropertyDescriptors/duplicate-keys.js:
+        * test262/test/built-ins/Object/getOwnPropertyDescriptors/proxy-undefined-descriptor.js: Added.
+        (badProxyHandlers.allowProxyTraps.getOwnPropertyDescriptor):
+        (badProxyHandlers.allowProxyTraps.ownKeys):
+        * test262/test/built-ins/Proxy/setPrototypeOf/boolean-trap-result-extensible-target.js: Removed.
+        (setPrototypeOf): Deleted.
+        * test262/test/built-ins/Proxy/setPrototypeOf/internals-call-order.js: Added.
+        (target.new.Proxy.Object.create.isExtensible):
+        (target.new.Proxy.Object.create.getPrototypeOf):
+        (target.new.Proxy.Object.create):
+        (setPrototypeOf):
+        * test262/test/built-ins/Proxy/setPrototypeOf/not-extensible-target-not-same-target-prototype.js:
+        (setPrototypeOf):
+        * test262/test/built-ins/Proxy/setPrototypeOf/not-extensible-target-same-target-prototype.js:
+        (setPrototypeOf):
+        * test262/test/built-ins/Proxy/setPrototypeOf/not-extensible-trap-is-false-return-false.js: Removed.
+        (setPrototypeOf): Deleted.
+        * test262/test/built-ins/Proxy/setPrototypeOf/return-abrupt-from-get-trap.js: Added.
+        * test262/test/built-ins/Proxy/setPrototypeOf/return-abrupt-from-isextensible-target.js: Added.
+        (isExtensible):
+        (setPrototypeOf):
+        * test262/test/built-ins/Proxy/setPrototypeOf/return-abrupt-from-target-getprototypeof.js: Added.
+        (getPrototypeOf):
+        (setPrototypeOf):
+        * test262/test/built-ins/Proxy/setPrototypeOf/return-abrupt-from-trap.js: Renamed from JSTests/test262/test/built-ins/Proxy/setPrototypeOf/return-is-abrupt.js.
+        (setPrototypeOf):
+        * test262/test/built-ins/Proxy/setPrototypeOf/return-is-abrupt.js:
+        (setPrototypeOf): Deleted.
+        * test262/test/built-ins/Proxy/setPrototypeOf/toboolean-trap-result-false.js: Added.
+        (isExtensible):
+        (setPrototypeOf):
+        * test262/test/built-ins/Proxy/setPrototypeOf/toboolean-trap-result-true-target-is-extensible.js: Added.
+        (isExtensible):
+        (getPrototypeOf):
+        (setPrototypeOf):
+        * test262/test/built-ins/Proxy/setPrototypeOf/trap-is-not-callable.js:
+        * test262/test/built-ins/Proxy/setPrototypeOf/trap-is-undefined-or-null.js: Added.
+        (setPrototypeOf):
+        * test262/test/built-ins/Proxy/setPrototypeOf/trap-is-undefined.js: Removed.
+        * test262/test/built-ins/RegExp/lastIndex.js: Added.
+        * test262/test/built-ins/RegExp/prototype/global/15.10.7.2-1.js: Removed.
+        * test262/test/built-ins/RegExp/prototype/global/this-val-invalid-obj.js: Added.
+        (get Object):
+        * test262/test/built-ins/RegExp/prototype/global/this-val-non-obj.js: Added.
+        (get Object):
+        * test262/test/built-ins/RegExp/prototype/global/this-val-regexp-prototype.js: Added.
+        * test262/test/built-ins/RegExp/prototype/ignoreCase/15.10.7.3-1.js: Removed.
+        * test262/test/built-ins/RegExp/prototype/ignoreCase/this-val-invalid-obj.js: Added.
+        (get Object):
+        * test262/test/built-ins/RegExp/prototype/ignoreCase/this-val-non-obj.js: Added.
+        (get Object):
+        * test262/test/built-ins/RegExp/prototype/ignoreCase/this-val-regexp-prototype.js: Added.
+        * test262/test/built-ins/RegExp/prototype/lastIndex/15.10.7.5-1.js: Removed.
+        * test262/test/built-ins/RegExp/prototype/lastIndex/15.10.7.5-2.js: Removed.
+        * test262/test/built-ins/RegExp/prototype/lastIndex/S15.10.7.5_A8.js: Removed.
+        (__re.hasOwnProperty): Deleted.
+        (__re.propertyIsEnumerable): Deleted.
+        (count.0): Deleted.
+        * test262/test/built-ins/RegExp/prototype/lastIndex/S15.10.7.5_A9.js: Removed.
+        (__re.hasOwnProperty): Deleted.
+        (catch): Deleted.
+        * test262/test/built-ins/RegExp/prototype/multiline/15.10.7.4-1.js: Removed.
+        * test262/test/built-ins/RegExp/prototype/multiline/this-val-invalid-obj.js: Added.
+        (get Object):
+        * test262/test/built-ins/RegExp/prototype/multiline/this-val-non-obj.js: Added.
+        (get Object):
+        * test262/test/built-ins/RegExp/prototype/multiline/this-val-regexp-prototype.js: Added.
+        * test262/test/built-ins/RegExp/prototype/no-regexp-matcher.js: Added.
+        * test262/test/built-ins/RegExp/prototype/source/15.10.7.1-1.js: Removed.
+        * test262/test/built-ins/RegExp/prototype/source/this-val-invalid-obj.js: Added.
+        (get Object):
+        * test262/test/built-ins/RegExp/prototype/source/this-val-non-obj.js: Added.
+        (get Object):
+        * test262/test/built-ins/RegExp/prototype/source/this-val-regexp-prototype.js: Added.
+        * test262/test/built-ins/RegExp/prototype/source/value-empty.js: Added.
+        * test262/test/built-ins/RegExp/prototype/source/value-line-terminator.js: Added.
+        * test262/test/built-ins/RegExp/prototype/source/value-u.js: Added.
+        * test262/test/built-ins/RegExp/prototype/source/value.js: Added.
+        * test262/test/built-ins/RegExp/prototype/sticky/this-val-invalid-obj.js: Renamed from JSTests/test262/test/built-ins/RegExp/prototype/sticky/this-invalid-obj.js.
+        * test262/test/built-ins/RegExp/prototype/sticky/this-val-non-obj.js: Renamed from JSTests/test262/test/built-ins/RegExp/prototype/sticky/this-non-obj.js.
+        * test262/test/built-ins/RegExp/prototype/sticky/this-val-regexp-prototype.js: Added.
+        * test262/test/built-ins/RegExp/prototype/sticky/this-val-regexp.js: Renamed from JSTests/test262/test/built-ins/RegExp/prototype/sticky/this-regexp.js.
+        * test262/test/built-ins/RegExp/prototype/unicode/this-val-invalid-obj.js: Renamed from JSTests/test262/test/built-ins/RegExp/prototype/unicode/this-invald-obj.js.
+        * test262/test/built-ins/RegExp/prototype/unicode/this-val-non-obj.js: Renamed from JSTests/test262/test/built-ins/RegExp/prototype/unicode/this-non-obj.js.
+        * test262/test/built-ins/RegExp/prototype/unicode/this-val-regexp-prototype.js: Added.
+        * test262/test/built-ins/RegExp/prototype/unicode/this-val-regexp.js: Renamed from JSTests/test262/test/built-ins/RegExp/prototype/unicode/this-regexp.js.
+        * test262/test/built-ins/String/numeric-properties.js: Added.
+        * test262/test/intl402/DateTimeFormat/prototype/formatToParts/date-is-infinity-throws.js: Added.
+        * test262/test/intl402/DateTimeFormat/prototype/formatToParts/date-is-nan-throws.js: Added.
+        * test262/test/intl402/DateTimeFormat/prototype/formatToParts/formatToParts.js: Added.
+        * test262/test/intl402/DateTimeFormat/prototype/formatToParts/length.js: Added.
+        * test262/test/intl402/DateTimeFormat/prototype/formatToParts/main.js: Added.
+        (reduce):
+        (compareFTPtoFormat):
+        * test262/test/intl402/DateTimeFormat/prototype/formatToParts/name.js: Added.
+        * test262/test/intl402/DateTimeFormat/prototype/formatToParts/return-abrupt-tonumber-date.js: Added.
+        (obj1.valueOf):
+        (obj2.toString):
+        * test262/test/intl402/DateTimeFormat/prototype/formatToParts/this-has-not-internal-throws.js: Added.
+        * test262/test/intl402/DateTimeFormat/prototype/formatToParts/this-is-not-object-throws.js: Added.
+        * test262/test/intl402/NumberFormat/prototype/formatToParts/formatToParts.js: Added.
+        * test262/test/intl402/NumberFormat/prototype/formatToParts/length.js: Added.
+        * test262/test/intl402/NumberFormat/prototype/formatToParts/main.js: Added.
+        (reduce):
+        (compareFTPtoFormat):
+        * test262/test/intl402/NumberFormat/prototype/formatToParts/name.js: Added.
+        * test262/test/intl402/NumberFormat/prototype/formatToParts/return-abrupt-tonumber.js: Added.
+        (obj1.valueOf):
+        (obj2.toString):
+        * test262/test/intl402/NumberFormat/prototype/formatToParts/this-has-not-internal-throws.js: Added.
+        * test262/test/intl402/NumberFormat/prototype/formatToParts/this-is-not-object-throws.js: Added.
+        * test262/test/language/arguments-object/10.6-10-c-ii-2-s.js:
+        (foo): Deleted.
+        * test262/test/language/arguments-object/unmapped/via-params-dflt.js: Added.
+        (dflt):
+        * test262/test/language/arguments-object/unmapped/via-params-dstr.js: Added.
+        (dstr):
+        * test262/test/language/arguments-object/unmapped/via-params-rest.js: Added.
+        (rest):
+        * test262/test/language/arguments-object/unmapped/via-strict.js: Renamed from JSTests/test262/test/language/arguments-object/10.6-10-c-ii-2-s.js.
+        (foo):
+        * test262/test/language/block-scope/syntax/redeclaration-global/allowed-to-redeclare-function-declaration-with-function-declaration.js:
+        (f): Deleted.
+        * test262/test/language/eval-code/direct/super-call-arrow.js: Added.
+        (catch):
+        * test262/test/language/eval-code/direct/super-call-fn.js: Added.
+        (f):
+        * test262/test/language/eval-code/direct/super-call.js: Added.
+        (catch):
+        * test262/test/language/eval-code/direct/super-prop-arrow.js: Added.
+        (catch):
+        * test262/test/language/eval-code/direct/super-prop-method.js: Added.
+        (o.method):
+        * test262/test/language/eval-code/direct/super-prop.js: Added.
+        (catch):
+        * test262/test/language/eval-code/indirect/super-call.js: Added.
+        (catch):
+        (try.m):
+        * test262/test/language/eval-code/indirect/super-prop.js: Added.
+        (catch):
+        (try.m):
+        * test262/test/language/expressions/arrow-function/params-trailing-comma-length.js: Added.
+        (assert.sameValue):
+        * test262/test/language/expressions/arrow-function/params-trailing-comma.js: Added.
+        * test262/test/language/expressions/async-arrow-function/arrow-returns-promise.js: Added.
+        (p.then):
+        * test262/test/language/expressions/async-arrow-function/early-errors-arrow-NSPL-with-USD.js: Added.
+        (async):
+        * test262/test/language/expressions/async-arrow-function/early-errors-arrow-arguments-in-formal-parameters.js: Added.
+        (async):
+        * test262/test/language/expressions/async-arrow-function/early-errors-arrow-await-in-formals-default.js: Added.
+        (async):
+        * test262/test/language/expressions/async-arrow-function/early-errors-arrow-await-in-formals.js: Added.
+        (async):
+        * test262/test/language/expressions/async-arrow-function/early-errors-arrow-body-contains-super-call.js: Added.
+        (async):
+        * test262/test/language/expressions/async-arrow-function/early-errors-arrow-body-contains-super-property.js: Added.
+        (async):
+        * test262/test/language/expressions/async-arrow-function/early-errors-arrow-duplicate-parameters.js: Added.
+        (async):
+        * test262/test/language/expressions/async-arrow-function/early-errors-arrow-eval-in-formal-parameters.js: Added.
+        (async):
+        * test262/test/language/expressions/async-arrow-function/early-errors-arrow-formals-body-duplicate.js: Added.
+        (async):
+        * test262/test/language/expressions/async-arrow-function/early-errors-arrow-formals-contains-super-call.js: Added.
+        (async.foo.super):
+        * test262/test/language/expressions/async-arrow-function/early-errors-arrow-formals-contains-super-property.js: Added.
+        (async):
+        * test262/test/language/expressions/async-function/early-errors-expression-NSPL-with-USD.js: Added.
+        (async):
+        * test262/test/language/expressions/async-function/early-errors-expression-binding-identifier-arguments.js: Added.
+        (async.arguments):
+        * test262/test/language/expressions/async-function/early-errors-expression-binding-identifier-eval.js: Added.
+        (async.eval):
+        * test262/test/language/expressions/async-function/early-errors-expression-body-contains-super-call.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/async-function/early-errors-expression-body-contains-super-property.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/async-function/early-errors-expression-eval-in-formal-parameters.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/async-function/early-errors-expression-formals-body-duplicate.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/async-function/early-errors-expression-formals-contains-super-call.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/async-function/early-errors-expression-formals-contains-super-property.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/async-function/early-errors-expression-not-simple-assignment-target.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/async-function/expression-returns-promise.js: Added.
+        (p.async):
+        * test262/test/language/expressions/async-function/syntax-expression-is-PrimaryExpression.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/await/await-BindingIdentifier-in-global.js: Added.
+        (async.await):
+        * test262/test/language/expressions/await/await-BindingIdentifier-nested.js: Added.
+        (async.foo.await):
+        (async.foo):
+        * test262/test/language/expressions/await/await-awaits-thenable-not-callable.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/await/await-awaits-thenables-that-throw.js: Added.
+        (thenable.then):
+        (async.foo):
+        * test262/test/language/expressions/await/await-awaits-thenables.js: Added.
+        (thenable.then):
+        (async.foo):
+        * test262/test/language/expressions/await/await-in-function.js: Added.
+        (foo):
+        * test262/test/language/expressions/await/await-in-generator.js: Added.
+        (foo):
+        * test262/test/language/expressions/await/await-in-global.js: Added.
+        * test262/test/language/expressions/await/await-in-nested-function.js: Added.
+        (async.foo.bar):
+        (async.foo):
+        * test262/test/language/expressions/await/await-in-nested-generator.js: Added.
+        (async.foo.bar):
+        (async.foo):
+        * test262/test/language/expressions/await/await-throws-rejections.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/await/early-errors-await-not-simple-assignment-target.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/await/no-operand.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/await/syntax-await-has-UnaryExpression-with-MultiplicativeExpression.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/await/syntax-await-has-UnaryExpression.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/call/trailing-comma.js: Added.
+        (foo):
+        * test262/test/language/expressions/function/arguments-with-arguments-fn.js: Added.
+        (f):
+        * test262/test/language/expressions/function/arguments-with-arguments-lex.js: Added.
+        (f):
+        * test262/test/language/expressions/function/params-trailing-comma-arguments.js: Added.
+        (f1):
+        (f2):
+        * test262/test/language/expressions/function/params-trailing-comma-length.js: Added.
+        (assert.sameValue):
+        * test262/test/language/expressions/function/params-trailing-comma.js: Added.
+        * test262/test/language/expressions/generators/arguments-with-arguments-fn.js: Added.
+        (g):
+        * test262/test/language/expressions/generators/arguments-with-arguments-lex.js: Added.
+        (g):
+        * test262/test/language/expressions/generators/params-trailing-comma-arguments.js: Added.
+        (f1):
+        (f2):
+        * test262/test/language/expressions/generators/params-trailing-comma-length.js: Added.
+        (assert.sameValue):
+        * test262/test/language/expressions/generators/params-trailing-comma.js: Added.
+        * test262/test/language/expressions/object/computed-property-evaluation-order.js: Added.
+        * test262/test/language/expressions/object/method-definition/async-super-call-body.js: Added.
+        (sup.method):
+        (child.async.method):
+        * test262/test/language/expressions/object/method-definition/async-super-call-param.js: Added.
+        (sup.method):
+        (child.async.method.x.super.method):
+        * test262/test/language/expressions/object/method-definition/early-errors-object-method-NSPL-with-USD.js: Added.
+        (foo):
+        * test262/test/language/expressions/object/method-definition/early-errors-object-method-arguments-in-formal-parameters.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/object/method-definition/early-errors-object-method-await-in-formals-default.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/object/method-definition/early-errors-object-method-await-in-formals.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/object/method-definition/early-errors-object-method-body-contains-super-call.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/object/method-definition/early-errors-object-method-duplicate-parameters.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/object/method-definition/early-errors-object-method-eval-in-formal-parameters.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/object/method-definition/early-errors-object-method-formals-body-duplicate.js: Added.
+        (async.foo):
+        * test262/test/language/expressions/object/method-definition/early-errors-object-method-formals-contains-super-call.js: Added.
+        (async.foo.foo.super):
+        * test262/test/language/expressions/object/method-definition/object-method-returns-promise.js: Added.
+        (obj.async.method):
+        * test262/test/language/expressions/object/method-definition/params-trailing-comma-arguments.js: Added.
+        (obj.f1):
+        (obj.f2):
+        * test262/test/language/expressions/object/method-definition/params-trailing-comma-length.js: Added.
+        (obj.one):
+        (obj.two):
+        * test262/test/language/expressions/object/method-definition/params-trailing-comma-rest.js: Added.
+        (m):
+        * test262/test/language/expressions/object/method-definition/params-trailing-comma.js: Added.
+        (one):
+        (two):
+        * test262/test/language/global-code/decl-func-dup.js: Renamed from JSTests/test262/test/language/block-scope/syntax/redeclaration-global/allowed-to-redeclare-function-declaration-with-function-declaration.js.
+        (f):
+        * test262/test/language/global-code/decl-func.js: Added.
+        (brandNew):
+        * test262/test/language/global-code/decl-lex-configurable-global.js: Added.
+        * test262/test/language/global-code/decl-lex-deletion.js: Added.
+        (test262class):
+        * test262/test/language/global-code/decl-lex-restricted-global.js: Added.
+        * test262/test/language/global-code/decl-lex.js: Added.
+        (test262class):
+        * test262/test/language/global-code/decl-var.js: Added.
+        * test262/test/language/global-code/return.js: Added.
+        * test262/test/language/global-code/script-decl-func-dups.js: Added.
+        * test262/test/language/global-code/script-decl-func-err-non-configurable.js: Added.
+        * test262/test/language/global-code/script-decl-func-err-non-extensible.js: Added.
+        * test262/test/language/global-code/script-decl-func.js: Added.
+        * test262/test/language/global-code/script-decl-lex-deletion.js: Added.
+        * test262/test/language/global-code/script-decl-lex-lex.js: Added.
+        (test262Class):
+        * test262/test/language/global-code/script-decl-lex-restricted-global.js: Added.
+        * test262/test/language/global-code/script-decl-lex-var.js: Added.
+        (test262Fn):
+        * test262/test/language/global-code/script-decl-lex.js: Added.
+        * test262/test/language/global-code/script-decl-var-collision.js: Added.
+        (test262Class):
+        * test262/test/language/global-code/script-decl-var-err.js: Added.
+        * test262/test/language/global-code/script-decl-var.js: Added.
+        * test262/test/language/global-code/super-call-arrow.js: Added.
+        * test262/test/language/global-code/super-call.js: Added.
+        * test262/test/language/global-code/super-prop-arrow.js: Added.
+        * test262/test/language/global-code/super-prop.js: Added.
+        * test262/test/language/global-code/yield-non-strict.js: Added.
+        (catch):
+        * test262/test/language/global-code/yield-strict.js: Added.
+        * test262/test/language/literals/regexp/lastIndex.js: Added.
+        * test262/test/language/literals/regexp/u-unicode-esc-bounds.js:
+        * test262/test/language/literals/regexp/y-assertion-start.js: Added.
+        * test262/test/language/module-code/instn-star-err-not-found-faulty_FIXTURE.js:
+        * test262/test/language/module-code/instn-star-err-not-found.js:
+        * test262/test/language/module-code/namespace/internals/get-own-property-str-found-init.js:
+        * test262/test/language/module-code/parse-err-return.js: Added.
+        * test262/test/language/module-code/parse-err-yield.js: Added.
+        * test262/test/language/rest-parameters/params-trailing-comma-rest.js: Added.
+        * test262/test/language/statements/async-function/declaration-returns-promise.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-declaration-NSPL-with-USD.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-declaration-arguments-in-formal-parameters.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-declaration-await-in-formals-default.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-declaration-await-in-formals.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-declaration-binding-identifier-arguments.js: Added.
+        (async.arguments):
+        * test262/test/language/statements/async-function/early-errors-declaration-binding-identifier-eval.js: Added.
+        (async.eval):
+        * test262/test/language/statements/async-function/early-errors-declaration-body-contains-super-call.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-declaration-body-contains-super-property.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-declaration-duplicate-parameters.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-declaration-eval-in-formal-parameters.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-declaration-formals-body-duplicate.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-declaration-formals-contains-super-call.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-declaration-formals-contains-super-property.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/early-errors-no-async-generator.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/evaluation-body-that-returns-after-await.js: Added.
+        (async.foo):
+        (foo.then):
+        * test262/test/language/statements/async-function/evaluation-body-that-returns.js: Added.
+        (async.foo):
+        (foo.then):
+        * test262/test/language/statements/async-function/evaluation-body-that-throws-after-await.js: Added.
+        (async.foo):
+        (foo.then):
+        * test262/test/language/statements/async-function/evaluation-body-that-throws.js: Added.
+        (async.foo):
+        (foo.then):
+        * test262/test/language/statements/async-function/evaluation-body.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/evaluation-default-that-throws.js: Added.
+        (async.foo):
+        (foo.then):
+        * test262/test/language/statements/async-function/evaluation-mapped-arguments.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/evaluation-this-value-global.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/evaluation-this-value-passed.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/evaluation-unmapped-arguments.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/syntax-declaration-line-terminators-allowed.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/syntax-declaration-no-line-terminator.js: Added.
+        (async.foo):
+        * test262/test/language/statements/async-function/syntax-declaration.js: Added.
+        (async.foo):
+        (foo.then):
+        * test262/test/language/statements/class/definition/class-method-returns-promise.js: Added.
+        (Foo.prototype.async.method):
+        (Foo):
+        * test262/test/language/statements/class/definition/early-errors-class-method-NSPL-with-USD.js: Added.
+        (Foo.prototype.async.bar):
+        (Foo):
+        * test262/test/language/statements/class/definition/early-errors-class-method-arguments-in-formal-parameters.js: Added.
+        (Foo.prototype.async.foo):
+        (Foo):
+        * test262/test/language/statements/class/definition/early-errors-class-method-await-in-formals-default.js: Added.
+        (Foo.prototype.async.foo):
+        (Foo):
+        * test262/test/language/statements/class/definition/early-errors-class-method-await-in-formals.js: Added.
+        (Foo.prototype.async.foo):
+        (Foo):
+        * test262/test/language/statements/class/definition/early-errors-class-method-body-contains-super-call.js: Added.
+        (Foo.prototype.async.foo):
+        (Foo):
+        * test262/test/language/statements/class/definition/early-errors-class-method-duplicate-parameters.js: Added.
+        (Foo.prototype.async.foo):
+        (Foo):
+        * test262/test/language/statements/class/definition/early-errors-class-method-eval-in-formal-parameters.js: Added.
+        (Foo.prototype.async.foo):
+        (Foo):
+        * test262/test/language/statements/class/definition/early-errors-class-method-formals-body-duplicate.js: Added.
+        (Foo.async.foo):
+        (Foo):
+        * test262/test/language/statements/class/definition/early-errors-class-method-formals-contains-super-call.js: Added.
+        (Foo.prototype.async.foo):
+        (Foo):
+        * test262/test/language/statements/class/definition/methods-async-super-call-body.js: Added.
+        (A.prototype.async.method):
+        (A):
+        (B.prototype.async.method):
+        (B):
+        * test262/test/language/statements/class/definition/methods-async-super-call-param.js: Added.
+        (A.prototype.async.method):
+        (A):
+        (B.prototype.async.method):
+        (B):
+        * test262/test/language/statements/class/definition/params-trailing-comma-arguments.js: Added.
+        (C.prototype.f1):
+        (C.prototype.f2):
+        (C):
+        * test262/test/language/statements/class/definition/params-trailing-comma-length.js: Added.
+        (C.prototype.one):
+        (C.prototype.two):
+        (C):
+        * test262/test/language/statements/class/definition/params-trailing-comma-rest.js: Added.
+        (C.prototype.m):
+        (C):
+        * test262/test/language/statements/class/definition/params-trailing-comma.js: Added.
+        (C.prototype.one):
+        (C.prototype.two):
+        (C):
+        * test262/test/language/statements/function/arguments-with-arguments-fn.js: Added.
+        (f):
+        * test262/test/language/statements/function/arguments-with-arguments-lex.js: Added.
+        (f):
+        * test262/test/language/statements/function/params-trailing-comma-arguments.js: Added.
+        (f1):
+        (f2):
+        * test262/test/language/statements/function/params-trailing-comma-length.js: Added.
+        (one):
+        (two):
+        * test262/test/language/statements/function/params-trailing-comma.js: Added.
+        (one):
+        (two):
+        * test262/test/language/statements/generators/arguments-with-arguments-fn.js: Added.
+        (g):
+        * test262/test/language/statements/generators/arguments-with-arguments-lex.js: Added.
+        (g):
+        * test262/test/language/statements/generators/params-trailing-comma-length.js: Added.
+        (one):
+        (two):
+        * test262/test/language/statements/generators/params-trailing-comma.js: Added.
+        (one):
+        (two):
+        * test262/test262-Revision.txt:
+
+2016-08-23  Benjamin Poulain  <bpoulain@apple.com>
+
+        [JSC] Make Math.cos() and Math.sin() work with any argument type
+        https://bugs.webkit.org/show_bug.cgi?id=161069
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/arith-cos-on-various-types.js: Added.
+        * stress/arith-sin-on-various-types.js: Added.
+
+2016-08-23  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [ES6] Module namespace object's Symbol.iterator method should only accept module namespace objects
+        https://bugs.webkit.org/show_bug.cgi?id=161097
+
+        Reviewed by Keith Miller.
+
+        * test262.yaml:
+
+2016-08-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [ES6] Modules' `export default function/class` should be declaration
+        https://bugs.webkit.org/show_bug.cgi?id=160499
+
+        Reviewed by Saam Barati.
+
+        Add several module tests. And flip the failed tests flags in test262.
+
+        * modules/export-default-function-name-in-assignment-expression.js: Added.
+        (export.default):
+        * modules/export-default-function-name-in-class-declaration.js: Added.
+        * modules/export-default-function-name-in-function-declaration.js: Added.
+        (export.default):
+        * modules/export-default-function-name-in-generator-declaration.js: Added.
+        (export.default):
+        * stress/method-name.js: Added.
+        (testSyntax):
+        (testSyntaxError):
+        (testSyntaxError.Hello.prototype.hello.hello):
+        (testSyntaxError.Hello):
+        (SyntaxError.Unexpected.identifier.string_appeared_here.Expected.an.opening.string_appeared_here.before.a.method.testSyntaxError.let.obj.hello.hello):
+        (testSyntaxError.Hello.prototype.get hello):
+        (testSyntaxError.Hello.prototype.set hello):
+        * test262.yaml:
+
+2016-08-22  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [ES6] Module should not allow HTML comments
+        https://bugs.webkit.org/show_bug.cgi?id=161041
+
+        Reviewed by Saam Barati.
+
+        * modules/html-comments.js: Added.
+        (shouldThrow):
+        * test262.yaml:
+
+2016-08-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Should not fixup AnyIntUse in 32_64
+        https://bugs.webkit.org/show_bug.cgi?id=161029
+
+        Reviewed by Saam Barati.
+
+        * typeProfiler/int52-dfg.js: Added.
+        (test):
+
+2016-08-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        Unreviewed, rolling out r204697
+        https://bugs.webkit.org/show_bug.cgi?id=161029
+
+        * typeProfiler/int52-dfg.js: Removed.
+        (test): Deleted.
+        * typeProfiler/number-filter-dfg.js: Removed.
+        (test): Deleted.
+
+2016-08-21  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [DFG] Should not fixup AnyIntUse in 32_64
+        https://bugs.webkit.org/show_bug.cgi?id=161029
+
+        Reviewed by Saam Barati.
+
+        * typeProfiler/int52-dfg.js: Added.
+        (test):
+        * typeProfiler/number-filter-dfg.js: Added.
+        (test):
+
+2016-08-19  Benjamin Poulain  <bpoulain@apple.com>
+
+        [JSC] ArithSqrt should work with any argument type
+        https://bugs.webkit.org/show_bug.cgi?id=160954
+
+        Reviewed by Saam Barati.
+
+        * stress/arith-sqrt-on-various-types.js: Added.
+        (let.validInputTypedTestCases.validInputTestCases.map):
+        (isIdentical):
+        (opaqueAllTypesSqrt):
+        (testAllTypesCall):
+        (testSingleTypeCall):
+        (opaqueSqrtForSideEffects):
+        (testSideEffect.let.testObject.valueOf):
+        (testSideEffect):
+        (opaqueSqrtForCSE):
+        (testCSE.let.testObject.valueOf):
+        (testCSE):
+        (testException.opaqueSqrtWithException):
+        (testException):
+
+2016-08-19  Joseph Pecoraro  <pecoraro@apple.com>
+
+        Make custom Error properties (line, column, sourceURL) configurable and writable
+        https://bugs.webkit.org/show_bug.cgi?id=160984
+        <rdar://problem/27905979>
+
+        Reviewed by Saam Barati.
+
+        * stress/native-error-properties.js: Added.
+        (assert):
+        (shouldNotThrow):
+
+        (checkEmptyErrorPropertiesDescriptors):
+        (checkNonEmptyErrorPropertiesDescriptors):
+        The spec only describes the "message" property, so
+        ensure it has the right descriptor attributes.
+
+        (checkErrorPropertiesWritable):
+        Ensure common error property names are writable.
+        In strict mode this would have thrown an exception
+        if they were readonly.
+
+2016-08-18  Mark Lam  <mark.lam@apple.com>
+
+        ScopedArguments is using the wrong owner object for a write barrier.
+        https://bugs.webkit.org/show_bug.cgi?id=160976
+        <rdar://problem/27328506>
+
+        Reviewed by Keith Miller.
+
+        * stress/scoped-arguments-write-barrier-should-be-on-scope-object.js: Added.
+
+2016-08-17  JF Bastien  <jfbastien@apple.com>
+
+        We allow assignments to const variables when in a for-in/for-of loop
+        https://bugs.webkit.org/show_bug.cgi?id=156673
+
+        Reviewed by Filip Pizlo.
+
+        * stress/for-in-of-const.js: Added.
+        (expect_nothrow):
+        (expect_throw):
+        (capture):
+
+2016-08-17  Mark Lam  <mark.lam@apple.com>
+
+        Remove an invalid assertion in the DFG backend's GetById emitter.
+        https://bugs.webkit.org/show_bug.cgi?id=160925
+        <rdar://problem/27248961>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/dfg-get-by-id-should-not-assert-non-null-prediction.js: Added.
+
+2016-08-16  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Unreviewed, rolling out r204464.
+
+        This is no longer needed after r204495.
+
+        Reverted changeset:
+
+        "Skip failing test mozilla/ecma/LexicalConventions/7.7.3.js"
+        https://bugs.webkit.org/show_bug.cgi?id=160662
+        http://trac.webkit.org/changeset/204464
+
+2016-08-15  Ryan Haddad  <ryanhaddad@apple.com>
+
+        Skip failing test mozilla/ecma/LexicalConventions/7.7.3.js
+        https://bugs.webkit.org/show_bug.cgi?id=160662
+
+        Unreviewed test gardening.
+
+        * mozilla/ecma/LexicalConventions/7.7.3.js:
+
+2016-08-14  Skachkov Oleksandr  <gskachkov@gmail.com>
+
+        [2016] Set correct status for test262 after implementation of Object.values&Object.entries
+        https://bugs.webkit.org/show_bug.cgi?id=160844
+
+        Reviewed by Saam Barati.
+
+        Patch contains fix statuses of specs in the test262 test collection after implementation of 
+        Object.values and Object.entries functions. Also patch contains small fixes in tests of the 
+        tests for Object.values/entries functions.
+
+        * stress/object-entries.js:
+        (Object.getOwnPropertyDescriptor):
+        * stress/object-values.js:
+        (Object.getOwnPropertyDescriptor):
+        * test262.yaml:
+
+2016-08-12  Saam Barati  <sbarati@apple.com>
+
+        Inline store loop for CopyRest in DFG and FTL for certain array modes
+        https://bugs.webkit.org/show_bug.cgi?id=159612
+
+        Reviewed by Filip Pizlo.
+
+        * stress/rest-parameter-having-a-bad-time.js: Added.
+        * stress/rest-parameter-many-arguments.js: Added.
+        * stress/rest-parameter-various-types.js: Added.
+
+2016-08-12  Skachkov Oleksandr  <gskachkov@gmail.com>
+
+        [ES2016] Implement Object.entries
+        https://bugs.webkit.org/show_bug.cgi?id=160412
+
+        Reviewed by Saam Barati.
+
+        Patch contains tests for Object.entries function and 
+        fix of wrong tests for Object.values function.
+
+        * stress/object-entries.js: 
+        (compare):
+        (string_appeared_here.forEach):
+        (const.getInvokedFunctions.):
+        (const.getInvokedFunctions):
+        (Array.prototype.push):
+        * stress/object-values.js:
+
+2016-08-11  Mark Lam  <mark.lam@apple.com>
+
+        OverridesHasInstance should not branch across register allocations.
+        https://bugs.webkit.org/show_bug.cgi?id=160792
+        <rdar://problem/27361778>
+
+        Reviewed by Benjamin Poulain.
+
+        * stress/OverrideHasInstance-should-not-branch-across-register-allocations.js: Added.
+
+2016-08-11  Mark Lam  <mark.lam@apple.com>
+
+        The jsc shell's Element host constructor should throw if it fails to construct an object.
+        https://bugs.webkit.org/show_bug.cgi?id=160773
+        <rdar://problem/27328608>
+
+        Reviewed by Saam Barati.
+
+        * stress/generational-opaque-roots.js:
+
+2016-08-11  Mark Lam  <mark.lam@apple.com>
+
+        Disallow synchronous sweeping for eden GCs.
+        https://bugs.webkit.org/show_bug.cgi?id=160716
+
+        Reviewed by Geoffrey Garen.
+
+        * stress/eden-gc-with-retired-blocks.js: Added.
+        - This test is just in case we add back support for eden GCs with synchronous
+          sweeping in the future.
+
+2016-08-10  Michael Saboff  <msaboff@apple.com>
+
+        Baseline GetByVal and PutByVal for cache ID stubs need to handle exceptions
+        https://bugs.webkit.org/show_bug.cgi?id=160749
+
+        Reviewed by Filip Pizlo.
+
+        New test that causes baseline GetByValWithCachedId and PutByValWithCachedId
+        stubs to be generated and then throws exceptions for those stub to handle
+        to verify that they are properly handled.
+
+        * stress/regress-160749.js: Added.
+        (testCachedGetByVal.):
+        (testCachedGetByVal.get for):
+        (testCachedGetByVal):
+        (testCachedPutByVal.):
+        (testCachedPutByVal.set for):
+        (testCachedPutByVal):
+
+2016-08-10  Mark Lam  <mark.lam@apple.com>
+
+        DFG's flushForTerminal() needs to add PhantomLocals for bytecode live locals.
+        https://bugs.webkit.org/show_bug.cgi?id=160755
+        <rdar://problem/27488507>
+
+        Reviewed by Filip Pizlo.
+
+        * stress/need-bytecode-liveness-for-unreachable-blocks-at-dfg-time.js: Added.
+
+2016-08-09  Skachkov Oleksandr  <gskachkov@gmail.com>
+
+        [ES2016] Implement Object.values
+        https://bugs.webkit.org/show_bug.cgi?id=160410
+
+        Reviewed by Saam Barati, Yusuke Suzuki.
+
+        * stress/object-values.js: Added.
+        (compare):
+        (string_appeared_here.forEach):
+        (const.getInvokedFunctions.):
+        (const.getInvokedFunctions):
+        (Array.prototype.push):
+
+2016-08-09  Saam Barati  <sbarati@apple.com>
+
+        JSBoundFunction should lazily generate its name string
+        https://bugs.webkit.org/show_bug.cgi?id=160678
+        <rdar://problem/27043194>
+
+        Reviewed by Mark Lam.
+
+        * stress/bound-function-lazy-name-generation.js: Added.
+        (assert):
+        (test.let.f):
+        (test.f):
+        (test):
+
+2016-08-08  Mark Lam  <mark.lam@apple.com>
+
+        ASSERTION FAILED: hasInlineStorage() in JSFinalObject::visitChildren().
+        https://bugs.webkit.org/show_bug.cgi?id=160666
+
+        Reviewed by Keith Miller.
+
+        * stress/object-constructor-should-be-new-target-aware.js:
+
+2016-08-07  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [ES6] Module namespace object should not allow unset IC
+        https://bugs.webkit.org/show_bug.cgi?id=160553
+
+        Reviewed by Saam Barati.
+
+        * modules/namespace-object-get-property.js: Added.
+        (import.as.ns.from.string_appeared_here.shouldThrow):
+        * modules/namespace-object-has-property.js: Added.
+        * modules/namespace-object-inline-caching.js: Added.
+        (import.as.A.from.string_appeared_here.import.as.B.from.string_appeared_here.lookup):
+        (shouldBe.lookup.lookup):
+        (shouldBe.lookup):
+        * modules/namespace-object-inline-caching/a.js: Added.
+        * modules/namespace-object-inline-caching/b.js: Added.
+        * modules/namespace-object-try-get.js: Added.
+        (import.as.ns.from.string_appeared_here.tryGetByIdText):
+        (tryGetByIdTextStrict):
+        * modules/namespace-object-typed-array-fast-path.js: Added.
+        * test262.yaml:
+
+2016-08-05  Saam Barati  <sbarati@apple.com>
+
+        various math operations don't properly check for an exception after calling toNumber() on the lhs
+        https://bugs.webkit.org/show_bug.cgi?id=160154
+
+        Reviewed by Mark Lam.
+
+        * stress/to-number-throws-correct-exception.js: Added.
+        (test.let.test.runTest.):
+        (test.let.test.runTest.get f):
+        (test.let.test.runTest):
+        (test.let.test):
+        (test):
+        (test2.runTest.):
+        (test2.runTest.get f):
+        (test2.runTest):
+        (test2):
+
+2016-08-05  Saam Barati  <sbarati@apple.com>
+
+        Assertion failure when accessing TDZ variable in catch through eval
+        https://bugs.webkit.org/show_bug.cgi?id=160554
+
+        Reviewed by Mark Lam and Keith Miller.
+
+        * stress/catch-variables-under-tdz.js: Added.
+        (test):
+
+2016-08-04  Yusuke Suzuki  <utatane.tea@gmail.com>
+
+        [ES6] JSModuleNamespaceObject's Symbol.iterator function should have name
+        https://bugs.webkit.org/show_bug.cgi?id=160549
+
+        Reviewed by Saam Barati.
+
+        * modules/namespace-object-symbol-iterator-name.js: Added.
+        * test262.yaml:
+
+2016-08-04  Keith Miller  <keith_miller@apple.com>
+
+        ASSERTION FAILED: !hasInstanceValueNode->isCellConstant() || defaultHasInstanceFunction == hasInstanceValueNode->asCell()
+        https://bugs.webkit.org/show_bug.cgi?id=160562
+
+        Reviewed by Mark Lam.
+
+        * stress/instanceof-late-constant-folding.js: Added.
+        (Constructor):
+        (value):
+        (body):
+
+2016-08-04  Caitlin Potter  <caitp@igalia.com>
+
+        [JSC] fix generator-syntax.js JSTest again after yield grammar fix
+        https://bugs.webkit.org/show_bug.cgi?id=160550
+
+        Reviewed by Yusuke Suzuki.
+
+        * stress/generator-syntax.js:
+        (testYieldBindingIdentifier):
+
+2016-08-03  Caitlin Potter  <caitp@igalia.com>
+
+        Clarify SyntaxErrors around yield and unskip tests
+        https://bugs.webkit.org/show_bug.cgi?id=158460
+
+        Reviewed by Saam Barati.
+
+        Fix and unskip tests which erroneously asserted that `yield` is not a
+        valid BindingIdentifier, and improve error message for YieldExpressions
+        occuring in Arrow formal parameters.
+
+        * stress/generator-syntax.js:
+        * stress/yield-out-of-generator.js:
+
+2016-08-03  Filip Pizlo  <fpizlo@apple.com>
+
+        REGRESSION(r203368): broke some test262 tests
+        https://bugs.webkit.org/show_bug.cgi?id=160479
+
+        Reviewed by Mark Lam.
+        
+        Added a stress test for this case, since we don't always run test262.
+
+        * stress/freeze-setter.js: Added.
+        (let.o.set foo):
+
+2016-08-03  Saam Barati  <sbarati@apple.com>
+
+        Implement nested rest destructuring w.r.t the ES7 spec
+        https://bugs.webkit.org/show_bug.cgi?id=160423
+
+        Reviewed by Filip Pizlo.
+
+        * stress/destructuring-rest-element.js: Added.
+        (assert):
+        (test):
+        (arr):
+        (eq):
+        (gen):
+        (fakeGen.return.Symbol.iterator):
+        (fakeGen):
+        * stress/rest-elements.js:
+        (testSyntaxError.String.raw):
+        * stress/rest-parameter-is-destructuring.js: Added.
+        (assert):
+        (test):
+        (foo):
+        (bar):
+        * test262.yaml:
+
+2016-08-02  Saam Barati  <sbarati@apple.com>
+
+        Rename Changelog to ChangeLog
+
+        Rubber stamped by Keith Miller.
+
+        * Changelog: Removed.
+
+2016-08-02  Saam Barati  <sbarati@apple.com>
+
+        update a class extending null w.r.t the ES7 spec
+        https://bugs.webkit.org/show_bug.cgi?id=160417
+
+        Reviewed by Keith Miller.
+
+        * Changelog:
+        * stress/class-derived-from-null.js: Added.
+        (assert):
+        (test):
+        (test1.C):
+        (test1):
+        (jsNull):
+        (test2.C):
+        (test2):
+        (test3.C):
+        (test3.D):
+        (test3.E):
+        (test3):
+        (test4.E):
+        (test4):
+        (test5.E):
+        (test5):
+        (test6.Base):
+        (test6.D):
+        (test6.E):
+        (test6.F):
+        (test6.G):
+        (test6):
+        * test262.yaml:
+
+2016-08-01  Filip Pizlo  <fpizlo@apple.com>
+
+        Rationalize varargs stack overflow checks
+        https://bugs.webkit.org/show_bug.cgi?id=160425
+
+        Reviewed by Michael Saboff.
+
+        * stress/arity-check-ftl-throw-more-args.js: Added.
+        (catch):
+
+2016-08-01  Keith Miller  <keith_miller@apple.com>
+
+        We should not keep the JavaScript tests inside the Source/JavaScriptCore/ directory.
+        https://bugs.webkit.org/show_bug.cgi?id=160372
+
+        Rubber stamped by Geoffrey Garen.
+
+        This patch moves all the JavaScript tests from Source/JavaScriptCore/tests to
+        a new top level directory, JSTests. Having the tests in the Source directory
+        was both confusing an inconvenient for people that just want to checkout the
+        source code of WebKit. Since there is no other obvious place to put all the
+        JavaScript tests a new top level directory seemed the most sensible.
+
+        * tests/: Deleted.

--- a/implementation-contributed/javascriptcore/stress/regress-169445.js
+++ b/implementation-contributed/javascriptcore/stress/regress-169445.js
@@ -1,0 +1,44 @@
+let args = new Array(0x10000);
+args.fill();
+args = args.map((_, i) => 'a' + i).join(', ');
+
+let gun = eval(`(function () {
+    class A {
+
+    }
+
+    class B extends A {
+        constructor(${args}) {
+            () => {
+                ${args};
+                super();
+            };
+
+            class C {
+                constructor() {
+                }
+
+                trigger() {
+                    (() => {
+                        super.x;
+                    })();
+                }
+
+                triggerWithRestParameters(...args) {
+                    (() => {
+                        super.x;
+                    })();
+                }
+            }
+
+            return new C();
+        }
+    }
+
+    return new B();
+})()`);
+
+for (let i = 0; i < 0x10000; i++) {
+    gun.trigger();
+    gun.triggerWithRestParameters(1, 2, 3);
+}

--- a/implementation-contributed/javascriptcore/stress/regress-169889-array-concat.js
+++ b/implementation-contributed/javascriptcore/stress/regress-169889-array-concat.js
@@ -1,0 +1,28 @@
+//@ runFTLNoCJIT
+
+Array.prototype.__defineGetter__(100, () => 1);
+
+let childGlobal = createGlobalObject();
+let a = new childGlobal.Array(2.3023e-320, 2.3023e-320);
+let b = new childGlobal.Array(2.3023e-320, 2.3023e-320);
+
+var tierWarmUpIterations = [
+    1, // LLInt
+    50, // baseline JIT
+    500, // DFG
+    10000, // FTL
+];
+
+function doTest(warmUpIterations) {
+    var test = new Function("a", "b", "return Array.prototype.concat.call(a, b).toString();");
+    noInline(test);
+
+    for (var i = 0; i < warmUpIterations; i++)
+        test([1, 2], [3, 4]);
+
+    test(a, b);
+}
+
+for (var warmUpIterations of tierWarmUpIterations)
+    doTest(warmUpIterations);
+

--- a/implementation-contributed/javascriptcore/stress/regress-169889-array-concat1.js
+++ b/implementation-contributed/javascriptcore/stress/regress-169889-array-concat1.js
@@ -1,0 +1,28 @@
+//@ runFTLNoCJIT
+
+Array.prototype.__defineGetter__(100, () => 1);
+
+let childGlobal = createGlobalObject();
+let a = new childGlobal.Array(2.3023e-320, 2.3023e-320);
+let b = 2.3023e-320;
+
+var tierWarmUpIterations = [
+    1, // LLInt
+    50, // baseline JIT
+    500, // DFG
+    10000, // FTL
+];
+
+function doTest(warmUpIterations) {
+    var test = new Function("a", "b", "return Array.prototype.concat.call(a, b).toString();");
+    noInline(test);
+
+    for (var i = 0; i < warmUpIterations; i++)
+        test([1, 2], [3, 4]);
+
+    test(a, b);
+}
+
+for (var warmUpIterations of tierWarmUpIterations)
+    doTest(warmUpIterations);
+

--- a/implementation-contributed/javascriptcore/stress/regress-169889-array-slice.js
+++ b/implementation-contributed/javascriptcore/stress/regress-169889-array-slice.js
@@ -1,0 +1,27 @@
+//@ runFTLNoCJIT
+
+Array.prototype.__defineGetter__(100, () => 1);
+
+let childGlobal = createGlobalObject();
+let a = new childGlobal.Array(2.3023e-320, 2.3023e-320, 2.3023e-320, 2.3023e-320, 2.3023e-320, 2.3023e-320);
+
+var tierWarmUpIterations = [
+    1, // LLInt
+    50, // baseline JIT
+    500, // DFG
+    10000, // FTL
+];
+
+function doTest(warmUpIterations) {
+    var test = new Function("a", "return Array.prototype.slice.call(a).toString();");
+    noInline(test);
+
+    for (var i = 0; i < warmUpIterations; i++)
+        test([1, 2, 3]);
+
+    test(a);
+}
+
+for (var warmUpIterations of tierWarmUpIterations)
+    doTest(warmUpIterations);
+

--- a/implementation-contributed/javascriptcore/stress/regress-170251.js
+++ b/implementation-contributed/javascriptcore/stress/regress-170251.js
@@ -1,0 +1,32 @@
+Object.prototype.__defineGetter__(1000, () => 2);
+
+let locales = [
+    'mr', 'bs', 'ee-TG', 'ms', 'kam-KE', 'mt', 'ha', 'es-HN', 'ml-IN', 'ro-MD',
+    'kab-DZ', 'he', 'es-CO', 'my', 'es-PA', 'az-Latn', 'mer', 'en-NZ', 'xog-UG',
+    'sg', 'fr-GP', 'sr-Cyrl-BA', 'hi', 'fil-PH', 'lt-LT', 'si', 'en-MT', 'si-LK',
+    'luo-KE', 'it-CH', 'teo', 'mfe', 'sk', 'uz-Cyrl-UZ', 'sl', 'rm-CH', 'az-Cyrl-AZ',
+    'fr-GQ', 'kde', 'sn', 'cgg-UG', 'so', 'fr-RW', 'es-SV', 'mas-TZ', 'en-MU', 'sq',
+    'hr', 'sr', 'en-PH', 'ca', 'hu', 'mk-MK', 'fr-TD', 'nb', 'sv', 'kln-KE', 'sw',
+    'nd', 'sr-Latn', 'el-GR', 'hy', 'ne', 'el-CY', 'es-CR', 'fo-FO', 'pa-Arab-PK',
+    'seh', 'ar-YE', 'ja-JP', 'ur-PK', 'pa-Guru', 'gl-ES', 'zh-Hant-HK', 'ar-EG', 'nl',
+    'th-TH', 'es-PE', 'fr-KM', 'nn', 'kk-Cyrl-KZ', 'kea', 'lv-LV', 'kln', 'tzm-Latn',
+    'yo', 'gsw-CH', 'ha-Latn-GH', 'is-IS', 'pt-BR', 'cs', 'en-PK', 'fa-IR', 'zh-Hans-SG',
+    'luo', 'ta', 'fr-TG', 'kde-TZ', 'mr-IN', 'ar-SA', 'ka-GE', 'mfe-MU', 'id', 'fr-LU',
+    'de-LU', 'ru-MD', 'cy', 'zh-Hans-HK', 'te', 'bg-BG', 'shi-Latn', 'ig', 'ses', 'ii',
+    'es-BO', 'th', 'ko-KR', 'ti', 'it-IT', 'shi-Latn-MA', 'pt-MZ', 'ff-SN', 'haw',
+    'zh-Hans', 'so-KE', 'bn-IN', 'en-UM', 'to', 'id-ID', 'uz-Cyrl', 'en-GU', 'es-EC',
+    'en-US-posix', 'sr-Latn-BA', 'is', 'luy', 'tr', 'en-NA', 'it', 'da', 'bo-IN',
+    'vun-TZ', 'ar-SD', 'uz-Latn-UZ', 'az-Latn-AZ', 'de', 'es-GQ', 'ta-IN', 'de-DE',
+    'fr-FR', 'rof-TZ', 'ar-LY', 'en-BW', 'asa', 'zh', 'ha-Latn', 'fr-NE', 'es-MX',
+    'bem-ZM', 'zh-Hans-CN', 'bn-BD', 'pt-GW', 'om', 'jmc', 'de-AT', 'kk-Cyrl', 'sw-TZ',
+    'ar-OM', 'et-EE', 'or', 'da-DK', 'ro-RO', 'zh-Hant', 'bm-ML', 'ja', 'fr-CA', 'naq',
+    'zu', 'en-IE', 'ar-MA', 'es-GT', 'uz-Arab-AF', 'en-AS', 'bs-BA', 'am-ET', 'ar-TN',
+    'haw-US', 'ar-JO', 'fa-AF', 'uz-Latn', 'en-BZ', 'nyn-UG', 'ebu-KE', 'te-IN', 'cy-GB',
+    'uk', 'nyn', 'en-JM', 'en-US', 'fil', 'ar-KW', 'af-ZA', 'en-CA', 'fr-DJ', 'ti-ER',
+    'ig-NG', 'en-AU', 'ur', 'fr-MC', 'pt-PT', 'pa', 'es-419', 'fr-CD', 'en-SG', 'bo-CN',
+    'kn-IN', 'sr-Cyrl-RS', 'lg-UG', 'gu-IN', 'ee', 'nd-ZW', 'bem', 'uz', 'sw-KE',
+    'sq-AL', 'hr-HR', 'mas-KE', 'el', 'ti-ET', 'es-AR', 'pl', 'en', 'eo', 'shi', 'kok',
+    'fr-CF', 'fr-RE', 'mas', 'rof', 'ru-UA', 'yo-NG', 'dav-KE', 'gv-GB', 'pa-Arab', 'es',
+    'teo-UG', 'ps', 'es-PR', 'fr-MF', 'et', 'pt', 'eu', 'ka', 'rwk-TZ', 'nb-NO', 'fr-CG'
+];
+Intl.getCanonicalLocales(locales);


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[a7577363f7](https://github.com///github/blob/a7577363f7) in JavaScriptCore and all changes made since [1f7948aa7](../blob/1f7948aa7) in
test262.













### 6 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/ChangeLog-2018-09-11](../blob/javascriptcore-test262-automation-export-1f7948aa7/implementation-contributed/javascriptcore/ChangeLog-2018-09-11)
 - [implementation-contributed/javascriptcore/stress/regress-169445.js](../blob/javascriptcore-test262-automation-export-1f7948aa7/implementation-contributed/javascriptcore/stress/regress-169445.js)
 - [implementation-contributed/javascriptcore/stress/regress-169889-array-concat.js](../blob/javascriptcore-test262-automation-export-1f7948aa7/implementation-contributed/javascriptcore/stress/regress-169889-array-concat.js)
 - [implementation-contributed/javascriptcore/stress/regress-169889-array-concat1.js](../blob/javascriptcore-test262-automation-export-1f7948aa7/implementation-contributed/javascriptcore/stress/regress-169889-array-concat1.js)
 - [implementation-contributed/javascriptcore/stress/regress-169889-array-slice.js](../blob/javascriptcore-test262-automation-export-1f7948aa7/implementation-contributed/javascriptcore/stress/regress-169889-array-slice.js)
 - [implementation-contributed/javascriptcore/stress/regress-170251.js](../blob/javascriptcore-test262-automation-export-1f7948aa7/implementation-contributed/javascriptcore/stress/regress-170251.js)