### PR TITLE
Intl.ListFormat: Add some tests for the localeMatcher constructor option.

### DIFF
--- a/test/intl402/ListFormat/constructor/constructor/options-localeMatcher-invalid.js
+++ b/test/intl402/ListFormat/constructor/constructor/options-localeMatcher-invalid.js
@@ -1,0 +1,29 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.ListFormat
+description: Checks handling of invalid value for the localeMatcher option to the ListFormat constructor.
+info: |
+    Intl.ListFormat ( [ locales [ , options ] ] )
+    12. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+features: [Intl.ListFormat]
+---*/
+
+const invalidOptions = [
+  null,
+  1,
+  "",
+  "Lookup",
+  "LOOKUP",
+  "lookup\0",
+  "Best fit",
+  "BEST FIT",
+  "best\u00a0fit",
+];
+
+for (const localeMatcher of invalidOptions) {
+  assert.throws(RangeError, function() {
+    new Intl.ListFormat([], { localeMatcher });
+  }, `${localeMatcher} is an invalid localeMatcher option value`);
+}

--- a/test/intl402/ListFormat/constructor/constructor/options-order.js
+++ b/test/intl402/ListFormat/constructor/constructor/options-order.js
@@ -5,10 +5,10 @@
 esid: sec-Intl.ListFormat
 description: Checks the order of operations on the options argument to the ListFormat constructor.
 info: |
-    InitializeListFormat (listFormat, locales, options)
-    7. Let matcher be ? GetOption(options, "localeMatcher", "string", «"lookup", "best fit"», "best fit").
-    14. Let s be ? GetOption(options, "style", "string", «"long", "short", "narrow"», "long").
-    16. Let numeric be ? GetOption(options, "numeric", "string", «"always", "auto"», "always").
+    Intl.ListFormat ( [ locales [ , options ] ] )
+    7. Let type be GetOption(options, "type", "string", « "conjunction", "disjunction", "unit" », "conjunction").
+    9. Let style be GetOption(options, "style", "string", « "long", "short", "narrow" », "long").
+    12. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
 includes: [compareArray.js]
 features: [Intl.ListFormat]
 ---*/
@@ -16,6 +16,16 @@ features: [Intl.ListFormat]
 const callOrder = [];
 
 new Intl.ListFormat([], {
+  get localeMatcher() {
+    callOrder.push("localeMatcher");
+    return {
+      toString() {
+        callOrder.push("localeMatcher toString");
+        return "best fit";
+      }
+    };
+  },
+
   get type() {
     callOrder.push("type");
     return {
@@ -25,6 +35,7 @@ new Intl.ListFormat([], {
       }
     };
   },
+
   get style() {
     callOrder.push("style");
     return {
@@ -41,4 +52,6 @@ assert.compareArray(callOrder, [
   "type toString",
   "style",
   "style toString",
+  "localeMatcher",
+  "localeMatcher toString",
 ]);


### PR DESCRIPTION
This was added in https://github.com/tc39/proposal-intl-list-format/pull/25.

I don't know how to test that the option has any effect, so this just checks
that it is read and verified.