### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "c9524b41",
-  "targetRevisionAtLastExport": "1e2181be02",
+  "sourceRevisionAtLastExport": "9f893284",
+  "targetRevisionAtLastExport": "234933fe8a",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/intl/general/supported-locales-of.js
+++ b/implementation-contributed/v8/intl/general/supported-locales-of.js
@@ -27,55 +27,67 @@
 
 // Tests supportedLocalesOf method.
 
-var undef = Intl.DateTimeFormat.supportedLocalesOf();
-assertEquals([], undef);
+var services = [
+  Intl.DateTimeFormat,
+  Intl.Collator,
+  Intl.NumberFormat,
+  Intl.PluralRules
+];
 
-var empty = Intl.DateTimeFormat.supportedLocalesOf([]);
-assertEquals([], empty);
+for (const service of services) {
+  let undef = service.supportedLocalesOf();
+  assertEquals([], undef);
 
-var strLocale = Intl.DateTimeFormat.supportedLocalesOf('sr');
-assertEquals('sr', strLocale[0]);
+  let empty = service.supportedLocalesOf([]);
+  assertEquals([], empty);
 
-var multiLocale =
-    Intl.DateTimeFormat.supportedLocalesOf(['sr-Thai-RS', 'de', 'zh-CN']);
-assertEquals('sr-Thai-RS', multiLocale[0]);
-assertEquals('de', multiLocale[1]);
-assertEquals('zh-CN', multiLocale[2]);
+  let strLocale = service.supportedLocalesOf("sr");
+  assertEquals("sr", strLocale[0]);
 
-collatorUndef = Intl.Collator.supportedLocalesOf();
-assertEquals([], collatorUndef);
+  var locales = ["sr-Thai-RS", "de", "zh-CN"];
+  let multiLocale = service.supportedLocalesOf(locales);
+  assertEquals("sr-Thai-RS", multiLocale[0]);
+  assertEquals("de", multiLocale[1]);
+  assertEquals("zh-CN", multiLocale[2]);
 
-collatorEmpty = Intl.Collator.supportedLocalesOf([]);
-assertEquals([], collatorEmpty);
+  let numLocale = service.supportedLocalesOf(1);
+  assertEquals([], numLocale);
+  assertThrows(function() {
+    numLocale = Intl.Collator.supportedLocalesOf([1]);
+  }, TypeError);
 
-collatorStrLocale = Intl.Collator.supportedLocalesOf('sr');
-assertEquals('sr', collatorStrLocale[0]);
+  extensionLocale = service.supportedLocalesOf("id-u-co-pinyin");
+  assertEquals("id-u-co-pinyin", extensionLocale[0]);
 
-collatorMultiLocale =
-    Intl.Collator.supportedLocalesOf(['sr-Thai-RS', 'de', 'zh-CN']);
-assertEquals('sr-Thai-RS', collatorMultiLocale[0]);
-assertEquals('de', collatorMultiLocale[1]);
-assertEquals('zh-CN', collatorMultiLocale[2]);
+  bestFitLocale = service.supportedLocalesOf("de", {
+    localeMatcher: "best fit"
+  });
+  assertEquals("de", bestFitLocale[0]);
 
-numLocale = Intl.Collator.supportedLocalesOf(1);
-assertEquals([], numLocale);
+  // Need a better test for "lookup" once it differs from "best fit".
+  lookupLocale = service.supportedLocalesOf("zh-CN", {
+    localeMatcher: "lookup"
+  });
+  assertEquals("zh-CN", lookupLocale[0]);
 
-assertThrows(function() {
-  numLocale = Intl.Collator.supportedLocalesOf([1]);
-}, TypeError);
+  assertThrows(function() {
+    service.supportedLocalesOf("id-u-co-pinyin", { localeMatcher: "xyz" });
+  }, RangeError);
 
-extensionLocale = Intl.Collator.supportedLocalesOf('id-u-co-pinyin');
-assertEquals('id-u-co-pinyin', extensionLocale[0]);
+  privateuseLocale = service.supportedLocalesOf("en-US-x-twain");
+  assertEquals("en-US-x-twain", privateuseLocale[0]);
 
-bestFitLocale =
-    Intl.Collator.supportedLocalesOf('de', {localeMatcher: 'best fit'});
-assertEquals('de', bestFitLocale[0]);
+  privateuseLocale2 = service.supportedLocalesOf("x-twain");
+  assertEquals(undefined, privateuseLocale2[0]);
 
-// Need a better test for "lookup" once it differs from "best fit".
-lookupLocale =
-    Intl.Collator.supportedLocalesOf('zh-CN', {localeMatcher: 'lookup'});
-assertEquals('zh-CN', lookupLocale[0]);
+  grandfatheredLocale = service.supportedLocalesOf("art-lojban");
+  assertEquals(undefined, grandfatheredLocale[0]);
 
-assertThrows(function() {
-  Intl.Collator.supportedLocalesOf('id-u-co-pinyin', {localeMatcher: 'xyz'});
-}, RangeError);
+  grandfatheredLocale2 = service.supportedLocalesOf("i-pwn");
+  assertEquals(undefined, grandfatheredLocale2[0]);
+
+  unicodeInPrivateuseLocale = service.supportedLocalesOf(
+    "en-US-x-u-co-phonebk"
+  );
+  assertEquals("en-US-x-u-co-phonebk", unicodeInPrivateuseLocale[0]);
+}

