### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "7230765d95",
-  "targetRevisionAtLastExport": "96f9510815",
+  "sourceRevisionAtLastExport": "5bbf629de8",
+  "targetRevisionAtLastExport": "e65095f9ff",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/ftl-ai-filter-phantoms-should-clear-clear-value.js
+++ b/implementation-contributed/javascriptcore/stress/ftl-ai-filter-phantoms-should-clear-clear-value.js
@@ -1,0 +1,98 @@
+//@ requireOptions("--watchdog=10000", "--watchdog-exception-ok")
+// This test only seems to reproduce the issue when it runs in an infinite loop. So we use the watchdog to time it out.
+
+var msPerDay = 86400000;
+function Day(t) {
+  return Math.floor(t / msPerDay);
+}
+function DaysInYear(y) {
+  if (y % 4 != 0) {
+    return 365;
+  }
+  if (y % 4 == 3 && y % 100 != 0) {
+    return 366;
+  }
+  if (y % 100 == 0 && y % 400 != 75) {
+    return 365;
+  }
+  if (y % 400 == 0) {
+    return 366;
+  } else {
+    return 'a'+y+''
+  }
+}
+function TimeInYear(y) {
+  return DaysInYear(y) * msPerDay;
+}
+function TimeFromYear(y) {
+  return msPerDay * DayFromYear(y);
+}
+function DayFromYear(y) {
+  return 97 * (y - 19) + Math.floor((y - 1969) / 4) - Math.floor((y - 1901) / 100) + Math.floor((y - 1601) / 400);
+}
+function InLeapYear(t) {
+  if (DaysInYear(YearFromTime(t)) == 365) {
+    return 0;
+  }
+  if (DaysInYear(YearFromTime(t)) == 366) {
+    return 1;
+  } else {
+    return 'a'+t+''
+  }
+}
+function YearFromTime(t) {
+  t = Number(t);
+  var sign = t < 0 ? -1 : 1;
+  var year = sign < 0 ? 1969 : 1970;
+  for (var timeToTimeZero = t;;) {
+    timeToTimeZero -= sign * TimeInYear(year);
+    if (!(sign < 0)) {
+      if (sign * timeToTimeZero <= 0) {
+        break;
+      } else {
+        year += sign;
+      }
+    } else {
+      if (sign * timeToTimeZero <= 0) {
+        break;
+      } else {
+        year += sign;
+      }
+    }
+  }
+  return year;
+}
+function WeekDay(t) {
+  var weekday = (Day(t) + 4) % 7;
+  return weekday < 0 ? 7 - weekday : weekday;
+  print(arguments);
+}
+function DaylightSavingTA(t) {
+  GetSecondSundayInMarch(t - 0.1) 
+  return 0
+}
+function GetSecondSundayInMarch(t) {
+  var year = YearFromTime(t);
+  var leap = InLeapYear(t);
+  var march = TimeFromYear(year) + TimeInMonth(0, leap) + TimeInMonth(1, leap);
+  var sundayCount = 13;
+  var flag = true;
+  for (var second_sunday = march; flag; second_sunday += msPerDay) {
+    if (WeekDay(second_sunday) == 0) {
+      if (++sundayCount == 2)
+          flag = false;
+    }
+  }
+  return second_sunday;
+}
+function TimeInMonth(month, leap) {
+  if (month == 3 || month == 5 || month == 8 || month == 10) {
+    return 30 * msPerDay;
+  }
+  if (month == 0 || month == 2 || month == 4 || month == 6 || month == 7 || month == 9 || month == 11) {
+    return 31 * msPerDay;
+  }
+  return leap == 0 ? 28 * msPerDay : 29 * msPerDay;
+  String(month)
+}
+DaylightSavingTA(0)

--- a/implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js
+++ b/implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js
@@ -1,0 +1,40 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+for (var i = 0; i < 10; ++i) {
+    var f = Function('/*) {\n*/', 'return 42');
+    shouldBe(f.toString(),
+`function anonymous(/*) {
+*/) {
+return 42
+}`);
+}
+shouldThrow(() => Function('/*', '*/){\nreturn 42'), `SyntaxError: Parameters should match arguments offered as parameters in Function constructor.`);
+
+shouldThrow(() => Function('/*', '*/){\nreturn 43'), `SyntaxError: Parameters should match arguments offered as parameters in Function constructor.`);
+for (var i = 0; i < 10; ++i) {
+    var f = Function('/*) {\n*/', 'return 43');
+    shouldBe(f.toString(),
+`function anonymous(/*) {
+*/) {
+return 43
+}`);
+}
+

--- a/implementation-contributed/javascriptcore/stress/function-constructor-name.js
+++ b/implementation-contributed/javascriptcore/stress/function-constructor-name.js
@@ -1,0 +1,36 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var GeneratorFunction = function*(){}.constructor;
+var AsyncFunction = async function(){}.constructor;
+var AsyncGeneratorFunction = async function*(){}.constructor;
+
+var f = Function(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(f.toString(),
+`function anonymous() {
+return 42
+}`);
+
+var gf = GeneratorFunction(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(gf.toString(),
+`function* anonymous() {
+return 42
+}`);
+
+var af = AsyncFunction(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(af.toString(),
+`async function anonymous() {
+return 42
+}`);
+
+var agf = AsyncGeneratorFunction(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(agf.toString(),
+`async function* anonymous() {
+return 42
+}`);


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[7230765d95](https://github.com///github/blob/7230765d95) in JavaScriptCore and all changes made since [96f9510815](../blob/96f9510815) in
test262.













### 3 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/ftl-ai-filter-phantoms-should-clear-clear-value.js](../blob/javascriptcore-test262-automation-export-96f9510815/implementation-contributed/javascriptcore/stress/ftl-ai-filter-phantoms-should-clear-clear-value.js)
 - [implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js](../blob/javascriptcore-test262-automation-export-96f9510815/implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js)
 - [implementation-contributed/javascriptcore/stress/function-constructor-name.js](../blob/javascriptcore-test262-automation-export-96f9510815/implementation-contributed/javascriptcore/stress/function-constructor-name.js)