### PR TITLE
Generation: fix more YAML frontmatter writer to eliminate errant newlines from yaml.dump()

### DIFF
--- a/tools/generation/lib/template.py
+++ b/tools/generation/lib/template.py
@@ -160,14 +160,14 @@ class Template:
         flags += case_values['meta'].get('flags', [])
         flags += self.attribs['meta'].get('flags', [])
         flags = list(OrderedDict.fromkeys(flags))
-        lines += ['flags: ' + yaml.dump(flags).strip()]
+        lines += ['flags: ' + re.sub('\n\s*', ' ', yaml.dump(flags).strip())]
 
         includes = []
         includes += case_values['meta'].get('includes', [])
         includes += self.attribs['meta'].get('includes', [])
         includes = list(OrderedDict.fromkeys(includes))
         if len(includes):
-            lines += ['includes: ' + yaml.dump(includes).strip()]
+            lines += ['includes: ' + re.sub('\n\s*', ' ', yaml.dump(includes).strip())]
 
         if case_values['meta'].get('negative'):
             if self.attribs['meta'].get('negative'):


### PR DESCRIPTION
This applies the fix from #1821 to the remaining frontmatter properties that consist of lists.

Ref. https://github.com/tc39/test262/pull/1821/files#r222811633.
Ref. #1817.