### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "4ab8215e",
-  "targetRevisionAtLastExport": "92143ed8c",
+  "sourceRevisionAtLastExport": "fb4d8c01",
+  "targetRevisionAtLastExport": "53ec6e9db",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-1.js
+++ b/implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-1.js
@@ -1,0 +1,31 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --async-stack-traces
+
+// Check that Error.prepareStackTrace doesn't expose strict
+// mode closures, even in the presence of async frames.
+Error.prepareStackTrace = (e, frames) => {
+  assertEquals(two, frames[0].getFunction());
+  assertEquals(two.name, frames[0].getFunctionName());
+  assertEquals(undefined, frames[1].getFunction());
+  assertEquals(one.name, frames[1].getFunctionName());
+  return frames;
+};
+
+async function one(x) {
+  "use strict";
+  return await two(x);
+}
+
+async function two(x) {
+  try {
+    x = await x;
+    throw new Error();
+  } catch (e) {
+    return e.stack;
+  }
+}
+
+one(1).catch(e => setTimeout(_ => {throw e}, 0));

--- a/implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-2.js
+++ b/implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-2.js
@@ -1,0 +1,31 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --async-stack-traces
+
+// Check that Error.prepareStackTrace doesn't expose strict
+// mode closures, even in the presence of async frames.
+Error.prepareStackTrace = (e, frames) => {
+  assertEquals(undefined, frames[0].getFunction());
+  assertEquals(two.name, frames[0].getFunctionName());
+  assertEquals(undefined, frames[1].getFunction());
+  assertEquals(one.name, frames[1].getFunctionName());
+  return frames;
+};
+
+async function one(x) {
+  return await two(x);
+}
+
+async function two(x) {
+  "use strict";
+  try {
+    x = await x;
+    throw new Error();
+  } catch (e) {
+    return e.stack;
+  }
+}
+
+one(1).catch(e => setTimeout(_ => {throw e}, 0));

--- a/implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-3.js
+++ b/implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-3.js
@@ -1,0 +1,31 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --async-stack-traces
+
+// Check that Error.prepareStackTrace properly marks async frames.
+Error.prepareStackTrace = (e, frames) => {
+  assertEquals(two, frames[0].getFunction());
+  assertEquals(two.name, frames[0].getFunctionName());
+  assertFalse(frames[0].isAsync());
+  assertEquals(two, frames[1].getFunction());
+  assertEquals(one.name, frames[1].getFunctionName());
+  assertTrue(frames[1].isAsync());
+  return frames;
+};
+
+async function one(x) {
+  return await two(x);
+}
+
+async function two(x) {
+  try {
+    x = await x;
+    throw new Error();
+  } catch (e) {
+    return e.stack;
+  }
+}
+
+one(1).catch(e => setTimeout(_ => {throw e}, 0));

--- a/implementation-contributed/v8/mjsunit/async-stack-traces.js
+++ b/implementation-contributed/v8/mjsunit/async-stack-traces.js
@@ -1,0 +1,174 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --async-stack-traces
+
+// Basic test with an explicit throw.
+(function() {
+  async function one(x) {
+    await two(x);
+  }
+
+  async function two(x) {
+    await x;
+    throw new Error();
+  }
+
+  async function test(f) {
+    try {
+      await f(1);
+      assertUnreachable();
+    } catch (e) {
+      assertInstanceof(e, Error);
+      assertMatches(/Error.+at two.+at async one.+at async test/ms, e.stack);
+    }
+  }
+
+  assertPromiseResult((async () => {
+    await test(one);
+    await test(one);
+    %OptimizeFunctionOnNextCall(two);
+    await test(one);
+    %OptimizeFunctionOnNextCall(one);
+    await test(one);
+  })());
+})();
+
+// Basic test with an implicit throw (via ToNumber on Symbol).
+(function() {
+  async function one(x) {
+    return await two(x);
+  }
+
+  async function two(x) {
+    await x;
+    return +x;  // This will raise a TypeError.
+  }
+
+  async function test(f) {
+    try {
+      await f(Symbol());
+      assertUnreachable();
+    } catch (e) {
+      assertInstanceof(e, TypeError);
+      assertMatches(/TypeError.+at two.+at async one.+at async test/ms, e.stack);
+    }
+  }
+
+  assertPromiseResult((async() => {
+    await test(one);
+    await test(one);
+    %OptimizeFunctionOnNextCall(two);
+    await test(one);
+    %OptimizeFunctionOnNextCall(one);
+    await test(one);
+  })());
+})();
+
+// Basic test with throw in inlined function.
+(function() {
+  function throwError() {
+    throw new Error();
+  }
+
+  async function one(x) {
+    return await two(x);
+  }
+
+  async function two(x) {
+    await x;
+    return throwError();
+  }
+
+  async function test(f) {
+    try {
+      await f(1);
+      assertUnreachable();
+    } catch (e) {
+      assertInstanceof(e, Error);
+      assertMatches(/Error.+at two.+at async one.+at async test/ms, e.stack);
+    }
+  }
+
+  assertPromiseResult((async() => {
+    await test(one);
+    await test(one);
+    %OptimizeFunctionOnNextCall(two);
+    await test(one);
+    %OptimizeFunctionOnNextCall(one);
+    await test(one);
+  })());
+})();
+
+// Basic test with async function inlined into sync function.
+(function() {
+  function callOne(x) {
+    return one(x);
+  }
+
+  function callTwo(x) {
+    return two(x);
+  }
+
+  async function one(x) {
+    return await callTwo(x);
+  }
+
+  async function two(x) {
+    await x;
+    throw new Error();
+  }
+
+  async function test(f) {
+    try {
+      await f(1);
+      assertUnreachable();
+    } catch (e) {
+      assertInstanceof(e, Error);
+      assertMatches(/Error.+at two.+at async one.+at async test/ms, e.stack);
+    }
+  }
+
+  assertPromiseResult((async() => {
+    await test(callOne);
+    await test(callOne);
+    %OptimizeFunctionOnNextCall(callTwo);
+    await test(callOne);
+    %OptimizeFunctionOnNextCall(callOne);
+    await test(callOne);
+  })());
+})();
+
+// Basic test with async functions and promises chained via
+// Promise.prototype.then(), which should still work following
+// the generic chain upwards.
+(function() {
+  async function one(x) {
+    return await two(x).then(x => x);
+  }
+
+  async function two(x) {
+    await x.then(x => x);
+    throw new Error();
+  }
+
+  async function test(f) {
+    try {
+      await f(Promise.resolve(1));
+      assertUnreachable();
+    } catch (e) {
+      assertInstanceof(e, Error);
+      assertMatches(/Error.+at two.+at async one.+at async test/ms, e.stack);
+    }
+  }
+
+  assertPromiseResult((async() => {
+    await test(one);
+    await test(one);
+    %OptimizeFunctionOnNextCall(two);
+    await test(one);
+    %OptimizeFunctionOnNextCall(one);
+    await test(one);
+  })());
+})();

--- a/implementation-contributed/v8/mjsunit/compiler/number-modulus.js
+++ b/implementation-contributed/v8/mjsunit/compiler/number-modulus.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Flags: --allow-natives-syntax --opt
+// Flags: --allow-natives-syntax --opt --noalways-opt
 
 // Test that NumberModulus with Number feedback works if only in the
 // end SimplifiedLowering figures out that the inputs to this operation
@@ -152,5 +152,105 @@
   // produce -0, aka when we pass a negative value for `x`.
   assertEquals(0, foo(-2));
   assertEquals(1, foo(-1));
