### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "d2e0166d",
-  "targetRevisionAtLastExport": "67c244b69",
+  "sourceRevisionAtLastExport": "7b32eb8c",
+  "targetRevisionAtLastExport": "ffefa2383",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/mjsunit/compiler/regress-890057.js
+++ b/implementation-contributed/v8/mjsunit/compiler/regress-890057.js
@@ -1,0 +1,16 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+function f() {}
+function g() {
+  f.prototype = undefined;
+  f();
+  new f();
+}
+
+// Do not use %OptimizeFunctionOnNextCall here, this particular bug needs
+// to trigger truly concurrent compilation.
+for (let i = 0; i < 10000; i++) g();


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[d2e0166d](https://github.com///github/blob/d2e0166d) in V8 and all changes made since [67c244b69](../blob/67c244b69) in
test262.













### 1 New File Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/compiler/regress-890057.js](../blob/v8-test262-automation-export-67c244b69/implementation-contributed/v8/mjsunit/compiler/regress-890057.js)