### PR TITLE
test: Add tests for duplicate private methods (early-errors)

### DIFF
--- a/src/class-elements/grammar-privatemeth-duplicate-get-field.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-get-field.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains a private getter and a private field with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private, class-fields-private]
+---*/
+
+//- elements
+#m;
+get #m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-get-get.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-get-get.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains multiple private getters with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private]
+---*/
+
+//- elements
+get #m() {}
+get #m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-get-set.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-get-set.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's valid if a class contains a private getter and a private setter with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/valid
+features: [class-methods-private]
+---*/
+
+//- elements
+get #m() {}
+set #m(_) {}

--- a/src/class-elements/grammar-privatemeth-duplicate-meth-field.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-meth-field.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains a private method and a private field with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private, class-fields-private]
+---*/
+
+//- elements
+#m;
+#m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-meth-get.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-meth-get.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains a private method and a private getter with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private]
+---*/
+
+//- elements
+get #m() {}
+#m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-meth-meth.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-meth-meth.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains multiple private methods with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private]
+---*/
+
+//- elements
+#m() {}
+#m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-meth-nestedclassmeth.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-meth-nestedclassmeth.case
@@ -1,0 +1,22 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's valid if a nested class shadows a private method
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/valid
+features: [class-methods-private]
+---*/
+
+//- elements
+constructor() {
+  class B {
+    #m() {}
+  }
+}
+
+#m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-meth-set.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-meth-set.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains a private method and a private setter with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private]
+---*/
+
+//- elements
+set #m(_) {}
+#m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-meth-staticfield.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-meth-staticfield.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains a private method and a private static field with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private, class-static-fields-private]
+---*/
+
+//- elements
+static #m;
+#m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-meth-staticmeth.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-meth-staticmeth.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains a private method and a private static method with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private, class-static-methods-private]
+---*/
+
+//- elements
+static #m() {}
+#m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-set-field.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-set-field.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains a private setter and a private field with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private, class-fields-private]
+---*/
+
+//- elements
+#m;
+set #m(_) {}

--- a/src/class-elements/grammar-privatemeth-duplicate-set-set.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-set-set.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains multiple private setters with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private]
+---*/
+
+//- elements
+set #m(_) {}
+set #m(_) {}

--- a/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-get-field.js
+++ b/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-get-field.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-get-field.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private getter and a private field with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+var C = class {
+  #m;
+  get #m() {}
+};

--- a/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-get-get.js
+++ b/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-get-get.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-get-get.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains multiple private getters with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+var C = class {
+  get #m() {}
+  get #m() {}
+};

--- a/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-field.js
+++ b/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-field.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-field.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private method and a private field with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+var C = class {
+  #m;
+  #m() {}
+};

--- a/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-get.js
+++ b/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-get.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-get.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private method and a private getter with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+var C = class {
+  get #m() {}
+  #m() {}
+};

--- a/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-meth.js
+++ b/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-meth.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-meth.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains multiple private methods with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+var C = class {
+  #m() {}
+  #m() {}
+};

--- a/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-set.js
+++ b/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-set.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-set.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private method and a private setter with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+var C = class {
+  set #m(_) {}
+  #m() {}
+};

--- a/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-staticfield.js
+++ b/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-staticfield.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-staticfield.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private method and a private static field with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class-static-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+var C = class {
+  static #m;
+  #m() {}
+};

--- a/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-staticmeth.js
+++ b/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-staticmeth.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-staticmeth.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private method and a private static method with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class-static-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+var C = class {
+  static #m() {}
+  #m() {}
+};

--- a/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-set-field.js
+++ b/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-set-field.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-set-field.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private setter and a private field with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+var C = class {
+  #m;
+  set #m(_) {}
+};

--- a/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-set-set.js
+++ b/test/language/expressions/class/syntax/early-errors/grammar-privatemeth-duplicate-set-set.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-set-set.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains multiple private setters with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+var C = class {
+  set #m(_) {}
+  set #m(_) {}
+};

