### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "a345e766",
-  "targetRevisionAtLastExport": "d1fe93a71",
+  "sourceRevisionAtLastExport": "69a502ce",
+  "targetRevisionAtLastExport": "67fc22e98",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/intl/date-format/resolved-options-unwrap.js
+++ b/implementation-contributed/v8/intl/date-format/resolved-options-unwrap.js
@@ -1,0 +1,11 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Test the Intl.DateTimeFormat.prototype.resolvedOptions will properly handle
+// 3. Let dtf be ? UnwrapDateTimeFormat(dtf).
+var x = Object.create(Intl.DateTimeFormat.prototype);
+x = Intl.DateTimeFormat.call(x, 'en');
+
+var resolvedOptions = Intl.DateTimeFormat.prototype.resolvedOptions.call(x);
+assertEquals(resolvedOptions.locale, 'en')

--- a/implementation-contributed/v8/intl/regress-888299.js
+++ b/implementation-contributed/v8/intl/regress-888299.js
@@ -1,0 +1,7 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+var i = 0;
+new Intl.DateTimeFormat(
+    undefined, { get hour() {  if (i == 0) { i = 1; return 'numeric'} } });

--- a/implementation-contributed/v8/mjsunit/compiler/regress-888923.js
+++ b/implementation-contributed/v8/mjsunit/compiler/regress-888923.js
@@ -1,0 +1,31 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+(function() {
+  function f(o) {
+    o.x;
+    Object.create(o);
+    return o.y.a;
+  }
+
+  f({ x : 0, y : { a : 1 } });
+  f({ x : 0, y : { a : 2 } });
+  %OptimizeFunctionOnNextCall(f);
+  assertEquals(3, f({ x : 0, y : { a : 3 } }));
+})();
+
+(function() {
+  function f(o) {
+    let a = o.y;
+    Object.create(o);
+    return o.x + a;
+  }
+
+  f({ x : 42, y : 21 });
+  f({ x : 42, y : 21 });
+  %OptimizeFunctionOnNextCall(f);
+  assertEquals(63, f({ x : 42, y : 21 }));
+})();

--- a/implementation-contributed/v8/test262/test262.status
+++ b/implementation-contributed/v8/test262/test262.status
@@ -502,17 +502,8 @@
   'built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab': ['--harmony-sharedarraybuffer'],
 
   # https://bugs.chromium.org/p/v8/issues/detail?id=8100
-  'built-ins/Atomics/add/bigint/*': [SKIP],
-  'built-ins/Atomics/and/bigint/*': [SKIP],
-  'built-ins/Atomics/compareExchange/bigint/*': [SKIP],
-  'built-ins/Atomics/exchange/bigint/*': [SKIP],
-  'built-ins/Atomics/load/bigint/*': [SKIP],
   'built-ins/Atomics/notify/bigint/*': [SKIP],
-  'built-ins/Atomics/or/bigint/*': [SKIP],
-  'built-ins/Atomics/store/bigint/*': [SKIP],
-  'built-ins/Atomics/sub/bigint/*': [SKIP],
   'built-ins/Atomics/wait/bigint/*': [SKIP],
-  'built-ins/Atomics/xor/bigint/*': [SKIP],
 
   # https://bugs.chromium.org/p/v8/issues/detail?id=6049
   'built-ins/Object/internals/DefineOwnProperty/consistent-value-function-caller': [FAIL_SLOPPY],


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[a345e766](https://github.com///github/blob/a345e766) in V8 and all changes made since [d1fe93a71](../blob/d1fe93a71) in
test262.



### 1 File Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/test262/test262.status](../blob/v8-test262-automation-export-d1fe93a71/implementation-contributed/v8/test262/test262.status)









### 3 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/intl/date-format/resolved-options-unwrap.js](../blob/v8-test262-automation-export-d1fe93a71/implementation-contributed/v8/intl/date-format/resolved-options-unwrap.js)
 - [implementation-contributed/v8/intl/regress-888299.js](../blob/v8-test262-automation-export-d1fe93a71/implementation-contributed/v8/intl/regress-888299.js)
 - [implementation-contributed/v8/mjsunit/compiler/regress-888923.js](../blob/v8-test262-automation-export-d1fe93a71/implementation-contributed/v8/mjsunit/compiler/regress-888923.js)