### PR TITLE
Intl.ListFormat / Intl.RelativeTimeFormat: Add some basic tests for CanonicalizeLocaleList.

### DIFF
--- a/test/intl402/ListFormat/constructor/constructor/locales-valid.js
+++ b/test/intl402/ListFormat/constructor/constructor/locales-valid.js
@@ -1,0 +1,31 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.ListFormat
+description: Checks various cases for the locales argument to the ListFormat constructor.
+info: |
+    InitializeListFormat (listFormat, locales, options)
+    1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
+includes: [testIntl.js]
+features: [Intl.ListFormat]
+---*/
+
+const defaultLocale = new Intl.ListFormat().resolvedOptions().locale;
+
+const tests = [
+  [undefined, defaultLocale, "undefined"],
+  ["EN", "en", "Single value"],
+  [[], defaultLocale, "Empty array"],
+  [["en-GB-oed"], "en-GB", "Grandfathered"],
+  [["x-private"], defaultLocale, "Private"],
+  [["en", "EN"], "en", "Duplicate value (canonical first)"],
+  [["EN", "en"], "en", "Duplicate value (canonical last)"],
+  [{ 0: "DE", length: 0 }, defaultLocale, "Object with zero length"],
+  [{ 0: "DE", length: 1 }, "de", "Object with length"],
+];
+
+for (const [locales, expected, name] of tests) {
+  const rtf = new Intl.ListFormat(locales);
+  assert.sameValue(rtf.resolvedOptions().locale, expected, name);
+}

--- a/test/intl402/RelativeTimeFormat/constructor/constructor/locales-valid.js
+++ b/test/intl402/RelativeTimeFormat/constructor/constructor/locales-valid.js
@@ -1,0 +1,31 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.RelativeTimeFormat
+description: Checks various cases for the locales argument to the RelativeTimeFormat constructor.
+info: |
+    InitializeRelativeTimeFormat (relativeTimeFormat, locales, options)
+    3. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
+includes: [testIntl.js]
+features: [Intl.RelativeTimeFormat]
+---*/
+
+const defaultLocale = new Intl.RelativeTimeFormat().resolvedOptions().locale;
+
+const tests = [
+  [undefined, defaultLocale, "undefined"],
+  ["EN", "en", "Single value"],
+  [[], defaultLocale, "Empty array"],
+  [["en-GB-oed"], "en-GB", "Grandfathered"],
+  [["x-private"], defaultLocale, "Private"],
+  [["en", "EN"], "en", "Duplicate value (canonical first)"],
+  [["EN", "en"], "en", "Duplicate value (canonical last)"],
+  [{ 0: "DE", length: 0 }, defaultLocale, "Object with zero length"],
+  [{ 0: "DE", length: 1 }, "de", "Object with length"],
+];
+
+for (const [locales, expected, name] of tests) {
+  const rtf = new Intl.RelativeTimeFormat(locales);
+  assert.sameValue(rtf.resolvedOptions().locale, expected, name);
+}


### PR DESCRIPTION
Fixes #1846.