### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "f1aff87cc3",
-  "targetRevisionAtLastExport": "fc866541d",
+  "sourceRevisionAtLastExport": "9dc12cff08",
+  "targetRevisionAtLastExport": "bebaa21ad",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-general.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-general.js
@@ -1,0 +1,97 @@
+//@ runBigIntEnabled
+
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+function assert(a) {
+    if (!a)
+        throw new Error("Bad assertion");
+}
+
+assert.sameValue = function (input, expected, message) {
+    if (input !== expected)
+        throw new Error(message);
+}
+
+assert.sameValue(0b00n & 0b00n, 0b00n, "0b00n & 0b00n === 0b00n");
+assert.sameValue(0b00n & 0b01n, 0b00n, "0b00n & 0b01n === 0b00n");
+assert.sameValue(0b01n & 0b00n, 0b00n, "0b01n & 0b00n === 0b00n");
+assert.sameValue(0b00n & 0b10n, 0b00n, "0b00n & 0b10n === 0b00n");
+assert.sameValue(0b10n & 0b00n, 0b00n, "0b10n & 0b00n === 0b00n");
+assert.sameValue(0b00n & 0b11n, 0b00n, "0b00n & 0b11n === 0b00n");
+assert.sameValue(0b11n & 0b00n, 0b00n, "0b11n & 0b00n === 0b00n");
+assert.sameValue(0b01n & 0b01n, 0b01n, "0b01n & 0b01n === 0b01n");
+assert.sameValue(0b01n & 0b10n, 0b00n, "0b01n & 0b10n === 0b00n");
+assert.sameValue(0b10n & 0b01n, 0b00n, "0b10n & 0b01n === 0b00n");
+assert.sameValue(0b01n & 0b11n, 0b01n, "0b01n & 0b11n === 0b01n");
+assert.sameValue(0b11n & 0b01n, 0b01n, "0b11n & 0b01n === 0b01n");
+assert.sameValue(0b10n & 0b10n, 0b10n, "0b10n & 0b10n === 0b10n");
+assert.sameValue(0b10n & 0b11n, 0b10n, "0b10n & 0b11n === 0b10n");
+assert.sameValue(0b11n & 0b10n, 0b10n, "0b11n & 0b10n === 0b10n");
+assert.sameValue(0xffffffffn & 0n, 0n, "0xffffffffn & 0n === 0n");
+assert.sameValue(0n & 0xffffffffn, 0n, "0n & 0xffffffffn === 0n");
+assert.sameValue(0xffffffffn & 0xffffffffn, 0xffffffffn, "0xffffffffn & 0xffffffffn === 0xffffffffn");
+assert.sameValue(0xffffffffffffffffn & 0n, 0n, "0xffffffffffffffffn & 0n === 0n");
+assert.sameValue(0n & 0xffffffffffffffffn, 0n, "0n & 0xffffffffffffffffn === 0n");
+assert.sameValue(0xffffffffffffffffn & 0xffffffffn, 0xffffffffn, "0xffffffffffffffffn & 0xffffffffn === 0xffffffffn");
+assert.sameValue(0xffffffffn & 0xffffffffffffffffn, 0xffffffffn, "0xffffffffn & 0xffffffffffffffffn === 0xffffffffn");
+assert.sameValue(
+  0xffffffffffffffffn & 0xffffffffffffffffn, 0xffffffffffffffffn,
+  "0xffffffffffffffffn & 0xffffffffffffffffn === 0xffffffffffffffffn");
+assert.sameValue(
+  0xbf2ed51ff75d380fd3be813ec6185780n & 0x4aabef2324cedff5387f1f65n, 0x42092803008e813400181700n,
+  "0xbf2ed51ff75d380fd3be813ec6185780n & 0x4aabef2324cedff5387f1f65n === 0x42092803008e813400181700n");
+assert.sameValue(
+  0x4aabef2324cedff5387f1f65n & 0xbf2ed51ff75d380fd3be813ec6185780n, 0x42092803008e813400181700n,
+  "0x4aabef2324cedff5387f1f65n & 0xbf2ed51ff75d380fd3be813ec6185780n === 0x42092803008e813400181700n");
+assert.sameValue(0n & -1n, 0n, "0n & -1n === 0n");
+assert.sameValue(-1n & 0n, 0n, "-1n & 0n === 0n");
+assert.sameValue(0n & -2n, 0n, "0n & -2n === 0n");
+assert.sameValue(-2n & 0n, 0n, "-2n & 0n === 0n");
+assert.sameValue(1n & -2n, 0n, "1n & -2n === 0n");
+assert.sameValue(-2n & 1n, 0n, "-2n & 1n === 0n");
+assert.sameValue(2n & -2n, 2n, "2n & -2n === 2n");
+assert.sameValue(-2n & 2n, 2n, "-2n & 2n === 2n");
+assert.sameValue(2n & -3n, 0n, "2n & -3n === 0n");
+assert.sameValue(-3n & 2n, 0n, "-3n & 2n === 0n");
+assert.sameValue(-1n & -2n, -2n, "-1n & -2n === -2n");
+assert.sameValue(-2n & -1n, -2n, "-2n & -1n === -2n");
+assert.sameValue(-2n & -2n, -2n, "-2n & -2n === -2n");
+assert.sameValue(-2n & -3n, -4n, "-2n & -3n === -4n");
+assert.sameValue(-3n & -2n, -4n, "-3n & -2n === -4n");
+assert.sameValue(0xffffffffn & -1n, 0xffffffffn, "0xffffffffn & -1n === 0xffffffffn");
+assert.sameValue(-1n & 0xffffffffn, 0xffffffffn, "-1n & 0xffffffffn === 0xffffffffn");
+assert.sameValue(0xffffffffffffffffn & -1n, 0xffffffffffffffffn, "0xffffffffffffffffn & -1n === 0xffffffffffffffffn");
+assert.sameValue(-1n & 0xffffffffffffffffn, 0xffffffffffffffffn, "-1n & 0xffffffffffffffffn === 0xffffffffffffffffn");
+assert.sameValue(
+  0xbf2ed51ff75d380fd3be813ec6185780n & -0x4aabef2324cedff5387f1f65n, 0xbf2ed51fb554100cd330000ac6004080n,
+  "0xbf2ed51ff75d380fd3be813ec6185780n & -0x4aabef2324cedff5387f1f65n === 0xbf2ed51fb554100cd330000ac6004080n");
+assert.sameValue(
+  -0x4aabef2324cedff5387f1f65n & 0xbf2ed51ff75d380fd3be813ec6185780n, 0xbf2ed51fb554100cd330000ac6004080n,
+  "-0x4aabef2324cedff5387f1f65n & 0xbf2ed51ff75d380fd3be813ec6185780n === 0xbf2ed51fb554100cd330000ac6004080n");
+assert.sameValue(
+  -0xbf2ed51ff75d380fd3be813ec6185780n & 0x4aabef2324cedff5387f1f65n, 0x8a2c72024405ec138670800n,
+  "-0xbf2ed51ff75d380fd3be813ec6185780n & 0x4aabef2324cedff5387f1f65n === 0x8a2c72024405ec138670800n");
+assert.sameValue(
+  0x4aabef2324cedff5387f1f65n & -0xbf2ed51ff75d380fd3be813ec6185780n, 0x8a2c72024405ec138670800n,
+  "0x4aabef2324cedff5387f1f65n & -0xbf2ed51ff75d380fd3be813ec6185780n === 0x8a2c72024405ec138670800n");
+assert.sameValue(
+  -0xbf2ed51ff75d380fd3be813ec6185780n & -0x4aabef2324cedff5387f1f65n, -0xbf2ed51fffffff2ff7fedffffe7f5f80n,
+  "-0xbf2ed51ff75d380fd3be813ec6185780n & -0x4aabef2324cedff5387f1f65n === -0xbf2ed51fffffff2ff7fedffffe7f5f80n");
+assert.sameValue(
+  -0x4aabef2324cedff5387f1f65n & -0xbf2ed51ff75d380fd3be813ec6185780n, -0xbf2ed51fffffff2ff7fedffffe7f5f80n,
+  "-0x4aabef2324cedff5387f1f65n & -0xbf2ed51ff75d380fd3be813ec6185780n === -0xbf2ed51fffffff2ff7fedffffe7f5f80n");
+assert.sameValue(-0xffffffffn & 0n, 0n, "-0xffffffffn & 0n === 0n");
+assert.sameValue(0n & -0xffffffffn, 0n, "0n & -0xffffffffn === 0n");
+assert.sameValue(
+  -0xffffffffffffffffn & 0x10000000000000000n, 0x10000000000000000n,
+  "-0xffffffffffffffffn & 0x10000000000000000n === 0x10000000000000000n");
+assert.sameValue(
+  0x10000000000000000n & -0xffffffffffffffffn, 0x10000000000000000n,
+  "0x10000000000000000n & -0xffffffffffffffffn === 0x10000000000000000n");
+assert.sameValue(
+  -0xffffffffffffffffffffffffn & 0x10000000000000000n, 0n,
+  "-0xffffffffffffffffffffffffn & 0x10000000000000000n === 0n");
+assert.sameValue(
+  0x10000000000000000n & -0xffffffffffffffffffffffffn, 0n,
+  "0x10000000000000000n & -0xffffffffffffffffffffffffn === 0n");

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-jit.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-jit.js
@@ -1,0 +1,20 @@
+//@ runBigIntEnabled
+
+let assert = {
+    sameValue: function(i, e, m) {
+        if (i !== e)
+            throw new Error(m);
+    }
+}
+
+function bigIntBitAnd(a, b) {
+    return (a & b) & (a & 0b11n);
+
+}
+noInline(bigIntBitAnd);
+
+for (let i = 0; i < 10000; i++) {
+    let r = bigIntBitAnd(0b11n, 0b1010n);
+    assert.sameValue(r, 0b10n, 0b11n + " & " + 0b1010n + " = " + r);
+}
+

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-memory-stress.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-memory-stress.js
@@ -1,0 +1,14 @@
+//@ runBigIntEnabled
+
+function assert(a) {
+    if (!a)
+        throw new Error("Bad assertion");
+}
+
+let a = 0b11n;
+for (let i = 0; i < 1000000; i++) {
+    a &= 0b01n;
+}
+
+assert(a === 0b01n);
+

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-to-primitive-precedence.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-to-primitive-precedence.js
@@ -1,0 +1,29 @@
+//@ runBigIntEnabled
+
+assert = {
+    sameValue: function (input, expected, message) {
+        if (input !== expected)
+            throw new Error(message);
+    }
+};
+
+let o = {
+    [Symbol.toPrimitive]: function() {
+        throw new Error("Bad");
+    }
+};
+
+try{
+    o & Symbol("2");
+    assert.sameValue(true, false, "Exception expected to be throwed, but executed without error");
+} catch (e) {
+    assert.sameValue(e.message, "Bad", "Expected to throw Error('Bad'), but got: " + e);
+}
+
+try{
+    Symbol("2") & o;
+    assert.sameValue(true, false, "Exception expected to be throwed, but executed without error");
+} catch (e) {
+    assert.sameValue(e instanceof TypeError, true, "Expected to throw TypeError, but got: " + e)
+}
+

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-type-error.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-type-error.js
@@ -1,0 +1,106 @@
+//@ runBigIntEnabled
+
+function assert(a, message) {
+    if (!a)
+        throw new Error(message);
+}
+
+function assertThrowTypeError(a, b, message) {
+    try {
+        let n = a & b;
+        assert(false, message + ": Should throw TypeError, but executed without exception");
+    } catch (e) {
+        assert(e instanceof TypeError, message + ": expected TypeError, got: " + e);
+    }
+}
+
+assertThrowTypeError(30n, "foo", "BigInt & String");
+assertThrowTypeError("bar", 18757382984821n, "String & BigInt");
+assertThrowTypeError(30n, Symbol("foo"), "BigInt & Symbol");
+assertThrowTypeError(Symbol("bar"), 18757382984821n, "Symbol & BigInt");
+assertThrowTypeError(30n, 3320, "BigInt & Int32");
+assertThrowTypeError(33256, 18757382984821n, "Int32 & BigInt");
+assertThrowTypeError(30n, 0.543, "BigInt & Double");
+assertThrowTypeError(230.19293, 18757382984821n, "Double & BigInt");
+assertThrowTypeError(30n, NaN, "BigInt & NaN");
+assertThrowTypeError(NaN, 18757382984821n, "NaN & BigInt");
+assertThrowTypeError(30n, NaN, "BigInt & NaN");
+assertThrowTypeError(NaN, 18757382984821n, "NaN & BigInt");
+assertThrowTypeError(30n, +Infinity, "BigInt & NaN");
+assertThrowTypeError(+Infinity, 18757382984821n, "NaN & BigInt");
+assertThrowTypeError(30n, -Infinity, "BigInt & -Infinity");
+assertThrowTypeError(-Infinity, 18757382984821n, "-Infinity & BigInt");
+assertThrowTypeError(30n, null, "BigInt & null");
+assertThrowTypeError(null, 18757382984821n, "null & BigInt");
+assertThrowTypeError(30n, undefined, "BigInt & undefined");
+assertThrowTypeError(undefined, 18757382984821n, "undefined & BigInt");
+assertThrowTypeError(30n, true, "BigInt & true");
+assertThrowTypeError(true, 18757382984821n, "true & BigInt");
+assertThrowTypeError(30n, false, "BigInt & false");
+assertThrowTypeError(false, 18757382984821n, "false & BigInt");
+
+// Error when returning from object
+
+let o = {
+    valueOf: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt & Object.valueOf returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Symbol & BigInt");
+
+o = {
+    valueOf: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt & Object.valueOf returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Int32 & BigInt");
+
+o = {
+    valueOf: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt & Object.valueOf returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Double & BigInt");
+
+o = {
+    toString: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt & Object.toString returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Symbol & BigInt");
+
+o = {
+    toString: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt & Object.toString returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Int32 & BigInt");
+
+o = {
+    toString: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt & Object.toString returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Double & BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt & Object.@@toPrimitive returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Symbol & BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt & Object.@@toPrimitive returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Int32 & BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt & Object.@@toPrimitive returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Double & BigInt");
+

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-wrapped-value.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-wrapped-value.js
@@ -1,0 +1,37 @@
+//@ runBigIntEnabled
+
+assert = {
+    sameValue: function (input, expected, message) {
+        if (input !== expected)
+            throw new Error(message);
+    }
+};
+
+function testBitAnd(x, y, z, message) {
+    assert.sameValue(x & y, z, message);
+    assert.sameValue(y & x, z, message);
+}
+
+testBitAnd(Object(0b10n), 0b01n, 0b00n, "ToPrimitive: unbox object with internal slot");
+
+let o = {
+    [Symbol.toPrimitive]: function() {
+        return 0b10n;
+    }
+};
+testBitAnd(o, 0b01n, 0b00n, "ToPrimitive: @@toPrimitive");
+
+o = {
+    valueOf: function() {
+        return 0b10n;
+    }
+};
+testBitAnd(o, 0b01n, 0b00n, "ToPrimitive: valueOf");
+
+o = {
+    toString: function() {
+        return 0b10n;
+    }
+}
+testBitAnd(o, 0b01n, 0b00n, "ToPrimitive: toString");
+

--- a/implementation-contributed/javascriptcore/stress/big-int-to-string.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-to-string.js
@@ -1,0 +1,57 @@
+//@ runBigIntEnabled
+
+function assert(a) {
+    if (!a)
+        throw new Error("Bad assertion");
+}
+
+let v = 10n;
+assert(v.toString() === "10");
+assert(v.toString(2) === "1010");
+assert(v.toString(3) === "101");
+assert(v.toString(8) === "12");
+assert(v.toString(16) === "a");
+assert(v.toString(32) === "a");
+
+v = 191561942608236107294793378393788647952342390272950271n;
+assert(v.toString() === "191561942608236107294793378393788647952342390272950271");
+assert(v.toString(2) === "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111");
+assert(v.toString(3) === "2002122121011101220102010210020102000210011100122221002112102021022221102202020101221000021200201121121100121121");
+assert(v.toString(8) === "77777777777777777777777777777777777777777777777777777777777");
+assert(v.toString(16) === "1ffffffffffffffffffffffffffffffffffffffffffff");
+assert(v.toString(32) === "3vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv");
+
+v = -10n;
+assert(v.toString() === "-10");
+assert(v.toString(2) === "-1010");
+assert(v.toString(3) === "-101");
+assert(v.toString(8) === "-12");
+assert(v.toString(16) === "-a");
+assert(v.toString(32) === "-a");
+
+v = -191561942608236107294793378393788647952342390272950271n;
+assert(v.toString() === "-191561942608236107294793378393788647952342390272950271");
+assert(v.toString(2) === "-111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111");
+assert(v.toString(3) === "-2002122121011101220102010210020102000210011100122221002112102021022221102202020101221000021200201121121100121121");
+assert(v.toString(8) === "-77777777777777777777777777777777777777777777777777777777777");
+assert(v.toString(16) === "-1ffffffffffffffffffffffffffffffffffffffffffff");
+assert(v.toString(32) === "-3vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv");
+
+// Invaid radix
+
+function testInvalidRadix(radix) {
+    try {
+        v.toString(radix);
+        assert(false);
+    } catch(e) {
+        assert(e instanceof RangeError);
+    }
+}
+
+testInvalidRadix(-10);
+testInvalidRadix(-1);
+testInvalidRadix(0);
+testInvalidRadix(1);
+testInvalidRadix(37);
+testInvalidRadix(4294967312);
+

--- a/implementation-contributed/javascriptcore/stress/dataview-jit-set-nan.js
+++ b/implementation-contributed/javascriptcore/stress/dataview-jit-set-nan.js
@@ -1,0 +1,52 @@
+//@ skip if $architecture == "mips"
+
+"use strict";
+
+function assert(b) {
+    if (!b)
+        throw new Error;
+}
+
+function test() {
+    function storeLittleEndian(dv, index, value) {
+        dv.setFloat32(index, value, true);
+    }
+    noInline(storeLittleEndian);
+
+    function storeBigEndian(dv, index, value) {
+        dv.setFloat32(index, value, false);
+    }
+    noInline(storeBigEndian);
+
+    function store(dv, index, value, littleEndian) {
+        dv.setFloat32(index, value, littleEndian);
+    }
+    noInline(store);
+
+    let buffer = new ArrayBuffer(4);
+    let arr = new Float32Array(buffer);
+    let bits = new Uint32Array(buffer);
+    let dv = new DataView(buffer);
+
+    for (let i = 0; i < 10000; ++i) {
+        storeLittleEndian(dv, 0, 1.5);
+        assert(arr[0] === 1.5);
+
+        storeLittleEndian(dv, 0, 12912.124123215122);
+        assert(arr[0] === 12912.1240234375);
+        assert(bits[0] === 0x4649c07f);
+
+        storeLittleEndian(dv, 0, NaN);
+        assert(isNaN(arr[0]));
+        assert(bits[0] === 0x7FC00000);
+
+        storeLittleEndian(dv, 0, 2.3879393e-38);
+        assert(arr[0] === 2.387939260590663e-38);
+        assert(bits[0] === 0x01020304);
+
+        storeBigEndian(dv, 0, 2.3879393e-38);
+        assert(arr[0] === 1.539989614439558e-36);
+        assert(bits[0] === 0x04030201);
+    }
+}
+test();

--- a/implementation-contributed/javascriptcore/stress/dataview-jit-set.js
+++ b/implementation-contributed/javascriptcore/stress/dataview-jit-set.js
@@ -1,0 +1,439 @@
+"use strict";
+
+function assert(b) {
+    if (!b)
+        throw new Error;
+}
+
+function readHex(dv, bytes) {
+    function isLittleEndian() { 
+        let b = new ArrayBuffer(4);
+        let dv = new DataView(b);
+        dv.setInt32(0, 0x00112233, true);
+        return dv.getUint8(0) === 0x33;
+    }
+    let str = "";
+    function readByte(i) {
+        let b = dv.getUint8(i).toString(16);
+        if (b.length === 1)
+            b = "0" + b;
+        else
+            assert(b.length === 2)
+        return b;
+    }
+    if (isLittleEndian()) {
+        for (let i = bytes; i--;)
+            str = str + readByte(i);
+    } else {
+        for (let i = 0; i < bytes; ++i)
+            str = str + readByte(i);
+    }
+
+    return "0x" + str;
+}
+
+{
+    let b = new ArrayBuffer(4);
+    let dv = new DataView(b);
+    dv.setInt32(0, 0x00112233, true);
+    assert(readHex(dv, 4) === "0x00112233");
+}
+
+function test() {
+    function storeLittleEndian(dv, index, value) {
+        dv.setInt16(index, value, true);
+    }
+    noInline(storeLittleEndian);
+
+    function storeBigEndian(dv, index, value) {
+        dv.setInt16(index, value, false);
+    }
+    noInline(storeBigEndian);
+
+    function store(dv, index, value, littleEndian) {
+        dv.setInt16(index, value, littleEndian);
+    }
+    noInline(store);
+
+    let buffer = new ArrayBuffer(2);
+    let arr = new Uint16Array(buffer);
+    let dv = new DataView(buffer);
+
+    for (let i = 0; i < 10000; ++i) {
+        storeLittleEndian(dv, 0, 0xfaba);
+        assert(arr[0] === 0xfaba);
+
+        store(dv, 0, 0xabcd, true);
+        assert(arr[0] === 0xabcd);
+
+        store(dv, 0, 0xbadbeef, true);
+        assert(arr[0] === 0xbeef);
+
+        storeLittleEndian(dv, 0, 0xbb4db33f, true);
+        assert(arr[0] === 0xb33f);
+
+        storeBigEndian(dv, 0, 0xfada);
+        assert(arr[0] === 0xdafa);
+
+        storeBigEndian(dv, 0, 0x12ab);
+        assert(arr[0] === 0xab12);
+
+        store(dv, 0, 0x1234, false);
+        assert(arr[0] === 0x3412);
+
+        store(dv, 0, 0x0102, false);
+        assert(arr[0] === 0x0201);
+
+        store(dv, 0, -1, false);
+        assert(arr[0] === 0xffff);
+
+        store(dv, 0, -2, false);
+        assert(arr[0] === 0xfeff);
+
+        storeBigEndian(dv, 0, -1);
+        assert(arr[0] === 0xffff);
+
+        storeBigEndian(dv, 0, -2);
+        assert(arr[0] === 0xfeff);
+
+        storeBigEndian(dv, 0, -2147483648); 
+        assert(arr[0] === 0x0000);
+
+        storeLittleEndian(dv, 0, -2147483648); 
+        assert(arr[0] === 0x0000);
+
+        storeLittleEndian(dv, 0, -2147478988); 
+        assert(arr[0] === 0x1234);
+
+        storeBigEndian(dv, 0, -2147478988); 
+        assert(arr[0] === 0x3412);
+    }
+}
+test();
+
+function test2() {
+    function storeLittleEndian(dv, index, value) {
+        dv.setUint16(index, value, true);
+    }
+    noInline(storeLittleEndian);
+
+    function storeBigEndian(dv, index, value) {
+        dv.setUint16(index, value, false);
+    }
+    noInline(storeBigEndian);
+
+    function store(dv, index, value, littleEndian) {
+        dv.setUint16(index, value, littleEndian);
+    }
+    noInline(store);
+
+    let buffer = new ArrayBuffer(2);
+    let arr = new Uint16Array(buffer);
+    let dv = new DataView(buffer);
+
+    for (let i = 0; i < 10000; ++i) {
+        storeLittleEndian(dv, 0, 0xfaba);
+        assert(arr[0] === 0xfaba);
+
+        store(dv, 0, 0xabcd, true);
+        assert(arr[0] === 0xabcd);
+
+        store(dv, 0, 0xbadbeef, true);
+        assert(arr[0] === 0xbeef);
+
+        storeLittleEndian(dv, 0, 0xbb4db33f, true);
+        assert(arr[0] === 0xb33f);
+
+        storeBigEndian(dv, 0, 0xfada);
+        assert(arr[0] === 0xdafa);
+
+        storeBigEndian(dv, 0, 0x12ab);
+        assert(arr[0] === 0xab12);
+
+        store(dv, 0, 0x1234, false);
+        assert(arr[0] === 0x3412);
+
+        store(dv, 0, 0x0102, false);
+        assert(arr[0] === 0x0201);
+
+        store(dv, 0, -1, false);
+        assert(arr[0] === 0xffff);
+
+        store(dv, 0, -2, false);
+        assert(arr[0] === 0xfeff);
+
+        storeBigEndian(dv, 0, -1);
+        assert(arr[0] === 0xffff);
+
+        storeBigEndian(dv, 0, -2);
+        assert(arr[0] === 0xfeff);
+
+        storeBigEndian(dv, 0, -2147483648); 
+        assert(arr[0] === 0x0000);
+
+        storeLittleEndian(dv, 0, -2147483648); 
+        assert(arr[0] === 0x0000);
+
+        storeLittleEndian(dv, 0, -2147478988); 
+        assert(arr[0] === 0x1234);
+
+        storeBigEndian(dv, 0, -2147478988); 
+        assert(arr[0] === 0x3412);
+    }
+}
+test2();
+
+function test3() {
+    function storeLittleEndian(dv, index, value) {
+        dv.setUint32(index, value, true);
+    }
+    noInline(storeLittleEndian);
+
+    function storeBigEndian(dv, index, value) {
+        dv.setUint32(index, value, false);
+    }
+    noInline(storeBigEndian);
+
+    function store(dv, index, value, littleEndian) {
+        dv.setUint32(index, value, littleEndian);
+    }
+    noInline(store);
+
+    let buffer = new ArrayBuffer(4);
+    let arr = new Uint32Array(buffer);
+    let arr2 = new Int32Array(buffer);
+    let dv = new DataView(buffer);
+
+    for (let i = 0; i < 10000; ++i) {
+        storeLittleEndian(dv, 0, 0xffffffff);
+        assert(arr[0] === 0xffffffff);
+        assert(arr2[0] === -1);
+
+        storeLittleEndian(dv, 0, 0xffaabbcc);
+        assert(arr[0] === 0xffaabbcc);
+
+        storeBigEndian(dv, 0, 0x12345678);
+        assert(arr[0] === 0x78563412);
+
+        storeBigEndian(dv, 0, 0xffaabbcc);
+        assert(arr[0] === 0xccbbaaff);
+
+        store(dv, 0, 0xfaeadaca, false);
+        assert(arr[0] === 0xcadaeafa);
+
+        store(dv, 0, 0xcadaeafa, false);
+        assert(arr2[0] === -85271862);
+
+        store(dv, 0, 0x12345678, false);
+        assert(arr[0] === 0x78563412);
+
+        storeBigEndian(dv, 0, 0xbeeffeeb);
+        assert(arr2[0] === -335614018);
+    }
+}
+test3();
+
+function test4() {
+    function storeLittleEndian(dv, index, value) {
+        dv.setInt32(index, value, true);
+    }
+    noInline(storeLittleEndian);
+
+    function storeBigEndian(dv, index, value) {
+        dv.setInt32(index, value, false);
+    }
+    noInline(storeBigEndian);
+
+    function store(dv, index, value, littleEndian) {
+        dv.setInt32(index, value, littleEndian);
+    }
+    noInline(store);
+
+    let buffer = new ArrayBuffer(4);
+    let arr = new Uint32Array(buffer);
+    let arr2 = new Int32Array(buffer);
+    let dv = new DataView(buffer);
+
+    for (let i = 0; i < 10000; ++i) {
+        storeLittleEndian(dv, 0, 0xffffffff);
+        assert(arr[0] === 0xffffffff);
+        assert(arr2[0] === -1);
+
+        storeLittleEndian(dv, 0, 0xffaabbcc);
+        assert(arr[0] === 0xffaabbcc);
+
+        storeBigEndian(dv, 0, 0x12345678);
+        assert(arr[0] === 0x78563412);
+
+        storeBigEndian(dv, 0, 0xffaabbcc);
+        assert(arr[0] === 0xccbbaaff);
+
+        store(dv, 0, 0xfaeadaca, false);
+        assert(arr[0] === 0xcadaeafa);
+
+        store(dv, 0, 0xcadaeafa, false);
+        assert(arr2[0] === -85271862);
+
+        store(dv, 0, 0x12345678, false);
+        assert(arr[0] === 0x78563412);
+
+        storeBigEndian(dv, 0, 0xbeeffeeb);
+        assert(arr2[0] === -335614018);
+    }
+}
+test4();
+
+function test5() {
+    function storeLittleEndian(dv, index, value) {
+        dv.setFloat32(index, value, true);
+    }
+    noInline(storeLittleEndian);
+
+    function storeBigEndian(dv, index, value) {
+        dv.setFloat32(index, value, false);
+    }
+    noInline(storeBigEndian);
+
+    function store(dv, index, value, littleEndian) {
+        dv.setFloat32(index, value, littleEndian);
+    }
+    noInline(store);
+
+    let buffer = new ArrayBuffer(4);
+    let arr = new Float32Array(buffer);
+    let bits = new Uint32Array(buffer);
+    let dv = new DataView(buffer);
+
+    for (let i = 0; i < 10000; ++i) {
+        storeLittleEndian(dv, 0, 1.5);
+        assert(arr[0] === 1.5);
+
+        storeLittleEndian(dv, 0, 12912.124123215122);
+        assert(arr[0] === 12912.1240234375);
+        assert(bits[0] === 0x4649c07f);
+
+        storeLittleEndian(dv, 0, NaN);
+        assert(isNaN(arr[0]));
+
+        storeLittleEndian(dv, 0, 2.3879393e-38);
+        assert(arr[0] === 2.387939260590663e-38);
+        assert(bits[0] === 0x01020304);
+
+        storeBigEndian(dv, 0, 2.3879393e-38);
+        assert(arr[0] === 1.539989614439558e-36);
+        assert(bits[0] === 0x04030201);
+    }
+}
+test5();
+
+function test6() {
+    function storeLittleEndian(dv, index, value) {
+        dv.setFloat64(index, value, true);
+    }
+    noInline(storeLittleEndian);
+
+    function storeBigEndian(dv, index, value) {
+        dv.setFloat64(index, value, false);
+    }
+    noInline(storeBigEndian);
+
+    function store(dv, index, value, littleEndian) {
+        dv.setFloat64(index, value, littleEndian);
+    }
+    noInline(store);
+
+    let buffer = new ArrayBuffer(8);
+    let arr = new Float64Array(buffer);
+    let dv = new DataView(buffer);
+
+    for (let i = 0; i < 10000; ++i) {
+        storeLittleEndian(dv, 0, NaN);
+        assert(isNaN(arr[0]));
+
+        storeLittleEndian(dv, 0, -2.5075187084135162e+284);
+        assert(arr[0] === -2.5075187084135162e+284);
+        assert(readHex(dv, 8) === "0xfafafafafafafafa");
+
+        store(dv, 0, 124.553, true);
+        assert(readHex(dv, 8) === "0x405f23645a1cac08");
+
+        store(dv, 0, Infinity, true);
+        assert(readHex(dv, 8) === "0x7ff0000000000000");
+
+        store(dv, 0, Infinity, false);
+        assert(readHex(dv, 8) === "0x000000000000f07f");
+
+        store(dv, 0, -Infinity, true);
+        assert(readHex(dv, 8) === "0xfff0000000000000");
+
+        storeBigEndian(dv, 0, -2.5075187084135162e+284);
+        assert(arr[0] === -2.5075187084135162e+284);
+        assert(readHex(dv, 8) === "0xfafafafafafafafa");
+
+        storeBigEndian(dv, 0, 124.553);
+        assert(readHex(dv, 8) === "0x08ac1c5a64235f40");
+    }
+}
+test6();
+
+function test7() {
+    function store(dv, index, value) {
+        dv.setInt8(index, value);
+    }
+    noInline(store);
+
+    let buffer = new ArrayBuffer(1);
+    let arr = new Uint8Array(buffer);
+    let arr2 = new Int8Array(buffer);
+    let dv = new DataView(buffer);
+
+    for (let i = 0; i < 10000; ++i) {
+        store(dv, 0, 0xff);
+        assert(arr[0] === 0xff);
+        assert(arr2[0] === -1);
+
+        store(dv, 0, 0xff00);
+        assert(arr[0] === 0);
+        assert(arr2[0] === 0);
+
+        store(dv, 0, -1);
+        assert(arr[0] === 0xff);
+        assert(arr2[0] === -1);
+
+        store(dv, 0, 0x0badbeef);
+        assert(arr[0] === 0xef);
+        assert(arr2[0] === -17);
+    }
+}
+test7();
+
+function test8() {
+    function store(dv, index, value) {
+        dv.setInt8(index, value);
+    }
+    noInline(store);
+
+    let buffer = new ArrayBuffer(1);
+    let arr = new Uint8Array(buffer);
+    let arr2 = new Int8Array(buffer);
+    let dv = new DataView(buffer);
+
+    for (let i = 0; i < 10000; ++i) {
+        store(dv, 0, 0xff);
+        assert(arr[0] === 0xff);
+        assert(arr2[0] === -1);
+
+        store(dv, 0, 0xff00);
+        assert(arr[0] === 0);
+        assert(arr2[0] === 0);
+
+        store(dv, 0, -1);
+        assert(arr[0] === 0xff);
+        assert(arr2[0] === -1);
+
+        store(dv, 0, 0x0badbeef);
+        assert(arr[0] === 0xef);
+        assert(arr2[0] === -17);
+    }
+}
+test8();

--- a/implementation-contributed/javascriptcore/stress/regress-190186.js
+++ b/implementation-contributed/javascriptcore/stress/regress-190186.js
@@ -1,0 +1,95 @@
+//@ runDefault("--useConcurrentJIT=false", "--sweepSynchronously=true")
+
+// This test passes if it does not crash with an ASAN build.
+
+(function() {
+    var bar = {};
+
+    for (var i = 0; i < 68; ++i)
+        String.raw`boo`;
+
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+    eval(String.raw`bar += 0;`);
+
+    eval(String.raw`foo = class { };`);
+    foo += 0;
+
+    gc();
+    try {
+        eval(foo.toString());
+    } catch (e) {
+        exception = e;
+    }
+
+    if (exception != "SyntaxError: Class statements must have a name.")
+        throw "FAIL";
+})();


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[f1aff87cc3](https://github.com///github/blob/f1aff87cc3) in JavaScriptCore and all changes made since [fc866541d](../blob/fc866541d) in
test262.



### 2 Files Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/big-int-to-string.js](../blob/javascriptcore-test262-automation-export-fc866541d/implementation-contributed/javascriptcore/stress/big-int-to-string.js)
 - [implementation-contributed/javascriptcore/stress/dataview-jit-set.js](../blob/javascriptcore-test262-automation-export-fc866541d/implementation-contributed/javascriptcore/stress/dataview-jit-set.js)









### 8 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-and-general.js](../blob/javascriptcore-test262-automation-export-fc866541d/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-general.js)
 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-and-jit.js](../blob/javascriptcore-test262-automation-export-fc866541d/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-jit.js)
 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-and-memory-stress.js](../blob/javascriptcore-test262-automation-export-fc866541d/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-memory-stress.js)
 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-and-to-primitive-precedence.js](../blob/javascriptcore-test262-automation-export-fc866541d/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-to-primitive-precedence.js)
 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-and-type-error.js](../blob/javascriptcore-test262-automation-export-fc866541d/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-type-error.js)
 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-and-wrapped-value.js](../blob/javascriptcore-test262-automation-export-fc866541d/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-wrapped-value.js)
 - [implementation-contributed/javascriptcore/stress/dataview-jit-set-nan.js](../blob/javascriptcore-test262-automation-export-fc866541d/implementation-contributed/javascriptcore/stress/dataview-jit-set-nan.js)
 - [implementation-contributed/javascriptcore/stress/regress-190186.js](../blob/javascriptcore-test262-automation-export-fc866541d/implementation-contributed/javascriptcore/stress/regress-190186.js)