+  assertOptimized(foo);
+})();
+
+// Test that CheckedInt32Mod handles the slow-path (when
+// the left hand side is negative) correctly.
+(function() {
+  // We need a SpeculativeNumberModulus with SignedSmall feedback.
+  function foo(x, y) {
+    return x % y;
+  }
+
+  assertEquals(0, foo(2, 1));
+  assertEquals(0, foo(2, 2));
+  assertEquals(-1, foo(-3, 2));
+  %OptimizeFunctionOnNextCall(foo);
+  assertEquals(0, foo(2, 1));
+  assertEquals(0, foo(2, 2));
+  assertEquals(-1, foo(-3, 2));
+  assertOptimized(foo);
+
+  // Now `foo` should deoptimize if the result is -0.
+  assertEquals(-0, foo(-2, 2));
+  assertUnoptimized(foo);
+})();
+
+// Test that NumberModulus passes kIdentifiesZero to the
+// left hand side input when the result doesn't care about
+// 0 vs -0, even when the inputs are outside Signed32.
+(function() {
+  function foo(x) {
+    return (x * -2) % (2 ** 32) === 0;
+  }
+
+  assertFalse(foo(2));
+  assertFalse(foo(1));
+  %OptimizeFunctionOnNextCall(foo);
+  assertFalse(foo(2));
+  assertFalse(foo(1));
+
+  // Now `foo` should stay optimized even if `x * -2` would
+  // produce -0, aka when we pass a zero value for `x`.
+  assertTrue(foo(0));
+  assertOptimized(foo);
+})();
+
+// Test that NumberModulus passes kIdentifiesZero to the
+// right hand side input, even when the inputs are outside
+// the Signed32 range.
+(function() {
+  function foo(x) {
+    return (2 ** 32) % (x * -2);
+  }
+
+  assertEquals(0, foo(1));
+  assertEquals(0, foo(1));
+  %OptimizeFunctionOnNextCall(foo);
+  assertEquals(0, foo(1));
+
+  // Now `foo` should stay optimized even if `x * -2` would
+  // produce -0, aka when we pass a zero value for `x`.
+  assertEquals(NaN, foo(0));
+  assertOptimized(foo);
+})();
+
+// Test that SpeculativeNumberModulus passes kIdentifiesZero
+// to the right hand side input, even when feedback is consumed.
+(function() {
+  function foo(x, y) {
+    return (x % (y * -2)) | 0;
+  }
+
+  assertEquals(0, foo(2, 1));
+  assertEquals(-1, foo(-3, 1));
+  %OptimizeFunctionOnNextCall(foo);
+  assertEquals(0, foo(2, 1));
+  assertEquals(-1, foo(-3, 1));
+  assertOptimized(foo);
+
+  // Now `foo` should stay optimized even if `y * -2` would
+  // produce -0, aka when we pass a zero value for `y`.
+  assertEquals(0, foo(2, 0));
+  assertOptimized(foo);
+})();
+
+// Test that SpeculativeNumberModulus passes kIdentifiesZero
+// to the left hand side input, even when feedback is consumed.
+(function() {
+  function foo(x, y) {
+    return ((x * -2) % y) | 0;
+  }
+
+  assertEquals(-2, foo(1, 3));
+  assertEquals(-2, foo(1, 3));
+  %OptimizeFunctionOnNextCall(foo);
+  assertEquals(-2, foo(1, 3));
+  assertOptimized(foo);
+
+  // Now `foo` should stay optimized even if `x * -2` would
+  // produce -0, aka when we pass a zero value for `x`.
+  assertEquals(0, foo(0, 2));
   assertOptimized(foo);
 })();

--- a/implementation-contributed/v8/mjsunit/compiler/number-round.js
+++ b/implementation-contributed/v8/mjsunit/compiler/number-round.js
@@ -1,0 +1,22 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --opt
+
+// Test that NumberRound propagates kIdentifyZeros truncations.
+(function() {
+  function foo(x) {
+    return Math.abs(Math.round(x * -2));
+  }
+
+  assertEquals(2, foo(1));
+  assertEquals(4, foo(2));
+  %OptimizeFunctionOnNextCall(foo);
+  assertEquals(2, foo(1));
+  assertEquals(4, foo(2));
+  assertOptimized(foo);
+  // Now `foo` should stay optimized even if `x * -2` would produce `-0`.
+  assertEquals(0, foo(0));
+  assertOptimized(foo);
+})();

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-891627.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-891627.js
@@ -1,0 +1,43 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+// We need a NumberModulus, so we make sure that we have a
+// SpeculativeNumberModulus with Number feedback, and later
+// on use it with known Number inputs (via the bitwise or),
+// such that JSTypedLowering turns it into the NumberModulus.
+function bar(x) { return x % 2; }
+bar(0.1);
+
+// Check that the Word32->Float64 conversion works properly.
+(function() {
+  function foo(x) {
+    // The NumberEqual identifies 0 and -0.
+    return bar(x | -1) == 4294967295;
+  }
+
+  assertFalse(foo(1));
+  assertFalse(foo(0));
+  %OptimizeFunctionOnNextCall(foo);
+  assertFalse(foo(1));
+  assertFalse(foo(0));
+})();
+
+// Check that the Word32->Word32 conversion works properly.
+(function() {
+  function makeFoo(y) {
+    return function foo(x) {
+      return bar(x | -1) == y;
+    }
+  }
+  makeFoo(0);  // Defeat the function context specialization.
+  const foo = makeFoo(1);
+
+  assertFalse(foo(1));
+  assertFalse(foo(0));
+  %OptimizeFunctionOnNextCall(foo);
+  assertFalse(foo(1));
+  assertFalse(foo(0));
+})();

--- a/implementation-contributed/v8/test262/test262.status
+++ b/implementation-contributed/v8/test262/test262.status
@@ -817,3 +817,879 @@
 }],  # system == windows
 
 ]
