### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "1e6d9607",
-  "targetRevisionAtLastExport": "eeae2a723",
+  "sourceRevisionAtLastExport": "a345e766",
+  "targetRevisionAtLastExport": "d1fe93a71",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/intl/general/getCanonicalLocales.js
+++ b/implementation-contributed/v8/intl/general/getCanonicalLocales.js
@@ -10,4 +10,6 @@ assertDoesNotThrow(() => Intl.getCanonicalLocales("en-a-ca-Chinese-u-ca-Chinese"
 
 // Check duplicate subtags (after the first tag) are detected.
 assertThrows(() => Intl.getCanonicalLocales("en-foobar-foobar"), RangeError);
-assertThrows(() => Intl.getCanonicalLocales("en-u-ca-gregory-ca-chinese"), RangeError);
+
+// Duplicate subtags are valid as per the ECMA262 spec.
+assertDoesNotThrow(() => Intl.getCanonicalLocales("en-u-ca-gregory-ca-chinese"));

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-888825.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-888825.js
@@ -1,0 +1,5 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+eval("((a=function g() { function g() {}}) => {})();");

--- a/implementation-contributed/v8/test262/test262.status
+++ b/implementation-contributed/v8/test262/test262.status
@@ -586,7 +586,6 @@
   'intl402/Locale/constructor-parse-twice': [FAIL],
   'intl402/Locale/constructor-tag': [FAIL],
   'intl402/Locale/constructor-unicode-ext-invalid': [FAIL],
-  'intl402/Locale/constructor-unicode-ext-valid': [FAIL],
   'intl402/Locale/extensions-grandfathered': [FAIL],
   'intl402/Locale/extensions-private': [FAIL],
   'intl402/Locale/getters': [FAIL],
@@ -607,9 +606,6 @@
   'language/expressions/generators/generator-created-after-decl-inst': [FAIL],
   'language/expressions/async-generator/generator-created-after-decl-inst': [FAIL],
   'language/statements/async-generator/generator-created-after-decl-inst': [FAIL],
-
-  # https://bugs.chromium.org/p/chromium/issues/detail?id=865351
-  'intl402/DateTimeFormat/prototype/formatToParts/main': [FAIL],
 
   # https://bugs.chromium.org/p/v8/issues/detail?id=8099
   'intl402/NumberFormat/prototype/format/format-negative-numbers': [FAIL],


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[1e6d9607](https://github.com///github/blob/1e6d9607) in V8 and all changes made since [eeae2a723](../blob/eeae2a723) in
test262.



### 2 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/intl/general/getCanonicalLocales.js](../blob/v8-test262-automation-export-eeae2a723/implementation-contributed/v8/intl/general/getCanonicalLocales.js)
 - [implementation-contributed/v8/test262/test262.status](../blob/v8-test262-automation-export-eeae2a723/implementation-contributed/v8/test262/test262.status)









### 1 New File Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-888825.js](../blob/v8-test262-automation-export-eeae2a723/implementation-contributed/v8/mjsunit/regress/regress-crbug-888825.js)