### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "69a502ce",
-  "targetRevisionAtLastExport": "67fc22e98",
+  "sourceRevisionAtLastExport": "d2e0166d",
+  "targetRevisionAtLastExport": "67c244b69",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/intl/relative-time-format/format-en.js
+++ b/implementation-contributed/v8/intl/relative-time-format/format-en.js
@@ -67,9 +67,6 @@ assertEquals('next month', longAuto.format(1, 'month'));
 assertEquals('in 2 months', longAuto.format(2, 'month'));
 assertEquals('in 345 months', longAuto.format(345, 'month'));
 
-// "quarter" is not working in ICU now
-// Tracked by ICU bug in http://bugs.icu-project.org/trac/ticket/12171
-/*
 assertEquals('3 quarters ago', longAuto.format(-3, 'quarter'));
 assertEquals('2 quarters ago', longAuto.format(-2, 'quarter'));
 assertEquals('last quarter', longAuto.format(-1, 'quarter'));
@@ -78,7 +75,6 @@ assertEquals('this quarter', longAuto.format(-0, 'quarter'));
 assertEquals('next quarter', longAuto.format(1, 'quarter'));
 assertEquals('in 2 quarters', longAuto.format(2, 'quarter'));
 assertEquals('in 345 quarters', longAuto.format(345, 'quarter'));
-*/
 
 assertEquals('3 years ago', longAuto.format(-3, 'year'));
 assertEquals('2 years ago', longAuto.format(-2, 'year'));
@@ -146,8 +142,6 @@ assertEquals('next mo.', shortAuto.format(1, 'month'));
 assertEquals('in 2 mo.', shortAuto.format(2, 'month'));
 assertEquals('in 345 mo.', shortAuto.format(345, 'month'));
 
-// "quarter" is not working in ICU now
-/*
 assertEquals('3 qtrs. ago', shortAuto.format(-3, 'quarter'));
 assertEquals('2 qtrs. ago', shortAuto.format(-2, 'quarter'));
 assertEquals('last qtr.', shortAuto.format(-1, 'quarter'));
@@ -156,7 +150,6 @@ assertEquals('this qtr.', shortAuto.format(-0, 'quarter'));
 assertEquals('next qtr.', shortAuto.format(1, 'quarter'));
 assertEquals('in 2 qtrs.', shortAuto.format(2, 'quarter'));
 assertEquals('in 345 qtrs.', shortAuto.format(345, 'quarter'));
-*/
 
 assertEquals('3 yr. ago', shortAuto.format(-3, 'year'));
 assertEquals('2 yr. ago', shortAuto.format(-2, 'year'));
@@ -225,8 +218,6 @@ assertEquals('next mo.', narrowAuto.format(1, 'month'));
 assertEquals('in 2 mo.', narrowAuto.format(2, 'month'));
 assertEquals('in 345 mo.', narrowAuto.format(345, 'month'));
 
-// "quarter" is not working in ICU now
-/*
 assertEquals('3 qtrs. ago', narrowAuto.format(-3, 'quarter'));
 assertEquals('2 qtrs. ago', narrowAuto.format(-2, 'quarter'));
 assertEquals('last qtr.', narrowAuto.format(-1, 'quarter'));
@@ -235,7 +226,6 @@ assertEquals('this qtr.', narrowAuto.format(-0, 'quarter'));
 assertEquals('next qtr.', narrowAuto.format(1, 'quarter'));
 assertEquals('in 2 qtrs.', narrowAuto.format(2, 'quarter'));
 assertEquals('in 345 qtrs.', narrowAuto.format(345, 'quarter'));
-*/
 
 assertEquals('3 yr. ago', narrowAuto.format(-3, 'year'));
 assertEquals('2 yr. ago', narrowAuto.format(-2, 'year'));
@@ -303,8 +293,6 @@ assertEquals('in 1 month', longAlways.format(1, 'month'));
 assertEquals('in 2 months', longAlways.format(2, 'month'));
 assertEquals('in 345 months', longAlways.format(345, 'month'));
 
-// "quarter" is not working in ICU now
-/*
 assertEquals('3 quarters ago', longAlways.format(-3, 'quarter'));
 assertEquals('2 quarters ago', longAlways.format(-2, 'quarter'));
 assertEquals('1 quarter ago', longAlways.format(-1, 'quarter'));
@@ -313,7 +301,6 @@ assertEquals('0 quarters ago', longAlways.format(-0, 'quarter'));
 assertEquals('in 1 quarter', longAlways.format(1, 'quarter'));
 assertEquals('in 2 quarters', longAlways.format(2, 'quarter'));
 assertEquals('in 345 quarters', longAlways.format(345, 'quarter'));
-*/
 
 assertEquals('3 years ago', longAlways.format(-3, 'year'));
 assertEquals('2 years ago', longAlways.format(-2, 'year'));
