### PR TITLE
intl: improve coverage for Intl.NumberFormat

### DIFF
--- a/test/intl402/NumberFormat/prototype/this-value-not-numberformat.js
+++ b/test/intl402/NumberFormat/prototype/this-value-not-numberformat.js
@@ -12,6 +12,7 @@ author: Norbert Lindenberg
 
 var functions = {
     "format getter": Object.getOwnPropertyDescriptor(Intl.NumberFormat.prototype, "format").get,
+    formatToParts: Intl.NumberFormat.prototype.formatToParts,
     resolvedOptions: Intl.NumberFormat.prototype.resolvedOptions
 };
 var invalidTargets = [undefined, null, true, 0, "NumberFormat", [], {}];

--- a/test/intl402/NumberFormat/prototype/this-value-not-numberformat.js
+++ b/test/intl402/NumberFormat/prototype/this-value-not-numberformat.js
@@ -15,7 +15,7 @@ var functions = {
     formatToParts: Intl.NumberFormat.prototype.formatToParts,
     resolvedOptions: Intl.NumberFormat.prototype.resolvedOptions
 };
-var invalidTargets = [undefined, null, true, 0, "NumberFormat", [], {}];
+var invalidTargets = [undefined, null, true, 0, "NumberFormat", [], {}, Symbol()];
 
 Object.getOwnPropertyNames(functions).forEach(function (functionName) {
     var f = functions[functionName];


### PR DESCRIPTION
Add Intl.NumberFormat.prototype.formatToParts to the test
this-value-not-numberformat.js to check if a TypeError is thrown if the
"this" value for the function call isn't a valid NumberFormat object.

/cc @gsathya @littledan @anba 