+
+    /*
+    ********************************** test262-automation **********************************
+    Summary: The two files have now diverged.
+        File Status: Partially curated & modified.
+        Source Status: Modified since its export.
+        Below is the current and modified source which was exported on Thu Oct 04 2018 18:37:16 GMT+0000 (Coordinated Universal Time)
+    */
+      # Copyright 2011 the V8 project authors. All rights reserved.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#     * Neither the name of Google Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+[
+
+[ALWAYS, {
+  ###################### MISSING ES6 FEATURES #######################
+
+  # https://code.google.com/p/v8/issues/detail?id=4248
+  'language/expressions/compound-assignment/S11.13.2_A5.*': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A6.*': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A7.10_T4': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A7.11_T4': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A7.1_T4': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A7.2_T4': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A7.3_T4': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A7.4_T4': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A7.5_T4': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A7.6_T4': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A7.7_T4': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A7.8_T4': [FAIL],
+  'language/expressions/compound-assignment/S11.13.2_A7.9_T4': [FAIL],
+  'language/statements/with/unscopables-inc-dec': [FAIL],
+
+  # https://code.google.com/p/v8/issues/detail?id=4249
+  'language/expressions/assignment/S11.13.1_A7_T1': [FAIL],
+  'language/expressions/assignment/S11.13.1_A7_T2': [FAIL],
+  'language/expressions/assignment/S11.13.1_A7_T3': [FAIL],
+  'language/expressions/postfix-increment/S11.3.1_A6_T3': [FAIL],
+  'language/expressions/postfix-decrement/S11.3.2_A6_T3': [FAIL],
+  'language/expressions/prefix-decrement/S11.4.5_A6_T3': [FAIL],
+  'language/expressions/prefix-increment/S11.4.4_A6_T3': [FAIL],
+
+  # https://code.google.com/p/v8/issues/detail?id=4250
+  'language/expressions/assignment/S11.13.1_A5*': [FAIL],
+  'language/expressions/assignment/S11.13.1_A6*': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=4709
+  'built-ins/Promise/reject-function-name': [FAIL],
+  'built-ins/Promise/resolve-function-name': [FAIL],
+  'built-ins/Promise/all/resolve-element-function-name': [FAIL],
+  'built-ins/Promise/executor-function-name': [FAIL],
+  'built-ins/Proxy/revocable/revocation-function-name': [FAIL],
+  'language/expressions/assignment/fn-name-lhs-cover': [FAIL],
+  'language/expressions/assignment/fn-name-lhs-member': [FAIL],
+  'language/expressions/function/name': [FAIL],
+  'language/expressions/generators/name': [FAIL],
+  'intl402/NumberFormat/prototype/format/format-function-name': [FAIL],
+  'intl402/DateTimeFormat/prototype/format/format-function-name': [FAIL],
+  'intl402/Collator/prototype/compare/compare-function-name': [FAIL],
+
+  # https://code.google.com/p/v8/issues/detail?id=4251
+  'language/expressions/postfix-increment/S11.3.1_A5_T1': [FAIL],
+  'language/expressions/postfix-increment/S11.3.1_A5_T2': [FAIL],
+  'language/expressions/postfix-increment/S11.3.1_A5_T3': [FAIL],
+  'language/expressions/postfix-increment/S11.3.1_A5_T4': [FAIL],
+  'language/expressions/postfix-increment/S11.3.1_A5_T5': [FAIL],
+  'language/expressions/postfix-decrement/S11.3.2_A5_*': [FAIL],
+  'language/expressions/prefix-decrement/S11.4.5_A5_*': [FAIL],
+  'language/expressions/prefix-increment/S11.4.4_A5_*': [FAIL],
+  'language/statements/variable/binding-resolution': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=4895
+  'built-ins/TypedArrayConstructors/internals/DefineOwnProperty/detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/DefineOwnProperty/detached-buffer-realm': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/detached-buffer-realm': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/DefineOwnProperty/tonumber-value-detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/tonumber-value-detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Get/detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Get/BigInt/detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Get/detached-buffer-realm': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Get/BigInt/detached-buffer-realm': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Get/infinity-detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Get/BigInt/infinity-detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/GetOwnProperty/detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/GetOwnProperty/BigInt/detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/GetOwnProperty/detached-buffer-realm': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/GetOwnProperty/BigInt/detached-buffer-realm': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/GetOwnProperty/enumerate-detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/GetOwnProperty/BigInt/enumerate-detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/HasProperty/detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/HasProperty/detached-buffer-realm': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/detached-buffer-realm': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/HasProperty/infinity-with-detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/infinity-with-detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Set/detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Set/BigInt/detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Set/detached-buffer-realm': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Set/BigInt/detached-buffer-realm': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Set/tonumber-value-detached-buffer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Set/BigInt/tonumber-value-detached-buffer': [FAIL],
+  # Some TypedArray methods throw due to the same bug, from Get
+  'built-ins/TypedArray/prototype/every/callbackfn-detachbuffer': [FAIL],
+  'built-ins/TypedArray/prototype/every/BigInt/callbackfn-detachbuffer': [FAIL],
+  'built-ins/TypedArray/prototype/find/predicate-may-detach-buffer': [FAIL],
+  'built-ins/TypedArray/prototype/find/BigInt/predicate-may-detach-buffer': [FAIL],
+  'built-ins/TypedArray/prototype/findIndex/predicate-may-detach-buffer': [FAIL],
+  'built-ins/TypedArray/prototype/findIndex/BigInt/predicate-may-detach-buffer': [FAIL],
+  'built-ins/TypedArray/prototype/forEach/callbackfn-detachbuffer': [FAIL],
+  'built-ins/TypedArray/prototype/forEach/BigInt/callbackfn-detachbuffer': [FAIL],
+  'built-ins/TypedArray/prototype/map/callbackfn-detachbuffer': [FAIL],
+  'built-ins/TypedArray/prototype/map/BigInt/callbackfn-detachbuffer': [FAIL],
+  'built-ins/TypedArray/prototype/reduce/callbackfn-detachbuffer': [FAIL],
+  'built-ins/TypedArray/prototype/reduce/BigInt/callbackfn-detachbuffer': [FAIL],
+  'built-ins/TypedArray/prototype/reduceRight/callbackfn-detachbuffer': [FAIL],
+  'built-ins/TypedArray/prototype/reduceRight/BigInt/callbackfn-detachbuffer': [FAIL],
+  'built-ins/TypedArray/prototype/some/callbackfn-detachbuffer': [FAIL],
+  'built-ins/TypedArray/prototype/some/BigInt/callbackfn-detachbuffer': [FAIL],
+  # DataView functions should also throw on detached buffers
+  'built-ins/ArrayBuffer/prototype/byteLength/detached-buffer': [FAIL],
+  'built-ins/DataView/detached-buffer': [FAIL],
+  'built-ins/DataView/prototype/byteLength/detached-buffer': [FAIL],
+  'built-ins/DataView/prototype/byteOffset/detached-buffer': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=4231
+  'language/eval-code/direct/var-env-lower-lex-catch-non-strict': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=4951
+  'language/expressions/assignment/dstr-array-elem-iter-rtrn-close-err': [FAIL],
+  'language/expressions/assignment/dstr-array-elem-iter-thrw-close': [FAIL],
+  'language/expressions/assignment/dstr-array-elem-iter-thrw-close-err': [FAIL],
+  'language/expressions/assignment/dstr-array-elem-trlg-iter-list-thrw-close': [FAIL],
+  'language/expressions/assignment/dstr-array-elem-trlg-iter-list-thrw-close-err': [FAIL],
+  'language/expressions/assignment/dstr-array-elem-trlg-iter-rest-rtrn-close': [FAIL],
+  'language/expressions/assignment/dstr-array-elem-trlg-iter-rest-rtrn-close-err': [FAIL],
+  'language/expressions/assignment/dstr-array-elem-trlg-iter-rest-rtrn-close-null': [FAIL],
+  'language/expressions/assignment/dstr-array-elem-trlg-iter-rest-thrw-close': [FAIL],
+  'language/expressions/assignment/dstr-array-elem-trlg-iter-rest-thrw-close-err': [FAIL],
+  'language/expressions/assignment/dstr-array-rest-iter-rtrn-close': [FAIL],
+  'language/expressions/assignment/dstr-array-rest-iter-rtrn-close-err': [FAIL],
+  'language/expressions/assignment/dstr-array-rest-iter-rtrn-close-null': [FAIL],
+  'language/expressions/assignment/dstr-array-rest-iter-thrw-close': [FAIL],
+  'language/expressions/assignment/dstr-array-rest-iter-thrw-close-err': [FAIL],
+  'language/expressions/assignment/dstr-array-rest-lref-err': [FAIL],
+  'language/statements/for-of/dstr-array-elem-iter-rtrn-close-err': [FAIL],
+  'language/statements/for-of/dstr-array-elem-iter-thrw-close': [FAIL],
+  'language/statements/for-of/dstr-array-elem-iter-thrw-close-err': [FAIL],
+  'language/statements/for-of/dstr-array-elem-trlg-iter-list-thrw-close': [FAIL],
+  'language/statements/for-of/dstr-array-elem-trlg-iter-list-thrw-close-err': [FAIL],
+  'language/statements/for-of/dstr-array-elem-trlg-iter-rest-rtrn-close': [FAIL],
+  'language/statements/for-of/dstr-array-elem-trlg-iter-rest-rtrn-close-err': [FAIL],
+  'language/statements/for-of/dstr-array-elem-trlg-iter-rest-rtrn-close-null': [FAIL],
+  'language/statements/for-of/dstr-array-elem-trlg-iter-rest-thrw-close': [FAIL],
+  'language/statements/for-of/dstr-array-elem-trlg-iter-rest-thrw-close-err': [FAIL],
+  'language/statements/for-of/dstr-array-rest-iter-rtrn-close': [FAIL],
+  'language/statements/for-of/dstr-array-rest-iter-rtrn-close-err': [FAIL],
+  'language/statements/for-of/dstr-array-rest-iter-rtrn-close-null': [FAIL],
+  'language/statements/for-of/dstr-array-rest-iter-thrw-close': [FAIL],
+  'language/statements/for-of/dstr-array-rest-iter-thrw-close-err': [FAIL],
+  'language/statements/for-of/dstr-array-rest-lref-err': [FAIL],
+  'language/expressions/assignment/destructuring/iterator-destructuring-property-reference-target-evaluation-order': [FAIL],
+  'language/expressions/assignment/destructuring/keyed-destructuring-property-reference-target-evaluation-order': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=896
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_F': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_F-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_Invalid': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_Invalid-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_N': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_N-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_No': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_No-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_T': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_T-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_Y': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_Y-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_Yes': [FAIL],
+  'built-ins/RegExp/property-escapes/binary-property-with-value-ASCII_-_Yes-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/character-class-range-end': [FAIL],
+  'built-ins/RegExp/property-escapes/character-class-range-no-dash-end': [FAIL],
+  'built-ins/RegExp/property-escapes/character-class-range-no-dash-start': [FAIL],
+  'built-ins/RegExp/property-escapes/character-class-range-start': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-In-prefix-Block-implicit': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-In-prefix-Block-implicit-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-In-prefix-Script': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-In-prefix-Script-implicit': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-In-prefix-Script-implicit-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-In-prefix-Script-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-Is-prefix-Script': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-Is-prefix-Script-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-circumflex-negation': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-circumflex-negation-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-empty': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-empty-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-invalid': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-invalid-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-no-braces': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-no-braces-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-no-braces-value': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-no-braces-value-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-separator': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-separator-and-value-only': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-separator-and-value-only-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-separator-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-separator-only': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-separator-only-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-unclosed': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-unclosed-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-unopened': [FAIL],
+  'built-ins/RegExp/property-escapes/grammar-extension-unopened-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-01': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-01-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-02': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-02-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-03': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-03-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-04': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-04-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-05': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-05-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-06': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-06-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-07': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-07-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-08': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-08-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-09': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-09-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-10': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-10-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-11': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-11-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-12': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-12-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-13': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-13-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-14': [FAIL],
+  'built-ins/RegExp/property-escapes/loose-matching-14-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-General_Category': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-General_Category-equals': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-General_Category-equals-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-General_Category-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-Script': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-Script-equals': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-Script-equals-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-Script-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-Script_Extensions': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-Script_Extensions-equals': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-Script_Extensions-equals-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-binary-property-without-value-Script_Extensions-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-binary-property': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-binary-property-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-property-and-value': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-property-and-value-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-property-existing-value': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-property-existing-value-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-property-value-General_Category-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-property-value-Script': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-property-value-Script-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-property-value-Script_Extensions': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-property-value-Script_Extensions-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/non-existent-property-value-general-category': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Composition_Exclusion': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Composition_Exclusion-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Expands_On_NFC': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Expands_On_NFC-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Expands_On_NFD': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Expands_On_NFD-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Expands_On_NFKC': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Expands_On_NFKC-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Expands_On_NFKD': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Expands_On_NFKD-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-FC_NFKC_Closure': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-FC_NFKC_Closure-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Full_Composition_Exclusion': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Full_Composition_Exclusion-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Grapheme_Link': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Grapheme_Link-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Hyphen': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Hyphen-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Alphabetic': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Alphabetic-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Default_Ignorable_Code_Point': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Default_Ignorable_Code_Point-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Grapheme_Extend': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Grapheme_Extend-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_ID_Continue': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_ID_Continue-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_ID_Start': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_ID_Start-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Lowercase': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Lowercase-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Math': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Math-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Uppercase': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Other_Uppercase-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Prepended_Concatenation_Mark': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-binary-property-Prepended_Concatenation_Mark-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-property-Block-with-value': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-property-Block-with-value-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-property-FC_NFKC_Closure': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-property-FC_NFKC_Closure-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-property-Line_Break': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-property-Line_Break-negated': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-property-Line_Break-with-value': [FAIL],
+  'built-ins/RegExp/property-escapes/unsupported-property-Line_Break-with-value-negated': [FAIL],
+  'language/literals/regexp/early-err-pattern': [FAIL],
+  'language/literals/regexp/invalid-braced-quantifier-exact': [FAIL],
+  'language/literals/regexp/invalid-braced-quantifier-lower': [FAIL],
+  'language/literals/regexp/invalid-braced-quantifier-range': [FAIL],
+  'language/literals/regexp/invalid-optional-lookbehind': [FAIL],
+  'language/literals/regexp/invalid-optional-negative-lookbehind': [FAIL],
+  'language/literals/regexp/invalid-range-lookbehind': [FAIL],
+  'language/literals/regexp/invalid-range-negative-lookbehind': [FAIL],
+  'language/literals/regexp/u-dec-esc': [FAIL],
+  'language/literals/regexp/u-invalid-class-escape': [FAIL],
+  'language/literals/regexp/u-invalid-extended-pattern-char': [FAIL],
+  'language/literals/regexp/u-invalid-identity-escape': [FAIL],
+  'language/literals/regexp/u-invalid-legacy-octal-escape': [FAIL],
+  'language/literals/regexp/u-invalid-non-empty-class-ranges': [FAIL],
+  'language/literals/regexp/u-invalid-non-empty-class-ranges-no-dash-a': [FAIL],
+  'language/literals/regexp/u-invalid-non-empty-class-ranges-no-dash-ab': [FAIL],
+  'language/literals/regexp/u-invalid-non-empty-class-ranges-no-dash-b': [FAIL],
+  'language/literals/regexp/u-invalid-oob-decimal-escape': [FAIL],
+  'language/literals/regexp/u-invalid-optional-lookahead': [FAIL],
+  'language/literals/regexp/u-invalid-optional-lookbehind': [FAIL],
+  'language/literals/regexp/u-invalid-optional-negative-lookahead': [FAIL],
+  'language/literals/regexp/u-invalid-optional-negative-lookbehind': [FAIL],
+  'language/literals/regexp/u-invalid-range-lookahead': [FAIL],
+  'language/literals/regexp/u-invalid-range-lookbehind': [FAIL],
+  'language/literals/regexp/u-invalid-range-negative-lookahead': [FAIL],
+  'language/literals/regexp/u-invalid-range-negative-lookbehind': [FAIL],
+  'language/literals/regexp/u-unicode-esc-bounds': [FAIL],
+  'language/literals/regexp/u-unicode-esc-non-hex': [FAIL],
+  'language/literals/regexp/unicode-escape-nls-err': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7828
+  'language/statements/try/early-catch-function': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7829
+  'language/block-scope/syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=4628
+  'language/eval-code/direct/non-definable-function-with-function': [FAIL],
+  'language/eval-code/direct/non-definable-function-with-variable': [FAIL],
+  'language/eval-code/indirect/non-definable-function-with-function': [FAIL],
+  'language/eval-code/indirect/non-definable-function-with-variable': [FAIL],
+  'language/global-code/script-decl-func-err-non-configurable': [FAIL],
+  'language/global-code/script-decl-var-collision': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=5116
+  'built-ins/TypedArray/prototype/fill/fill-values-conversion-operations-consistent-nan': [PASS, FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=5135
+  'annexB/language/eval-code/direct/func-block-decl-eval-func-block-scoping': [FAIL],
+  'annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-block-scoping': [FAIL],
+  'annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-block-scoping': [FAIL],
+  'annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-block-scoping': [FAIL],
+  'annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-block-scoping': [FAIL],
+  'annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-block-scoping': [FAIL],
+  'annexB/language/eval-code/direct/func-switch-case-eval-func-block-scoping': [FAIL],
+  'annexB/language/eval-code/direct/func-switch-dflt-eval-func-block-scoping': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=5139
+  'annexB/built-ins/Date/prototype/setYear/year-number-relative': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=4698
+  'language/expressions/call/tco-call-args': [SKIP],
+  'language/expressions/call/tco-cross-realm-class-construct': [SKIP],
+  'language/expressions/call/tco-cross-realm-class-derived-construct': [SKIP],
+  'language/expressions/call/tco-cross-realm-fun-call': [SKIP],
+  'language/expressions/call/tco-cross-realm-fun-construct': [SKIP],
+  'language/expressions/call/tco-member-args': [SKIP],
+  'language/expressions/call/tco-non-eval-function': [SKIP],
+  'language/expressions/call/tco-non-eval-function-dynamic': [SKIP],
+  'language/expressions/call/tco-non-eval-global': [SKIP],
+  'language/expressions/call/tco-non-eval-with': [SKIP],
+  'language/expressions/comma/tco-final': [SKIP],
+  'language/expressions/conditional/tco-cond': [SKIP],
+  'language/expressions/conditional/tco-pos': [SKIP],
+  'language/expressions/logical-and/tco-right': [SKIP],
+  'language/expressions/logical-or/tco-right': [SKIP],
+  'language/expressions/tagged-template/tco-call': [SKIP],
+  'language/expressions/tagged-template/tco-member': [SKIP],
+  'language/expressions/tco-pos': [SKIP],
+  'language/statements/block/tco-stmt': [SKIP],
+  'language/statements/block/tco-stmt-list': [SKIP],
+  'language/statements/do-while/tco-body': [SKIP],
+  'language/statements/for/tco-const-body': [SKIP],
+  'language/statements/for/tco-let-body': [SKIP],
+  'language/statements/for/tco-lhs-body': [SKIP],
+  'language/statements/for/tco-var-body': [SKIP],
+  'language/statements/if/tco-else-body': [SKIP],
+  'language/statements/if/tco-if-body': [SKIP],
+  'language/statements/labeled/tco': [SKIP],
+  'language/statements/return/tco': [SKIP],
+  'language/statements/switch/tco-case-body': [SKIP],
+  'language/statements/switch/tco-case-body-dflt': [SKIP],
+  'language/statements/switch/tco-dftl-body': [SKIP],
+  'language/statements/try/tco-catch': [SKIP],
+  'language/statements/try/tco-catch-finally': [SKIP],
+  'language/statements/try/tco-finally': [SKIP],
+  'language/statements/while/tco-body': [SKIP],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=5064
+  'language/expressions/arrow-function/dflt-params-duplicates': [FAIL],
+  'language/expressions/async-arrow-function/dflt-params-duplicates': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=5327
+  'built-ins/TypedArrayConstructors/internals/Set/key-is-minus-zero': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-minus-zero': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Set/key-is-not-integer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-not-integer': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Set/key-is-out-of-bounds': [FAIL],
+  'built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-out-of-bounds': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=5329
+  'built-ins/RegExp/prototype/source/value-line-terminator': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=5112
+  'annexB/language/eval-code/direct/func-block-decl-eval-func-no-skip-try': [FAIL],
+  'annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-no-skip-try': [FAIL],
+  'annexB/language/eval-code/direct/func-if-decl-else-decl-b-eval-func-no-skip-try': [FAIL],
+  'annexB/language/eval-code/direct/func-if-decl-else-stmt-eval-func-no-skip-try': [FAIL],
+  'annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-no-skip-try': [FAIL],
+  'annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-no-skip-try': [FAIL],
+  'annexB/language/eval-code/direct/func-switch-case-eval-func-no-skip-try': [FAIL],
+  'annexB/language/eval-code/direct/func-switch-dflt-eval-func-no-skip-try': [FAIL],
+
+  # PreParser doesn't produce early errors
+  # https://bugs.chromium.org/p/v8/issues/detail?id=2728
+  'language/expressions/async-arrow-function/early-errors-arrow-formals-body-duplicate': [FAIL],
+  'language/expressions/object/method-definition/generator-param-redecl-const': [FAIL],
+  'language/expressions/object/method-definition/generator-param-redecl-let': [FAIL],
+  'language/expressions/object/method-definition/name-param-redecl': [FAIL],
+  'language/statements/async-function/early-errors-declaration-formals-body-duplicate': [FAIL],
+
+  # SharedArrayBuffer tests that require flags
+  'built-ins/SharedArrayBuffer/*': ['--harmony-sharedarraybuffer'],
+  'built-ins/Atomics/*': ['--harmony-sharedarraybuffer'],
+  'built-ins/ArrayBuffer/prototype/byteLength/this-is-sharedarraybuffer': ['--harmony-sharedarraybuffer'],
+  'built-ins/ArrayBuffer/prototype/slice/this-is-sharedarraybuffer': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/buffer-does-not-have-arraybuffer-data-throws-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/buffer-reference-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/byteoffset-is-negative-throws-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/custom-proto-if-not-object-fallbacks-to-default-prototype-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/custom-proto-if-object-is-used-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/defined-bytelength-and-byteoffset-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/defined-byteoffset-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/defined-byteoffset-undefined-bytelength-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/excessive-bytelength-throws-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/excessive-byteoffset-throws-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/instance-extensibility-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/negative-bytelength-throws-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/negative-byteoffset-throws-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/newtarget-undefined-throws-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/proto-from-ctor-realm-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/buffer/return-buffer-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/buffer/this-has-no-dataview-internal-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/byteLength/return-bytelength-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/byteLength/this-has-no-dataview-internal-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/byteOffset/return-byteoffset-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/byteOffset/this-has-no-dataview-internal-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/getInt32/index-is-out-of-range-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/getInt32/negative-byteoffset-throws-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/getInt32/return-abrupt-from-tonumber-byteoffset-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/getInt32/return-abrupt-from-tonumber-byteoffset-symbol-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/getInt32/return-value-clean-arraybuffer-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/getInt32/return-values-custom-offset-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/getInt32/return-values-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/getInt32/this-has-no-dataview-internal-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/prototype/getInt32/to-boolean-littleendian-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/return-abrupt-tonumber-bytelength-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/return-abrupt-tonumber-bytelength-symbol-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/return-abrupt-tonumber-byteoffset-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/return-abrupt-tonumber-byteoffset-symbol-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/return-instance-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/toindex-bytelength-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/DataView/toindex-byteoffset-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab': ['--harmony-sharedarraybuffer'],
+  'built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab': ['--harmony-sharedarraybuffer'],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8100
+  'built-ins/Atomics/notify/bigint/*': [SKIP],
+  'built-ins/Atomics/wait/bigint/*': [SKIP],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=6049
+  'built-ins/Object/internals/DefineOwnProperty/consistent-value-function-caller': [FAIL_SLOPPY],
+  'built-ins/Object/internals/DefineOwnProperty/consistent-value-function-arguments': [FAIL_SLOPPY],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7874
+  'built-ins/Reflect/ownKeys/return-on-corresponding-order-large-index': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=6776
+  'built-ins/Proxy/ownKeys/return-duplicate-entries-throws': [FAIL],
+  'built-ins/Proxy/ownKeys/return-duplicate-symbol-entries-throws': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7184
+  'annexB/language/expressions/yield/star-iterable-return-emulates-undefined-throws-when-called': [FAIL],
+  'annexB/language/statements/for-await-of/iterator-close-return-emulates-undefined-throws-when-called': [FAIL],
+  'annexB/language/statements/for-of/iterator-close-return-emulates-undefined-throws-when-called': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7186
+  'language/statements/class/fields-indirect-eval-err-contains-arguments': [FAIL],
+  'language/expressions/class/fields-indirect-eval-err-contains-arguments': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7468
+  'language/statements/class/privatename-not-valid-earlyerr-script-8': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=5690
+  'language/expressions/call/eval-spread': [FAIL],
+  'language/expressions/call/eval-spread-empty-leading': [FAIL],
+  'language/expressions/call/eval-spread-empty-trailing': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7472
+  'intl402/NumberFormat/currency-digits': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7474
+  'intl402/NumberFormat/prototype/format/format-fraction-digits': [FAIL],
+  'intl402/NumberFormat/prototype/format/format-significant-digits': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7481
+  'intl402/NumberFormat/ignore-invalid-unicode-ext-values': [FAIL],
+  'intl402/DateTimeFormat/ignore-invalid-unicode-ext-values': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7482
+  'intl402/DateTimeFormat/prototype/resolvedOptions/resolved-locale-with-hc-unicode': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7483
+  'annexB/built-ins/Function/createdynfn-html-close-comment-params': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7669
+  'intl402/Intl/getCanonicalLocales/canonicalized-tags': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8051
+  'intl402/Collator/unicode-ext-seq-in-private-tag': [FAIL],
+
+  # Tests assume that the sort order of "same elements" (comparator returns 0)
+  # is deterministic.
+  # https://crbug.com/v8/7808
+  'intl402/String/prototype/localeCompare/returns-same-results-as-Collator': [SKIP],
+  'intl402/Collator/prototype/compare/bound-to-collator-instance': [SKIP],
+  'intl402/Collator/ignore-invalid-unicode-ext-values': [SKIP],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8260
+  'intl402/Locale/constructor-non-iana-canon': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8261
+  'intl402/Locale/constructor-options-language-valid': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8262
+  'intl402/Locale/constructor-parse-twice': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8259
+  'intl402/Locale/subclassing': [SKIP],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8246
+  'intl402/Locale/constructor-tag': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8244
+  'intl402/Locale/constructor-getter-order': [FAIL],
+  'intl402/Locale/constructor-locale-object': [FAIL],
+  'intl402/Locale/constructor-options-language-grandfathered': [FAIL],
+  'intl402/Locale/constructor-options-language-invalid': [FAIL],
+  'intl402/Locale/constructor-options-region-invalid': [FAIL],
+  'intl402/Locale/constructor-options-region-valid': [FAIL],
+  'intl402/Locale/constructor-options-script-invalid': [FAIL],
+  'intl402/Locale/constructor-options-script-valid': [FAIL],
+  'intl402/Locale/constructor-unicode-ext-invalid': [FAIL],
+  'intl402/Locale/getters': [FAIL],
+  'intl402/Locale/invalid-tag-throws': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8243
+  'intl402/Locale/extensions-private': [FAIL],
+  'intl402/Locale/getters-privateuse': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8236
+  'intl402/Locale/likely-subtags': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8242
+  'intl402/Locale/extensions-grandfathered': [FAIL],
+  'intl402/Locale/getters-grandfathered': [FAIL],
+  'intl402/Locale/likely-subtags-grandfathered': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=6705
+  'built-ins/Object/assign/strings-and-symbol-order': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7781
+  'built-ins/Date/parse/time-value-maximum-range': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7831
+  'language/statements/generators/generator-created-after-decl-inst': [FAIL],
+  'language/expressions/generators/generator-created-after-decl-inst': [FAIL],
+  'language/expressions/async-generator/generator-created-after-decl-inst': [FAIL],
+  'language/statements/async-generator/generator-created-after-decl-inst': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8099
+  'intl402/NumberFormat/prototype/format/format-negative-numbers': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7871
+  'intl402/ListFormat/prototype/formatToParts/en-us-disjunction': [FAIL],
+
+  ######################## NEEDS INVESTIGATION ###########################
+
+  # These test failures are specific to the intl402 suite and need investigation
+  # to be either marked as bugs with issues filed for them or as deliberate
+  # incompatibilities if the test cases turn out to be broken or ambiguous.
+  # Some of these are related to v8:4361 in being visible side effects from Intl.
+  'intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7833
+  'built-ins/Atomics/wait/cannot-suspend-throws': [SKIP],
+  'built-ins/Atomics/wait/undefined-index-defaults-to-zero': [SKIP],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=6890#c12
+  'built-ins/RegExp/prototype/Symbol.matchAll/isregexp-called-once': [FAIL],
+  'built-ins/RegExp/prototype/Symbol.matchAll/species-constructor': [FAIL],
+  'built-ins/RegExp/prototype/Symbol.matchAll/species-regexp-get-global-throws': [FAIL],
+  'built-ins/RegExp/prototype/Symbol.matchAll/species-regexp-get-unicode-throws': [FAIL],
+  'built-ins/String/prototype/matchAll/regexp-prototype-has-no-matchAll': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8258
+  'intl402/DateTimeFormat/constructor-options-throwing-getters': [FAIL],
+  'intl402/Locale/constructor-options-language-valid-undefined': [FAIL],
+  'intl402/Locale/constructor-options-throwing-getters': [FAIL],
+  'intl402/Locale/constructor-tag-tostring': [FAIL],
+  'intl402/NumberFormat/prototype/format/format-fraction-digits-precision': [FAIL],
+  'intl402/NumberFormat/prototype/format/format-significant-digits-precision': [FAIL],
+  'intl402/NumberFormat/prototype/formatToParts/value-tonumber': [FAIL],
+
+  ##################### DELIBERATE INCOMPATIBILITIES #####################
+
+  # https://github.com/tc39/ecma262/pull/889
+  'annexB/language/function-code/block-decl-func-skip-arguments': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=6538
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=6541
+  'language/export/escaped-as-export-specifier': [FAIL],
+  'language/export/escaped-from': [FAIL],
+  'language/expressions/object/method-definition/escaped-get': [FAIL],
+  'language/expressions/object/method-definition/escaped-set': [FAIL],
+  'language/import/escaped-as-import-specifier': [FAIL],
+  'language/import/escaped-as-namespace-import': [FAIL],
+  'language/import/escaped-from': [FAIL],
+  'language/statements/for-await-of/escaped-of': [FAIL],
+  'language/statements/for-of/escaped-of': [FAIL],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=6543
+  'language/statements/labeled/value-await-non-module-escaped': [FAIL],
+  'language/statements/labeled/value-yield-non-strict-escaped': [FAIL],
+  'language/expressions/async-arrow-function/escaped-async-line-terminator': [FAIL],
+  'language/expressions/class/class-name-ident-await-escaped': [FAIL],
+  'language/statements/class/class-name-ident-await-escaped': [FAIL],
+
+  ############################ INVALID TESTS #############################
+
+  # https://github.com/tc39/test262/pull/1816#issuecomment-426799415
+  # https://github.com/tc39/test262/pull/1818
+  'language/reserved-words/unreserved-words': [PASS, FAIL],
+
+  # Test makes unjustified assumptions about the number of calls to SortCompare.
+  # Test262 Bug: https://bugs.ecmascript.org/show_bug.cgi?id=596
+  'built-ins/Array/prototype/sort/bug_596_1': [PASS, FAIL_OK],
+
+  # https://github.com/tc39/test262/pull/688#pullrequestreview-14025354
+  'built-ins/Function/internals/Construct/derived-this-uninitialized-realm': [FAIL],
+
+  # Date tests that fail in CE(S)T timezone.
+  # https://bugs.chromium.org/p/v8/issues/detail?id=5449
+  'built-ins/Date/prototype/setFullYear/new-value-time-clip': [PASS, FAIL],
+  'built-ins/Date/prototype/setMonth/new-value-time-clip': [PASS, FAIL],
+
+  # Test against internals of harness; we plug in differently
+  'harness/detachArrayBuffer': [SKIP],
+  'harness/detachArrayBuffer-host-detachArrayBuffer': [SKIP],
+
+  ############################ SKIPPED TESTS #############################
+
+  # These tests take a looong time to run.
+  'built-ins/decodeURI/S15.1.3.1_A1.10_T1': [SKIP],
+  'built-ins/decodeURI/S15.1.3.1_A1.11_T1': [SKIP],
+  'built-ins/decodeURI/S15.1.3.1_A1.11_T2': [SKIP],
+  'built-ins/decodeURI/S15.1.3.1_A1.12_T1': [SKIP],
+  'built-ins/decodeURI/S15.1.3.1_A1.12_T2': [SKIP],
+  'built-ins/decodeURI/S15.1.3.1_A2.5_T1': [SKIP],
+  'built-ins/decodeURIComponent/S15.1.3.2_A1.11_T1': [SKIP],
+  'built-ins/decodeURIComponent/S15.1.3.2_A1.12_T1': [SKIP],
+  'built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1': [SKIP],
+  'language/literals/regexp/S7.8.5_A1.1_T2': [SKIP],
+  'language/literals/regexp/S7.8.5_A1.4_T2': [SKIP],
+  'language/literals/regexp/S7.8.5_A2.1_T2': [SKIP],
+  'language/literals/regexp/S7.8.5_A2.4_T2': [SKIP],
+  'built-ins/Array/prototype/slice/S15.4.4.10_A3_T1': [SKIP],
+  'built-ins/Array/prototype/slice/S15.4.4.10_A3_T2': [SKIP],
+
+  # https://bugs.chromium.org/p/v8/issues/detail?id=7187
+  'built-ins/Function/prototype/toString/line-terminator-normalisation-CR': [SKIP],
+  'language/expressions/class/fields-after-same-line-static-async-gen-static-private-methods-with-fields': [FAIL],
+  'language/expressions/class/fields-after-same-line-static-async-method-static-private-methods-with-fields': [FAIL],
+  'language/expressions/class/fields-new-sc-line-gen-static-private-methods-with-fields': [FAIL],
+  'language/expressions/class/fields-private-derived-cls-direct-eval-err-contains-supercall': [FAIL],
+  'language/expressions/class/fields-private-derived-cls-direct-eval-err-contains-supercall-1': [FAIL],
+  'language/expressions/class/fields-private-derived-cls-direct-eval-err-contains-supercall-2': [FAIL],
+  'language/expressions/class/fields-private-derived-cls-direct-eval-err-contains-superproperty-1': [FAIL],
+  'language/expressions/class/fields-private-derived-cls-direct-eval-err-contains-superproperty-2': [FAIL],
+  'language/expressions/class/fields-private-derived-cls-indirect-eval-err-contains-supercall': [FAIL],
+  'language/expressions/class/fields-private-derived-cls-indirect-eval-err-contains-supercall-1': [FAIL],
+  'language/expressions/class/fields-private-derived-cls-indirect-eval-err-contains-supercall-2': [FAIL],
+  'language/expressions/class/fields-private-derived-cls-indirect-eval-err-contains-superproperty-1': [FAIL],
+  'language/expressions/class/fields-private-derived-cls-indirect-eval-err-contains-superproperty-2': [FAIL],
+  'language/expressions/class/fields-same-line-async-gen-static-private-methods-with-fields': [FAIL],
+  'language/expressions/class/fields-same-line-async-method-static-private-methods-with-fields': [FAIL],
+  'language/expressions/class/fields-same-line-gen-static-private-methods-with-fields': [FAIL],
+  'language/statements/class/fields-after-same-line-static-async-gen-static-private-methods-with-fields': [FAIL],
+  'language/statements/class/fields-after-same-line-static-async-method-static-private-methods-with-fields': [FAIL],
+  'language/statements/class/fields-new-sc-line-gen-static-private-methods-with-fields': [FAIL],
+  'language/statements/class/fields-private-derived-cls-direct-eval-err-contains-supercall': [FAIL],
+  'language/statements/class/fields-private-derived-cls-direct-eval-err-contains-supercall-1': [FAIL],
+  'language/statements/class/fields-private-derived-cls-direct-eval-err-contains-supercall-2': [FAIL],
+  'language/statements/class/fields-private-derived-cls-direct-eval-err-contains-superproperty-1': [FAIL],
+  'language/statements/class/fields-private-derived-cls-direct-eval-err-contains-superproperty-2': [FAIL],
+  'language/statements/class/fields-private-derived-cls-indirect-eval-err-contains-supercall': [FAIL],
+  'language/statements/class/fields-private-derived-cls-indirect-eval-err-contains-supercall-1': [FAIL],
+  'language/statements/class/fields-private-derived-cls-indirect-eval-err-contains-supercall-2': [FAIL],
+  'language/statements/class/fields-private-derived-cls-indirect-eval-err-contains-superproperty-1': [FAIL],
+  'language/statements/class/fields-private-derived-cls-indirect-eval-err-contains-superproperty-2': [FAIL],
+  'language/statements/class/fields-same-line-async-gen-static-private-methods-with-fields': [FAIL],
+  'language/statements/class/fields-same-line-async-method-static-private-methods-with-fields': [FAIL],
+  'language/statements/class/fields-same-line-gen-static-private-methods-with-fields': [FAIL],
+
+  # https://github.com/tc39/test262/issues/1817
+  'language/expressions/class/dstr-private-gen-meth-dflt-ary-init-iter-close': [FAIL],
+  'language/expressions/class/dstr-private-gen-meth-dflt-ary-init-iter-no-close': [FAIL],
+  'language/expressions/class/dstr-private-gen-meth-dflt-ary-ptrn-rest-id-exhausted': [FAIL],
+  'language/expressions/class/dstr-private-gen-meth-static-dflt-ary-init-iter-close': [FAIL],
+  'language/expressions/class/dstr-private-gen-meth-static-dflt-ary-init-iter-no-close': [FAIL],
+  'language/expressions/class/dstr-private-gen-meth-static-dflt-ary-ptrn-rest-id': [FAIL],
+  'language/expressions/class/dstr-private-gen-meth-static-dflt-ary-ptrn-rest-id-exhausted': [FAIL],
+  'language/expressions/class/dstr-private-gen-meth-static-dflt-obj-ptrn-rest-getter': [FAIL],
+  'language/expressions/class/dstr-private-gen-meth-static-dflt-obj-ptrn-rest-skip-non-enumerable': [FAIL],
+  'language/expressions/class/dstr-private-gen-meth-static-dflt-obj-ptrn-rest-val-obj': [FAIL],
+  'language/statements/class/dstr-private-gen-meth-dflt-ary-init-iter-close': [FAIL],
+  'language/statements/class/dstr-private-gen-meth-dflt-ary-init-iter-no-close': [FAIL],
+  'language/statements/class/dstr-private-gen-meth-dflt-ary-ptrn-rest-id-exhausted': [FAIL],
+  'language/statements/class/dstr-private-gen-meth-static-dflt-ary-init-iter-close': [FAIL],
+  'language/statements/class/dstr-private-gen-meth-static-dflt-ary-init-iter-no-close': [FAIL],
+  'language/statements/class/dstr-private-gen-meth-static-dflt-ary-ptrn-rest-id': [FAIL],
+  'language/statements/class/dstr-private-gen-meth-static-dflt-ary-ptrn-rest-id-exhausted': [FAIL],
+  'language/statements/class/dstr-private-gen-meth-static-dflt-obj-ptrn-rest-getter': [FAIL],
+  'language/statements/class/dstr-private-gen-meth-static-dflt-obj-ptrn-rest-skip-non-enumerable': [FAIL],
+  'language/statements/class/dstr-private-gen-meth-static-dflt-obj-ptrn-rest-val-obj': [FAIL],
+
+  ############################ SLOW TESTS #############################
+
+  'annexB/built-ins/RegExp/RegExp-leading-escape-BMP': [PASS, SLOW],
+  'annexB/built-ins/RegExp/RegExp-trailing-escape-BMP': [PASS, SLOW],
+  'language/comments/S7.4_A5': [PASS, SLOW],
+  'language/comments/S7.4_A6': [PASS, SLOW],
+
+}],  # ALWAYS
+
+['no_i18n == True', {
+  # Unicode canonicalization is not available with i18n turned off.
+  'built-ins/String/prototype/localeCompare/15.5.4.9_CE': [SKIP],
+
+  # Unicode regexp case mapping is not available with i18n turned off.
+  'language/literals/regexp/u-case-mapping': [SKIP],
+
+  # BUG(v8:4437).
+  'built-ins/String/prototype/normalize/return-normalized-string': [SKIP],
+  'built-ins/String/prototype/normalize/return-normalized-string-from-coerced-form': [SKIP],
+  'built-ins/String/prototype/normalize/return-normalized-string-using-default-parameter': [SKIP],
+
+  # Case-conversion is not fully compliant to the Unicode spec with i18n off.
+  'built-ins/String/prototype/toLocaleLowerCase/Final_Sigma_U180E': [FAIL],
+  'built-ins/String/prototype/toLocaleLowerCase/special_casing_conditional': [FAIL],
+  'built-ins/String/prototype/toLocaleLowerCase/supplementary_plane': [FAIL],
+  'built-ins/String/prototype/toLowerCase/Final_Sigma_U180E': [FAIL],
+  'built-ins/String/prototype/toLowerCase/special_casing_conditional': [FAIL],
+  'built-ins/String/prototype/toLowerCase/supplementary_plane': [FAIL],
+  'built-ins/String/prototype/toLocaleUpperCase/supplementary_plane': [FAIL],
+  'built-ins/String/prototype/toUpperCase/supplementary_plane': [FAIL],
+
+  # Locale-sensitive case-conversion is not available with i18n off.
+  'intl402/String/prototype/toLocaleLowerCase/special_casing_Azeri': [FAIL],
+  'intl402/String/prototype/toLocaleLowerCase/special_casing_Lithuanian': [FAIL],
+  'intl402/String/prototype/toLocaleLowerCase/special_casing_Turkish': [FAIL],
+  'intl402/String/prototype/toLocaleUpperCase/special_casing_Azeri': [FAIL],
+  'intl402/String/prototype/toLocaleUpperCase/special_casing_Lithuanian': [FAIL],
+  'intl402/String/prototype/toLocaleUpperCase/special_casing_Turkish': [FAIL],
+
+  # Unicode property escapes unavailable without i18n
+  'built-ins/RegExp/property-escapes/*': [SKIP],
+  'built-ins/RegExp/named-groups/unicode-property-names': [SKIP],
+}],  # no_i18n == True
+
+['arch == arm or arch == mipsel or arch == mips or arch == arm64 or arch == mips64 or arch == mips64el', {
+
+  # TODO(mstarzinger): Causes stack overflow on simulators due to eager
+  # compilation of parenthesized function literals. Needs investigation.
+  'language/statements/function/S13.2.1_A1_T1': [SKIP],
+
+  # BUG(3251225): Tests that timeout with --noopt.
+  'built-ins/decodeURI/S15.1.3.1_A2.4_T1': [SKIP],
+  'built-ins/decodeURI/S15.1.3.1_A2.5_T1': [SKIP],
+  'built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1': [SKIP],
+  'built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1': [SKIP],
+  'built-ins/encodeURI/S15.1.3.3_A2.3_T1': [SKIP],
+  'built-ins/encodeURIComponent/S15.1.3.4_A2.3_T1': [SKIP],
+}],  # 'arch == arm or arch == mipsel or arch == mips or arch == arm64'
+
+['byteorder == big', {
+  # Test failures on big endian platforms due to the way the tests
+  # are written
+
+  # https://github.com/tc39/test262/issues/757
+  'built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-other-type': [SKIP],
+}],
+
+['asan == True', {
+  # BUG(v8:4653): Test262 tests which rely on quit() are not compatible with
+  # asan's --omit-quit flag.
+  'built-ins/Promise/prototype/then/deferred-is-resolved-value': [SKIP],
+}],  # asan == True
+
+['asan == True or msan == True or tsan == True', {
+  # https://bugs.chromium.org/p/v8/issues/detail?id=4639
+  # The failed allocation causes an asan/msan/tsan error
+  'built-ins/ArrayBuffer/allocation-limit': [SKIP],
+  'built-ins/ArrayBuffer/length-is-too-large-throws': [SKIP],
+  'built-ins/SharedArrayBuffer/allocation-limit': [SKIP],
+  'built-ins/SharedArrayBuffer/length-is-too-large-throws': [SKIP],
+}],  # asan == True or msan == True or tsan == True
+
+['variant == no_wasm_traps', {
+  '*': [SKIP],
+}],  # variant == no_wasm_traps
+
+['variant != default or arch == arm or arch == arm64 or arch == mipsel or arch == mips or arch == mips64 or arch == mips64el', {
+  # These tests take a long time to run
+  'built-ins/RegExp/property-escapes/generated/*': [SKIP],
+}],  # variant != default or arch == arm or arch == arm64
+
+['system == windows', {
+  # https://crbug.com/856119
+  'intl402/DateTimeFormat/prototype/resolvedOptions/basic': [SKIP],
+}],  # system == windows
+
+]

