### PR TITLE
test: Add tests for private methods and accessors productions

### DIFF
--- a/src/class-elements/rs-private-getter-alt.case
+++ b/src/class-elements/rs-private-getter-alt.case
@@ -54,6 +54,7 @@ features: [class-methods-private]
 ---*/
 
 //- fields
+#$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
 get #$() {
   return this.#$_;
 }

--- a/src/class-elements/rs-private-getter-alt.case
+++ b/src/class-elements/rs-private-getter-alt.case
@@ -1,0 +1,108 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Valid PrivateName as private getter
+info: |
+
+  ClassElement :
+    MethodDefinition
+    ...
+    ;
+
+  MethodDefinition :
+    ...
+    get ClassElementName ( ){ FunctionBody }
+    ...
+
+  ClassElementName :
+    PropertyName
+    PrivateName
+
+  PrivateName ::
+    # IdentifierName
+
+  IdentifierName ::
+    IdentifierStart
+    IdentifierName IdentifierPart
+
+  IdentifierStart ::
+    UnicodeIDStart
+    $
+    _
+    \ UnicodeEscapeSequence
+
+  IdentifierPart::
+    UnicodeIDContinue
+    $
+    \ UnicodeEscapeSequence
+    <ZWNJ> <ZWJ>
+
+  UnicodeIDStart::
+    any Unicode code point with the Unicode property "ID_Start"
+
+  UnicodeIDContinue::
+    any Unicode code point with the Unicode property "ID_Continue"
+
+  NOTE 3
+  The sets of code points with Unicode properties "ID_Start" and
+  "ID_Continue" include, respectively, the code points with Unicode
+  properties "Other_ID_Start" and "Other_ID_Continue".
+
+template: productions
+features: [class-methods-private]
+---*/
+
+//- fields
+get #$() {
+  return this.#$_;
+}
+get #_() {
+  return this.#__;
+}
+get #\u{6F}() {
+  return this.#\u{6F}_;
+}
+get #℘() {
+  return this.#℘_;
+}
+get #ZW_‌_NJ() {
+  return this.#ZW_‌_NJ_;
+}
+get #ZW_‍_J() {
+  return this.#ZW_‍_J_;
+}
+
+//- privateinspectionfunctions
+$(value) {
+  this.#$_ = value;
+  return this.#$;
+}
+_(value) {
+  this.#__ = value;
+  return this.#_;
+}
+\u{6F}(value) {
+  this.#\u{6F}_ = value;
+  return this.#\u{6F};
+}
+℘(value) {
+  this.#℘_ = value;
+  return this.#℘;
+}
+ZW_‌_NJ(value) {
+  this.#ZW_‌_NJ_ = value;
+  return this.#ZW_‌_NJ;
+}
+ZW_‍_J(value) {
+  this.#ZW_‍_J_ = value;
+  return this.#ZW_‍_J;
+}
+
+//- assertions
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/src/class-elements/rs-private-getter.case
+++ b/src/class-elements/rs-private-getter.case
@@ -1,0 +1,108 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Valid PrivateName as private getter
+info: |
+
+  ClassElement :
+    MethodDefinition
+    ...
+    ;
+
+  MethodDefinition :
+    ...
+    get ClassElementName ( ){ FunctionBody }
+    ...
+
+  ClassElementName :
+    PropertyName
+    PrivateName
+
+  PrivateName ::
+    # IdentifierName
+
+  IdentifierName ::
+    IdentifierStart
+    IdentifierName IdentifierPart
+
+  IdentifierStart ::
+    UnicodeIDStart
+    $
+    _
+    \ UnicodeEscapeSequence
+
+  IdentifierPart::
+    UnicodeIDContinue
+    $
+    \ UnicodeEscapeSequence
+    <ZWNJ> <ZWJ>
+
+  UnicodeIDStart::
+    any Unicode code point with the Unicode property "ID_Start"
+
+  UnicodeIDContinue::
+    any Unicode code point with the Unicode property "ID_Continue"
+
+  NOTE 3
+  The sets of code points with Unicode properties "ID_Start" and
+  "ID_Continue" include, respectively, the code points with Unicode
+  properties "Other_ID_Start" and "Other_ID_Continue".
+
+template: productions
+features: [class-methods-private]
+---*/
+
+//- fields
+get #$() {
+  return this.#$_;
+}
+get #_() {
+  return this.#__;
+}
+get #\u{6F}() {
+  return this.#\u{6F}_;
+}
+get #\u2118() {
+  return this.#\u2118_;
+}
+get #ZW_\u200C_NJ() {
+  return this.#ZW_\u200C_NJ_;
+}
+get #ZW_\u200D_J() {
+  return this.#ZW_\u200D_J_;
+}
+
+//- privateinspectionfunctions
+$(value) {
+  this.#$_ = value;
+  return this.#$;
+}
+_(value) {
+  this.#__ = value;
+  return this.#_;
+}
+\u{6F}(value) {
+  this.#\u{6F}_ = value;
+  return this.#\u{6F};
+}
+\u2118(value) {
+  this.#\u2118_ = value;
+  return this.#\u2118;
+}
+ZW_\u200C_NJ(value) {
+  this.#ZW_\u200C_NJ_ = value;
+  return this.#ZW_\u200C_NJ;
+}
+ZW_\u200D_J(value) {
+  this.#ZW_\u200D_J_ = value;
+  return this.#ZW_\u200D_J;
+}
+
+//- assertions
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/src/class-elements/rs-private-getter.case
+++ b/src/class-elements/rs-private-getter.case
@@ -54,6 +54,7 @@ features: [class-methods-private]
 ---*/
 
 //- fields
