### PR TITLE
Quote variables in ci_build.sh

### DIFF
--- a/tools/scripts/ci_build.sh
+++ b/tools/scripts/ci_build.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-if [ $TRAVIS_PULL_REQUEST != "false" ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   ./make.py clean > /dev/null
 fi
 ./make.py
-if [ -n "$(git status --porcelain)" -a $TRAVIS_PULL_REQUEST != "false" ]; then
+if [ -n "$(git status --porcelain)" -a "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo New changes were found after re-generating the tests.
   echo Please, read the documentation on procedurally generated tests
   echo 'https://github.com/tc39/test262/blob/master/CONTRIBUTING.md#procedurally-generated-tests'


### PR DESCRIPTION
This makes it possible to run the script locally even if `TRAVIS_PULL_REQUEST` is not set.

Currently, it results in an error:

tools/scripts/ci_build.sh: line 2: [: !=: unary operator expected