### PR TITLE
intl: increase coverage from the NumberFormat constructor

### DIFF
--- a/test/intl402/NumberFormat/constructor-locales-arraylike.js
+++ b/test/intl402/NumberFormat/constructor-locales-arraylike.js
@@ -11,7 +11,13 @@ description: >
 const actual = Intl.NumberFormat({
   length: 1,
   1: 'en-US'
-});
-const expected = Intl.NumberFormat(['en-US']);
+}).resolvedOptions();
+const expected = Intl.NumberFormat(['en-US']).resolvedOptions();
 
-assert.sameValue(actual.resolvedOptions(), expected.resolvedOptions());
+assert.sameValue(actual.locale, expected.locale);
+assert.sameValue(actual.minimumIntegerDigits, expected.minimumIntegerDigits);
+assert.sameValue(actual.minimumFractionDigits, expected.minimumFractionDigits);
+assert.sameValue(actual.maximumFractionDigits, expected.maximumFractionDigits);
+assert.sameValue(actual.numberingSystem, expected.numberingSystem);
+assert.sameValue(actual.style, expected.style);
+assert.sameValue(actual.useGrouping, expected.useGrouping);

--- a/test/intl402/NumberFormat/constructor-locales-arraylike.js
+++ b/test/intl402/NumberFormat/constructor-locales-arraylike.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Ujjwal Sharma. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-initializenumberformat
+description: >
+  Tests that the Intl.NumberFormat constructor accepts Array-like values for the
+  locales argument and treats them well.
+---*/
+
+const actual = Intl.NumberFormat({
+  length: 1,
+  1: 'en-US'
+});
+const expected = Intl.NumberFormat(['en-US']);
+
+assert.sameValue(actual.resolvedOptions(), expected.resolvedOptions());


### PR DESCRIPTION
Improve coverage for the Intl.NumberFormat constructor by testing that
it accepts Array-like objects and handles them properly.

/cc @gsathya @rwaldron @littledan @anba 