### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "3353b2924e",
-  "targetRevisionAtLastExport": "b0b5c9f9e",
+  "sourceRevisionAtLastExport": "13bea0a046",
+  "targetRevisionAtLastExport": "d544eaced",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/arguments-elimination-will-generate-edge-without-result.js
+++ b/implementation-contributed/javascriptcore/stress/arguments-elimination-will-generate-edge-without-result.js
@@ -1,0 +1,9 @@
+//@ runDefault("--validateGraphAtEachPhase=true", "--jitPolicyScale=0", "--useConcurrentJIT=0")
+
+'use strict';
+function foo() {
+  return arguments[1][0] === arguments[0];
+}
+for (let i = 0; i < 100000; ++i) {
+  foo(0, 0);
+}

--- a/implementation-contributed/javascriptcore/stress/array-indexof-cached-length.js
+++ b/implementation-contributed/javascriptcore/stress/array-indexof-cached-length.js
@@ -1,0 +1,24 @@
+function assert(b) {
+    if (!b)
+        throw new Error;
+
+}
+
+const originalLength = 10000;
+let arr = new Proxy([], {
+    has(...args) {
+        assert(parseInt(args[1]) < originalLength);
+        assert(args[0].length - 10 === originalLength);
+        return Reflect.has(...args);
+    }
+});
+
+for (var i = 0; i < originalLength; i++)
+    arr[i] = [];
+
+arr.indexOf(new Object(), {
+    valueOf: function () {
+        arr.length += 10;
+        return 0;
+    }
+});

--- a/implementation-contributed/javascriptcore/stress/array-indexof-fast-path-effects.js
+++ b/implementation-contributed/javascriptcore/stress/array-indexof-fast-path-effects.js
@@ -1,0 +1,11 @@
+// This shouldn't crash when running with ASAN.
+let arr = [];
+for (var i = 0; i < 1000000; i++)
+    arr[i] = [];
+
+arr.indexOf(new Object(), {
+    valueOf: function () {
+        arr.length = 0;
+        return 0;
+    }
+});

--- a/implementation-contributed/javascriptcore/stress/array-lastindexof-array-prototype-trap.js
+++ b/implementation-contributed/javascriptcore/stress/array-lastindexof-array-prototype-trap.js
@@ -1,0 +1,45 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+class AncestorArray extends Object {
+    get 2() {
+        this.called = true;
+        return 42;
+    }
+}
+
+Array.prototype.__proto__ = AncestorArray.prototype;
+
+{
+    let array = [];
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = [20, 20];
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = ["Hello"];
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = [42.195];
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = ["Hello"];
+    array.length = 42;
+    ensureArrayStorage(array);
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}

--- a/implementation-contributed/javascriptcore/stress/array-lastindexof-cached-length.js
+++ b/implementation-contributed/javascriptcore/stress/array-lastindexof-cached-length.js
@@ -1,0 +1,24 @@
+function assert(b) {
+    if (!b)
+        throw new Error;
+
+}
+
+const originalLength = 10000;
+let arr = new Proxy([], {
+    has(...args) {
+        assert(parseInt(args[1]) < originalLength);
+        assert(args[0].length - 10 === originalLength);
+        return Reflect.has(...args);
+    }
+});
+
+for (var i = 0; i < originalLength; i++)
+    arr[i] = [];
+
+arr.lastIndexOf(new Object(), {
+    valueOf: function () {
+        arr.length += 10;
+        return 0;
+    }
+});

--- a/implementation-contributed/javascriptcore/stress/array-lastindexof-fast-path-effects.js
+++ b/implementation-contributed/javascriptcore/stress/array-lastindexof-fast-path-effects.js
@@ -1,0 +1,11 @@
+// This shouldn't crash when running with ASAN.
+let arr = [];
+for (var i = 0; i < 1000000; i++)
+    arr[i] = [];
+
+arr.lastIndexOf(new Object(), {
+    valueOf: function () {
+        arr.length = 0;
+        return 0;
+    }
+});

