### PR TITLE
intl: increase coverage for NumberFormat constructor

### DIFF
--- a/test/intl402/NumberFormat/constructor-options-toobject.js
+++ b/test/intl402/NumberFormat/constructor-options-toobject.js
@@ -15,7 +15,9 @@ info: |
 const toObjectResults = [
   [true, new Boolean(true)],
   [42, new Number(42)],
-  ['foo', new String('foo')]
+  ['foo', new String('foo')],
+  [{}, {}],
+  [Symbol(), Object(Symbol())]
 ];
 
 // Test if ToObject is used to convert primitives to Objects.

--- a/test/intl402/NumberFormat/constructor-options-toobject.js
+++ b/test/intl402/NumberFormat/constructor-options-toobject.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2018 Ujjwal Sharma. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-initializenumberformat
+description: >
+  Tests that Intl.NumberFormat contructor converts the options argument
+  to an object using `ToObject` (7.1.13).
+info: |
+  11.1.2 InitializeNumberFormat
+
+  3.a. Let options be ? ToObject(options).
+---*/
+
+const toObjectResults = [
+  [true, new Boolean(true)],
+  [42, new Number(42)],
+  ['foo', new String('foo')]
+];
+
+// Test if ToObject is used to convert primitives to Objects.
+toObjectResults.forEach(pair => {
+  const [value, result] = pair;
+  assert.sameValue(
+    new Intl.NumberFormat(['en-US'], value).resolvedOptions(),
+    new Intl.NumberFormat(['en-US'], result).resolvedOptions()
+  );
+});
+
+// ToObject throws a TypeError for undefined and null, but it's not called
+// when options is undefined.
+assert.throws(TypeError, () => new Intl.NumberFormat(['en-US'], null));


### PR DESCRIPTION
Increase coverage for the Intl.NumberFormat class contructor by adding
tests for checking that it calls ToObject on the options argument.

/cc @rwaldron @gsathya @littledan @anba 