+#$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
 get #$() {
   return this.#$_;
 }

--- a/src/class-elements/rs-private-method-alt.case
+++ b/src/class-elements/rs-private-method-alt.case
@@ -53,6 +53,7 @@ features: [class-methods-private]
 ---*/
 
 //- fields
+#$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
 #$() {
   return this.#$_;
 }

--- a/src/class-elements/rs-private-method-alt.case
+++ b/src/class-elements/rs-private-method-alt.case
@@ -1,0 +1,107 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Valid PrivateName as private method
+info: |
+
+  ClassElement :
+    MethodDefinition
+    ...
+    ;
+
+  MethodDefinition :
+    ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+    ...
+
+  ClassElementName :
+    PropertyName
+    PrivateName
+
+  PrivateName ::
+    # IdentifierName
+
+  IdentifierName ::
+    IdentifierStart
+    IdentifierName IdentifierPart
+
+  IdentifierStart ::
+    UnicodeIDStart
+    $
+    _
+    \ UnicodeEscapeSequence
+
+  IdentifierPart::
+    UnicodeIDContinue
+    $
+    \ UnicodeEscapeSequence
+    <ZWNJ> <ZWJ>
+
+  UnicodeIDStart::
+    any Unicode code point with the Unicode property "ID_Start"
+
+  UnicodeIDContinue::
+    any Unicode code point with the Unicode property "ID_Continue"
+
+  NOTE 3
+  The sets of code points with Unicode properties "ID_Start" and
+  "ID_Continue" include, respectively, the code points with Unicode
+  properties "Other_ID_Start" and "Other_ID_Continue".
+
+template: productions
+features: [class-methods-private]
+---*/
+
+//- fields
+#$() {
+  return this.#$_;
+}
+#_() {
+  return this.#__;
+}
+#\u{6F}() {
+  return this.#\u{6F}_;
+}
+#℘() {
+  return this.#℘_;
+}
+#ZW_‌_NJ() {
+  return this.#ZW_‌_NJ_;
+}
+#ZW_‍_J() {
+  return this.#ZW_‍_J_;
+}
+
+//- privateinspectionfunctions
+$(value) {
+  this.#$_ = value;
+  return this.#$();
+}
+_(value) {
+  this.#__ = value;
+  return this.#_();
+}
+\u{6F}(value) {
+  this.#\u{6F}_ = value;
+  return this.#\u{6F}();
+}
+℘(value) {
+  this.#℘_ = value;
+  return this.#℘();
+}
+ZW_‌_NJ(value) {
+  this.#ZW_‌_NJ_ = value;
+  return this.#ZW_‌_NJ();
+}
+ZW_‍_J(value) {
+  this.#ZW_‍_J_ = value;
+  return this.#ZW_‍_J();
+}
+
+//- assertions
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/src/class-elements/rs-private-method.case
+++ b/src/class-elements/rs-private-method.case
@@ -53,6 +53,7 @@ features: [class-methods-private]
 ---*/
 
 //- fields
+#$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
 #$() {
   return this.#$_;
 }