--- a/implementation-contributed/javascriptcore/stress/array-lastindexof-have-a-bad-time-c-runtime.js
+++ b/implementation-contributed/javascriptcore/stress/array-lastindexof-have-a-bad-time-c-runtime.js
@@ -1,0 +1,43 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+Object.defineProperty(Array.prototype, 2, {
+    get() {
+        this.called = true;
+        return 42;
+    }
+});
+
+{
+    let array = [];
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = [20, 20];
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = ["Hello"];
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = [42.195];
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = ["Hello"];
+    array.length = 42;
+    ensureArrayStorage(array);
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}

--- a/implementation-contributed/javascriptcore/stress/array-lastindexof-hole-nan.js
+++ b/implementation-contributed/javascriptcore/stress/array-lastindexof-hole-nan.js
@@ -1,0 +1,19 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+
+{
+    let array = [42, , , 0];
+    shouldBe(array.lastIndexOf(Number.NaN), -1);
+    shouldBe(array.lastIndexOf(0), 3);
+}
+{
+    let array = [42.195, , , 0];
+    shouldBe(array.lastIndexOf(Number.NaN), -1);
+}
+{
+    let array = [42.195, Number.NaN, , 0];
+    shouldBe(array.lastIndexOf(Number.NaN), -1);
+}

--- a/implementation-contributed/javascriptcore/stress/array-lastindexof-infinity.js
+++ b/implementation-contributed/javascriptcore/stress/array-lastindexof-infinity.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let array = [42.195, -0.0, -Infinity];
+    shouldBe(array.lastIndexOf(Infinity), -1);
+    shouldBe(array.lastIndexOf(-Infinity), 2);
+    shouldBe(array.lastIndexOf(42), -1);
+}
+{
+    let array = [1, 2, 3, 0];
+    shouldBe(array.lastIndexOf(Infinity), -1);
+    shouldBe(array.lastIndexOf(-Infinity), -1);
+}
+{
+    let array = ["String", 42.5, Infinity, 33];
+    shouldBe(array.lastIndexOf(Infinity), 2);
+    shouldBe(array.lastIndexOf(-Infinity), -1);
+}

--- a/implementation-contributed/javascriptcore/stress/array-lastindexof-negative-zero.js
+++ b/implementation-contributed/javascriptcore/stress/array-lastindexof-negative-zero.js
@@ -1,0 +1,25 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let array = [42.195, -0.0];
+    shouldBe(array.lastIndexOf(0), 1);
+    shouldBe(array.lastIndexOf(-0), 1);
+}
+{
+    let array = [42.195, 0, -0.0];
+    shouldBe(array.lastIndexOf(0), 2);
+    shouldBe(array.lastIndexOf(-0), 2);
+}
+{
+    let array = [42, 0];
+    shouldBe(array.lastIndexOf(0), 1);
+    shouldBe(array.lastIndexOf(-0), 1);
+}
+{
+    let array = [42, 0, 44];
+    shouldBe(array.lastIndexOf(0), 1);
+    shouldBe(array.lastIndexOf(-0), 1);
+}

--- a/implementation-contributed/javascriptcore/stress/array-lastindexof-own-getter.js
+++ b/implementation-contributed/javascriptcore/stress/array-lastindexof-own-getter.js
@@ -1,0 +1,66 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let array = [];
+    Object.defineProperty(array, 2, {
+        get() {
+            this.called = true;
+            return 42;
+        }
+    });
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = [20, 20];
+    Object.defineProperty(array, 2, {
+        get() {
+            this.called = true;
+            return 42;
+        }
+    });
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = ["Hello"];
+    Object.defineProperty(array, 2, {
+        get() {
+            this.called = true;
+            return 42;
+        }
+    });
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = [42.195];
+    Object.defineProperty(array, 2, {
+        get() {
+            this.called = true;
+            return 42;
+        }
+    });
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = ["Hello"];
+    Object.defineProperty(array, 2, {
+        get() {
+            this.called = true;
+            return 42;
+        }
+    });
+    array.length = 42;
+    ensureArrayStorage(array);
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}

