### PR TITLE
intl: increase coverage for the NumberFormat constructor

### DIFF
--- a/test/intl402/NumberFormat/constructor-locales-hasproperty.js
+++ b/test/intl402/NumberFormat/constructor-locales-hasproperty.js
@@ -34,6 +34,6 @@ const proxyLocales = new Proxy(locales, handlers);
 const nf = new Intl.NumberFormat(proxyLocales);
 
 assert.sameValue(actualLookups.length, locales.length);
-for (index in actualLookups) {
+for (let index in actualLookups) {
   assert.sameValue(actualLookups[index], String(index));
 }

--- a/test/intl402/NumberFormat/constructor-locales-hasproperty.js
+++ b/test/intl402/NumberFormat/constructor-locales-hasproperty.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2018 Ujjwal Sharma. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-initializenumberformat
+description: >
+  Tests that HasProperty(O, Pk) is properly called within the constructor for
+  Intl.NumberFormat
+info: |
+  9.2.1 CanonicalizeLocaleList ( locales )
+
+  7.b. Let kPresent be ? HasProperty(O, Pk).
+---*/
+
+const locales = {
+  length: 8,
+  1: 'en-US',
+  3: 'de-DE',
+  5: 'en-IN',
+  7: 'en-GB'
+};
+
+const actualLookups = [];
+
+const handlers = {
+  has(obj, prop) {
+    actualLookups.push(prop);
+    return Reflect.has(...arguments);
+  }
+};
+
+const proxyLocales = new Proxy(locales, handlers);
+
+const nf = new Intl.NumberFormat(proxyLocales);
+
+assert.sameValue(actualLookups.length, locales.length);
+for (index in actualLookups) {
+  assert.sameValue(actualLookups[index], String(index));
+}


### PR DESCRIPTION
Increase the coverage for the constructor for Intl.NumberFormat by
ensuring that HasProperty(O, Pk) is properly called.

/cc @gsathya @rwaldron