### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "9dc12cff08",
-  "targetRevisionAtLastExport": "bebaa21ad",
+  "sourceRevisionAtLastExport": "204d982056",
+  "targetRevisionAtLastExport": "0eb3a6f9e",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/ftl-should-always-filter-for-low-type-check-functions.js
+++ b/implementation-contributed/javascriptcore/stress/ftl-should-always-filter-for-low-type-check-functions.js
@@ -1,0 +1,31 @@
+//@ runDefault("--useConcurrentJIT=0", "--jitPolicyScale=0", "--maximumInliningDepth=2")
+
+function foo(x, y) {
+    var w = 0;
+    for (var i = 0; i < x.length; ++i) {
+        for (var j = 0; j < x.length; ++j)
+            w += foo(j, i);
+        y[i] = w;
+    }
+}
+
+function test(x, a3) {
+      a1 = [];
+      a2 = [];
+
+    for (i = 0; i < x; ++i)
+        a1[i] = 0;
+
+    for (i = 0; i < 10; ++i) {
+        foo(a3, a2);
+        foo(a3, a1);
+    }
+}
+noDFG(test);
+
+a3 = [];
+for (var i = 0; i < 3; ++i)
+    a3[i] = 0;
+
+for (var i = 3; i <= 12; i *= 2)
+    test(i, a3);

--- a/implementation-contributed/javascriptcore/stress/regress-190187.js
+++ b/implementation-contributed/javascriptcore/stress/regress-190187.js
@@ -1,0 +1,18 @@
+//@ runDefault
+//@ skip if $memoryLimited or $buildType == "debug"
+//@ slow!
+
+try {
+    var v1 = "AAAAAAAAAAA";
+    for(var i = 0; i < 27; i++)
+      v1 = v1 + v1;
+    var v2;
+    var v3 = RegExp.prototype.toString.call({source:v1,flags:v1});
+    v3 += v1;
+    v2 += v3.localeCompare(v1);
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "Error: Out of memory")
+    throw "FAILED";


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[9dc12cff08](https://github.com///github/blob/9dc12cff08) in JavaScriptCore and all changes made since [bebaa21ad](../blob/bebaa21ad) in
test262.













### 2 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/ftl-should-always-filter-for-low-type-check-functions.js](../blob/javascriptcore-test262-automation-export-bebaa21ad/implementation-contributed/javascriptcore/stress/ftl-should-always-filter-for-low-type-check-functions.js)
 - [implementation-contributed/javascriptcore/stress/regress-190187.js](../blob/javascriptcore-test262-automation-export-bebaa21ad/implementation-contributed/javascriptcore/stress/regress-190187.js)