--- a/src/class-elements/rs-private-method.case
+++ b/src/class-elements/rs-private-method.case
@@ -1,0 +1,107 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Valid PrivateName as private method
+info: |
+
+  ClassElement :
+    MethodDefinition
+    ...
+    ;
+
+  MethodDefinition :
+    ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+    ...
+
+  ClassElementName :
+    PropertyName
+    PrivateName
+
+  PrivateName ::
+    # IdentifierName
+
+  IdentifierName ::
+    IdentifierStart
+    IdentifierName IdentifierPart
+
+  IdentifierStart ::
+    UnicodeIDStart
+    $
+    _
+    \ UnicodeEscapeSequence
+
+  IdentifierPart::
+    UnicodeIDContinue
+    $
+    \ UnicodeEscapeSequence
+    <ZWNJ> <ZWJ>
+
+  UnicodeIDStart::
+    any Unicode code point with the Unicode property "ID_Start"
+
+  UnicodeIDContinue::
+    any Unicode code point with the Unicode property "ID_Continue"
+
+  NOTE 3
+  The sets of code points with Unicode properties "ID_Start" and
+  "ID_Continue" include, respectively, the code points with Unicode
+  properties "Other_ID_Start" and "Other_ID_Continue".
+
+template: productions
+features: [class-methods-private]
+---*/
+
+//- fields
+#$() {
+  return this.#$_;
+}
+#_() {
+  return this.#__;
+}
+#\u{6F}() {
+  return this.#\u{6F}_;
+}
+#\u2118() {
+  return this.#\u2118_;
+}
+#ZW_\u200C_NJ() {
+  return this.#ZW_\u200C_NJ_;
+}
+#ZW_\u200D_J() {
+  return this.#ZW_\u200D_J_;
+}
+
+//- privateinspectionfunctions
+$(value) {
+  this.#$_ = value;
+  return this.#$();
+}
+_(value) {
+  this.#__ = value;
+  return this.#_();
+}
+\u{6F}(value) {
+  this.#\u{6F}_ = value;
+  return this.#\u{6F}();
+}
+\u2118(value) {
+  this.#\u2118_ = value;
+  return this.#\u2118();
+}
+ZW_\u200C_NJ(value) {
+  this.#ZW_\u200C_NJ_ = value;
+  return this.#ZW_\u200C_NJ();
+}
+ZW_\u200D_J(value) {
+  this.#ZW_\u200D_J_ = value;
+  return this.#ZW_\u200D_J();
+}
+
+//- assertions
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/src/class-elements/rs-private-setter-alt.case
+++ b/src/class-elements/rs-private-setter-alt.case
@@ -1,0 +1,107 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Valid PrivateName as private setter
+info: |
+
+  ClassElement :
+    MethodDefinition
+    ...
+    ;
+
+  MethodDefinition :
+    ...
+    set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+  ClassElementName :
+    PropertyName
+    PrivateName
+
+  PrivateName ::
+    # IdentifierName
+
+  IdentifierName ::
+    IdentifierStart
+    IdentifierName IdentifierPart
+
+  IdentifierStart ::
+    UnicodeIDStart
+    $
+    _
+    \ UnicodeEscapeSequence
+
+  IdentifierPart::
+    UnicodeIDContinue
+    $
+    \ UnicodeEscapeSequence
+    <ZWNJ> <ZWJ>
+
+  UnicodeIDStart::
+    any Unicode code point with the Unicode property "ID_Start"
+
+  UnicodeIDContinue::
+    any Unicode code point with the Unicode property "ID_Continue"
+
+  NOTE 3
+  The sets of code points with Unicode properties "ID_Start" and
+  "ID_Continue" include, respectively, the code points with Unicode
+  properties "Other_ID_Start" and "Other_ID_Continue".
+
+template: productions
+features: [class-methods-private]
+---*/
+
+//- fields
+set #$(value) {
+  this.#$_ = value;
+}
+set #_(value) {
+  this.#__ = value;
+}
+set #\u{6F}(value) {
+  this.#\u{6F}_ = value;
+}
+set #℘(value) {
+  this.#℘_ = value;
+}
+set #ZW_‌_NJ(value) {
+  this.#ZW_‌_NJ_ = value;
+}
+set #ZW_‍_J(value) {
+  this.#ZW_‍_J_ = value;
+}
+
+//- privateinspectionfunctions
+$(value) {
+  this.#$ = value;
+  return this.#$_;
+}
+_(value) {
+  this.#_ = value;
+  return this.#__;
+}
+\u{6F}(value) {
+  this.#\u{6F} = value;
+  return this.#\u{6F}_;
+}
+℘(value) {
+  this.#℘ = value;
+  return this.#℘_;
+}
+ZW_‌_NJ(value) {
+  this.#ZW_‌_NJ = value;
+  return this.#ZW_‌_NJ_;
+}
+ZW_‍_J(value) {
+  this.#ZW_‍_J = value;
+  return this.#ZW_‍_J_;
+}
+
+//- assertions
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/src/class-elements/rs-private-setter-alt.case
+++ b/src/class-elements/rs-private-setter-alt.case
@@ -53,6 +53,7 @@ features: [class-methods-private]
 ---*/
 
 //- fields
+#$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
 set #$(value) {
   this.#$_ = value;
 }

--- a/src/class-elements/rs-private-setter.case
+++ b/src/class-elements/rs-private-setter.case
@@ -53,6 +53,7 @@ features: [class-methods-private]
 ---*/
 
 //- fields
+#$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
 set #$(value) {
   this.#$_ = value;
 }

