### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "f2e2ad6325",
-  "targetRevisionAtLastExport": "f4f5a415f",
+  "sourceRevisionAtLastExport": "f1aff87cc3",
+  "targetRevisionAtLastExport": "fc866541d",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/jsc-read.js
+++ b/implementation-contributed/javascriptcore/stress/jsc-read.js
@@ -1,0 +1,38 @@
+(function test() {
+    // Read this test file using jsc shell's builtins, and check that its content is as expected.
+    const in_file = 'jsc-read.js';
+
+    const check = content_read => {
+        let testContent = test.toString();
+        let lineEnding = testContent.match(/\r?\n/)[0];
+        let expect = `(${testContent})();${lineEnding}`;
+        if (content_read !== expect)
+            throw Error('Expected to read this file as-is, instead read:\n==========\n' + content_read + '\n==========');
+    };
+
+    const test_arraybuffer = read_function => {
+        let file = read_function(in_file, 'binary');
+        if (typeof file.buffer !== 'object' || file.byteLength === undefined || file.length === undefined || file.BYTES_PER_ELEMENT !== 1 || file.byteOffset !== 0)
+            throw Error('Expected a Uint8Array');
+        let str = '';
+        for (var i = 0; i != file.length; ++i)
+            str += String.fromCharCode(file[i]);  // Assume ASCII.
+        check(str);
+    };
+
+    const test_string = read_function => {
+        let str = read_function(in_file);
+        if (typeof str !== 'string')
+            throw Error('Expected a string');
+        check(str);
+    };
+
+    // jsc's original file reading function is `readFile`, whereas SpiderMonkey
+    // shell's file reading function is `read`. The latter is used by
+    // emscripten's shell.js (d8 calls it `readbuffer`, which shell.js
+    // polyfills).
+    test_arraybuffer(readFile);
+    test_arraybuffer(read);
+    test_string(readFile);
+    test_string(read);
+})();

--- a/implementation-contributed/javascriptcore/stress/regress-169445.js
+++ b/implementation-contributed/javascriptcore/stress/regress-169445.js
@@ -1,0 +1,46 @@
+//@ defaultNoNoLLIntRun if $architecture == "arm"
+
+let args = new Array(0x10000);
+args.fill();
+args = args.map((_, i) => 'a' + i).join(', ');
+
+let gun = eval(`(function () {
+    class A {
+
+    }
+
+    class B extends A {
+        constructor(${args}) {
+            () => {
+                ${args};
+                super();
+            };
+
+            class C {
+                constructor() {
+                }
+
+                trigger() {
+                    (() => {
+                        super.x;
+                    })();
+                }
+
+                triggerWithRestParameters(...args) {
+                    (() => {
+                        super.x;
+                    })();
+                }
+            }
+
+            return new C();
+        }
+    }
+
+    return new B();
+})()`);
+
+for (let i = 0; i < 0x10000; i++) {
+    gun.trigger();
+    gun.triggerWithRestParameters(1, 2, 3);
+}

--- a/implementation-contributed/javascriptcore/stress/regress-189132.js
+++ b/implementation-contributed/javascriptcore/stress/regress-189132.js
@@ -1,0 +1,14 @@
+//@ skip if $memoryLimited
+
+try {
+    var a0 = '\ud801';
+    var a1 = [];
+    a2 = a0.padEnd(2147483644,'x');
+    a1[a2];
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "Error: Out of memory")
+    throw "FAILED";
+


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[f2e2ad6325](https://github.com///github/blob/f2e2ad6325) in JavaScriptCore and all changes made since [f4f5a415f](../blob/f4f5a415f) in
test262.



### 3 Files Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/jsc-read.js](../blob/javascriptcore-test262-automation-export-f4f5a415f/implementation-contributed/javascriptcore/stress/jsc-read.js)
 - [implementation-contributed/javascriptcore/stress/regress-169445.js](../blob/javascriptcore-test262-automation-export-f4f5a415f/implementation-contributed/javascriptcore/stress/regress-169445.js)
 - [implementation-contributed/javascriptcore/stress/regress-189132.js](../blob/javascriptcore-test262-automation-export-f4f5a415f/implementation-contributed/javascriptcore/stress/regress-189132.js)