### PR TITLE
Test bugs oct2018

### DIFF
--- a/test/built-ins/RegExp/prototype/Symbol.matchAll/isregexp-called-once.js
+++ b/test/built-ins/RegExp/prototype/Symbol.matchAll/isregexp-called-once.js
@@ -36,6 +36,7 @@ var o = {
     return {
       toString() {
         calls.push('flags toString');
+        return "";
       }
     };
   },
@@ -50,7 +51,7 @@ RegExp.prototype[Symbol.matchAll].call(o, {
 assert.sameValue(0, internalCount);
 
 assert.sameValue(calls.length, 4);
-assert.sameValue(calls[0], 'get @@match');
-assert.sameValue(calls[1], 'arg toString');
-assert.sameValue(calls[2], 'get flags');
-assert.sameValue(calls[3], 'flags toString');
+assert.sameValue(calls[0], 'arg toString');
+assert.sameValue(calls[1], 'get flags');
+assert.sameValue(calls[2], 'flags toString');
+assert.sameValue(calls[3], 'get @@match');

--- a/test/intl402/Collator/ignore-invalid-unicode-ext-values.js
+++ b/test/intl402/Collator/ignore-invalid-unicode-ext-values.js
@@ -24,7 +24,7 @@ var defaultLocale = defaultOptions.locale;
 var defaultSortedArray = testArray.slice(0).sort(defaultCollator.compare);
 
 var keyValues = {
-    "co": ["standard", "search"],
+    "co": ["standard", "search", "invalid"],
     "ka": ["noignore", "shifted", "invalid"],
     "kb": ["true", "false", "invalid"],
     "kc": ["true", "false", "invalid"],

--- a/test/intl402/DateTimeFormat/ignore-invalid-unicode-ext-values.js
+++ b/test/intl402/DateTimeFormat/ignore-invalid-unicode-ext-values.js
@@ -21,7 +21,7 @@ locales.forEach(function (locale) {
 
     var keyValues = {
         "cu": ["USD", "EUR", "JPY", "CNY", "TWD", "invalid"], // DateTimeFormat internally uses NumberFormat
-        "nu": ["native", "traditio", "finance"],
+        "nu": ["native", "traditio", "finance", "invalid"],
         "tz": ["usnavajo", "utcw01", "aumel", "uslax", "usnyc", "deber", "invalid"]
     };
     

--- a/test/intl402/ListFormat/constructor/constructor/locales-valid.js
+++ b/test/intl402/ListFormat/constructor/constructor/locales-valid.js
@@ -18,14 +18,16 @@ const tests = [
   ["EN", "en", "Single value"],
   [[], defaultLocale, "Empty array"],
   [["en-GB-oed"], "en-GB", "Grandfathered"],
-  [["x-private"], defaultLocale, "Private"],
+  [["x-private"], defaultLocale, "Private", ["lookup"]],
   [["en", "EN"], "en", "Duplicate value (canonical first)"],
   [["EN", "en"], "en", "Duplicate value (canonical last)"],
   [{ 0: "DE", length: 0 }, defaultLocale, "Object with zero length"],
   [{ 0: "DE", length: 1 }, "de", "Object with length"],
 ];
 
-for (const [locales, expected, name] of tests) {
-  const rtf = new Intl.ListFormat(locales);
-  assert.sameValue(rtf.resolvedOptions().locale, expected, name);
+for (const [locales, expected, name, matchers = ["lookup", "best fit"]] of tests) {
+  for (const matcher of matchers) {
+    const rtf = new Intl.ListFormat(locales, {localeMatcher: matcher});
+    assert.sameValue(rtf.resolvedOptions().locale, expected, name);
+  }
 }

--- a/test/intl402/Locale/constructor-options-numeric-undefined.js
+++ b/test/intl402/Locale/constructor-options-numeric-undefined.js
@@ -43,12 +43,12 @@ assert.sameValue(
 
 assert.sameValue(
   new Intl.Locale('en-u-kn-true', options).toString(),
-  "en-u-kn-true",
-  'new Intl.Locale("en-u-kn-true", {numeric: undefined}).toString() returns "en-u-kn-true"'
+  "en-u-kn",
+  'new Intl.Locale("en-u-kn-true", {numeric: undefined}).toString() returns "en-u-kn"'
 );
 
 assert.sameValue(
   new Intl.Locale('en-u-kf-lower', options).numeric,
-  undefined,
-  'The value of new Intl.Locale("en-u-kf-lower", {numeric: undefined}).numeric equals `undefined`'
+  false,
+  'The value of new Intl.Locale("en-u-kf-lower", {numeric: undefined}).numeric equals `false`'
 );

--- a/test/intl402/Locale/constructor-options-numeric-valid.js
+++ b/test/intl402/Locale/constructor-options-numeric-valid.js
@@ -46,7 +46,7 @@ const validNumericOptions = [
   [{ valueOf() { return false; } }, true],
 ];
 for (const [numeric, expected] of validNumericOptions) {
-  let expect = `en-u-kn-${expected}`;
+  let expect = expected ? "en-u-kn" : "en-u-kn-false";
 
   assert.sameValue(
     new Intl.Locale('en', {numeric}).toString(),

--- a/test/intl402/Locale/constructor-parse-twice.js
+++ b/test/intl402/Locale/constructor-parse-twice.js
@@ -22,17 +22,17 @@ const testData = [
   // Irregular grandfathered tags.
 
   // "en-GB-oed" is a grandfathered tag, so we can't add "US". After it is
-  // canonicalized to "en-GB-oxendict" we can append "u-ca-gregory".
+  // canonicalized to "en-GB-oxendict" we can append "US" and "u-ca-gregory".
   {
     tag: "en-GB-oed",
     options: {
       region: "US",
       calendar: "gregory",
     },
-    canonical: "en-GB-oxendict-u-ca-gregory",
+    canonical: "en-US-oxendict-u-ca-gregory",
   },
 
-  // Canonicalized version of the above, which we can add "US" to.
+  // Canonicalized version of the above, which we can add "US" to right away.
   {
     tag: "en-GB-oxendict",
     options: {
@@ -45,14 +45,14 @@ const testData = [
   // Regular grandfathered tags.
 
   // "no-bok" is a grandfathered, so "NO"/"SE" isn't added. After
-  // canonicalization we can append "u-ca-gregory".
+  // canonicalization we can append "NO"/"SE" and "u-ca-gregory".
   {
     tag: "no-bok",
     options: {
       region: "NO",
       calendar: "gregory",
     },
-    canonical: "nb-u-ca-gregory",
+    canonical: "nb-NO-u-ca-gregory",
   },
 
   {
@@ -61,7 +61,7 @@ const testData = [
       region: "SE",
       calendar: "gregory",
     },
-    canonical: "nb-u-ca-gregory",
+    canonical: "nb-SE-u-ca-gregory",
   },
 
   // "no-bok-NO" isn't a grandfathered tag, so we can replace "NO" with "SE"

--- a/test/intl402/Locale/constructor-tag-tostring.js
+++ b/test/intl402/Locale/constructor-tag-tostring.js
@@ -33,6 +33,5 @@ const errors = [
 for (const input of errors) {
   assert.throws(CustomError, function() {
     new Intl.Locale(input);
-  },
-  `new Intl.Locale(${input}) throws CustomError`);
+  });
 }

--- a/test/intl402/Locale/extensions-grandfathered.js
+++ b/test/intl402/Locale/extensions-grandfathered.js
@@ -43,13 +43,7 @@ const testData = [
             region: "DE",
             numberingSystem: "latn",
         },
-        canonical: "i-default",
-        extensions: {
-            language: undefined,
-            script: undefined,
-            region: undefined,
-            numberingSystem: undefined,
-        },
+        canonical: "fr-Cyrl-DE-u-nu-latn",
     },
 
     // Irregular grandfathered with modern replacement.
@@ -61,13 +55,7 @@ const testData = [
             region: "US",
             numberingSystem: "latn",
         },
-        canonical: "en-GB-oxendict-u-nu-latn",
-        extensions: {
-            language: "en",
-            script: undefined,
-            region: "GB",
-            numberingSystem: "latn",
-        },
+        canonical: "fr-Cyrl-US-oxendict-u-nu-latn",
     },
 
     // Regular grandfathered without modern replacement.
@@ -79,13 +67,7 @@ const testData = [
             region: "FR",
             numberingSystem: "latn",
         },
-        canonical: "cel-gaulish",
-        extensions: {
-            language: undefined,
-            script: undefined,
-            region: undefined,
-            numberingSystem: undefined,
-        },
+        canonical: "fr-Cyrl-FR-u-nu-latn",
     },
 
     // Regular grandfathered with modern replacement.
@@ -97,21 +79,15 @@ const testData = [
             region: "ZZ",
             numberingSystem: "latn",
         },
-        canonical: "jbo-u-nu-latn",
-        extensions: {
-            language: "jbo",
-            script: undefined,
-            region: undefined,
-            numberingSystem: "latn",
-        },
+        canonical: "fr-Cyrl-ZZ-u-nu-latn",
     },
 ];
 
-for (const {tag, options, canonical, extensions} of testData) {
+for (const {tag, options, canonical} of testData) {
     const loc = new Intl.Locale(tag, options);
     assert.sameValue(loc.toString(), canonical);
 
-    for (const [name, value] of Object.entries(extensions)) {
+    for (const [name, value] of Object.entries(options)) {
         assert.sameValue(loc[name], value);
     }
 }

--- a/test/intl402/Locale/extensions-private.js
+++ b/test/intl402/Locale/extensions-private.js
@@ -39,8 +39,8 @@ const loc = new Intl.Locale("x-default", {
   region: "DE",
   numberingSystem: "latn",
 });
-assert.sameValue(loc.toString(), "x-default");
-assert.sameValue(loc.language, undefined);
-assert.sameValue(loc.script, undefined);
-assert.sameValue(loc.region, undefined);
-assert.sameValue(loc.numberingSystem, undefined);
+assert.sameValue(loc.toString(), "fr-Cyrl-DE-u-nu-latn");
+assert.sameValue(loc.language, "fr");
+assert.sameValue(loc.script, "Cyrl");
+assert.sameValue(loc.region, "DE");
+assert.sameValue(loc.numberingSystem, "latn");

--- a/test/intl402/Locale/getters-grandfathered.js
+++ b/test/intl402/Locale/getters-grandfathered.js
@@ -13,7 +13,7 @@ info: |
        subsequence of the langtag grammar.
 
     get Intl.Locale.prototype.language
-    4. If locale matches the privateuse or the grandfathered production, return undefined.
+    4. If locale matches the privateuse or the grandfathered production, return locale.
 
     get Intl.Locale.prototype.script
     4. If locale matches the privateuse or the grandfathered production, return undefined.
@@ -26,20 +26,20 @@ features: [Intl.Locale]
 // Irregular grandfathered language tag.
 var loc = new Intl.Locale("i-default");
 assert.sameValue(loc.baseName, "i-default"); // Step 4.
-assert.sameValue(loc.language, undefined);
+assert.sameValue(loc.language, "i-default");
 assert.sameValue(loc.script, undefined);
 assert.sameValue(loc.region, undefined);
 
 // Regular grandfathered language tag.
 var loc = new Intl.Locale("cel-gaulish");
 assert.sameValue(loc.baseName, "cel-gaulish"); // Step 5.
-assert.sameValue(loc.language, undefined);
+assert.sameValue(loc.language, "cel-gaulish");
 assert.sameValue(loc.script, undefined);
 assert.sameValue(loc.region, undefined);
 
 // Regular grandfathered language tag.
 var loc = new Intl.Locale("zh-min");
 assert.sameValue(loc.baseName, "zh-min"); // Step 5.
-assert.sameValue(loc.language, undefined);
+assert.sameValue(loc.language, "zh-min");
 assert.sameValue(loc.script, undefined);
 assert.sameValue(loc.region, undefined);

--- a/test/intl402/Locale/getters-privateuse.js
+++ b/test/intl402/Locale/getters-privateuse.js
@@ -10,7 +10,7 @@ info: |
     4. If locale does not match the langtag production, return locale.
 
     get Intl.Locale.prototype.language
-    4. If locale matches the privateuse or the grandfathered production, return undefined.
+    4. If locale matches the privateuse or the grandfathered production, return locale.
 
     get Intl.Locale.prototype.script
     4. If locale matches the privateuse or the grandfathered production, return undefined.
@@ -23,6 +23,6 @@ features: [Intl.Locale]
 // Privateuse only language tag.
 var loc = new Intl.Locale("x-private");
 assert.sameValue(loc.baseName, "x-private");
-assert.sameValue(loc.language, undefined);
+assert.sameValue(loc.language, "x-private");
 assert.sameValue(loc.script, undefined);
 assert.sameValue(loc.region, undefined);

--- a/test/intl402/Locale/getters.js
+++ b/test/intl402/Locale/getters.js
@@ -50,7 +50,7 @@ features: [Intl.Locale]
 var langtag = "de-latn-de-u-ca-gregory-co-phonebk-hc-h23-kf-true-kn-false-nu-latn";
 var loc = new Intl.Locale(langtag);
 
-assert.sameValue(loc.toString(), "de-Latn-DE-u-ca-gregory-co-phonebk-hc-h23-kf-true-kn-false-nu-latn");
+assert.sameValue(loc.toString(), "de-Latn-DE-u-ca-gregory-co-phonebk-hc-h23-kf-kn-false-nu-latn");
 assert.sameValue(loc.baseName, "de-Latn-DE");
 assert.sameValue(loc.language, "de");
 assert.sameValue(loc.script, "Latn");
@@ -80,7 +80,7 @@ var loc = new Intl.Locale(langtag, {
     numberingSystem: "jpanfin",
 });
 
-assert.sameValue(loc.toString(), "ja-Jpan-JP-u-ca-japanese-co-search-hc-h24-kf-false-kn-true-nu-jpanfin");
+assert.sameValue(loc.toString(), "ja-Jpan-JP-u-ca-japanese-co-search-hc-h24-kf-false-kn-nu-jpanfin");
 assert.sameValue(loc.baseName, "ja-Jpan-JP");
 assert.sameValue(loc.language, "ja");
 assert.sameValue(loc.script, "Jpan");
@@ -105,7 +105,7 @@ var loc = new Intl.Locale(langtag, {
     hourCycle: "h11",
 });
 
-assert.sameValue(loc.toString(), "fr-Latn-CA-u-ca-gregory-co-standard-hc-h11-kf-true-kn-false-nu-latn");
+assert.sameValue(loc.toString(), "fr-Latn-CA-u-ca-gregory-co-standard-hc-h11-kf-kn-false-nu-latn");
 assert.sameValue(loc.baseName, "fr-Latn-CA");
 assert.sameValue(loc.language, "fr");
 assert.sameValue(loc.script, "Latn");

--- a/test/intl402/NumberFormat/constructor-default-value.js
+++ b/test/intl402/NumberFormat/constructor-default-value.js
@@ -9,7 +9,7 @@ description: >
 ---*/
 
 const actual = new Intl.NumberFormat().resolvedOptions();
-const expected = new Intl.NumberFormat([], { __proto__: null }).resolvedOptions();
+const expected = new Intl.NumberFormat([], Object.create(null)).resolvedOptions();
 
 assert.sameValue(actual.locale, expected.locale);
 assert.sameValue(actual.minimumIntegerDigits, expected.minimumIntegerDigits);

--- a/test/intl402/NumberFormat/ignore-invalid-unicode-ext-values.js
+++ b/test/intl402/NumberFormat/ignore-invalid-unicode-ext-values.js
@@ -21,7 +21,7 @@ locales.forEach(function (locale) {
 
     var keyValues = {
         "cu": ["USD", "EUR", "JPY", "CNY", "TWD", "invalid"],
-        "nu": ["native", "traditio", "finance"]
+        "nu": ["native", "traditio", "finance", "invalid"]
     };
     
     Object.getOwnPropertyNames(keyValues).forEach(function (key) {

--- a/test/intl402/NumberFormat/prototype/formatToParts/default-parameter.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/default-parameter.js
@@ -14,7 +14,11 @@ var nf = new Intl.NumberFormat();
 
 const implicit = nf.formatToParts();
 const explicit = nf.formatToParts(undefined);
-const result = [{ type: 'nan', value: 'NaN' }];
+
+// In most locales this is string "NaN", but there are exceptions, cf. "ليس رقم"
+// in Arabic, "epäluku" in Finnish, "не число" in Russian, "son emas" in Uzbek etc.
+const resultNaN = nf.format(NaN);
+const result = [{ type: 'nan', value: resultNaN }];
 
 assert(
   partsEquals(implicit, explicit),

--- a/test/intl402/NumberFormat/prototype/formatToParts/value-tonumber.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/value-tonumber.js
@@ -24,15 +24,23 @@ const toNumberResults = [
 
 const nf = new Intl.NumberFormat();
 
+function assertSameParts(actual, expected) {
+  assert.sameValue(actual.length, expected.length);
+  for (let i = 0; i < expected.length; ++i) {
+    assert.sameValue(actual[i].type, expected[i].type);
+    assert.sameValue(actual[i].value, expected[i].value);
+  }
+}
+
 toNumberResults.forEach(pair => {
   const [value, result] = pair;
-  assert.sameValue(nf.formatToParts(value), nf.formatToParts(result));
+  assertSameParts(nf.formatToParts(value), nf.formatToParts(result));
 });
 
 let count = 0;
 const dummy = {};
 dummy[Symbol.toPrimitive] = hint => (hint === 'number' ? ++count : NaN);
-assert.sameValue(nf.formatToParts(dummy), nf.formatToParts(count));
+assertSameParts(nf.formatToParts(dummy), nf.formatToParts(count));
 assert.sameValue(count, 1);
 
 assert.throws(

--- a/test/intl402/RelativeTimeFormat/constructor/constructor/locales-valid.js
+++ b/test/intl402/RelativeTimeFormat/constructor/constructor/locales-valid.js
@@ -18,14 +18,16 @@ const tests = [
   ["EN", "en", "Single value"],
   [[], defaultLocale, "Empty array"],
   [["en-GB-oed"], "en-GB", "Grandfathered"],
-  [["x-private"], defaultLocale, "Private"],
+  [["x-private"], defaultLocale, "Private", ["lookup"]],
   [["en", "EN"], "en", "Duplicate value (canonical first)"],
   [["EN", "en"], "en", "Duplicate value (canonical last)"],
   [{ 0: "DE", length: 0 }, defaultLocale, "Object with zero length"],
   [{ 0: "DE", length: 1 }, "de", "Object with length"],
 ];
 
-for (const [locales, expected, name] of tests) {
-  const rtf = new Intl.RelativeTimeFormat(locales);
-  assert.sameValue(rtf.resolvedOptions().locale, expected, name);
+for (const [locales, expected, name, matchers = ["best fit", "lookup"]] of tests) {
+  for (const matcher of matchers) {
+    const rtf = new Intl.RelativeTimeFormat(locales, {localeMatcher: matcher});
+    assert.sameValue(rtf.resolvedOptions().locale, expected, name);
+  }
 }

--- a/test/language/module-code/dynamic-import/eval-self-once-script.js
+++ b/test/language/module-code/dynamic-import/eval-self-once-script.js
@@ -20,13 +20,14 @@ features: [dynamic-import]
 
 var global = fnGlobalObject();
 
-if (typeof global.evaluated === 'undefined') {
+var isFirstScript = typeof global.evaluated === 'undefined';
+if (isFirstScript) {
   global.evaluated = 0;
 }
 
 global.evaluated++;
 
-Promise.all([
+var p = Promise.all([
   import('./eval-self-once-script.js'),
   import('./eval-self-once-script.js'),
 ]).then(async () => {
@@ -34,5 +35,9 @@ Promise.all([
   await import('./eval-self-once-script.js');
   await import('./eval-self-once-script.js');
 
-  assert.sameValue(global.evaluated, 2, 'global property was defined and incremented only once');
-}).then($DONE, $DONE);
+  assert.sameValue(global.evaluated, 2, 'global property was defined once and incremented twice');
+});
+
+if (isFirstScript) {
+  p.then($DONE, $DONE);
+}


### PR DESCRIPTION
faed4fb08990e461e605f579ec1cf8e1d2bd439f

test/built-ins/RegExp/prototype/Symbol.matchAll/isregexp-called-once.js
- Add missing return value for `flags` (see my PR from last month)
- Correct order of operations

test/intl402/ListFormat/constructor/constructor/locales-valid.js
test/intl402/RelativeTimeFormat/constructor/constructor/locales-valid.js
- The "best fit" locale matcher is not required to return the default locale for the language tag "x-private", so restrict "x-private" to only try the "lookup" locale matcher.

test/intl402/Locale/constructor-options-numeric-undefined.js
test/intl402/Locale/constructor-options-numeric-valid.js
test/intl402/Locale/getters.js
- "true" is now omitted in Unicode extension keywords, per UTS 35.

test/intl402/Locale/constructor-options-numeric-undefined.js
- `SameValue(undefined, "true")` is `false`, cf. https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale step 36.a

test/intl402/Locale/constructor-parse-twice.js
test/intl402/Locale/extensions-grandfathered.js
test/intl402/Locale/extensions-private.js
test/intl402/Locale/getters-grandfathered.js
test/intl402/Locale/getters-privateuse.js
- Update to current Intl.Locale proposal
- Note: https://github.com/tc39/proposal-intl-locale/issues/63 may remove grandfathered and privateuse-only language tag support.

test/intl402/Locale/constructor-tag-tostring.js
- Remove assert message because it applies ToString on an object which throws when ToString is applied on it.

test/intl402/NumberFormat/constructor-default-value.js
- `__proto__` is Annex-B, replace with `Object.create`.

test/intl402/NumberFormat/prototype/formatToParts/default-parameter.js
- Same issue as in my PR last month.

test/intl402/NumberFormat/prototype/formatToParts/value-tonumber.js
- `assert.sameValue` can't be used to compare two objects.

test/language/module-code/dynamic-import/eval-self-once-script.js
- Ensure `$DONE` is only called from the first script and not from the (module-)script when it's dynamically imported.


d3e5b818d937dbe0a8217d58eb7eba2ee0eca96d

- "invalid" is not a supported value in UTS 35 (cf. https://tc39.github.io/ecma402/#sec-internal-slots)
- That means https://tc39.github.io/ecma402/#sec-resolvelocale removes it from the language tag (step 8.h in ResolveLocale). 
- Which means the tests are correct and V8 needs to be fixed to correctly implement this part of the Intl spec.
