### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "3a8f232444",
-  "targetRevisionAtLastExport": "0e9545be99",
+  "sourceRevisionAtLastExport": "2c8aa42eb8",
+  "targetRevisionAtLastExport": "5ca4d8770b",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-jit.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-jit.js
@@ -9,7 +9,6 @@ let assert = {
 
 function bigIntBitAnd(a, b) {
     return (a & b) & (a & 0b11n);
-
 }
 noInline(bigIntBitAnd);
 

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-general.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-general.js
@@ -1,0 +1,98 @@
+//@ runBigIntEnabled
+
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+function assert(a) {
+    if (!a)
+        throw new Error("Bad assertion");
+}
+
+assert.sameValue = function (input, expected, message) {
+    if (input !== expected)
+        throw new Error(message);
+}
+
+assert.sameValue(0b00n | 0b00n, 0b00n, "0b00n | 0b00n === 0b00n");
+assert.sameValue(0b00n | 0b01n, 0b01n, "0b00n | 0b01n === 0b01n");
+assert.sameValue(0b01n | 0b00n, 0b01n, "0b01n | 0b00n === 0b01n");
+assert.sameValue(0b00n | 0b10n, 0b10n, "0b00n | 0b10n === 0b10n");
+assert.sameValue(0b10n | 0b00n, 0b10n, "0b10n | 0b00n === 0b10n");
+assert.sameValue(0b00n | 0b11n, 0b11n, "0b00n | 0b11n === 0b11n");
+assert.sameValue(0b11n | 0b00n, 0b11n, "0b11n | 0b00n === 0b11n");
+assert.sameValue(0b01n | 0b01n, 0b01n, "0b01n | 0b01n === 0b01n");
+assert.sameValue(0b01n | 0b10n, 0b11n, "0b01n | 0b10n === 0b11n");
+assert.sameValue(0b10n | 0b01n, 0b11n, "0b10n | 0b01n === 0b11n");
+assert.sameValue(0b01n | 0b11n, 0b11n, "0b01n | 0b11n === 0b11n");
+assert.sameValue(0b11n | 0b01n, 0b11n, "0b11n | 0b01n === 0b11n");
+assert.sameValue(0b10n | 0b10n, 0b10n, "0b10n | 0b10n === 0b10n");
+assert.sameValue(0b10n | 0b11n, 0b11n, "0b10n | 0b11n === 0b11n");
+assert.sameValue(0b11n | 0b10n, 0b11n, "0b11n | 0b10n === 0b11n");
+assert.sameValue(0xffffffffn | 0n, 0xffffffffn, "0xffffffffn | 0n === 0xffffffffn");
+assert.sameValue(0n | 0xffffffffn, 0xffffffffn, "0n | 0xffffffffn === 0xffffffffn");
+assert.sameValue(0xffffffffn | 0xffffffffn, 0xffffffffn, "0xffffffffn | 0xffffffffn === 0xffffffffn");
+assert.sameValue(0xffffffffffffffffn | 0n, 0xffffffffffffffffn, "0xffffffffffffffffn | 0n === 0xffffffffffffffffn");
+assert.sameValue(0n | 0xffffffffffffffffn, 0xffffffffffffffffn, "0n | 0xffffffffffffffffn === 0xffffffffffffffffn");
+assert.sameValue(0xffffffffffffffffn | 0xffffffffn, 0xffffffffffffffffn, "0xffffffffffffffffn | 0xffffffffn === 0xffffffffffffffffn");
+assert.sameValue(0xffffffffn | 0xffffffffffffffffn, 0xffffffffffffffffn, "0xffffffffn | 0xffffffffffffffffn === 0xffffffffffffffffn");
+assert.sameValue(
+  0xffffffffffffffffn | 0xffffffffffffffffn, 0xffffffffffffffffn,
+  "0xffffffffffffffffn | 0xffffffffffffffffn === 0xffffffffffffffffn");
+assert.sameValue(
+  0xbf2ed51ff75d380fd3be813ec6185780n | 0x4aabef2324cedff5387f1f65n, 0xbf2ed51fffffff2ff7fedffffe7f5fe5n,
+  "0xbf2ed51ff75d380fd3be813ec6185780n | 0x4aabef2324cedff5387f1f65n === 0xbf2ed51fffffff2ff7fedffffe7f5fe5n");
+assert.sameValue(
+  0x4aabef2324cedff5387f1f65n | 0xbf2ed51ff75d380fd3be813ec6185780n, 0xbf2ed51fffffff2ff7fedffffe7f5fe5n,
+  "0x4aabef2324cedff5387f1f65n | 0xbf2ed51ff75d380fd3be813ec6185780n === 0xbf2ed51fffffff2ff7fedffffe7f5fe5n");
+assert.sameValue(0n | -1n, -1n, "0n | -1n === -1n");
+assert.sameValue(-1n | 0n, -1n, "-1n | 0n === -1n");
+assert.sameValue(0n | -2n, -2n, "0n | -2n === -2n");
+assert.sameValue(-2n | 0n, -2n, "-2n | 0n === -2n");
+assert.sameValue(1n | -2n, -1n, "1n | -2n === -1n");
+assert.sameValue(-2n | 1n, -1n, "-2n | 1n === -1n");
+assert.sameValue(2n | -2n, -2n, "2n | -2n === -2n");
+assert.sameValue(-2n | 2n, -2n, "-2n | 2n === -2n");
+assert.sameValue(2n | -3n, -1n, "2n | -3n === -1n");
+assert.sameValue(-3n | 2n, -1n, "-3n | 2n === -1n");
+assert.sameValue(-1n | -2n, -1n, "-1n | -2n === -1n");
+assert.sameValue(-2n | -1n, -1n, "-2n | -1n === -1n");
+assert.sameValue(-2n | -2n, -2n, "-2n | -2n === -2n");
+assert.sameValue(-2n | -3n, -1n, "-2n | -3n === -1n");
+assert.sameValue(-3n | -2n, -1n, "-3n | -2n === -1n");
+assert.sameValue(0xffffffffn | -1n, -1n, "0xffffffffn | -1n === -1n");
+assert.sameValue(-1n | 0xffffffffn, -1n, "-1n | 0xffffffffn === -1n");
+assert.sameValue(0xffffffffffffffffn | -1n, -1n, "0xffffffffffffffffn | -1n === -1n");
+assert.sameValue(-1n | 0xffffffffffffffffn, -1n, "-1n | 0xffffffffffffffffn === -1n");
+assert.sameValue(
+  0xbf2ed51ff75d380fd3be813ec6185780n | -0x4aabef2324cedff5387f1f65n, -0x8a2c72024405ec138670865n,
+  "0xbf2ed51ff75d380fd3be813ec6185780n | -0x4aabef2324cedff5387f1f65n === -0x8a2c72024405ec138670865n");
+assert.sameValue(
+  -0x4aabef2324cedff5387f1f65n | 0xbf2ed51ff75d380fd3be813ec6185780n, -0x8a2c72024405ec138670865n,
+  "-0x4aabef2324cedff5387f1f65n | 0xbf2ed51ff75d380fd3be813ec6185780n === -0x8a2c72024405ec138670865n");
+assert.sameValue(
+  -0xbf2ed51ff75d380fd3be813ec6185780n | 0x4aabef2324cedff5387f1f65n, -0xbf2ed51fb554100cd330000ac600401bn,
+  "-0xbf2ed51ff75d380fd3be813ec6185780n | 0x4aabef2324cedff5387f1f65n === -0xbf2ed51fb554100cd330000ac600401bn");
+assert.sameValue(
+  0x4aabef2324cedff5387f1f65n | -0xbf2ed51ff75d380fd3be813ec6185780n, -0xbf2ed51fb554100cd330000ac600401bn,
+  "0x4aabef2324cedff5387f1f65n | -0xbf2ed51ff75d380fd3be813ec6185780n === -0xbf2ed51fb554100cd330000ac600401bn");
+assert.sameValue(
+  -0xbf2ed51ff75d380fd3be813ec6185780n | -0x4aabef2324cedff5387f1f65n, -0x42092803008e813400181765n,
+  "-0xbf2ed51ff75d380fd3be813ec6185780n | -0x4aabef2324cedff5387f1f65n === -0x42092803008e813400181765n");
+assert.sameValue(
+  -0x4aabef2324cedff5387f1f65n | -0xbf2ed51ff75d380fd3be813ec6185780n, -0x42092803008e813400181765n,
+  "-0x4aabef2324cedff5387f1f65n | -0xbf2ed51ff75d380fd3be813ec6185780n === -0x42092803008e813400181765n");
+assert.sameValue(-0xffffffffn | 0n, -0xffffffffn, "-0xffffffffn | 0n === -0xffffffffn");
+assert.sameValue(0n | -0xffffffffn, -0xffffffffn, "0n | -0xffffffffn === -0xffffffffn");
+assert.sameValue(
+  -0xffffffffffffffffn | 0x10000000000000000n, -0xffffffffffffffffn,
+  "-0xffffffffffffffffn | 0x10000000000000000n === -0xffffffffffffffffn");
+assert.sameValue(
+  0x10000000000000000n | -0xffffffffffffffffn, -0xffffffffffffffffn,
+  "0x10000000000000000n | -0xffffffffffffffffn === -0xffffffffffffffffn");
+assert.sameValue(
+  -0xffffffffffffffffffffffffn | 0x10000000000000000n, -0xfffffffeffffffffffffffffn,
+  "-0xffffffffffffffffffffffffn | 0x10000000000000000n === -0xfffffffeffffffffffffffffn");
+assert.sameValue(
+  0x10000000000000000n | -0xffffffffffffffffffffffffn, -0xfffffffeffffffffffffffffn,
+  "0x10000000000000000n | -0xffffffffffffffffffffffffn === -0xfffffffeffffffffffffffffn");
+

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-jit-untyped.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-jit-untyped.js
@@ -1,0 +1,20 @@
+//@ runBigIntEnabled
+
+let assert = {
+    sameValue: function(i, e, m) {
+        if (i !== e)
+            throw new Error(m);
+    }
+}
+
+function bigIntBitOrUntyped(a, b) {
+    return a | b;
+}
+noInline(bigIntBitOrUntyped);
+
+let o = { valueOf: () => 0b1111n };
+for (let i = 0; i < 10000; i++) {
+    let r = bigIntBitOrUntyped(o, 0b1010n);
+    assert.sameValue(r, 0b1111n, 0b101n + " | " + 0b1010n + " = " + r);
+}
+

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-jit.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-jit.js
@@ -1,0 +1,19 @@
+//@ runBigIntEnabled
+
+let assert = {
+    sameValue: function(i, e, m) {
+        if (i !== e)
+            throw new Error(m);
+    }
+}
+
+function bigIntBitOr(a, b) {
+    return (a | b) | (a | 0b111n);
+}
+noInline(bigIntBitOr);
+
+for (let i = 0; i < 10000; i++) {
+    let r = bigIntBitOr(0b101n, 0b1010n);
+    assert.sameValue(r, 0b1111n, 0b101n + " | " + 0b1010n + " = " + r);
+}
+

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-memory-stress.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-memory-stress.js
@@ -1,0 +1,14 @@
+//@ runBigIntEnabled
+
+function assert(a) {
+    if (!a)
+        throw new Error("Bad assertion");
+}
+
+let a = 0b11n;
+for (let i = 0; i < 1000000; i++) {
+    a |= 0b01n;
+}
+
+assert(a === 0b11n);
+

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-to-primitive-precedence.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-to-primitive-precedence.js
@@ -1,0 +1,29 @@
+//@ runBigIntEnabled
+
+assert = {
+    sameValue: function (input, expected, message) {
+        if (input !== expected)
+            throw new Error(message);
+    }
+};
+
+let o = {
+    [Symbol.toPrimitive]: function() {
+        throw new Error("Bad");
+    }
+};
+
+try{
+    o | Symbol("2");
+    assert.sameValue(true, false, "Exception expected to be throwed, but executed without error");
+} catch (e) {
+    assert.sameValue(e.message, "Bad", "Expected to throw Error('Bad'), but got: " + e);
+}
+
+try{
+    Symbol("2") | o;
+    assert.sameValue(true, false, "Exception expected to be throwed, but executed without error");
+} catch (e) {
+    assert.sameValue(e instanceof TypeError, true, "Expected to throw TypeError, but got: " + e)
+}
+

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-type-error.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-type-error.js
@@ -1,0 +1,106 @@
+//@ runBigIntEnabled
+
+function assert(a, message) {
+    if (!a)
+        throw new Error(message);
+}
+
+function assertThrowTypeError(a, b, message) {
+    try {
+        let n = a | b;
+        assert(false, message + ": Should throw TypeError, but executed without exception");
+    } catch (e) {
+        assert(e instanceof TypeError, message + ": expected TypeError, got: " + e);
+    }
+}
+
+assertThrowTypeError(30n, "foo", "BigInt | String");
+assertThrowTypeError("bar", 18757382984821n, "String | BigInt");
+assertThrowTypeError(30n, Symbol("foo"), "BigInt | Symbol");
+assertThrowTypeError(Symbol("bar"), 18757382984821n, "Symbol | BigInt");
+assertThrowTypeError(30n, 3320, "BigInt | Int32");
+assertThrowTypeError(33256, 18757382984821n, "Int32 | BigInt");
+assertThrowTypeError(30n, 0.543, "BigInt | Double");
+assertThrowTypeError(230.19293, 18757382984821n, "Double | BigInt");
+assertThrowTypeError(30n, NaN, "BigInt | NaN");
+assertThrowTypeError(NaN, 18757382984821n, "NaN | BigInt");
+assertThrowTypeError(30n, NaN, "BigInt | NaN");
+assertThrowTypeError(NaN, 18757382984821n, "NaN | BigInt");
+assertThrowTypeError(30n, +Infinity, "BigInt | +Infinity");
+assertThrowTypeError(+Infinity, 18757382984821n, "+Infinity | BigInt");
+assertThrowTypeError(30n, -Infinity, "BigInt | -Infinity");
+assertThrowTypeError(-Infinity, 18757382984821n, "-Infinity | BigInt");
+assertThrowTypeError(30n, null, "BigInt | null");
+assertThrowTypeError(null, 18757382984821n, "null | BigInt");
+assertThrowTypeError(30n, undefined, "BigInt | undefined");
+assertThrowTypeError(undefined, 18757382984821n, "undefined | BigInt");
+assertThrowTypeError(30n, true, "BigInt | true");
+assertThrowTypeError(true, 18757382984821n, "true | BigInt");
+assertThrowTypeError(30n, false, "BigInt | false");
+assertThrowTypeError(false, 18757382984821n, "false | BigInt");
+
+// Error when returning from object
+
+let o = {
+    valueOf: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt | Object.valueOf returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Symbol | BigInt");
+
+o = {
+    valueOf: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt | Object.valueOf returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Int32 | BigInt");
+
+o = {
+    valueOf: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt | Object.valueOf returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Double | BigInt");
+
+o = {
+    toString: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt | Object.toString returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Symbol | BigInt");
+
+o = {
+    toString: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt | Object.toString returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Int32 | BigInt");
+
+o = {
+    toString: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt | Object.toString returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Double | BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt | Object.@@toPrimitive returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Symbol | BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt | Object.@@toPrimitive returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Int32 | BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt | Object.@@toPrimitive returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Double | BigInt");
+

--- a/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-wrapped-value.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-wrapped-value.js
@@ -1,0 +1,62 @@
+//@ runBigIntEnabled
+
+assert = {
+    sameValue: function (input, expected, message) {
+        if (input !== expected)
+            throw new Error(message);
+    }
+};
+
+function testBitOr(x, y, z, message) {
+    assert.sameValue(x | y, z, message);
+    assert.sameValue(y | x, z, message);
+}
+
+testBitOr(Object(0b10n), 0b01n, 0b11n, "ToPrimitive: unbox object with internal slot");
+
+let o = {
+    [Symbol.toPrimitive]: function() {
+        return 0b10n;
+    }
+};
+testBitOr(o, 0b01n, 0b11n, "ToPrimitive: @@toPrimitive");
+
+o = {
+    valueOf: function() {
+        return 0b10n;
+    }
+};
+testBitOr(o, 0b01n, 0b11n, "ToPrimitive: valueOf");
+
+o = {
+    toString: function() {
+        return 0b10n;
+    }
+}
+testBitOr(o, 0b01n, 0b11n, "ToPrimitive: toString");
+
+// BigInt with length > 1
+
+testBitOr(Object(0b1111000000000000000000000000000000000000000000000000000000000000000n), 0b1000000000000000000000000000000000000000000000000000000000000001111n, 0b1111000000000000000000000000000000000000000000000000000000000001111n, "ToPrimitive: unbox object with internal slot");
+
+o = {
+    [Symbol.toPrimitive]: function() {
+        return 0b1111000000000000000000000000000000000000000000000000000000000000000n;
+    }
+};
+testBitOr(o, 0b1000000000000000000000000000000000000000000000000000000000000001111n, 0b1111000000000000000000000000000000000000000000000000000000000001111n, "ToPrimitive: @@toPrimitive");
+
+o = {
+    valueOf: function() {
+        return 0b1111000000000000000000000000000000000000000000000000000000000000000n;
+    }
+};
+testBitOr(o, 0b1000000000000000000000000000000000000000000000000000000000000001111n, 0b1111000000000000000000000000000000000000000000000000000000000001111n, "ToPrimitive: valueOf");
+
+o = {
+    toString: function() {
+        return 0b1111000000000000000000000000000000000000000000000000000000000000000n;
+    }
+}
+testBitOr(o, 0b1000000000000000000000000000000000000000000000000000000000000001111n, 0b1111000000000000000000000000000000000000000000000000000000000001111n, "ToPrimitive: toString");
+


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[3a8f232444](https://github.com///github/blob/3a8f232444) in JavaScriptCore and all changes made since [0e9545be99](../blob/0e9545be99) in
test262.



### 1 File Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-and-jit.js](../blob/javascriptcore-test262-automation-export-0e9545be99/implementation-contributed/javascriptcore/stress/big-int-bitwise-and-jit.js)









### 7 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-or-general.js](../blob/javascriptcore-test262-automation-export-0e9545be99/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-general.js)
 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-or-jit-untyped.js](../blob/javascriptcore-test262-automation-export-0e9545be99/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-jit-untyped.js)
 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-or-jit.js](../blob/javascriptcore-test262-automation-export-0e9545be99/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-jit.js)
 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-or-memory-stress.js](../blob/javascriptcore-test262-automation-export-0e9545be99/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-memory-stress.js)
 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-or-to-primitive-precedence.js](../blob/javascriptcore-test262-automation-export-0e9545be99/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-to-primitive-precedence.js)
 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-or-type-error.js](../blob/javascriptcore-test262-automation-export-0e9545be99/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-type-error.js)
 - [implementation-contributed/javascriptcore/stress/big-int-bitwise-or-wrapped-value.js](../blob/javascriptcore-test262-automation-export-0e9545be99/implementation-contributed/javascriptcore/stress/big-int-bitwise-or-wrapped-value.js)