### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "1fc8452b",
-  "targetRevisionAtLastExport": "603acd9ca0",
+  "sourceRevisionAtLastExport": "0039b340",
+  "targetRevisionAtLastExport": "6ddea08809",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/mjsunit/BUILD.gn
+++ b/implementation-contributed/v8/mjsunit/BUILD.gn
@@ -23,8 +23,5 @@ group("v8_mjsunit") {
     "../../tools/splaytree.js",
     "../../tools/tickprocessor.js",
     "../../tools/dumpcpp.js",
-    "../wasm-js/test/harness/wasm-constants.js",
-    "../wasm-js/test/harness/wasm-module-builder.js",
-    "../wasm-js/test/js-api/jsapi.js",
   ]
 }

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/cleanup-is-a-microtask.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/cleanup-is-a-microtask.js
@@ -1,0 +1,56 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+// This test asserts that the cleanup function call, scheduled by GC, is a
+// microtask and not a normal task.
+
+// Inside a microtask, cause GC (which should schedule the cleanup as
+// microtask).  lso schedule another microtask. Assert that the cleanup
+// function ran before the other microtask.
+
+function scheduleMicrotask(func) {
+  Promise.resolve().then(func);
+}
+
+let log = [];
+
+let cleanup = (iter) => {
+  log.push("cleanup");
+  for (wc of iter) { }
+}
+
+let wf = new WeakFactory(cleanup);
+let o = null;
+
+(function() {
+  // Use a closure here to avoid other references to o which might keep it alive
+  // (e.g., stack frames pointing to it).
+  o = {};
+  wf.makeCell(o);
+})();
+
+let microtask_after_cleanup = () => {
+  log.push("microtask_after_cleanup");
+}
+
+let first_microtask = function() {
+  log.push("first_microtask");
+
+  // This schedules the cleanup function as microtask.
+  o = null;
+  gc();
+
+  // Schedule a microtask which should run after the cleanup microtask.
+  scheduleMicrotask(microtask_after_cleanup);
+}
+
+scheduleMicrotask(first_microtask);
+
+setTimeout(() => {
+  // Assert that the functions got called in the right order.
+  let wanted_log = ["first_microtask", "cleanup", "microtask_after_cleanup"];
+  assertEquals(wanted_log, log);
+}, 0);

--- a/implementation-contributed/v8/mjsunit/mjsunit.status
+++ b/implementation-contributed/v8/mjsunit/mjsunit.status
@@ -32,6 +32,8 @@
   'modules-skip*': [SKIP],
   'harmony/modules-skip*': [SKIP],
   'regress/modules-skip*': [SKIP],
+  'wasm/wasm-constants': [SKIP],
+  'wasm/wasm-module-builder': [SKIP],
 
   # All tests in the bug directory are expected to fail.
   'bugs/*': [FAIL],
@@ -171,10 +173,11 @@
   'string-replace-gc': [PASS, SLOW],
   'wasm/asm-wasm-f32': [PASS, SLOW],
   'wasm/asm-wasm-f64': [PASS, SLOW],
-  'wasm/compare-exchange-stress': [PASS, SLOW],
   'wasm/embenchen/*': [PASS, SLOW],
   'wasm/grow-memory': [PASS, SLOW],
   'wasm/unreachable-validation': [PASS, SLOW],
+  'wasm/compare-exchange-stress': [PASS, SLOW, NO_VARIANTS],
+  'wasm/compare-exchange64-stress': [PASS, SLOW, NO_VARIANTS],
 
   # case-insensitive unicode regexp relies on case mapping provided by ICU.
   'es6/unicode-regexp-ignore-case': [PASS, ['no_i18n == True', FAIL]],
@@ -224,6 +227,11 @@
 
   # BUG(v8:8169)
   'external-backing-store-gc': [SKIP],
