### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "65db7e4aa7",
-  "targetRevisionAtLastExport": "c32d19125",
+  "sourceRevisionAtLastExport": "fc056044dc",
+  "targetRevisionAtLastExport": "8e4c01405",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/verbose-failure-dont-graph-dump-availability-already-freed.js
+++ b/implementation-contributed/javascriptcore/stress/verbose-failure-dont-graph-dump-availability-already-freed.js
@@ -1,0 +1,9 @@
+//@ runDefault("--verboseValidationFailure=true")
+
+function foo() {
+    arguments.length;
+}
+let a = 0;
+for (var i = 0; i < 1000000; i++) {
+    a += foo();
+}


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[65db7e4aa7](https://github.com///github/blob/65db7e4aa7) in JavaScriptCore and all changes made since [c32d19125](../blob/c32d19125) in
test262.













### 1 New File Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/verbose-failure-dont-graph-dump-availability-already-freed.js](../blob/javascriptcore-test262-automation-export-c32d19125/implementation-contributed/javascriptcore/stress/verbose-failure-dont-graph-dump-availability-already-freed.js)