@@ -381,17 +368,14 @@ assertEquals('in 1 mo.', shortAlways.format(1, 'month'));
 assertEquals('in 2 mo.', shortAlways.format(2, 'month'));
 assertEquals('in 345 mo.', shortAlways.format(345, 'month'));
 
-// "quarter" is not working in ICU now
-/*
 assertEquals('3 qtrs. ago', shortAlways.format(-3, 'quarter'));
 assertEquals('2 qtrs. ago', shortAlways.format(-2, 'quarter'));
 assertEquals('1 qtr. ago', shortAlways.format(-1, 'quarter'));
 assertEquals('in 0 qtrs.', shortAlways.format(0, 'quarter'));
-assertEquals('0 qtr. ago', shortAlways.format(-0, 'quarter'));
+assertEquals('0 qtrs. ago', shortAlways.format(-0, 'quarter'));
 assertEquals('in 1 qtr.', shortAlways.format(1, 'quarter'));
 assertEquals('in 2 qtrs.', shortAlways.format(2, 'quarter'));
 assertEquals('in 345 qtrs.', shortAlways.format(345, 'quarter'));
-*/
 
 assertEquals('3 yr. ago', shortAlways.format(-3, 'year'));
 assertEquals('2 yr. ago', shortAlways.format(-2, 'year'));
@@ -460,17 +444,14 @@ assertEquals('in 1 mo.', narrowAlways.format(1, 'month'));
 assertEquals('in 2 mo.', narrowAlways.format(2, 'month'));
 assertEquals('in 345 mo.', narrowAlways.format(345, 'month'));
 
-// "quarter" is not working in ICU now
-/*
 assertEquals('3 qtrs. ago', narrowAlways.format(-3, 'quarter'));
 assertEquals('2 qtrs. ago', narrowAlways.format(-2, 'quarter'));
 assertEquals('1 qtr. ago', narrowAlways.format(-1, 'quarter'));
 assertEquals('in 0 qtrs.', narrowAlways.format(0, 'quarter'));
-assertEquals('0 qtr. ago', narrowAlways.format(-0, 'quarter'));
+assertEquals('0 qtrs. ago', narrowAlways.format(-0, 'quarter'));
 assertEquals('in 1 qtr.', narrowAlways.format(1, 'quarter'));
 assertEquals('in 2 qtrs.', narrowAlways.format(2, 'quarter'));
 assertEquals('in 345 qtrs.', narrowAlways.format(345, 'quarter'));
-*/
 
 assertEquals('3 yr. ago', narrowAlways.format(-3, 'year'));
 assertEquals('2 yr. ago', narrowAlways.format(-2, 'year'));

--- a/implementation-contributed/v8/intl/relative-time-format/format-to-parts-plural.js
+++ b/implementation-contributed/v8/intl/relative-time-format/format-to-parts-plural.js
@@ -19,8 +19,7 @@ function verifyElement(part, expectedUnit) {
   }
 };
 
-// TODO(ftang): add "quarter" after the fix of 8151
-['year', 'month', 'week', 'day', 'hour', 'minute', 'second'].forEach(
+['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second'].forEach(
     function(unit) {
       rtf.formatToParts(100, unit + 's').forEach(
           function(part) {

--- a/implementation-contributed/v8/mjsunit/regress/regress-889722.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-889722.js
@@ -1,0 +1,11 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+function getRandomProperty(v, rand) {
+  var properties = Object.getOwnPropertyNames(v);
+  return properties[rand % properties.length];
+}
+r = Realm.create();
+o = Realm.eval(r, "() => { return Realm.global(-10) instanceof Object }");
+o.__p_211203344 = o[getRandomProperty(o, 211203344)];


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[69a502ce](https://github.com///github/blob/69a502ce) in V8 and all changes made since [67fc22e98](../blob/67fc22e98) in
test262.



### 2 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/intl/relative-time-format/format-en.js](../blob/v8-test262-automation-export-67fc22e98/implementation-contributed/v8/intl/relative-time-format/format-en.js)
 - [implementation-contributed/v8/intl/relative-time-format/format-to-parts-plural.js](../blob/v8-test262-automation-export-67fc22e98/implementation-contributed/v8/intl/relative-time-format/format-to-parts-plural.js)









### 1 New File Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/regress/regress-889722.js](../blob/v8-test262-automation-export-67fc22e98/implementation-contributed/v8/mjsunit/regress/regress-889722.js)