### PR TITLE
Some fixes to dynamic import + a few cosmetic changes

### DIFF
--- a/src/dynamic-import/is-call-expression-square-brackets.case
+++ b/src/dynamic-import/is-call-expression-square-brackets.case
@@ -5,6 +5,9 @@ desc: ImportCall is a CallExpression, it can be followed by square brackets
 template: default
 ---*/
 
+//- setup
+// import('./dynamic-import-module_FIXTURE.js')
+
 //- import
 import('./dynamic-import-module_FIXTURE.js')['then'](x => x)
 //- body

--- a/src/dynamic-import/specifier-tostring.case
+++ b/src/dynamic-import/specifier-tostring.case
@@ -24,6 +24,8 @@ template: default
 ---*/
 
 //- setup
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/assign-expr/additive-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/additive-expr.js
@@ -26,12 +26,12 @@ const a = '_FIXTURE.js';
 const b = '-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(x + a);
+    const ns1 = await import(x + a); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import(y + b);
+    const ns2 = await import(y + b); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/array-literal.js
+++ b/test/language/expressions/dynamic-import/assign-expr/array-literal.js
@@ -23,13 +23,13 @@ const a = './module-code_FIXTURE.js';
 const b = './module-code-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import([a]);
+    const ns1 = await import([a]); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
     Array.prototype.toString = () => b;
-    const ns2 = await import([]);
+    const ns2 = await import([]); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/arrow-function.js
+++ b/test/language/expressions/dynamic-import/assign-expr/arrow-function.js
@@ -22,7 +22,7 @@ features: [dynamic-import]
 Function.prototype.toString = () => './module-code_FIXTURE.js';
 
 async function fn() {
-    const ns = await import(() => {});
+    const ns = await import(() => {}); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns.local1, 'Test262');
     assert.sameValue(ns.default, 42);

--- a/test/language/expressions/dynamic-import/assign-expr/await-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/await-expr.js
@@ -23,12 +23,12 @@ const a = './module-code_FIXTURE.js';
 const b = './module-code-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(await a);
+    const ns1 = await import(await a); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import(await b);
+    const ns2 = await import(await b); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/await-identifier.js
+++ b/test/language/expressions/dynamic-import/assign-expr/await-identifier.js
@@ -21,7 +21,7 @@ features: [dynamic-import]
 
 const await = './module-code_FIXTURE.js';
 