--- a/implementation-contributed/v8/intl/intl.status
+++ b/implementation-contributed/v8/intl/intl.status
@@ -30,8 +30,6 @@
   # TODO(jochen): The following test is flaky.
   'overrides/caching': [PASS, FAIL],
 
-  'date-format/constructor-order': [FAIL],
-
   # https://bugs.chromium.org/p/v8/issues/detail?id=6891
   'segmenter/segment': [FAIL],
   'segmenter/segment-iterator': [FAIL],

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js
@@ -1,0 +1,38 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs
+
+(function TestConstructWeakFactory() {
+  let wf = new WeakFactory();
+  assertEquals(wf.toString(), "[object WeakFactory]");
+  assertNotSame(wf.__proto__, Object.prototype);
+  assertSame(wf.__proto__.__proto__, Object.prototype);
+})();
+
+(function TestWeakFactoryConstructorCallAsFunction() {
+  let caught = false;
+  let message = "";
+  try {
+    let f = WeakFactory();
+  } catch (e) {
+    message = e.message;
+    caught = true;
+  } finally {
+    assertTrue(caught);
+    assertEquals(message, "Constructor WeakFactory requires 'new'");
+  }
+})();
+
+(function TestMakeCell() {
+  let wf = new WeakFactory();
+  let wc = wf.makeCell({});
+  assertEquals(wc.toString(), "[object WeakCell]");
+  assertNotSame(wc.__proto__, Object.prototype);
+  assertSame(wc.__proto__.__proto__, Object.prototype);
+})();
+
+(function TestMakeCellWithoutWeakFactory() {
+  assertThrows(() => WeakFactory.prototype.makeCell.call({}, {}), TypeError);
+})();

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/iterating-weak-cells.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/iterating-weak-cells.js
@@ -1,0 +1,45 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+let cleanup_called = false;
+let cleanup = function(iter) {
+  assertFalse(cleanup_called);
+  let cells = [];
+  for (wc of iter) {
+    cells.push(wc);
+  }
+  assertEquals(cells.length, 2);
+  if (cells[0] == wc1) {
+    assertEquals(cells[1], wc2);
+  } else {
+    assertEquals(cells[0], wc2);
+    assertEquals(cells[1], wc1);
+  }
+  cleanup_called = true;
+}
+
+let wf = new WeakFactory(cleanup);
+let o1 = {};
+let o2 = {};
+let wc1 = wf.makeCell(o1);
+let wc2 = wf.makeCell(o2);
+
+gc();
+assertFalse(cleanup_called);
+
+// Drop the last references to o1 and o2.
+o1 = null;
+o2 = null;
+// GC will clear the WeakCells; the cleanup function will be called the next time
+// we enter the event loop.
+gc();
+assertFalse(cleanup_called);
+
+let timeout_func = function() {
+  assertTrue(cleanup_called);
+}
+
+setTimeout(timeout_func, 0);

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/weak-cell-basics.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/weak-cell-basics.js
@@ -1,0 +1,36 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+let cleanup_called = false;
+let cleanup = function(iter) {
+  assertFalse(cleanup_called);
+  let result = iter.next();
+  assertEquals(result.value, wc);
+  assertFalse(result.done);
+  result = iter.next();
+  assertTrue(result.done);
+  cleanup_called = true;
+}
+
+let wf = new WeakFactory(cleanup);
+let o = {};
+let wc = wf.makeCell(o);
+
+gc();
+assertFalse(cleanup_called);
+
+// Drop the last reference to o.
+o = null;
+// GC will clear the WeakCell; the cleanup function will be called the next time
+// we enter the event loop.
+gc();
+assertFalse(cleanup_called);
+
+let timeout_func = function() {
+  assertTrue(cleanup_called);
+}
+
+setTimeout(timeout_func, 0);