+
+  # BUG(v8:8332)
+  'wasm/atomics-stress': [SKIP],
+  # BUG(v8:8331)
+  'wasm/atomics64-stress': [SKIP],
 }],  # ALWAYS
 
 ['novfp3 == True', {
@@ -805,9 +813,6 @@
 
   # Too memory hungry on Odroid devices.
   'regress/regress-678917': [PASS, ['arch == arm and not simulator_run', SKIP]],
-
-  # https://crbug.com/v8/8164
-  'wasm/compare-exchange-stress': [SKIP],
 
   # Too slow for verify-csa builds.
   'big-object-literal': [PASS, ['verify_csa == True', SKIP]],

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-881247.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-881247.js
@@ -1,0 +1,24 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+const resolvedPromise = Promise.resolve();
+
+function spread() {
+  const result = { ...resolvedPromise };
+  %HeapObjectVerify(result);
+  return result;
+}
+
+resolvedPromise[undefined] =  {a:1};
+%HeapObjectVerify(resolvedPromise);
+
+spread();
+
+resolvedPromise[undefined] = undefined;
+%HeapObjectVerify(resolvedPromise);
+
+spread();
+%HeapObjectVerify(resolvedPromise);

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-896700.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-896700.js
@@ -1,0 +1,10 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --async-stack-traces --expose-async-hooks
+
+async_hooks.createHook({
+  after() { throw new Error(); }
+}).enable();
+Promise.resolve().then();

--- a/implementation-contributed/v8/wasm-js/BUILD.gn
+++ b/implementation-contributed/v8/wasm-js/BUILD.gn
@@ -1,0 +1,17 @@
+# Copyright 2018 the V8 project authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+group("v8_wasm_js") {
+  testonly = true
+
+  data_deps = [
+    "../..:d8",
+    "../../tools:v8_testrunner",
+  ]
+
+  data = [
+    "./",
+    "../mjsunit/mjsunit.js",
+  ]
+}

--- a/implementation-contributed/v8/wasm-js/LICENSE.testharness
+++ b/implementation-contributed/v8/wasm-js/LICENSE.testharness
@@ -1,0 +1,30 @@
+W3C 3-clause BSD License
+
+http://www.w3.org/Consortium/Legal/2008/03-bsd-license.html
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of works must retain the original copyright notice,
+  this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the original copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name of the W3C nor the names of its contributors may be
+  used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/implementation-contributed/v8/wasm-js/testcfg.py
+++ b/implementation-contributed/v8/wasm-js/testcfg.py
@@ -1,0 +1,74 @@
+# Copyright 2018 the V8 project authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import os
+import re
+
+from testrunner.local import testsuite
+from testrunner.objects import testcase
+
+ANY_JS = ".any.js"
+WPT_ROOT = "/wasm/jsapi/"
+META_SCRIPT_REGEXP = re.compile(r"META:\s*script=(.*)")
+
+class TestSuite(testsuite.TestSuite):
+  def __init__(self, *args, **kwargs):
+    super(TestSuite, self).__init__(*args, **kwargs)
+    self.testroot = os.path.join(self.root, "data", "test", "js-api")
+    self.mjsunit_js = os.path.join(os.path.dirname(self.root), "mjsunit",
+                                   "mjsunit.js")
+
+  def ListTests(self):
+    tests = []
+    for dirname, dirs, files in os.walk(self.testroot):
+      for dotted in [x for x in dirs if x.startswith(".")]:
+        dirs.remove(dotted)
+      dirs.sort()
+      files.sort()
+      for filename in files:
+        if (filename.endswith(ANY_JS)):
+          fullpath = os.path.join(dirname, filename)
+          relpath = fullpath[len(self.testroot) + 1 : -len(ANY_JS)]
+          testname = relpath.replace(os.path.sep, "/")
+          test = self._create_test(testname)
+          tests.append(test)
+    return tests
+
+  def _test_class(self):
+    return TestCase
+
+
+class TestCase(testcase.D8TestCase):
+  def _get_files_params(self):
+    files = [os.path.join(self.suite.mjsunit_js),
+             os.path.join(self.suite.root, "testharness.js")]
+
+    source = self.get_source()
+    for script in META_SCRIPT_REGEXP.findall(source):
+      if script.startswith(WPT_ROOT):
+        # Matched an absolute path, strip the root and replace it with our
+        # local root.
+        script = os.path.join(self.suite.testroot, script[len(WPT_ROOT):])
+      elif not script.startswith("/"):
+        # Matched a relative path, prepend this test's directory.
+        thisdir = os.path.dirname(self._get_source_path())
+        script = os.path.join(thisdir, script)
+      else:
+        raise Exception("Unexpected absolute path for script: \"%s\"" % script);
+
+      files.append(script)
+
+    files.extend([
+      self._get_source_path(),
+      os.path.join(self.suite.root, "testharness-after.js")
+    ])
+    return files
+
+  def _get_source_path(self):
+    # All tests are named `path/name.any.js`
+    return os.path.join(self.suite.testroot, self.path + ANY_JS)
+
+
+def GetSuite(*args, **kwargs):
+  return TestSuite(*args, **kwargs)

--- a/implementation-contributed/v8/wasm-js/testharness-after.js
+++ b/implementation-contributed/v8/wasm-js/testharness-after.js
@@ -1,0 +1,16 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Uses lastPromise defined in testharness.js
+
+assertPromiseResult(lastPromise, _ => {
+  if (failures.length > 0) {
+    let message = 'Some tests FAILED:\n';
+    for (const failure of failures) {
+      message += `  ${failure}\n`;
+    }
+
+    failWithMessage(message);
+  }
+});

--- a/implementation-contributed/v8/wasm-js/testharness.js
+++ b/implementation-contributed/v8/wasm-js/testharness.js
@@ -1,0 +1,142 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Implementations of some functions from testharness.js
+// See https://github.com/web-platform-tests/wpt/blob/master/resources/testharness.js
+// Licensed as follows:
+//
+// Distributed under both the W3C Test Suite License [1] and the W3C
+// 3-clause BSD License [2]. To contribute to a W3C Test Suite, see the
+// policies and contribution forms [3].
+// [1] http://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+// [2] http://www.w3.org/Consortium/Legal/2008/03-bsd-license
+// [3] http://www.w3.org/2004/10/27-testcases
+
+const failures = [];
+
+let lastPromise = Promise.resolve();
+
+function test(func, description) {
+  let maybeErr;
+  try { func({unreached_func: assert_unreached}); }
+  catch(e) { maybeErr = e; }
+  if (typeof maybeErr !== 'undefined') {
+    console.log(`${description}: FAIL. ${maybeErr}`);
+    failures.push(description);
+  } else {
+    console.log(`${description}: PASS.`);
+  }
+}
+
+function promise_test(func, description) {
+  lastPromise = lastPromise.then(func)
+  .then(_ => {
+    console.log(`${description}: PASS.`);
+  })
+  .catch(err => {
+    console.log(`${description}: FAIL. ${err}`);
+    failures.push(description);
+  });
+}
+
+const assert_true = assertEquals.bind(null, true);
+const assert_false = assertEquals.bind(null, false);
+
+function same_value(x, y) {
+  if (y !== y) {
+    // NaN case
+    return x!==x;
+  }
+  if (x === 0 && y === 0) {
+    // Distinguish +0 and -0
+    return 1/x === 1/y;
+  }
+  return x === y;
+}
+
+function assert_equals(expected, found, description) {
+  if (typeof found != typeof expected) {
+    assert_true(false, "assert_equals", description,
+        "expected (" + typeof expected + ") ${expected} but got (" +
+        typeof found + ") ${found}", {expected:expected, found:found});
+  }
+  assert_true(same_value(found, expected), "assert_equals", description,
+      "expected ${expected} but got ${found}",
+      {expected:expected, found:found});
+}
+
+function assert_not_equals(expected, found, description) {
+  assert_true(!same_value(found, expected), "assert_not_equals", description,
+      "got disallowed value ${found}", {found:found});
+}
+
+function assert_array_equals(actual, expected, description) {
+  assert_true(
+      typeof actual === 'object' && actual !== null && 'length' in actual,
+      'assert_array_equals', description, 'value is ${actual}, expected array',
+      {actual: actual});
+  assert_true(
+      actual.length === expected.length, 'assert_array_equals', description,
+      'lengths differ, expected ${expected} got ${actual}',
+      {expected: expected.length, actual: actual.length});
+
+  for (let i = 0; i < actual.length; i++) {
+    assert_true(
+        actual.hasOwnProperty(i) === expected.hasOwnProperty(i),
+        'assert_array_equals', description,
+        'property ${i}, property expected to be ${expected} but was ${actual}',
+        {
+          i: i,
+          expected: expected.hasOwnProperty(i) ? 'present' : 'missing',
+          actual: actual.hasOwnProperty(i) ? 'present' : 'missing'
+        });
+    assert_true(
+        same_value(expected[i], actual[i]), 'assert_array_equals', description,
+        'property ${i}, expected ${expected} but got ${actual}',
+        {i: i, expected: expected[i], actual: actual[i]});
+  }
+}
+
+function assert_unreached(description) {
+  throw new Error(`unreachable:\n${description}`);
+}
+
+function format_value(s) {
+  // TODO
+  try {
+    return String(s);
+  } catch(e) {
+    return `<String(e) for type ${typeof(e)} threw>`;
+  }
+}
+
+function promise_rejects(test, expected, promise, description) {
+  return promise
+      .then(() => assert_unreached('Should have rejected: ' + description))
+      .catch(function(e) {
+        assert_throws(expected, function() {
+          throw e;
+        }, description);
+      });
+}
+
+function assert_class_string(object, class_string, description) {
+  assert_equals(
+      {}.toString.call(object), '[object ' + class_string + ']', description);
+}
+
+function assert_throws(code, func, description) {
+  try {
+    func();
+  } catch (e) {
+    assert_true(e.name === code.name, "expected exception " + code.name + ", got " + e.name);
+    return;
+  }
+  assert_true(false, "expected exception " + code.name + ", no exception thrown");
+}
+
+function setup(func) {
+  // TODO need to do anything fancier here?
+  func();
+}

--- a/implementation-contributed/v8/wasm-js/wasm-js.status
+++ b/implementation-contributed/v8/wasm-js/wasm-js.status
@@ -1,0 +1,18 @@
+# Copyright 2018 the V8 project authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+[
+[ALWAYS, {
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8319
+  'interface': [FAIL],
+  'memory/grow': [FAIL],
+  'memory/constructor': [FAIL],
+  'table/grow': [FAIL],
+  'table/constructor': [FAIL],
+  'table/get-set': [FAIL],
+  'module/customSections': [FAIL],
+  'global/constructor': [FAIL],
+  'global/value-get-set': [FAIL],
+}] # ALWAYS
+]


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[1fc8452b](https://github.com///github/blob/1fc8452b) in V8 and all changes made since [603acd9ca0](../blob/603acd9ca0) in
test262.



### 2 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/mjsunit/BUILD.gn](../blob/v8-test262-automation-export-603acd9ca0/implementation-contributed/v8/mjsunit/BUILD.gn)
 - [implementation-contributed/v8/mjsunit/mjsunit.status](../blob/v8-test262-automation-export-603acd9ca0/implementation-contributed/v8/mjsunit/mjsunit.status)









### 9 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/cleanup-is-a-microtask.js](../blob/v8-test262-automation-export-603acd9ca0/implementation-contributed/v8/mjsunit/harmony/weakrefs/cleanup-is-a-microtask.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-881247.js](../blob/v8-test262-automation-export-603acd9ca0/implementation-contributed/v8/mjsunit/regress/regress-crbug-881247.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-896700.js](../blob/v8-test262-automation-export-603acd9ca0/implementation-contributed/v8/mjsunit/regress/regress-crbug-896700.js)
 - [implementation-contributed/v8/wasm-js/BUILD.gn](../blob/v8-test262-automation-export-603acd9ca0/implementation-contributed/v8/wasm-js/BUILD.gn)
 - [implementation-contributed/v8/wasm-js/LICENSE.testharness](../blob/v8-test262-automation-export-603acd9ca0/implementation-contributed/v8/wasm-js/LICENSE.testharness)
 - [implementation-contributed/v8/wasm-js/testcfg.py](../blob/v8-test262-automation-export-603acd9ca0/implementation-contributed/v8/wasm-js/testcfg.py)
 - [implementation-contributed/v8/wasm-js/testharness-after.js](../blob/v8-test262-automation-export-603acd9ca0/implementation-contributed/v8/wasm-js/testharness-after.js)
 - [implementation-contributed/v8/wasm-js/testharness.js](../blob/v8-test262-automation-export-603acd9ca0/implementation-contributed/v8/wasm-js/testharness.js)
 - [implementation-contributed/v8/wasm-js/wasm-js.status](../blob/v8-test262-automation-export-603acd9ca0/implementation-contributed/v8/wasm-js/wasm-js.status)