### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "54374edc2b",
-  "targetRevisionAtLastExport": "bbc9ae15d9",
+  "sourceRevisionAtLastExport": "ac12ca41a6",
+  "targetRevisionAtLastExport": "b47fed1a36",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/json-stringify-no-arguments.js
+++ b/implementation-contributed/javascriptcore/stress/json-stringify-no-arguments.js
@@ -1,0 +1,7 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+shouldBe(JSON.stringify(), undefined);
+shouldBe(JSON.stringify(undefined), undefined);


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[54374edc2b](https://github.com///github/blob/54374edc2b) in JavaScriptCore and all changes made since [bbc9ae15d9](../blob/bbc9ae15d9) in
test262.













### 1 New File Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/json-stringify-no-arguments.js](../blob/javascriptcore-test262-automation-export-bbc9ae15d9/implementation-contributed/javascriptcore/stress/json-stringify-no-arguments.js)