### PR TITLE
Intl: Add tests for table iteration order.

### DIFF
--- a/test/intl402/Collator/prototype/resolvedOptions/order.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/order.js
@@ -1,0 +1,31 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.collator.prototype.resolvedoptions
+description: Verifies the property order for the object returned by resolvedOptions().
+includes: [compareArray.js]
+---*/
+
+const options = new Intl.Collator([], {
+  "numeric": true,
+  "caseFirst": "upper",
+}).resolvedOptions();
+
+const expected = [
+  "locale",
+  "usage",
+  "sensitivity",
+  "ignorePunctuation",
+  "collation",
+];
+
+if ("numeric" in options) {
+  expected.push("numeric");
+}
+
+if ("caseFirst" in options) {
+  expected.push("caseFirst");
+}
+
+assert.compareArray(Object.getOwnPropertyNames(options), expected);

--- a/test/intl402/DateTimeFormat/constructor-options-order.js
+++ b/test/intl402/DateTimeFormat/constructor-options-order.js
@@ -1,0 +1,114 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-initializedatetimeformat
+description: Checks the order of getting options for the DateTimeFormat constructor.
+includes: [compareArray.js]
+---*/
+
+const expected = [
+  // ToDateTimeOptions step 4.
+  "weekday", "year", "month", "day",
+  // ToDateTimeOptions step 5.
+  "hour", "minute", "second",
+
+  // InitializeDateTimeFormat step 4.
+  "localeMatcher",
+  // InitializeDateTimeFormat step 6.
+  "hour12",
+  // InitializeDateTimeFormat step 7.
+  "hourCycle",
+  // InitializeDateTimeFormat step 17.
+  "timeZone",
+  // InitializeDateTimeFormat step 22.
+  "weekday",
+  "era",
+  "year",
+  "month",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "timeZoneName",
+  // InitializeDateTimeFormat step 25.
+  "formatMatcher",
+];
+
+const actual = [];
+
+const options = {
+  get day() {
+    actual.push("day");
+    return "numeric";
+  },
+
+  get era() {
+    actual.push("era");
+    return "long";
+  },
+
+  get formatMatcher() {
+    actual.push("formatMatcher");
+    return "best fit";
+  },
+
+  get hour() {
+    actual.push("hour");
+    return "numeric";
+  },
+
+  get hour12() {
+    actual.push("hour12");
+    return true;
+  },
+
+  get hourCycle() {
+    actual.push("hourCycle");
+    return "h24";
+  },
+
+  get localeMatcher() {
+    actual.push("localeMatcher");
+    return "best fit";
+  },
+
+  get minute() {
+    actual.push("minute");
+    return "numeric";
+  },
+
+  get month() {
+    actual.push("month");
+    return "numeric";
+  },
+
+  get second() {
+    actual.push("second");
+    return "numeric";
+  },
+
+  get timeZone() {
+    actual.push("timeZone");
+    return "UTC";
+  },
+
+  get timeZoneName() {
+    actual.push("timeZoneName");
+    return "long";
+  },
+
+  get weekday() {
+    actual.push("weekday");
+    return "long";
+  },
+
+  get year() {
+    actual.push("year");
+    return "numeric";
+  },
+};
+
+new Intl.DateTimeFormat("en", options);
+
+assert.compareArray(actual, expected);

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order.js
@@ -1,0 +1,41 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.datetimeformat.prototype.resolvedoptions
+description: Verifies the property order for the object returned by resolvedOptions().
+includes: [compareArray.js]
+---*/
+
+const options = new Intl.DateTimeFormat([], {
+  "hourCycle": "h24",
+  "weekday": "short",
+  "era": "short",
+  "year": "numeric",
+  "month": "numeric",
+  "day": "numeric",
+  "hour": "numeric",
+  "minute": "numeric",
+  "second": "numeric",
+  "timeZoneName": "short",
+}).resolvedOptions();
+
+const expected = [
+  "locale",
+  "calendar",
+  "numberingSystem",
+  "timeZone",
+  "hourCycle",
+  "hour12",
+  "weekday",
+  "era",
+  "year",
+  "month",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "timeZoneName",
+];
+
+assert.compareArray(Object.getOwnPropertyNames(options), expected);

--- a/test/intl402/NumberFormat/prototype/resolvedOptions/order.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/order.js
@@ -1,0 +1,32 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.resolvedoptions
+description: Verifies the property order for the object returned by resolvedOptions().
+includes: [compareArray.js]
+---*/
+
+const options = new Intl.NumberFormat([], {
+  "style": "currency",
+  "currency": "EUR",
+  "currencyDisplay": "symbol",
+  "minimumSignificantDigits": 1,
+  "maximumSignificantDigits": 2,
+}).resolvedOptions();
+
+const expected = [
+  "locale",
+  "numberingSystem",
+  "style",
+  "currency",
+  "currencyDisplay",
+  "minimumIntegerDigits",
+  "minimumFractionDigits",
+  "maximumFractionDigits",
+  "minimumSignificantDigits",
+  "maximumSignificantDigits",
+  "useGrouping",
+];
+
+assert.compareArray(Object.getOwnPropertyNames(options), expected);

--- a/test/intl402/PluralRules/prototype/resolvedOptions/order.js
+++ b/test/intl402/PluralRules/prototype/resolvedOptions/order.js
@@ -1,0 +1,26 @@
+// Copyright 2018 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.resolvedoptions
+description: Verifies the property order for the object returned by resolvedOptions().
+includes: [compareArray.js]
+---*/
+
+const options = new Intl.PluralRules([], {
+  "minimumSignificantDigits": 1,
+  "maximumSignificantDigits": 2,
+}).resolvedOptions();
+
+const expected = [
+  "locale",
+  "type",
+  "minimumIntegerDigits",
+  "minimumFractionDigits",
+  "maximumFractionDigits",
+  "minimumSignificantDigits",
+  "maximumSignificantDigits",
+  "pluralCategories",
+];
+
+assert.compareArray(Object.getOwnPropertyNames(options), expected);


### PR DESCRIPTION
The order was defined in <https://github.com/tc39/ecma402/pull/279>.