-const getpromise = () => import(await);
+const getpromise = () => import(await); // import('./module-code_FIXTURE.js')
 
 async function fn() {
     const ns1 = await getpromise();

--- a/test/language/expressions/dynamic-import/assign-expr/call-expr-arguments.js
+++ b/test/language/expressions/dynamic-import/assign-expr/call-expr-arguments.js
@@ -31,12 +31,12 @@ const a = () => () => './module-code_FIXTURE.js';
 const b = () => () => './module-code-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(a()());
+    const ns1 = await import(a()()); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import(b()());
+    const ns2 = await import(b()()); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/call-expr-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/call-expr-expr.js
@@ -30,12 +30,12 @@ features: [dynamic-import]
 const a = () => ['./module-code_FIXTURE.js', './module-code-other_FIXTURE.js'];
 
 async function fn() {
-    const ns1 = await import(a()[0]);
+    const ns1 = await import(a()[0]); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import(a()[0, 1]);
+    const ns2 = await import(a()[0, 1]); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/call-expr-identifier.js
+++ b/test/language/expressions/dynamic-import/assign-expr/call-expr-identifier.js
@@ -33,12 +33,12 @@ const a = () => ({
 });
 
 async function fn() {
-    const ns1 = await import(a().x);
+    const ns1 = await import(a().x); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import(a().y);
+    const ns2 = await import(a().y); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/cover-call-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/cover-call-expr.js
@@ -31,12 +31,12 @@ const a = () => './module-code_FIXTURE.js';
 const b = () => './module-code-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(a());
+    const ns1 = await import(a()); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import(b());
+    const ns2 = await import(b()); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/cover-parenthesized-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/cover-parenthesized-expr.js
@@ -23,12 +23,12 @@ features: [dynamic-import]
 ---*/
 
 async function fn() {
-    const ns1 = await import((((((('./module-code_FIXTURE.js')))))));
+    const ns1 = await import((((((('./module-code_FIXTURE.js'))))))); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import((1, 0, './module-code-other_FIXTURE.js'));
+    const ns2 = await import((1, 0, './module-code-other_FIXTURE.js')); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/identifier.js
+++ b/test/language/expressions/dynamic-import/assign-expr/identifier.js
@@ -23,12 +23,12 @@ const a = './module-code_FIXTURE.js';
 const b = './module-code-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(a);
+    const ns1 = await import(a); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import(b);
+    const ns2 = await import(b); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/lhs-assign-operator-assign-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/lhs-assign-operator-assign-expr.js
@@ -26,12 +26,12 @@ const a = '_FIXTURE.js';
 const b = '-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(x += a);
+    const ns1 = await import(x += a); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import(y += b);
+    const ns2 = await import(y += b); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/lhs-eq-assign-expr-nostrict.js
+++ b/test/language/expressions/dynamic-import/assign-expr/lhs-eq-assign-expr-nostrict.js
@@ -3,6 +3,7 @@
 /*---
 description: >
     Dynamic Import receives an AssignmentExpression (LHS Expr = AssignmentExpression)
+    Using a frozen object property
 esid: prod-ImportCall
 info: |
     ImportCall [Yield]:
@@ -15,23 +16,17 @@ info: |
         AsyncArrowFunction[?In, ?Yield, ?Await]
         LeftHandSideExpression[?Yield, ?Await] = AssignmentExpression[?In, ?Yield, ?Await]
         LeftHandSideExpression[?Yield, ?Await] AssignmentOperator AssignmentExpression[?In, ?Yield, ?Await]
-flags: [async]
+flags: [async, noStrict]
 features: [dynamic-import]
 ---*/
 
-let x = 'foo';
 const y = {
     z: 0
 };
-const a = './module-code_FIXTURE.js';
+Object.freeze(y);
 const b = './module-code-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(x = a); // import('./module-code_FIXTURE.js')
-
-    assert.sameValue(ns1.local1, 'Test262');
-    assert.sameValue(ns1.default, 42);
-
     const ns2 = await import(y.z = b); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');

--- a/test/language/expressions/dynamic-import/assign-expr/lhs-eq-assign-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/lhs-eq-assign-expr.js
@@ -28,12 +28,12 @@ const a = './module-code_FIXTURE.js';
 const b = './module-code-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(x = a);
+    const ns1 = await import(x = a); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import(y.z = b);
+    const ns2 = await import(y.z = b); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/logical-and-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/logical-and-expr.js
@@ -23,13 +23,13 @@ const a = './module-code_FIXTURE.js';
 const b = './module-code-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(b && a);
+    const ns1 = await import(b && a); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
     // mix it in with Unary Expressions
-    const ns2 = await import(delete void typeof +-~! 0 && b);
+    const ns2 = await import(delete void typeof +-~! 0 && b); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/logical-or-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/logical-or-expr.js
@@ -23,12 +23,12 @@ const a = './module-code_FIXTURE.js';
 const b = './module-code-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(a || b);
+    const ns1 = await import(a || b); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import(false || b);
+    const ns2 = await import(false || b); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/member-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/member-expr.js
@@ -26,13 +26,13 @@ const obj = {
 
 async function fn() {
     // MemberExpression [ Expression ]
-    const ns1 = await import(obj['a']);
+    const ns1 = await import(obj['a']); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
     // MemberExpression . IdentifierName
-    const ns2 = await import(obj.b);
+    const ns2 = await import(obj.b); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/new-target.js
+++ b/test/language/expressions/dynamic-import/assign-expr/new-target.js
@@ -20,7 +20,7 @@ features: [dynamic-import]
 ---*/
 
 function ctor() {
-    return import(new.target);
+    return import(new.target); // import('./module-code_FIXTURE.js')
 }
 
 ctor.toString = () => './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/assign-expr/object-literal.js
+++ b/test/language/expressions/dynamic-import/assign-expr/object-literal.js
@@ -23,13 +23,13 @@ const a = './module-code_FIXTURE.js';
 const b = './module-code-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import({ toString() { return a; } });
+    const ns1 = await import({ toString() { return a; } }); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
     Object.prototype.toString = () => b;
-    const ns2 = await import({});
+    const ns2 = await import({}); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/tagged-function-call.js
+++ b/test/language/expressions/dynamic-import/assign-expr/tagged-function-call.js
@@ -19,16 +19,13 @@ flags: [async]
 features: [dynamic-import]
 ---*/
 
-const a = './module-code_FIXTURE.js';
-const b = './module-code-other_FIXTURE.js';
-
 function tag(arg) {
     return arg[0];
 }
 
 async function fn() {
     // MemberExpression TemplateLiteral
-    const ns = await import(tag`./module-code-other_FIXTURE.js`);
+    const ns = await import(tag`./module-code-other_FIXTURE.js`); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns.local1, 'one six one two');
     assert.sameValue(ns.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/ternary.js
+++ b/test/language/expressions/dynamic-import/assign-expr/ternary.js
@@ -23,12 +23,12 @@ const a = './module-code_FIXTURE.js';
 const b = './module-code-other_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(true ? a : b);
+    const ns1 = await import(true ? a : b); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
 
-    const ns2 = await import(false ? a : b);
+    const ns2 = await import(false ? a : b); // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/this.js
+++ b/test/language/expressions/dynamic-import/assign-expr/this.js
@@ -23,7 +23,7 @@ features: [dynamic-import]
 ---*/
 
 async function fn() {
-    const ns1 = await import(this);
+    const ns1 = await import(this); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);

--- a/test/language/expressions/dynamic-import/assign-expr/yield-assign-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/yield-assign-expr.js
@@ -30,7 +30,7 @@ async function *fn() {
     let iter = g();
     assert.sameValue(iter.next().value, 42);
 
-    const ns1 = await iter.next(a).value;
+    const ns1 = await iter.next(a).value; // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
@@ -38,7 +38,7 @@ async function *fn() {
     iter = g();
     assert.sameValue(iter.next().value, 42);
 
-    const ns2 = await iter.next(b).value;
+    const ns2 = await iter.next(b).value; // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/yield-assign-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/yield-assign-expr.js
@@ -26,7 +26,7 @@ function *g() {
     return import(yield 42);
 }
 
-async function *fn() {
+async function fn() {
     let iter = g();
     assert.sameValue(iter.next().value, 42);
 
@@ -44,4 +44,4 @@ async function *fn() {
     assert.sameValue(ns2.default, 1612);
 }
 
-fn().next(a).then($DONE, $DONE).catch($DONE);
+fn().then($DONE, $DONE).catch($DONE);

--- a/test/language/expressions/dynamic-import/assign-expr/yield-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/yield-expr.js
@@ -30,7 +30,7 @@ async function *fn() {
     let iter = g();
     iter.next();
 
-    const ns1 = await iter.next(a).value;
+    const ns1 = await iter.next(a).value; // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);
@@ -38,7 +38,7 @@ async function *fn() {
     iter = g();
     iter.next();
 
-    const ns2 = await iter.next(b).value;
+    const ns2 = await iter.next(b).value; // import('./module-code-other_FIXTURE.js')
 
     assert.sameValue(ns2.local1, 'one six one two');
     assert.sameValue(ns2.default, 1612);

--- a/test/language/expressions/dynamic-import/assign-expr/yield-expr.js
+++ b/test/language/expressions/dynamic-import/assign-expr/yield-expr.js
@@ -26,7 +26,7 @@ function *g() {
     return import(yield);
 }
 
-async function *fn() {
+async function fn() {
     let iter = g();
     iter.next();
 
@@ -44,4 +44,4 @@ async function *fn() {
     assert.sameValue(ns2.default, 1612);
 }
 
-fn().next(a).then($DONE, $DONE).catch($DONE);
+fn().then($DONE, $DONE).catch($DONE);

--- a/test/language/expressions/dynamic-import/assign-expr/yield-identifier.js
+++ b/test/language/expressions/dynamic-import/assign-expr/yield-identifier.js
@@ -22,7 +22,7 @@ features: [dynamic-import]
 const yield = './module-code_FIXTURE.js';
 
 async function fn() {
-    const ns1 = await import(yield);
+    const ns1 = await import(yield); // import('./module-code_FIXTURE.js')
 
     assert.sameValue(ns1.local1, 'Test262');
     assert.sameValue(ns1.default, 42);

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 let f = () => import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {
 

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 let f = () => {
   return import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 const f = async () => {
   await import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 const f = async () => await import('./dynamic-import-module_FIXTURE.js')['then'](x => x);
 

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-await-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-await-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 async function f() {
   await import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-await-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-await-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 async function f() {
   import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 async function f() {
   return await import('./dynamic-import-module_FIXTURE.js')['then'](x => x);

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-await-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-await-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 let callCount = 0;
 

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-await-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-await-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 async function * f() {
   return await import('./dynamic-import-module_FIXTURE.js')['then'](x => x);

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-block-import-then-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-block-import-then-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 {
   import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {

--- a/test/language/expressions/dynamic-import/usage/nested-block-import-then-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-block-import-then-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-do-while-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-do-while-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 do {
   import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {

--- a/test/language/expressions/dynamic-import/usage/nested-do-while-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-do-while-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-else-import-then-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-else-import-then-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 if (false) {
 

--- a/test/language/expressions/dynamic-import/usage/nested-else-import-then-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-else-import-then-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-function-import-then-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-function-import-then-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 function f() {
   import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {

--- a/test/language/expressions/dynamic-import/usage/nested-function-import-then-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-function-import-then-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-if-braceless-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-if-braceless-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 if (true) import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {
 

--- a/test/language/expressions/dynamic-import/usage/nested-if-braceless-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-if-braceless-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-if-import-then-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-if-import-then-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 if (true) {
   import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {

--- a/test/language/expressions/dynamic-import/usage/nested-if-import-then-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-if-import-then-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/nested-while-import-then-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/nested-while-import-then-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 let x = 0;
 while (!x) {

--- a/test/language/expressions/dynamic-import/usage/nested-while-import-then-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/nested-while-import-then-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 label: {
   import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {

--- a/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';

--- a/test/language/expressions/dynamic-import/usage/top-level-import-then-is-call-expression-square-brackets.js
+++ b/test/language/expressions/dynamic-import/usage/top-level-import-then-is-call-expression-square-brackets.js
@@ -21,6 +21,8 @@ info: |
     9. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./dynamic-import-module_FIXTURE.js')
+
 
 import('./dynamic-import-module_FIXTURE.js')['then'](x => x).then(imported => {
 

--- a/test/language/expressions/dynamic-import/usage/top-level-import-then-specifier-tostring.js
+++ b/test/language/expressions/dynamic-import/usage/top-level-import-then-specifier-tostring.js
@@ -37,6 +37,8 @@ info: |
     8. Return promiseCapability.[[Promise]].
 
 ---*/
+// import('./module-code_FIXTURE.js')
+
 const obj = {
     toString() {
         return './module-code_FIXTURE.js';


### PR DESCRIPTION
Some cosmetic changes include commenting specifiers resolution when it's not immediately set with direct strings.

Other small fixes consider runs in strict modes and removes unnecessary async generator productions.

The tests are also passing just fine on V8. I had to include the `--harmony` flag to include the `export * as ns from 'mod'` productions.

```
test262-harness --hostType=d8 --hostPath=`which v8` --hostArgs='--harmony'  'test/language/expressions/dynamic-import/**/*.js'
Ran 882 tests
882 passed
0 failed
```