### PR TITLE
Remove some trailing commas in calls

### DIFF
--- a/test/built-ins/Atomics/notify/undefined-index-defaults-to-zero.js
+++ b/test/built-ins/Atomics/notify/undefined-index-defaults-to-zero.js
@@ -67,7 +67,7 @@ assert.sameValue($262.agent.getReport(), 'ok', '$262.agent.getReport() returns "
 
 // Notify again at index 0, default => 0.
 var woken = 0;
-while ((woken = Atomics.notify(i32a, /*, default values used */)) === 0) ;
+while ((woken = Atomics.notify(i32a /*, default values used */)) === 0) ;
 assert.sameValue(woken, 1, 'Atomics.notify(i32a /*, default values used */) returns 1');
 
 assert.sameValue($262.agent.getReport(), 'ok', '$262.agent.getReport() returns "ok"');

--- a/test/built-ins/String/prototype/trimEnd/this-value-line-terminator.js
+++ b/test/built-ins/String/prototype/trimEnd/this-value-line-terminator.js
@@ -26,5 +26,5 @@ var expected = lt + 'a' + lt + 'b';
 
 assert.sameValue(
   trimEnd.call(str),
-  expected,
+  expected
 );

--- a/test/built-ins/String/prototype/trimEnd/this-value-object-cannot-convert-to-primitive-err.js
+++ b/test/built-ins/String/prototype/trimEnd/this-value-object-cannot-convert-to-primitive-err.js
@@ -55,5 +55,5 @@ assert.throws(
   TypeError,
   function() {
     String.prototype.trimEnd.call(thisVal);
-  },
+  }
 );

