### PR TITLE
remove "invalid" from invalid date of "co" and "nu"

### DIFF
--- a/test/intl402/Collator/ignore-invalid-unicode-ext-values.js
+++ b/test/intl402/Collator/ignore-invalid-unicode-ext-values.js
@@ -24,7 +24,7 @@ var defaultLocale = defaultOptions.locale;
 var defaultSortedArray = testArray.slice(0).sort(defaultCollator.compare);
 
 var keyValues = {
-    "co": ["standard", "search", "invalid"],
+    "co": ["standard", "search"],
     "ka": ["noignore", "shifted", "invalid"],
     "kb": ["true", "false", "invalid"],
     "kc": ["true", "false", "invalid"],

--- a/test/intl402/DateTimeFormat/ignore-invalid-unicode-ext-values.js
+++ b/test/intl402/DateTimeFormat/ignore-invalid-unicode-ext-values.js
@@ -21,7 +21,7 @@ locales.forEach(function (locale) {
 
     var keyValues = {
         "cu": ["USD", "EUR", "JPY", "CNY", "TWD", "invalid"], // DateTimeFormat internally uses NumberFormat
-        "nu": ["native", "traditio", "finance", "invalid"],
+        "nu": ["native", "traditio", "finance"],
         "tz": ["usnavajo", "utcw01", "aumel", "uslax", "usnyc", "deber", "invalid"]
     };
     

--- a/test/intl402/NumberFormat/ignore-invalid-unicode-ext-values.js
+++ b/test/intl402/NumberFormat/ignore-invalid-unicode-ext-values.js
@@ -21,7 +21,7 @@ locales.forEach(function (locale) {
 
     var keyValues = {
         "cu": ["USD", "EUR", "JPY", "CNY", "TWD", "invalid"],
-        "nu": ["native", "traditio", "finance", "invalid"]
+        "nu": ["native", "traditio", "finance"]
     };
     
     Object.getOwnPropertyNames(keyValues).forEach(function (key) {


### PR DESCRIPTION
I see nowhere in https://www.ecma-international.org/ecma-402/ mention "cu" and "nu" cannot use "invalid" as value. I think we should remove this from the test. "invalid" should be treated as a valid value for the -u-co- and -u-nu- extension in locale. This is different from "standard" and "search" for "co" and "native", "traditio", or "finance" for "nu" because those are explicitly mentioned in the spec.