--- a/src/class-elements/rs-private-setter.case
+++ b/src/class-elements/rs-private-setter.case
@@ -1,0 +1,107 @@
+// Copyright (C) 2018 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Valid PrivateName as private setter
+info: |
+
+  ClassElement :
+    MethodDefinition
+    ...
+    ;
+
+  MethodDefinition :
+    ...
+    set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+  ClassElementName :
+    PropertyName
+    PrivateName
+
+  PrivateName ::
+    # IdentifierName
+
+  IdentifierName ::
+    IdentifierStart
+    IdentifierName IdentifierPart
+
+  IdentifierStart ::
+    UnicodeIDStart
+    $
+    _
+    \ UnicodeEscapeSequence
+
+  IdentifierPart::
+    UnicodeIDContinue
+    $
+    \ UnicodeEscapeSequence
+    <ZWNJ> <ZWJ>
+
+  UnicodeIDStart::
+    any Unicode code point with the Unicode property "ID_Start"
+
+  UnicodeIDContinue::
+    any Unicode code point with the Unicode property "ID_Continue"
+
+  NOTE 3
+  The sets of code points with Unicode properties "ID_Start" and
+  "ID_Continue" include, respectively, the code points with Unicode
+  properties "Other_ID_Start" and "Other_ID_Continue".
+
+template: productions
+features: [class-methods-private]
+---*/
+
+//- fields
+set #$(value) {
+  this.#$_ = value;
+}
+set #_(value) {
+  this.#__ = value;
+}
+set #\u{6F}(value) {
+  this.#\u{6F}_ = value;
+}
+set #\u2118(value) {
+  this.#\u2118_ = value;
+}
+set #ZW_\u200C_NJ(value) {
+  this.#ZW_\u200C_NJ_ = value;
+}
+set #ZW_\u200D_J(value) {
+  this.#ZW_\u200D_J_ = value;
+}
+
+//- privateinspectionfunctions
+$(value) {
+  this.#$ = value;
+  return this.#$_;
+}
+_(value) {
+  this.#_ = value;
+  return this.#__;
+}
+\u{6F}(value) {
+  this.#\u{6F} = value;
+  return this.#\u{6F}_;
+}
+\u2118(value) {
+  this.#\u2118 = value;
+  return this.#\u2118_;
+}
+ZW_\u200C_NJ(value) {
+  this.#ZW_\u200C_NJ = value;
+  return this.#ZW_\u200C_NJ_;
+}
+ZW_\u200D_J(value) {
+  this.#ZW_\u200D_J = value;
+  return this.#ZW_\u200D_J_;
+}
+
+//- assertions
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-gen-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-gen-rs-private-getter.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-gen-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-gen-rs-private-method.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-gen-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-gen-rs-private-setter.js
+++ b/test/language/expressions/class/fields-after-same-line-gen-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-method-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-method-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-method-rs-private-getter.js
+++ b/test/language/expressions/class/fields-after-same-line-method-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-after-same-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-method-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-method-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-method-rs-private-method.js
+++ b/test/language/expressions/class/fields-after-same-line-method-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-after-same-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-method-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-method-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-method-rs-private-setter.js
+++ b/test/language/expressions/class/fields-after-same-line-method-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-after-same-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-getter-alt.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-getter.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-getter.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-method-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-method.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-method.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-setter-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-setter.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-gen-rs-private-setter.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-getter-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-getter.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-getter.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-method-alt.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-method.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-method.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-setter-alt.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-setter.js
+++ b/test/language/expressions/class/fields-after-same-line-static-async-method-rs-private-setter.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-getter.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-method.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-setter.js
+++ b/test/language/expressions/class/fields-after-same-line-static-gen-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-method-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-method-rs-private-getter.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-method-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-method-rs-private-method.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-method-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-after-same-line-static-method-rs-private-setter.js
+++ b/test/language/expressions/class/fields-after-same-line-static-method-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-definitions-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-multiple-definitions-rs-private-getter-alt.js
@@ -1,0 +1,160 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-multiple-definitions.template
+/*---
+description: Valid PrivateName as private getter (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-definitions-rs-private-getter.js
+++ b/test/language/expressions/class/fields-multiple-definitions-rs-private-getter.js
@@ -1,0 +1,160 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-multiple-definitions.template
+/*---
+description: Valid PrivateName as private getter (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-definitions-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-multiple-definitions-rs-private-method-alt.js
@@ -1,0 +1,159 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-multiple-definitions.template
+/*---
+description: Valid PrivateName as private method (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-definitions-rs-private-method.js
+++ b/test/language/expressions/class/fields-multiple-definitions-rs-private-method.js
@@ -1,0 +1,159 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-multiple-definitions.template
+/*---
+description: Valid PrivateName as private method (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-definitions-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-multiple-definitions-rs-private-setter-alt.js
@@ -1,0 +1,159 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-multiple-definitions.template
+/*---
+description: Valid PrivateName as private setter (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-definitions-rs-private-setter.js
+++ b/test/language/expressions/class/fields-multiple-definitions-rs-private-setter.js
@@ -1,0 +1,159 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-multiple-definitions.template
+/*---
+description: Valid PrivateName as private setter (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-getter-alt.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private getter (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-getter.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-getter.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private getter (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-method-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private method (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-method.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-method.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private method (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-setter-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private setter (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-setter.js
+++ b/test/language/expressions/class/fields-multiple-stacked-definitions-rs-private-setter.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private setter (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-getter-alt.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-getter.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-getter.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-method-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-method.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-method.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-setter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-setter.js
+++ b/test/language/expressions/class/fields-new-no-sc-line-method-rs-private-setter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-gen-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-rs-private-getter-alt.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-gen-rs-private-getter.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-rs-private-getter.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-gen-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-rs-private-method-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-gen-rs-private-method.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-rs-private-method.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-gen-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-rs-private-setter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-gen-rs-private-setter.js
+++ b/test/language/expressions/class/fields-new-sc-line-gen-rs-private-setter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-method-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-rs-private-getter-alt.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-method-rs-private-getter.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-rs-private-getter.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-method-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-rs-private-method-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-method-rs-private-method.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-rs-private-method.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-method-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-rs-private-setter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-new-sc-line-method-rs-private-setter.js
+++ b/test/language/expressions/class/fields-new-sc-line-method-rs-private-setter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-regular-definitions-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-regular-definitions-rs-private-getter-alt.js
@@ -1,0 +1,113 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-regular-definitions.template
+/*---
+description: Valid PrivateName as private getter (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-regular-definitions-rs-private-getter.js
+++ b/test/language/expressions/class/fields-regular-definitions-rs-private-getter.js
@@ -1,0 +1,113 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-regular-definitions.template
+/*---
+description: Valid PrivateName as private getter (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-regular-definitions-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-regular-definitions-rs-private-method-alt.js
@@ -1,0 +1,112 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-regular-definitions.template
+/*---
+description: Valid PrivateName as private method (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-regular-definitions-rs-private-method.js
+++ b/test/language/expressions/class/fields-regular-definitions-rs-private-method.js
@@ -1,0 +1,112 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-regular-definitions.template
+/*---
+description: Valid PrivateName as private method (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-regular-definitions-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-regular-definitions-rs-private-setter-alt.js
@@ -1,0 +1,112 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-regular-definitions.template
+/*---
+description: Valid PrivateName as private setter (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-regular-definitions-rs-private-setter.js
+++ b/test/language/expressions/class/fields-regular-definitions-rs-private-setter.js
@@ -1,0 +1,112 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-regular-definitions.template
+/*---
+description: Valid PrivateName as private setter (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-async-gen-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-rs-private-getter-alt.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-gen-rs-private-getter.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-rs-private-getter.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-gen-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-rs-private-method-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-gen-rs-private-method.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-rs-private-method.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-gen-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-rs-private-setter-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-gen-rs-private-setter.js
+++ b/test/language/expressions/class/fields-same-line-async-gen-rs-private-setter.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-same-line-async-method-rs-private-getter-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-rs-private-getter.js
+++ b/test/language/expressions/class/fields-same-line-async-method-rs-private-getter.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-same-line-async-method-rs-private-method-alt.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-rs-private-method.js
+++ b/test/language/expressions/class/fields-same-line-async-method-rs-private-method.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-same-line-async-method-rs-private-setter-alt.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-async-method-rs-private-setter.js
+++ b/test/language/expressions/class/fields-same-line-async-method-rs-private-setter.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/expressions/class/fields-same-line-gen-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-same-line-gen-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-same-line-generator.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-gen-rs-private-getter.js
+++ b/test/language/expressions/class/fields-same-line-gen-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-same-line-generator.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-gen-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-same-line-gen-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-same-line-generator.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-gen-rs-private-method.js
+++ b/test/language/expressions/class/fields-same-line-gen-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-same-line-generator.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-gen-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-same-line-gen-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-same-line-generator.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-gen-rs-private-setter.js
+++ b/test/language/expressions/class/fields-same-line-gen-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-same-line-generator.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-method-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-same-line-method-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-same-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-method-rs-private-getter.js
+++ b/test/language/expressions/class/fields-same-line-method-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-same-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-method-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-same-line-method-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-same-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-method-rs-private-method.js
+++ b/test/language/expressions/class/fields-same-line-method-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-same-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-method-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-same-line-method-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-same-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-same-line-method-rs-private-setter.js
+++ b/test/language/expressions/class/fields-same-line-method-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-same-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-wrapped-in-sc-rs-private-getter-alt.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-rs-private-getter-alt.js
@@ -1,0 +1,115 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-expr-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private getter (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-wrapped-in-sc-rs-private-getter.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-rs-private-getter.js
@@ -1,0 +1,115 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-expr-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private getter (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-wrapped-in-sc-rs-private-method-alt.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-rs-private-method-alt.js
@@ -1,0 +1,114 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-expr-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private method (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-wrapped-in-sc-rs-private-method.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-rs-private-method.js
@@ -1,0 +1,114 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-expr-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private method (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/expressions/class/fields-wrapped-in-sc-rs-private-setter-alt.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-rs-private-setter-alt.js
@@ -1,0 +1,114 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-expr-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private setter (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/expressions/class/fields-wrapped-in-sc-rs-private-setter.js
+++ b/test/language/expressions/class/fields-wrapped-in-sc-rs-private-setter.js
@@ -1,0 +1,114 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-expr-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private setter (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+var C = class {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-gen-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-gen-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-gen-rs-private-getter.js
+++ b/test/language/statements/class/fields-after-same-line-gen-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-gen-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-after-same-line-gen-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-gen-rs-private-method.js
+++ b/test/language/statements/class/fields-after-same-line-gen-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-gen-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-gen-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-gen-rs-private-setter.js
+++ b/test/language/statements/class/fields-after-same-line-gen-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-after-same-line-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-method-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-method-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-method-rs-private-getter.js
+++ b/test/language/statements/class/fields-after-same-line-method-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-after-same-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-method-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-after-same-line-method-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-method-rs-private-method.js
+++ b/test/language/statements/class/fields-after-same-line-method-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-after-same-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-method-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-method-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-method-rs-private-setter.js
+++ b/test/language/statements/class/fields-after-same-line-method-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-after-same-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-getter-alt.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-getter.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-getter.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-method-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-method.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-method.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-setter-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-setter.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-gen-rs-private-setter.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-getter-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-getter.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-getter.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-method-alt.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-method.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-method.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-setter-alt.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-setter.js
+++ b/test/language/statements/class/fields-after-same-line-static-async-method-rs-private-setter.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-async-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+C.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-after-same-line-static-gen-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-gen-rs-private-getter.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-gen-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-gen-rs-private-method.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-gen-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-gen-rs-private-setter.js
+++ b/test/language/statements/class/fields-after-same-line-static-gen-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, generators, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m().next().value, 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-method-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-method-rs-private-getter.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-method-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-method-rs-private-method.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-method-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-after-same-line-static-method-rs-private-setter.js
+++ b/test/language/statements/class/fields-after-same-line-static-method-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-after-same-line-static-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after a static method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  static m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(C.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "m"), false);
+
+verifyProperty(C, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-multiple-definitions-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-multiple-definitions-rs-private-getter-alt.js
@@ -1,0 +1,160 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-multiple-definitions.template
+/*---
+description: Valid PrivateName as private getter (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-multiple-definitions-rs-private-getter.js
+++ b/test/language/statements/class/fields-multiple-definitions-rs-private-getter.js
@@ -1,0 +1,160 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-multiple-definitions.template
+/*---
+description: Valid PrivateName as private getter (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-multiple-definitions-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-multiple-definitions-rs-private-method-alt.js
@@ -1,0 +1,159 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-multiple-definitions.template
+/*---
+description: Valid PrivateName as private method (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-multiple-definitions-rs-private-method.js
+++ b/test/language/statements/class/fields-multiple-definitions-rs-private-method.js
@@ -1,0 +1,159 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-multiple-definitions.template
+/*---
+description: Valid PrivateName as private method (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-multiple-definitions-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-multiple-definitions-rs-private-setter-alt.js
@@ -1,0 +1,159 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-multiple-definitions.template
+/*---
+description: Valid PrivateName as private setter (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-multiple-definitions-rs-private-setter.js
+++ b/test/language/statements/class/fields-multiple-definitions-rs-private-setter.js
@@ -1,0 +1,159 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-multiple-definitions.template
+/*---
+description: Valid PrivateName as private setter (multiple fields definitions)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  foo = "foobar";
+  m() { return 42 }
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+
+  m2() { return 39 }
+  bar = "barbaz";
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.m2(), 39);
+assert.sameValue(Object.hasOwnProperty.call(c, "m2"), false);
+assert.sameValue(c.m2, C.prototype.m2);
+
+verifyProperty(C.prototype, "m2", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-getter-alt.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private getter (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-getter.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-getter.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private getter (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-method-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private method (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-method.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-method.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private method (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-setter-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private setter (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-setter.js
+++ b/test/language/statements/class/fields-multiple-stacked-definitions-rs-private-setter.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-multiple-stacked-definitions.template
+/*---
+description: Valid PrivateName as private setter (multiple stacked fields definitions through ASI)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+
+  foo = "foobar"
+  bar = "barbaz";
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.foo, "foobar");
+assert.sameValue(Object.hasOwnProperty.call(C, "foo"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "foo"), false);
+
+verifyProperty(c, "foo", {
+  value: "foobar",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.bar, "barbaz");
+assert.sameValue(Object.hasOwnProperty.call(C, "bar"), false);
+assert.sameValue(Object.hasOwnProperty.call(C.prototype, "bar"), false);
+
+verifyProperty(c, "bar", {
+  value: "barbaz",
+  enumerable: true,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-new-no-sc-line-method-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-rs-private-getter-alt.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-new-no-sc-line-method-rs-private-getter.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-rs-private-getter.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-new-no-sc-line-method-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-rs-private-method-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-new-no-sc-line-method-rs-private-method.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-rs-private-method.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-new-no-sc-line-method-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-rs-private-setter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-new-no-sc-line-method-rs-private-setter.js
+++ b/test/language/statements/class/fields-new-no-sc-line-method-rs-private-setter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-new-no-sc-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line without a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+
+  m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-gen-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-rs-private-getter-alt.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-gen-rs-private-getter.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-rs-private-getter.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-gen-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-rs-private-method-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-gen-rs-private-method.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-rs-private-method.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-gen-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-rs-private-setter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-gen-rs-private-setter.js
+++ b/test/language/statements/class/fields-new-sc-line-gen-rs-private-setter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-new-sc-line-generator.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  *m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-method-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-new-sc-line-method-rs-private-getter-alt.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-method-rs-private-getter.js
+++ b/test/language/statements/class/fields-new-sc-line-method-rs-private-getter.js
@@ -1,0 +1,125 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-method-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-new-sc-line-method-rs-private-method-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-method-rs-private-method.js
+++ b/test/language/statements/class/fields-new-sc-line-method-rs-private-method.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-method-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-new-sc-line-method-rs-private-setter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-new-sc-line-method-rs-private-setter.js
+++ b/test/language/statements/class/fields-new-sc-line-method-rs-private-setter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-new-sc-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in a new line with a semicolon)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-regular-definitions-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-regular-definitions-rs-private-getter-alt.js
@@ -1,0 +1,113 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-regular-definitions.template
+/*---
+description: Valid PrivateName as private getter (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-regular-definitions-rs-private-getter.js
+++ b/test/language/statements/class/fields-regular-definitions-rs-private-getter.js
@@ -1,0 +1,113 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-regular-definitions.template
+/*---
+description: Valid PrivateName as private getter (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-regular-definitions-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-regular-definitions-rs-private-method-alt.js
@@ -1,0 +1,112 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-regular-definitions.template
+/*---
+description: Valid PrivateName as private method (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-regular-definitions-rs-private-method.js
+++ b/test/language/statements/class/fields-regular-definitions-rs-private-method.js
@@ -1,0 +1,112 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-regular-definitions.template
+/*---
+description: Valid PrivateName as private method (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-regular-definitions-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-regular-definitions-rs-private-setter-alt.js
@@ -1,0 +1,112 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-regular-definitions.template
+/*---
+description: Valid PrivateName as private setter (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-regular-definitions-rs-private-setter.js
+++ b/test/language/statements/class/fields-regular-definitions-rs-private-setter.js
@@ -1,0 +1,112 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-regular-definitions.template
+/*---
+description: Valid PrivateName as private setter (regular fields defintion)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-same-line-async-gen-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-same-line-async-gen-rs-private-getter-alt.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-gen-rs-private-getter.js
+++ b/test/language/statements/class/fields-same-line-async-gen-rs-private-getter.js
@@ -1,0 +1,138 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private getter (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-gen-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-same-line-async-gen-rs-private-method-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-gen-rs-private-method.js
+++ b/test/language/statements/class/fields-same-line-async-gen-rs-private-method.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private method (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-gen-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-same-line-async-gen-rs-private-setter-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-gen-rs-private-setter.js
+++ b/test/language/statements/class/fields-same-line-async-gen-rs-private-setter.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-gen.template
+/*---
+description: Valid PrivateName as private setter (field definitions after an async generator in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-iteration]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async *m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().next().then(function(v) {
+  assert.sameValue(v.value, 42);
+  assert.sameValue(v.done, true);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-same-line-async-method-rs-private-getter-alt.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-rs-private-getter.js
+++ b/test/language/statements/class/fields-same-line-async-method-rs-private-getter.js
@@ -1,0 +1,137 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-same-line-async-method-rs-private-method-alt.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-rs-private-method.js
+++ b/test/language/statements/class/fields-same-line-async-method-rs-private-method.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private method (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-same-line-async-method-rs-private-setter-alt.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.℘(1), 1);
+    assert.sameValue(c.ZW_‌_NJ(1), 1);
+    assert.sameValue(c.ZW_‍_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-async-method-rs-private-setter.js
+++ b/test/language/statements/class/fields-same-line-async-method-rs-private-setter.js
@@ -1,0 +1,136 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-after-same-line-async-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions after an async method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, async-functions]
+flags: [generated, async]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  async m() { return 42; } #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+assert.sameValue(c.m, C.prototype.m);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+}, {restore: true});
+
+c.m().then(function(v) {
+  assert.sameValue(v, 42);
+
+  function assertions() {
+    // Cover $DONE handler for async cases.
+    function $DONE(error) {
+      if (error) {
+        throw new Test262Error('Test262:AsyncTestFailure')
+      }
+    }
+    assert.sameValue(c.$(1), 1);
+    assert.sameValue(c._(1), 1);
+    assert.sameValue(c.\u{6F}(1), 1);
+    assert.sameValue(c.\u2118(1), 1);
+    assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+    assert.sameValue(c.ZW_\u200D_J(1), 1);
+  }
+
+  return Promise.resolve(assertions());
+}, $DONE).then($DONE, $DONE);

--- a/test/language/statements/class/fields-same-line-gen-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-same-line-gen-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-same-line-generator.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-same-line-gen-rs-private-getter.js
+++ b/test/language/statements/class/fields-same-line-gen-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-same-line-generator.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-same-line-gen-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-same-line-gen-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-same-line-generator.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-same-line-gen-rs-private-method.js
+++ b/test/language/statements/class/fields-same-line-gen-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-same-line-generator.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-same-line-gen-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-same-line-gen-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-same-line-generator.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-same-line-gen-rs-private-setter.js
+++ b/test/language/statements/class/fields-same-line-gen-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-same-line-generator.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a generator method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public, generators]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+; *m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m().next().value, 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-same-line-method-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-same-line-method-rs-private-getter-alt.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-same-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-same-line-method-rs-private-getter.js
+++ b/test/language/statements/class/fields-same-line-method-rs-private-getter.js
@@ -1,0 +1,124 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-same-line-method.template
+/*---
+description: Valid PrivateName as private getter (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-same-line-method-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-same-line-method-rs-private-method-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-same-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-same-line-method-rs-private-method.js
+++ b/test/language/statements/class/fields-same-line-method-rs-private-method.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-same-line-method.template
+/*---
+description: Valid PrivateName as private method (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-same-line-method-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-same-line-method-rs-private-setter-alt.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-same-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-same-line-method-rs-private-setter.js
+++ b/test/language/statements/class/fields-same-line-method-rs-private-setter.js
@@ -1,0 +1,123 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-same-line-method.template
+/*---
+description: Valid PrivateName as private setter (field definitions followed by a method in the same line)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  #$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+; m() { return 42; }
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.m(), 42);
+assert.sameValue(c.m, C.prototype.m);
+assert.sameValue(Object.hasOwnProperty.call(c, "m"), false);
+
+verifyProperty(C.prototype, "m", {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+});
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-wrapped-in-sc-rs-private-getter-alt.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-rs-private-getter-alt.js
@@ -1,0 +1,115 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter-alt.case
+// - src/class-elements/productions/cls-decl-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private getter (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #℘() {
+    return this.#℘_;
+  }
+  get #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  get #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-wrapped-in-sc-rs-private-getter.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-rs-private-getter.js
@@ -1,0 +1,115 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-getter.case
+// - src/class-elements/productions/cls-decl-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private getter (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      get ClassElementName ( ){ FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  get #$() {
+    return this.#$_;
+  }
+  get #_() {
+    return this.#__;
+  }
+  get #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  get #\u2118() {
+    return this.#\u2118_;
+  }
+  get #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  get #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$_ = value;
+    return this.#$;
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_;
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F};
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-wrapped-in-sc-rs-private-method-alt.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-rs-private-method-alt.js
@@ -1,0 +1,114 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method-alt.case
+// - src/class-elements/productions/cls-decl-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private method (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #℘() {
+    return this.#℘_;
+  }
+  #ZW_‌_NJ() {
+    return this.#ZW_‌_NJ_;
+  }
+  #ZW_‍_J() {
+    return this.#ZW_‍_J_;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  ℘(value) {
+    this.#℘_ = value;
+    return this.#℘();
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+    return this.#ZW_‌_NJ();
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+    return this.#ZW_‍_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-wrapped-in-sc-rs-private-method.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-rs-private-method.js
@@ -1,0 +1,114 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-method.case
+// - src/class-elements/productions/cls-decl-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private method (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ClassElementName ( UniqueFormalParameters ) { FunctionBody }
+      ...
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  #$() {
+    return this.#$_;
+  }
+  #_() {
+    return this.#__;
+  }
+  #\u{6F}() {
+    return this.#\u{6F}_;
+  }
+  #\u2118() {
+    return this.#\u2118_;
+  }
+  #ZW_\u200C_NJ() {
+    return this.#ZW_\u200C_NJ_;
+  }
+  #ZW_\u200D_J() {
+    return this.#ZW_\u200D_J_;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$_ = value;
+    return this.#$();
+  }
+  _(value) {
+    this.#__ = value;
+    return this.#_();
+  }
+  \u{6F}(value) {
+    this.#\u{6F}_ = value;
+    return this.#\u{6F}();
+  }
+  \u2118(value) {
+    this.#\u2118_ = value;
+    return this.#\u2118();
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+    return this.#ZW_\u200C_NJ();
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+    return this.#ZW_\u200D_J();
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);

--- a/test/language/statements/class/fields-wrapped-in-sc-rs-private-setter-alt.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-rs-private-setter-alt.js
@@ -1,0 +1,114 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter-alt.case
+// - src/class-elements/productions/cls-decl-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private setter (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #℘_; #ZW_‌_NJ_; #ZW_‍_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #℘(value) {
+    this.#℘_ = value;
+  }
+  set #ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ_ = value;
+  }
+  set #ZW_‍_J(value) {
+    this.#ZW_‍_J_ = value;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  ℘(value) {
+    this.#℘ = value;
+    return this.#℘_;
+  }
+  ZW_‌_NJ(value) {
+    this.#ZW_‌_NJ = value;
+    return this.#ZW_‌_NJ_;
+  }
+  ZW_‍_J(value) {
+    this.#ZW_‍_J = value;
+    return this.#ZW_‍_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.℘(1), 1);
+assert.sameValue(c.ZW_‌_NJ(1), 1);
+assert.sameValue(c.ZW_‍_J(1), 1);

--- a/test/language/statements/class/fields-wrapped-in-sc-rs-private-setter.js
+++ b/test/language/statements/class/fields-wrapped-in-sc-rs-private-setter.js
@@ -1,0 +1,114 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/rs-private-setter.case
+// - src/class-elements/productions/cls-decl-wrapped-in-sc.template
+/*---
+description: Valid PrivateName as private setter (fields definition wrapped in semicolons)
+esid: prod-FieldDefinition
+features: [class-methods-private, class, class-fields-public]
+flags: [generated]
+info: |
+    
+    ClassElement :
+      MethodDefinition
+      ...
+      ;
+
+    MethodDefinition :
+      ...
+      set ClassElementName ( PropertySetParameterList ) { FunctionBody }
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+class C {
+  ;;;;
+  ;;;;;;#$_; #__; #\u{6F}_; #\u2118_; #ZW_\u200C_NJ_; #ZW_\u200D_J_;
+  set #$(value) {
+    this.#$_ = value;
+  }
+  set #_(value) {
+    this.#__ = value;
+  }
+  set #\u{6F}(value) {
+    this.#\u{6F}_ = value;
+  }
+  set #\u2118(value) {
+    this.#\u2118_ = value;
+  }
+  set #ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ_ = value;
+  }
+  set #ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J_ = value;
+  }
+;;;;;;;
+  ;;;;
+  $(value) {
+    this.#$ = value;
+    return this.#$_;
+  }
+  _(value) {
+    this.#_ = value;
+    return this.#__;
+  }
+  \u{6F}(value) {
+    this.#\u{6F} = value;
+    return this.#\u{6F}_;
+  }
+  \u2118(value) {
+    this.#\u2118 = value;
+    return this.#\u2118_;
+  }
+  ZW_\u200C_NJ(value) {
+    this.#ZW_\u200C_NJ = value;
+    return this.#ZW_\u200C_NJ_;
+  }
+  ZW_\u200D_J(value) {
+    this.#ZW_\u200D_J = value;
+    return this.#ZW_\u200D_J_;
+  }
+
+}
+
+var c = new C();
+
+assert.sameValue(c.$(1), 1);
+assert.sameValue(c._(1), 1);
+assert.sameValue(c.\u{6F}(1), 1);
+assert.sameValue(c.\u2118(1), 1);
+assert.sameValue(c.ZW_\u200C_NJ(1), 1);
+assert.sameValue(c.ZW_\u200D_J(1), 1);


### PR DESCRIPTION
Adds coverage for semantics of private methods and private accessors according to the test plan posted in #1343.

> - Semantics > Private method constructs
>   - Private ordinary methods
>   - Private accessors

I used private fields as an intermediate storage to test the behaviour of private methods. Let me know if that makes the tests too tightly coupled. 

---
@leobalter @rwaldron for review.
cc: @littledan @jbhoosreddy 