--- a/test/built-ins/String/prototype/trimEnd/this-value-object-toprimitive-meth-priority.js
+++ b/test/built-ins/String/prototype/trimEnd/this-value-object-toprimitive-meth-priority.js
@@ -63,7 +63,7 @@ assert.sameValue(
 assert.sameValue(
   result,
   '42',
-  'thisVal[Symbol.toPrimitive] expected to have been called.',
+  'thisVal[Symbol.toPrimitive] expected to have been called.'
 );
 
 // Test that thisVal.toString and thisVal.valueOf have not been accessedo

--- a/test/built-ins/String/prototype/trimEnd/this-value-object-tostring-meth-priority.js
+++ b/test/built-ins/String/prototype/trimEnd/this-value-object-tostring-meth-priority.js
@@ -77,7 +77,7 @@ assert.sameValue(
 assert.sameValue(
   result,
   '42',
-  'thisVal.toString expected to have been called.',
+  'thisVal.toString expected to have been called.'
 );
 
 // Test that thisVal[toPrimitive] has been accessed.

--- a/test/built-ins/String/prototype/trimEnd/this-value-object-valueof-meth-priority.js
+++ b/test/built-ins/String/prototype/trimEnd/this-value-object-valueof-meth-priority.js
@@ -76,7 +76,7 @@ assert.sameValue(
 assert.sameValue(
   result,
   '42',
-  'thisVal.valueOf expected to have been called.',
+  'thisVal.valueOf expected to have been called.'
 );
 
 // Test that thisVal[toPrimitive] and thisVal.toString has been accessed.

--- a/test/built-ins/String/prototype/trimEnd/this-value-whitespace.js
+++ b/test/built-ins/String/prototype/trimEnd/this-value-whitespace.js
@@ -29,5 +29,5 @@ var expected = wspc + 'a' + wspc + 'b';
 
 assert.sameValue(
   trimEnd.call(str),
-  expected,
+  expected
 );

--- a/test/built-ins/String/prototype/trimStart/this-value-line-terminator.js
+++ b/test/built-ins/String/prototype/trimStart/this-value-line-terminator.js
@@ -26,5 +26,5 @@ var expected = 'a' + lt + 'b' + lt;
 
 assert.sameValue(
   trimStart.call(str),
-  expected,
+  expected
 );

--- a/test/built-ins/String/prototype/trimStart/this-value-object-cannot-convert-to-primitive-err.js
+++ b/test/built-ins/String/prototype/trimStart/this-value-object-cannot-convert-to-primitive-err.js
@@ -55,5 +55,5 @@ assert.throws(
   TypeError,
   function() {
     String.prototype.trimStart.call(thisVal);
-  },
+  }
 );

--- a/test/built-ins/String/prototype/trimStart/this-value-object-toprimitive-meth-priority.js
+++ b/test/built-ins/String/prototype/trimStart/this-value-object-toprimitive-meth-priority.js
@@ -63,7 +63,7 @@ assert.sameValue(
 assert.sameValue(
   result,
   '42',
-  'thisVal[Symbol.toPrimitive] expected to have been called.',
+  'thisVal[Symbol.toPrimitive] expected to have been called.'
 );
 
 // Test that thisVal.toString and thisVal.valueOf have not been accessedo

--- a/test/built-ins/String/prototype/trimStart/this-value-object-tostring-meth-priority.js
+++ b/test/built-ins/String/prototype/trimStart/this-value-object-tostring-meth-priority.js
@@ -77,7 +77,7 @@ assert.sameValue(
 assert.sameValue(
   result,
   '42',
-  'thisVal.toString expected to have been called.',
+  'thisVal.toString expected to have been called.'
 );
 
 // Test that thisVal[toPrimitive] has been accessed.

--- a/test/built-ins/String/prototype/trimStart/this-value-object-valueof-meth-priority.js
+++ b/test/built-ins/String/prototype/trimStart/this-value-object-valueof-meth-priority.js
@@ -76,7 +76,7 @@ assert.sameValue(
 assert.sameValue(
   result,
   '42',
-  'thisVal.valueOf expected to have been called.',
+  'thisVal.valueOf expected to have been called.'
 );
 
 // Test that thisVal[toPrimitive] and thisVal.toString has been accessed.

--- a/test/built-ins/String/prototype/trimStart/this-value-whitespace.js
+++ b/test/built-ins/String/prototype/trimStart/this-value-whitespace.js
@@ -29,5 +29,5 @@ var expected = 'a' + wspc + 'b' + wspc;
 
 assert.sameValue(
   trimStart.call(str),
-  expected,
+  expected
 );

--- a/test/intl402/Locale/constructor-options-casefirst-valid.js
+++ b/test/intl402/Locale/constructor-options-casefirst-valid.js
@@ -47,18 +47,18 @@ for (const caseFirst of validCaseFirstOptions) {
   const expected = String(caseFirst);
   assert.sameValue(
     new Intl.Locale('en', options).toString(),
-    "en-u-kf-" + expected,
+    "en-u-kf-" + expected
   );
 
   assert.sameValue(
     new Intl.Locale('en-u-kf-lower', options).toString(),
-    "en-u-kf-" + expected,
+    "en-u-kf-" + expected
   );
 
   if ("caseFirst" in Intl.Locale.prototype) {
     assert.sameValue(
       new Intl.Locale('en-u-kf-lower', options).caseFirst,
-      expected,
+      expected
     );
   }
 }

--- a/test/intl402/Locale/constructor-options-numeric-valid.js
+++ b/test/intl402/Locale/constructor-options-numeric-valid.js
@@ -48,18 +48,18 @@ for (const [numeric, expected] of validNumericOptions) {
   const options = { numeric };
   assert.sameValue(
     new Intl.Locale('en', options).toString(),
-    expected ? ("en-u-kn-" + expected) : "en",
+    expected ? ("en-u-kn-" + expected) : "en"
   );
 
   assert.sameValue(
     new Intl.Locale('en-u-kn-true', options).toString(),
-    "en-u-kn-" + (expected || "true"),
+    "en-u-kn-" + (expected || "true")
   );
 
   if ("numeric" in Intl.Locale.prototype) {
     assert.sameValue(
       new Intl.Locale('en-u-kf-lower', options).numeric,
-      expected,
+      expected
     );
   }
 }


### PR DESCRIPTION
This doesn't affect correctness, but makes the tests more broadly useful. Also, this is generally a step in the direction of more consistent style (even within individual files, in several cases).