### PR TITLE
intl: add assertion to test that the result for default parameter

### DIFF
--- a/test/intl402/NumberFormat/prototype/formatToParts/default-parameter.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/default-parameter.js
@@ -1,5 +1,6 @@
 // Copyright (C) 2017 Josh Wolfe. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
+
 /*---
 esid: sec-intl.numberformat.prototype.formattoparts
 description: Intl.NumberFormat.prototype.formatToParts called with no parameters
@@ -11,12 +12,19 @@ info: |
 
 var nf = new Intl.NumberFormat();
 
-// Example value: [{"type":"nan","value":"NaN"}]
-var implicit = nf.formatToParts();
-var explicit = nf.formatToParts(undefined);
+const implicit = nf.formatToParts();
+const explicit = nf.formatToParts(undefined);
+const result = [{ type: 'nan', value: 'NaN' }];
 
-assert(partsEquals(implicit, explicit),
-  "formatToParts() should be equivalent to formatToParts(undefined)");
+assert(
+  partsEquals(implicit, explicit),
+  'formatToParts() should be equivalent to formatToParts(undefined)'
+);
+
+assert(
+  partsEquals(implicit, result),
+  'Both implicit and explicit calls should have the correct result'
+);
 
 function partsEquals(parts1, parts2) {
   if (parts1.length !== parts2.length) return false;


### PR DESCRIPTION
Add an assertion to the test for default parameters in Intl.NumberFormat's
method formatToParts checking that both the values are equal to the correct
result.

/cc @rwaldron @gsathya 