### PR TITLE
Remove `undefined` from “unreserved words” test

### DIFF
--- a/test/language/reserved-words/unreserved-words.js
+++ b/test/language/reserved-words/unreserved-words.js
@@ -99,7 +99,6 @@ var typeid = 1;
 // u
 var uint = 1;
 var unchecked = 1;
-var undefined = 1;
 var union = 1;
 var unsafe = 1;
 var unsigned = 1;


### PR DESCRIPTION
Although `undefined` is not a reserved word, the global `undefined` property is read-only, and trying to assign to it throws a `TypeError` exception in strict mode.

https://github.com/tc39/test262/pull/1816.