--- a/implementation-contributed/javascriptcore/stress/array-lastindexof-prototype-trap.js
+++ b/implementation-contributed/javascriptcore/stress/array-lastindexof-prototype-trap.js
@@ -1,0 +1,48 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+class DerivedArray extends Array {
+    get 2() {
+        this.called = true;
+        return 42;
+    }
+}
+
+{
+    let array = [];
+    array.__proto__ = DerivedArray.prototype;
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = [20, 20];
+    array.__proto__ = DerivedArray.prototype;
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = ["Hello"];
+    array.__proto__ = DerivedArray.prototype;
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = [42.195];
+    array.__proto__ = DerivedArray.prototype;
+    array.length = 42;
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}
+{
+    let array = ["Hello"];
+    array.__proto__ = DerivedArray.prototype;
+    array.length = 42;
+    ensureArrayStorage(array);
+    shouldBe(array.lastIndexOf(42), 2);
+    shouldBe(array.called, true);
+}

--- a/implementation-contributed/javascriptcore/stress/use-baseline-codeblock-materialize-osr-exit.js
+++ b/implementation-contributed/javascriptcore/stress/use-baseline-codeblock-materialize-osr-exit.js
@@ -1,0 +1,13 @@
+//@ runDefault("--jitPolicyScale=0")
+
+function foo() {
+    let j = 0;
+    let arr = [0];
+    arr.foo = 0;
+    for (var i = 0; i < 1024; i++) {
+        arr[0] = new Array(1024);
+    }
+}
+
+foo();
+foo();


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[3353b2924e](https://github.com///github/blob/3353b2924e) in JavaScriptCore and all changes made since [b0b5c9f9e](../blob/b0b5c9f9e) in
test262.













### 13 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/arguments-elimination-will-generate-edge-without-result.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/arguments-elimination-will-generate-edge-without-result.js)
 - [implementation-contributed/javascriptcore/stress/array-indexof-cached-length.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/array-indexof-cached-length.js)
 - [implementation-contributed/javascriptcore/stress/array-indexof-fast-path-effects.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/array-indexof-fast-path-effects.js)
 - [implementation-contributed/javascriptcore/stress/array-lastindexof-array-prototype-trap.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/array-lastindexof-array-prototype-trap.js)
 - [implementation-contributed/javascriptcore/stress/array-lastindexof-cached-length.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/array-lastindexof-cached-length.js)
 - [implementation-contributed/javascriptcore/stress/array-lastindexof-fast-path-effects.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/array-lastindexof-fast-path-effects.js)
 - [implementation-contributed/javascriptcore/stress/array-lastindexof-have-a-bad-time-c-runtime.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/array-lastindexof-have-a-bad-time-c-runtime.js)
 - [implementation-contributed/javascriptcore/stress/array-lastindexof-hole-nan.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/array-lastindexof-hole-nan.js)
 - [implementation-contributed/javascriptcore/stress/array-lastindexof-infinity.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/array-lastindexof-infinity.js)
 - [implementation-contributed/javascriptcore/stress/array-lastindexof-negative-zero.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/array-lastindexof-negative-zero.js)
 - [implementation-contributed/javascriptcore/stress/array-lastindexof-own-getter.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/array-lastindexof-own-getter.js)
 - [implementation-contributed/javascriptcore/stress/array-lastindexof-prototype-trap.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/array-lastindexof-prototype-trap.js)
 - [implementation-contributed/javascriptcore/stress/use-baseline-codeblock-materialize-osr-exit.js](../blob/javascriptcore-test262-automation-export-b0b5c9f9e/implementation-contributed/javascriptcore/stress/use-baseline-codeblock-materialize-osr-exit.js)