### PR TITLE
Remove "ar-ma-u-ca-islamicc" from Locale/constructor-tag.js (Intl402)

### DIFF
--- a/test/intl402/Locale/constructor-tag.js
+++ b/test/intl402/Locale/constructor-tag.js
@@ -15,7 +15,6 @@ const validLanguageTags = {
     "eN": "en",
     "en-gb": "en-GB",
     "IT-LATN-iT": "it-Latn-IT",
-    "ar-ma-u-ca-islamicc": "ar-MA-u-ca-islamicc",
     "th-th-u-nu-thai": "th-TH-u-nu-thai",
     "X-u-foo": "x-u-foo",
     "en-x-u-foo": "en-x-u-foo",


### PR DESCRIPTION
Same as https://github.com/tc39/test262/pull/789
remove "ar-ma-u-ca-islamicc" from test.