### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "ceacdcd0",
-  "targetRevisionAtLastExport": "55d559e57",
+  "sourceRevisionAtLastExport": "a9b9c338",
+  "targetRevisionAtLastExport": "6cebba406",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/mjsunit/compiler/regress-884052.js
+++ b/implementation-contributed/v8/mjsunit/compiler/regress-884052.js
@@ -1,0 +1,16 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+function foo() {
+  var a = new Array(2);
+  for (var i = 1; i > -1; i = i - 2) {
+    if (i < a.length) a = new Array(i);
+  }
+}
+
+foo();
+%OptimizeFunctionOnNextCall(foo);
+foo();

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-884933.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-884933.js
@@ -1,0 +1,85 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+// Test Uint8 -> Word64 conversions.
+(function() {
+  function bar(x, y) {
+    return x + y;
+  }
+
+  bar(0.1, 0.2);
+  bar(0.1, 0.2);
+
+  function foo(dv) {
+    return bar(dv.getUint8(0, true), 0xFFFFFFFF);
+  }
+
+  const dv = new DataView(new ArrayBuffer(8));
+  assertEquals(0xFFFFFFFF, foo(dv));
+  assertEquals(0xFFFFFFFF, foo(dv));
+  %OptimizeFunctionOnNextCall(foo);
+  assertEquals(0xFFFFFFFF, foo(dv));
+})();
+
+// Test Int8 -> Word64 conversions.
+(function() {
+  function bar(x, y) {
+    return x + y;
+  }
+
+  bar(0.1, 0.2);
+  bar(0.1, 0.2);
+
+  function foo(dv) {
+    return bar(dv.getInt8(0, true), 0xFFFFFFFF);
+  }
+
+  const dv = new DataView(new ArrayBuffer(8));
+  assertEquals(0xFFFFFFFF, foo(dv));
+  assertEquals(0xFFFFFFFF, foo(dv));
+  %OptimizeFunctionOnNextCall(foo);
+  assertEquals(0xFFFFFFFF, foo(dv));
+})();
+
+// Test Uint16 -> Word64 conversions.
+(function() {
+  function bar(x, y) {
+    return x + y;
+  }
+
+  bar(0.1, 0.2);
+  bar(0.1, 0.2);
+
+  function foo(dv) {
+    return bar(dv.getUint16(0, true), 0xFFFFFFFF);
+  }
+
+  const dv = new DataView(new ArrayBuffer(8));
+  assertEquals(0xFFFFFFFF, foo(dv));
+  assertEquals(0xFFFFFFFF, foo(dv));
+  %OptimizeFunctionOnNextCall(foo);
+  assertEquals(0xFFFFFFFF, foo(dv));
+})();
+
+// Test Int16 -> Word64 conversions.
+(function() {
+  function bar(x, y) {
+    return x + y;
+  }
+
+  bar(0.1, 0.2);
+  bar(0.1, 0.2);
+
+  function foo(dv) {
+    return bar(dv.getInt16(0, true), 0xFFFFFFFF);
+  }
+
+  const dv = new DataView(new ArrayBuffer(8));
+  assertEquals(0xFFFFFFFF, foo(dv));
+  assertEquals(0xFFFFFFFF, foo(dv));
+  %OptimizeFunctionOnNextCall(foo);
+  assertEquals(0xFFFFFFFF, foo(dv));
+})();


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[ceacdcd0](https://github.com///github/blob/ceacdcd0) in V8 and all changes made since [55d559e57](../blob/55d559e57) in
test262.













### 2 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/compiler/regress-884052.js](../blob/v8-test262-automation-export-55d559e57/implementation-contributed/v8/mjsunit/compiler/regress-884052.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-884933.js](../blob/v8-test262-automation-export-55d559e57/implementation-contributed/v8/mjsunit/regress/regress-crbug-884933.js)