--- a/implementation-contributed/v8/test262/testcfg.py
+++ b/implementation-contributed/v8/test262/testcfg.py
@@ -54,6 +54,7 @@ FEATURE_FLAGS = {
   'Intl.RelativeTimeFormat': '--harmony-intl-relative-time-format',
   'Symbol.prototype.description': '--harmony-symbol-description',
   'globalThis': '--harmony-global',
+  'well-formed-json-stringify': '--harmony-json-stringify',
 }
 
 SKIPPED_FEATURES = set(['Intl.Segmenter',


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[4ab8215e](https://github.com///github/blob/4ab8215e) in V8 and all changes made since [92143ed8c](../blob/92143ed8c) in
test262.



### 2 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/mjsunit/compiler/number-modulus.js](../blob/v8-test262-automation-export-92143ed8c/implementation-contributed/v8/mjsunit/compiler/number-modulus.js)
 - [implementation-contributed/v8/test262/testcfg.py](../blob/v8-test262-automation-export-92143ed8c/implementation-contributed/v8/test262/testcfg.py)
### 1 File with changes in both test262 and V8

The updated version of these files will be appended to the end of the
original file with a code comment noting there was a curation in
progress.

 - [implementation-contributed/v8/test262/test262.status](../blob/v8-test262-automation-export-92143ed8c/implementation-contributed/v8/test262/test262.status)








### 6 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-1.js](../blob/v8-test262-automation-export-92143ed8c/implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-1.js)
 - [implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-2.js](../blob/v8-test262-automation-export-92143ed8c/implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-2.js)
 - [implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-3.js](../blob/v8-test262-automation-export-92143ed8c/implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-3.js)
 - [implementation-contributed/v8/mjsunit/async-stack-traces.js](../blob/v8-test262-automation-export-92143ed8c/implementation-contributed/v8/mjsunit/async-stack-traces.js)
 - [implementation-contributed/v8/mjsunit/compiler/number-round.js](../blob/v8-test262-automation-export-92143ed8c/implementation-contributed/v8/mjsunit/compiler/number-round.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-891627.js](../blob/v8-test262-automation-export-92143ed8c/implementation-contributed/v8/mjsunit/regress/regress-crbug-891627.js)