### PR TITLE
Change tests to reflect https://github.com/tc39/proposal-intl-list-format/pull/27 

### DIFF
--- a/test/intl402/ListFormat/constructor/constructor/options-style-valid.js
+++ b/test/intl402/ListFormat/constructor/constructor/options-style-valid.js
@@ -8,6 +8,7 @@ info: |
     InitializeListFormat (listFormat, locales, options)
     9. Let s be ? GetOption(options, "style", "string", «"long", "short", "narrow"», "long").
     10. Set listFormat.[[Style]] to s.
+    14. If style is "narrow" and type is not "unit", throw a RangeError exception.
 features: [Intl.ListFormat]
 ---*/
 
@@ -15,8 +16,7 @@ const validOptions = [
   [undefined, "long"],
   ["long", "long"],
   ["short", "short"],
-  ["narrow", "narrow"],
-  [{ toString() { return "narrow"; } }, "narrow"],
+  [{ toString() { return "short"; } }, "short"],
 ];
 
 for (const [validOption, expected] of validOptions) {
@@ -24,3 +24,7 @@ for (const [validOption, expected] of validOptions) {
   const resolvedOptions = lf.resolvedOptions();
   assert.sameValue(resolvedOptions.style, expected);
 }
+
+const lf = new Intl.ListFormat([], {"style": "narrow", "type": "unit"});
+const resolvedOptions = lf.resolvedOptions();
+assert.sameValue(resolvedOptions.style, "narrow");

--- a/test/intl402/ListFormat/constructor/constructor/options-style-valid.js
+++ b/test/intl402/ListFormat/constructor/constructor/options-style-valid.js
@@ -28,3 +28,11 @@ for (const [validOption, expected] of validOptions) {
 const lf = new Intl.ListFormat([], {"style": "narrow", "type": "unit"});
 const resolvedOptions = lf.resolvedOptions();
 assert.sameValue(resolvedOptions.style, "narrow");
+
+/*---
+    14. If style is "narrow" and type is not "unit", throw a RangeError exception.
+features: [Intl.ListFormat]
+---*/
+assert.throws(RangeError, () => lf = new Intl.ListFormat([], {"style": "narrow"}));
+assert.throws(RangeError, () => lf = new Intl.ListFormat([], {"style": "narrow", "type": "conjuction"}));
+assert.throws(RangeError, () => lf = new Intl.ListFormat([], {"style": "narrow", "type": "disjuction"}));

--- a/test/intl402/ListFormat/constructor/constructor/options-style-valid.js
+++ b/test/intl402/ListFormat/constructor/constructor/options-style-valid.js
@@ -29,10 +29,6 @@ const lf = new Intl.ListFormat([], {"style": "narrow", "type": "unit"});
 const resolvedOptions = lf.resolvedOptions();
 assert.sameValue(resolvedOptions.style, "narrow");
 
-/*---
-    14. If style is "narrow" and type is not "unit", throw a RangeError exception.
-features: [Intl.ListFormat]
----*/
 assert.throws(RangeError, () => lf = new Intl.ListFormat([], {"style": "narrow"}));
 assert.throws(RangeError, () => lf = new Intl.ListFormat([], {"style": "narrow", "type": "conjuction"}));
 assert.throws(RangeError, () => lf = new Intl.ListFormat([], {"style": "narrow", "type": "disjuction"}));

--- a/test/intl402/ListFormat/prototype/format/en-us-narrow.js
+++ b/test/intl402/ListFormat/prototype/format/en-us-narrow.js
@@ -38,6 +38,7 @@ const transforms = [
 
 const lf = new Intl.ListFormat("en-US", {
   "style": "narrow",
+  "type": "unit",
 });
 
 assert.sameValue(typeof lf.format, "function", "format should be supported");
@@ -45,9 +46,9 @@ assert.sameValue(typeof lf.format, "function", "format should be supported");
 for (const f of transforms) {
   assert.sameValue(lf.format(f([])), "");
   assert.sameValue(lf.format(f(["foo"])), "foo");
-  assert.sameValue(lf.format(f(["foo", "bar"])), "foo and bar");
-  assert.sameValue(lf.format(f(["foo", "bar", "baz"])), "foo, bar, and baz");
-  assert.sameValue(lf.format(f(["foo", "bar", "baz", "quux"])), "foo, bar, baz, and quux");
+  assert.sameValue(lf.format(f(["foo", "bar"])), "foo bar");
+  assert.sameValue(lf.format(f(["foo", "bar", "baz"])), "foo bar baz");
+  assert.sameValue(lf.format(f(["foo", "bar", "baz", "quux"])), "foo bar baz quux");
 }
 
-assert.sameValue(lf.format("foo"), "f, o, and o");
+assert.sameValue(lf.format("foo"), "f o o");

--- a/test/intl402/ListFormat/prototype/formatToParts/en-us-narrow.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/en-us-narrow.js
@@ -47,6 +47,7 @@ const transforms = [
 
 const lf = new Intl.ListFormat("en-US", {
   "style": "narrow",
+  "type": "unit",
 });
 
 assert.sameValue(typeof lf.formatToParts, "function", "formatToParts should be supported");
@@ -58,31 +59,31 @@ for (const f of transforms) {
   ]);
   verifyFormatParts(lf.formatToParts(f(["foo", "bar"])), [
     { "type": "element", "value": "foo" },
-    { "type": "literal", "value": " and " },
+    { "type": "literal", "value": " " },
     { "type": "element", "value": "bar" },
   ]);
   verifyFormatParts(lf.formatToParts(f(["foo", "bar", "baz"])), [
     { "type": "element", "value": "foo" },
-    { "type": "literal", "value": ", " },
+    { "type": "literal", "value": " " },
     { "type": "element", "value": "bar" },
-    { "type": "literal", "value": ", and " },
+    { "type": "literal", "value": " " },
     { "type": "element", "value": "baz" },
   ]);
   verifyFormatParts(lf.formatToParts(f(["foo", "bar", "baz", "quux"])), [
     { "type": "element", "value": "foo" },
-    { "type": "literal", "value": ", " },
+    { "type": "literal", "value": " " },
     { "type": "element", "value": "bar" },
-    { "type": "literal", "value": ", " },
+    { "type": "literal", "value": " " },
     { "type": "element", "value": "baz" },
-    { "type": "literal", "value": ", and " },
+    { "type": "literal", "value": " " },
     { "type": "element", "value": "quux" },
   ]);
 }
 
 verifyFormatParts(lf.formatToParts("foo"), [
   { "type": "element", "value": "f" },
-  { "type": "literal", "value": ", " },
+  { "type": "literal", "value": " " },
   { "type": "element", "value": "o" },
-  { "type": "literal", "value": ", and " },
+  { "type": "literal", "value": " " },
   { "type": "element", "value": "o" },
 ]);


### PR DESCRIPTION
Based on 
https://github.com/tc39/proposal-intl-list-format/issues/16
https://github.com/tc39/proposal-intl-list-format/pull/27 change the spec so we need to change the test that 
1) either assert the throws of RangeError if 'style' is 'narrow' but 'type' is not set to 'unit', OR
2) change the test for 'style': 'narrow' for 'type':'unit'