--- a/test/language/expressions/class/syntax/valid/grammar-privatemeth-duplicate-get-set.js
+++ b/test/language/expressions/class/syntax/valid/grammar-privatemeth-duplicate-get-set.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-get-set.case
+// - src/class-elements/syntax/valid/cls-expr-elements-valid-syntax.template
+/*---
+description: It's valid if a class contains a private getter and a private setter with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+var C = class {
+  get #m() {}
+  set #m(_) {}
+};

--- a/test/language/expressions/class/syntax/valid/grammar-privatemeth-duplicate-meth-nestedclassmeth.js
+++ b/test/language/expressions/class/syntax/valid/grammar-privatemeth-duplicate-meth-nestedclassmeth.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-nestedclassmeth.case
+// - src/class-elements/syntax/valid/cls-expr-elements-valid-syntax.template
+/*---
+description: It's valid if a nested class shadows a private method (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+var C = class {
+  constructor() {
+    class B {
+      #m() {}
+    }
+  }
+
+  #m() {}
+};

--- a/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-get-field.js
+++ b/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-get-field.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-get-field.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private getter and a private field with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+class C {
+  #m;
+  get #m() {}
+}

--- a/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-get-get.js
+++ b/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-get-get.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-get-get.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains multiple private getters with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+class C {
+  get #m() {}
+  get #m() {}
+}

--- a/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-field.js
+++ b/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-field.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-field.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private method and a private field with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+class C {
+  #m;
+  #m() {}
+}

--- a/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-get.js
+++ b/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-get.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-get.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private method and a private getter with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+class C {
+  get #m() {}
+  #m() {}
+}

--- a/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-meth.js
+++ b/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-meth.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-meth.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains multiple private methods with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+class C {
+  #m() {}
+  #m() {}
+}

--- a/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-set.js
+++ b/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-set.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-set.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private method and a private setter with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+class C {
+  set #m(_) {}
+  #m() {}
+}

--- a/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-staticfield.js
+++ b/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-staticfield.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-staticfield.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private method and a private static field with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class-static-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+class C {
+  static #m;
+  #m() {}
+}

--- a/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-staticmeth.js
+++ b/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-meth-staticmeth.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-staticmeth.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private method and a private static method with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class-static-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+class C {
+  static #m() {}
+  #m() {}
+}

--- a/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-set-field.js
+++ b/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-set-field.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-set-field.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private setter and a private field with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+class C {
+  #m;
+  set #m(_) {}
+}

--- a/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-set-set.js
+++ b/test/language/statements/class/syntax/early-errors/grammar-privatemeth-duplicate-set-set.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-set-set.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains multiple private setters with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+throw "Test262: This statement should not be evaluated.";
+
+class C {
+  set #m(_) {}
+  set #m(_) {}
+}

--- a/test/language/statements/class/syntax/valid/grammar-privatemeth-duplicate-get-set.js
+++ b/test/language/statements/class/syntax/valid/grammar-privatemeth-duplicate-get-set.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-get-set.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax.template
+/*---
+description: It's valid if a class contains a private getter and a private setter with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+class C {
+  get #m() {}
+  set #m(_) {}
+}

--- a/test/language/statements/class/syntax/valid/grammar-privatemeth-duplicate-meth-nestedclassmeth.js
+++ b/test/language/statements/class/syntax/valid/grammar-privatemeth-duplicate-meth-nestedclassmeth.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-nestedclassmeth.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax.template
+/*---
+description: It's valid if a nested class shadows a private method (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+class C {
+  constructor() {
+    class B {
+      #m() {}
+    }
+  }
+
+  #m() {}
+}


### PR DESCRIPTION
Adds tests for duplicate private methods according to the test plan posted in #1343.

|Valid|Case|Description|
|:---:|:---|:---|
| :red_circle: | `grammar-privatemeth-duplicate-meth-meth` | Cannot have multiple private methods with the same name |
| :red_circle: | `grammar-privatemeth-duplicate-meth-get` | Cannot have a private method and a private getter with the same name |
| :red_circle: | `grammar-privatemeth-duplicate-meth-set ` | Cannot have a private method and a private setter with the same name |
| :red_circle: | `grammar-privatemeth-duplicate-get-get` | Cannot have multiple private getters with the same name |
| :red_circle: | `grammar-privatemeth-duplicate-set-set` | Cannot have multiple private setters with the same name |
| :white_circle: | `grammar-privatemeth-duplicate-get-set` | Can have a private getter and a private setter with the same name |
| :red_circle: | `grammar-privatemeth-duplicate-meth-field` | Cannot have a private method and a private field with the same name |
| :red_circle: | `grammar-privatemeth-duplicate-get-field` | Cannot have a private getter and a private field with the same name |
| :red_circle: | `grammar-privatemeth-duplicate-set-field` | Cannot have a private setter and a private field with the same name |
| :red_circle: | `grammar-privatemeth-duplicate-meth-staticmeth` | Cannot have a private method and a private static method with the same name |
| :red_circle: | `grammar-privatemeth-duplicate-meth-staticfield` | Cannot have a private method and a private static field with the same name |
| :white_circle: | `grammar-privatemeth-duplicate-meth-nestedclassmeth` | Nested class can shadow private methods  |

---

@littledan Could you please have a look and see if I missed anything? One thing I wasn't clear is whether we can have a private getter/setter and a private field with the same name. 

```js
class C {
   #x;

   get #x() {} 
}
```

I can add a test for this if you tell me what the correct behavior should be.

---
Tracking Issue: #1343
cc: @jbhoosreddy