### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "466306e9",
-  "targetRevisionAtLastExport": "4bc81c1dc2",
+  "sourceRevisionAtLastExport": "fdfdce1d",
+  "targetRevisionAtLastExport": "fd1b13ca85",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/intl/locale/locale-properties.js
+++ b/implementation-contributed/v8/intl/locale/locale-properties.js
@@ -24,7 +24,7 @@ assertEquals('buddhist', locale.calendar);
 assertEquals('phonebk', locale.collation);
 assertEquals('h23', locale.hourCycle);
 assertEquals('upper', locale.caseFirst);
-assertEquals('true', locale.numeric);
+assertEquals(true, locale.numeric);
 assertEquals('roman', locale.numberingSystem);
 // Not defined, expected to undefined.
 assertEquals(undefined, locale.currency);

--- a/implementation-contributed/v8/test262/test262.status
+++ b/implementation-contributed/v8/test262/test262.status
@@ -585,7 +585,6 @@
   'intl402/Locale/constructor-options-script-invalid': [FAIL],
   'intl402/Locale/constructor-options-script-valid': [FAIL],
   'intl402/Locale/getters': [FAIL],
-  'intl402/Locale/invalid-tag-throws': [FAIL],
 
   # https://bugs.chromium.org/p/v8/issues/detail?id=8243
   'intl402/Locale/extensions-private': [FAIL],
@@ -598,6 +597,9 @@
   'intl402/Locale/extensions-grandfathered': [FAIL],
   'intl402/Locale/getters-grandfathered': [FAIL],
   'intl402/Locale/likely-subtags-grandfathered': [FAIL],
+
+  # Wrong test see https://github.com/tc39/test262/pull/1835
+  'intl402/Locale/constructor-options-numeric-valid': [FAIL],
 
   # https://bugs.chromium.org/p/v8/issues/detail?id=6705
   'built-ins/Object/assign/strings-and-symbol-order': [FAIL],


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[466306e9](https://github.com///github/blob/466306e9) in V8 and all changes made since [4bc81c1dc2](../blob/4bc81c1dc2) in
test262.



### 2 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/intl/locale/locale-properties.js](../blob/v8-test262-automation-export-4bc81c1dc2/implementation-contributed/v8/intl/locale/locale-properties.js)
 - [implementation-contributed/v8/test262/test262.status](../blob/v8-test262-automation-export-4bc81c1dc2/implementation-contributed/v8/test262/test262.status)