--- a/implementation-contributed/v8/mjsunit/mjsunit.status
+++ b/implementation-contributed/v8/mjsunit/mjsunit.status
@@ -105,7 +105,8 @@
   'migrations': [SKIP],
   'array-functions-prototype-misc': [PASS, SLOW, ['mode == debug', SKIP]],
   'compiler/regress-808472': [PASS, ['mode == debug', SKIP]],
-  'es6/promise-all-overflow-*': [PASS, SLOW, ['mode == debug or arch != x64', SKIP]],
+  'es6/promise-all-overflow-1': [SKIP],
+  'es6/promise-all-overflow-2': [PASS, SLOW, ['mode == debug or arch != x64', SKIP]],
 
   ##############################################################################
   # This test sets the umask on a per-process basis and hence cannot be

--- a/implementation-contributed/v8/mjsunit/regress/regress-preparse-inner-arrow-duplicate-parameter.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-preparse-inner-arrow-duplicate-parameter.js
@@ -1,0 +1,5 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+assertThrows("()=>{ (x,x)=>1 }", SyntaxError)

--- a/implementation-contributed/v8/test262/test262.status
+++ b/implementation-contributed/v8/test262/test262.status
@@ -569,9 +569,6 @@
   # https://bugs.chromium.org/p/v8/issues/detail?id=8262
   'intl402/Locale/constructor-parse-twice': [FAIL],
 
-  # https://bugs.chromium.org/p/v8/issues/detail?id=8259
-  'intl402/Locale/subclassing': [SKIP],
-
   # https://bugs.chromium.org/p/v8/issues/detail?id=8246
   'intl402/Locale/constructor-tag': [FAIL],
 
@@ -639,7 +636,6 @@
   'built-ins/String/prototype/matchAll/regexp-prototype-has-no-matchAll': [FAIL],
 
   # https://bugs.chromium.org/p/v8/issues/detail?id=8258
-  'intl402/DateTimeFormat/constructor-options-throwing-getters': [FAIL],
   'intl402/Locale/constructor-options-language-valid-undefined': [FAIL],
   'intl402/Locale/constructor-options-throwing-getters': [FAIL],
   'intl402/Locale/constructor-tag-tostring': [FAIL],


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[c9524b41](https://github.com///github/blob/c9524b41) in V8 and all changes made since [1e2181be02](../blob/1e2181be02) in
test262.



### 4 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/intl/general/supported-locales-of.js](../blob/v8-test262-automation-export-1e2181be02/implementation-contributed/v8/intl/general/supported-locales-of.js)
 - [implementation-contributed/v8/intl/intl.status](../blob/v8-test262-automation-export-1e2181be02/implementation-contributed/v8/intl/intl.status)
 - [implementation-contributed/v8/mjsunit/mjsunit.status](../blob/v8-test262-automation-export-1e2181be02/implementation-contributed/v8/mjsunit/mjsunit.status)
 - [implementation-contributed/v8/test262/test262.status](../blob/v8-test262-automation-export-1e2181be02/implementation-contributed/v8/test262/test262.status)









### 4 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js](../blob/v8-test262-automation-export-1e2181be02/implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/iterating-weak-cells.js](../blob/v8-test262-automation-export-1e2181be02/implementation-contributed/v8/mjsunit/harmony/weakrefs/iterating-weak-cells.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/weak-cell-basics.js](../blob/v8-test262-automation-export-1e2181be02/implementation-contributed/v8/mjsunit/harmony/weakrefs/weak-cell-basics.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-preparse-inner-arrow-duplicate-parameter.js](../blob/v8-test262-automation-export-1e2181be02/implementation-contributed/v8/mjsunit/regress/regress-preparse-inner-arrow-duplicate-parameter.js)