### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "d44c4f5a10",
-  "targetRevisionAtLastExport": "f595c41625",
+  "sourceRevisionAtLastExport": "54374edc2b",
+  "targetRevisionAtLastExport": "bbc9ae15d9",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js
+++ b/implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js
@@ -1,0 +1,40 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+for (var i = 0; i < 10; ++i) {
+    var f = Function('/*) {\n*/', 'return 42');
+    shouldBe(f.toString(),
+`function anonymous(/*) {
+*/) {
+return 42
+}`);
+}
+shouldThrow(() => Function('/*', '*/){\nreturn 42'), `SyntaxError: Parameters should match arguments offered as parameters in Function constructor.`);
+
+shouldThrow(() => Function('/*', '*/){\nreturn 43'), `SyntaxError: Parameters should match arguments offered as parameters in Function constructor.`);
+for (var i = 0; i < 10; ++i) {
+    var f = Function('/*) {\n*/', 'return 43');
+    shouldBe(f.toString(),
+`function anonymous(/*) {
+*/) {
+return 43
+}`);
+}
+

--- a/implementation-contributed/javascriptcore/stress/function-constructor-name.js
+++ b/implementation-contributed/javascriptcore/stress/function-constructor-name.js
@@ -1,0 +1,36 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var GeneratorFunction = function*(){}.constructor;
+var AsyncFunction = async function(){}.constructor;
+var AsyncGeneratorFunction = async function*(){}.constructor;
+
+var f = Function(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(f.toString(),
+`function anonymous() {
+return 42
+}`);
+
+var gf = GeneratorFunction(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(gf.toString(),
+`function* anonymous() {
+return 42
+}`);
+
+var af = AsyncFunction(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(af.toString(),
+`async function anonymous() {
+return 42
+}`);
+
+var agf = AsyncGeneratorFunction(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(agf.toString(),
+`async function* anonymous() {
+return 42
+}`);


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[d44c4f5a10](https://github.com///github/blob/d44c4f5a10) in JavaScriptCore and all changes made since [f595c41625](../blob/f595c41625) in
test262.













### 2 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js](../blob/javascriptcore-test262-automation-export-f595c41625/implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js)
 - [implementation-contributed/javascriptcore/stress/function-constructor-name.js](../blob/javascriptcore-test262-automation-export-f595c41625/implementation-contributed/javascriptcore/stress/function-constructor-name.js)