### PR TITLE
Add initial tests for import.meta

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -131,6 +131,10 @@ globalThis
 # https://github.com/tc39/ecma262/pull/1174
 export-star-as-namespace-from-module
 
+# import.meta
+# https://github.com/tc39/proposal-import-meta
+import.meta
+
 # Standard language features
 #
 # Language features that have been included in a published version of the

--- a/test/language/expressions/import.meta/distinct-for-each-module.js
+++ b/test/language/expressions/import.meta/distinct-for-each-module.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-meta-properties-runtime-semantics-evaluation
+description: >
+  The import.meta object is not shared across modules.
+info: |
+  Runtime Semantics: Evaluation
+
+   ImportMeta : import.meta
+
+    1. Let module be GetActiveScriptOrModule().
+    ...
+    3. Let importMeta be module.[[ImportMeta]].
+    4. If importMeta is undefined.
+        ...
+        f. Set module.[[ImportMeta]] to importMeta.
+        g. Return importMeta.
+    ...
+flags: [module]
+features: [import.meta]
+---*/
+
+import {meta as fixture_meta, getMeta} from "./distinct-for-each-module_FIXTURE.js";
+
+// The imported module has a distinct import.meta object.
+assert.notSameValue(import.meta, fixture_meta,
+                    "foreign import.meta accessed via import binding");
+assert.notSameValue(import.meta, getMeta(),
+                    "foreign import.meta accessed via function call");
+
+// Calling a function which returns import.meta returns the import.meta object
+// from the module in which the function is declared.
+assert.sameValue(fixture_meta, getMeta(),
+                 "import.meta accessed via import binding is identical to the one accessed via call");

--- a/test/language/expressions/import.meta/distinct-for-each-module_FIXTURE.js
+++ b/test/language/expressions/import.meta/distinct-for-each-module_FIXTURE.js
@@ -1,0 +1,8 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export var meta = import.meta;
+
+export function getMeta() {
+    return import.meta;
+}

--- a/test/language/expressions/import.meta/import-meta-is-an-ordinary-object.js
+++ b/test/language/expressions/import.meta/import-meta-is-an-ordinary-object.js
@@ -1,0 +1,77 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-meta-properties-runtime-semantics-evaluation
+description: >
+  import.meta is an ordinary object.
+info: |
+  Runtime Semantics: Evaluation
+
+   ImportMeta : import.meta
+
+    ...
+    4. If importMeta is undefined.
+        a. Set importMeta to ObjectCreate(null).
+        b. Let importMetaValues be ! HostGetImportMetaProperties(module).
+        ...
+        e. Perform ! HostFinalizeImportMeta(importMeta, module).
+        ...
+        g. Return importMeta.
+    ...
+flags: [module]
+features: [import.meta]
+---*/
+
+// import.meta is an object.
+assert.sameValue(typeof import.meta, "object",
+                 "typeof import.meta is 'object'");
+assert.notSameValue(import.meta, null,
+                    "typeof import.meta is 'object' and import.meta isn't |null|.");
+
+assert.throws(TypeError, function() {
+    import.meta();
+}, "import.meta is not callable");
+
+assert.throws(TypeError, function() {
+    new import.meta();
+}, "import.meta is not a constructor");
+
+// Note: The properties, the shape of the properties, the extensibility state, and the prototype
+//       of import.meta are implementation-defined via HostGetImportMetaProperties and
+//       HostFinalizeImportMeta.
+
+// Properties and the prototype can only be modified when import.meta is extensible.
+if (Object.isExtensible(import.meta)) {
+    assert.sameValue(Object.getOwnPropertyDescriptor(import.meta, "test262prop"), undefined,
+                     "test262 test property is not present initially");
+
+    import.meta.test262prop = "blubb";
+
+    assert.sameValue(import.meta.test262prop, "blubb",
+                     "Properties can be added and retrieved from import.meta");
+
+    assert.sameValue(delete import.meta.test262prop, true,
+                     "Properties can be removed from import.meta");
+
+    assert.sameValue(Object.getOwnPropertyDescriptor(import.meta, "test262prop"), undefined,
+                     "test262 test property is no longer present");
+
+    var proto = {};
+    Object.setPrototypeOf(import.meta, proto);
+
+    assert.sameValue(Object.getPrototypeOf(import.meta), proto,
+                     "[[Prototype]] of import.meta can be changed");
+}
+
+Object.preventExtensions(import.meta);
+assert.sameValue(Object.isExtensible(import.meta), false,
+                 "import.meta is non-extensible after calling |Object.preventExtensions|");
+
+Object.seal(import.meta);
+assert.sameValue(Object.isSealed(import.meta), true,
+                 "import.meta is sealed after calling |Object.seal|");
+
+Object.freeze(import.meta);
+assert.sameValue(Object.isFrozen(import.meta), true,
+                 "import.meta is frozen after calling |Object.freeze|");

--- a/test/language/expressions/import.meta/not-accessible-from-direct-eval.js
+++ b/test/language/expressions/import.meta/not-accessible-from-direct-eval.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-left-hand-side-expressions-static-semantics-early-errors
+description: >
+  import.meta is not allowed in direct eval in module code.
+info: |
+  It is an early Syntax Error if Module is not the syntactic goal symbol.
+flags: [module]
+features: [import.meta]
+---*/
+
+assert.throws(SyntaxError, function() {
+    eval("import.meta");
+});

--- a/test/language/expressions/import.meta/same-object-returned.js
+++ b/test/language/expressions/import.meta/same-object-returned.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-meta-properties-runtime-semantics-evaluation
+description: >
+  The same import.meta object is returned for a module.
+info: |
+  Runtime Semantics: Evaluation
+
+   ImportMeta : import.meta
+
+    1. Let module be GetActiveScriptOrModule().
+    ...
+    3. Let importMeta be module.[[ImportMeta]].
+    4. If importMeta is undefined.
+        ...
+        f. Set module.[[ImportMeta]] to importMeta.
+        g. Return importMeta.
+    5. Else,
+        a. Assert: Type(importMeta) is Object.
+        b. Return importMeta.
+flags: [module]
+features: [import.meta]
+---*/
+
+var a = import.meta;
+var b = function() { return import.meta; }();
+
+assert.sameValue(import.meta, a,
+                 "import.meta accessed directly and accessed via variable declaration");
+
+assert.sameValue(import.meta, b,
+                 "import.meta accessed directly and accessed via function return value");

--- a/test/language/expressions/import.meta/syntax/escape-sequence-import.js
+++ b/test/language/expressions/import.meta/syntax/escape-sequence-import.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-left-hand-side-expressions
+description: >
+  "import" in import.meta must not contain escape sequences.
+info: |
+  5.1.5 Grammar Notation
+
+  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown in fixed width
+  font, both in the productions of the grammars and throughout this specification whenever the
+  text directly refers to such a terminal symbol. These are to appear in a script exactly as
+  written. All terminal symbol code points specified in this way are to be understood as the
+  appropriate Unicode code points from the Basic Latin range, as opposed to any similar-looking
+  code points from other Unicode ranges.
+
+  12.3 Left-Hand-Side Expressions
+    MetaProperty:
+      NewTarget
+      ImportMeta
+
+    ImportMeta:
+      import.meta
+flags: [module]
+negative:
+  phase: parse
+  type: SyntaxError
+features: [import.meta]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+im\u0070ort.meta;

--- a/test/language/expressions/import.meta/syntax/escape-sequence-meta.js
+++ b/test/language/expressions/import.meta/syntax/escape-sequence-meta.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-left-hand-side-expressions
+description: >
+  "meta" in import.meta must not contain escape sequences.
+info: |
+  5.1.5 Grammar Notation
+
+  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown in fixed width
+  font, both in the productions of the grammars and throughout this specification whenever the
+  text directly refers to such a terminal symbol. These are to appear in a script exactly as
+  written. All terminal symbol code points specified in this way are to be understood as the
+  appropriate Unicode code points from the Basic Latin range, as opposed to any similar-looking
+  code points from other Unicode ranges.
+
+  12.3 Left-Hand-Side Expressions
+    MetaProperty:
+      NewTarget
+      ImportMeta
+
+    ImportMeta:
+      import.meta
+flags: [module]
+negative:
+  phase: parse
+  type: SyntaxError
+features: [import.meta]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+import.m\u0065ta;

--- a/test/language/expressions/import.meta/syntax/goal-async-function-params-or-body.js
+++ b/test/language/expressions/import.meta/syntax/goal-async-function-params-or-body.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-left-hand-side-expressions-static-semantics-early-errors
+description: >
+  An Syntax Error is thrown when the syntactic goal symbol is AsyncFunctionBody or FormalParameters.
+info: |
+  It is an early Syntax Error if Module is not the syntactic goal symbol.
+features: [import.meta, async-functions]
+---*/
+
+var AsyncFunction = async function(){}.constructor;
+
+assert.throws(SyntaxError, function() {
+    AsyncFunction("import.meta");
+}, "import.meta in AsyncFunctionBody");
+
+assert.throws(SyntaxError, function() {
+    AsyncFunction("a = import.meta", "");
+}, "import.meta in FormalParameters");

--- a/test/language/expressions/import.meta/syntax/goal-async-generator-params-or-body.js
+++ b/test/language/expressions/import.meta/syntax/goal-async-generator-params-or-body.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-left-hand-side-expressions-static-semantics-early-errors
+description: >
+  An Syntax Error is thrown when the syntactic goal symbol is AsyncGeneratorBody or FormalParameters.
+info: |
+  It is an early Syntax Error if Module is not the syntactic goal symbol.
+features: [import.meta, async-iteration]
+---*/
+
+var AsyncGenerator = async function*(){}.constructor;
+
+assert.throws(SyntaxError, function() {
+    AsyncGenerator("import.meta");
+}, "import.meta in AsyncGeneratorBody");
+
+assert.throws(SyntaxError, function() {
+    AsyncGenerator("a = import.meta", "");
+}, "import.meta in FormalParameters");

--- a/test/language/expressions/import.meta/syntax/goal-function-params-or-body.js
+++ b/test/language/expressions/import.meta/syntax/goal-function-params-or-body.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-left-hand-side-expressions-static-semantics-early-errors
+description: >
+  An Syntax Error is thrown when the syntactic goal symbol is FunctionBody or FormalParameters.
+info: |
+  It is an early Syntax Error if Module is not the syntactic goal symbol.
+features: [import.meta]
+---*/
+
+assert.throws(SyntaxError, function() {
+    Function("import.meta");
+}, "import.meta in FunctionBody");
+
+assert.throws(SyntaxError, function() {
+    Function("a = import.meta", "");
+}, "import.meta in FormalParameters");

--- a/test/language/expressions/import.meta/syntax/goal-generator-params-or-body.js
+++ b/test/language/expressions/import.meta/syntax/goal-generator-params-or-body.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-left-hand-side-expressions-static-semantics-early-errors
+description: >
+  An Syntax Error is thrown when the syntactic goal symbol is GeneratorBody or FormalParameters.
+info: |
+  It is an early Syntax Error if Module is not the syntactic goal symbol.
+features: [import.meta, generators]
+---*/
+
+var Generator = function*(){}.constructor;
+
+assert.throws(SyntaxError, function() {
+    Generator("import.meta");
+}, "import.meta in GeneratorBody");
+
+assert.throws(SyntaxError, function() {
+    Generator("a = import.meta", "");
+}, "import.meta in FormalParameters");

--- a/test/language/expressions/import.meta/syntax/goal-module-nested-function.js
+++ b/test/language/expressions/import.meta/syntax/goal-module-nested-function.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-left-hand-side-expressions-static-semantics-early-errors
+description: >
+  No SyntaxError is thrown when import.meta appears in nested functions in module scripts.
+info: |
+  It is an early Syntax Error if Module is not the syntactic goal symbol.
+flags: [module]
+features: [import.meta]
+---*/
+
+function f() {
+  import.meta;
+}

--- a/test/language/expressions/import.meta/syntax/goal-module.js
+++ b/test/language/expressions/import.meta/syntax/goal-module.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-left-hand-side-expressions-static-semantics-early-errors
+description: >
+  No early Syntax Error is thrown when the syntactic goal symbol is Module.
+info: |
+  It is an early Syntax Error if Module is not the syntactic goal symbol.
+flags: [module]
+features: [import.meta]
+---*/
+
+import.meta;

--- a/test/language/expressions/import.meta/syntax/goal-script.js
+++ b/test/language/expressions/import.meta/syntax/goal-script.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-left-hand-side-expressions-static-semantics-early-errors
+description: >
+  An early Syntax Error is thrown when the syntactic goal symbol is Script.
+info: |
+  It is an early Syntax Error if Module is not the syntactic goal symbol.
+negative:
+  phase: early
+  type: SyntaxError
+features: [import.meta]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+import.meta;

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-array-destructuring-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-array-destructuring-expr.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-static-semantics-static-semantics-assignmenttargettype
+description: >
+  import.meta is not a valid assignment target.
+info: |
+  Static Semantics: AssignmentTargetType
+
+    ImportMeta:
+      import.meta
+
+    Return invalid.
+
+  12.15.5.1 Static Semantics: Early Errors
+
+    DestructuringAssignmentTarget : LeftHandSideExpression
+
+    It is a Syntax Error if LeftHandSideExpression is neither an ObjectLiteral nor an ArrayLiteral
+    and AssignmentTargetType(LeftHandSideExpression) is not simple.
+flags: [module]
+negative:
+  phase: early
+  type: SyntaxError
+features: [import.meta, destructuring-assignment]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+[import.meta] = [];

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-array-rest-destructuring-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-array-rest-destructuring-expr.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-static-semantics-static-semantics-assignmenttargettype
+description: >
+  import.meta is not a valid assignment target.
+info: |
+  Static Semantics: AssignmentTargetType
+
+    ImportMeta:
+      import.meta
+
+    Return invalid.
+
+  12.15.5.1 Static Semantics: Early Errors
+
+    DestructuringAssignmentTarget : LeftHandSideExpression
+
+    It is a Syntax Error if LeftHandSideExpression is neither an ObjectLiteral nor an ArrayLiteral
+    and AssignmentTargetType(LeftHandSideExpression) is not simple.
+flags: [module]
+negative:
+  phase: early
+  type: SyntaxError
+features: [import.meta, destructuring-assignment]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+[...import.meta] = [];

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-assignment-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-assignment-expr.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-static-semantics-static-semantics-assignmenttargettype
+description: >
+  import.meta is not a valid assignment target.
+info: |
+  Static Semantics: AssignmentTargetType
+
+    ImportMeta:
+      import.meta
+
+    Return invalid.
+
+  12.15.1 Static Semantics: Early Errors
+
+    AssignmentExpression : LeftHandSideExpression = AssignmentExpression
+
+    It is an early Reference Error if LeftHandSideExpression is neither an ObjectLiteral nor an
+    ArrayLiteral and AssignmentTargetType of LeftHandSideExpression is invalid.
+flags: [module]
+negative:
+  phase: early
+  type: ReferenceError
+features: [import.meta]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+import.meta = 0;

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-await-of-loop.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-await-of-loop.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-static-semantics-static-semantics-assignmenttargettype
+description: >
+  import.meta is not a valid assignment target.
+info: |
+  Static Semantics: AssignmentTargetType
+
+    ImportMeta:
+      import.meta
+
+    Return invalid.
+
+  13.7.5.1 Static Semantics: Early Errors
+    IterationStatement:
+      for await ( LeftHandSideExpression of AssignmentExpression ) Statement
+
+    It is a Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
+flags: [module]
+negative:
+  phase: early
+  type: SyntaxError
+features: [import.meta, async-iteration]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+async function* f() {
+    for await (import.meta of null) ;
+}

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-in-loop.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-in-loop.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-static-semantics-static-semantics-assignmenttargettype
+description: >
+  import.meta is not a valid assignment target.
+info: |
+  Static Semantics: AssignmentTargetType
+
+    ImportMeta:
+      import.meta
+
+    Return invalid.
+
+  13.7.5.1 Static Semantics: Early Errors
+    IterationStatement:
+      for ( LeftHandSideExpression in Expression ) Statement
+
+    It is a Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
+flags: [module]
+negative:
+  phase: early
+  type: SyntaxError
+features: [import.meta]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+for (import.meta in null) ;

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-of-loop.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-of-loop.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-static-semantics-static-semantics-assignmenttargettype
+description: >
+  import.meta is not a valid assignment target.
+info: |
+  Static Semantics: AssignmentTargetType
+
+    ImportMeta:
+      import.meta
+
+    Return invalid.
+
+  13.7.5.1 Static Semantics: Early Errors
+    IterationStatement:
+      for ( LeftHandSideExpression of AssignmentExpression ) Statement
+
+    It is a Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
+flags: [module]
+negative:
+  phase: early
+  type: SyntaxError
+features: [import.meta]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+for (import.meta of null) ;

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-object-destructuring-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-object-destructuring-expr.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-static-semantics-static-semantics-assignmenttargettype
+description: >
+  import.meta is not a valid assignment target.
+info: |
+  Static Semantics: AssignmentTargetType
+
+    ImportMeta:
+      import.meta
+
+    Return invalid.
+
+  12.15.5.1 Static Semantics: Early Errors
+
+    DestructuringAssignmentTarget : LeftHandSideExpression
+
+    It is a Syntax Error if LeftHandSideExpression is neither an ObjectLiteral nor an ArrayLiteral
+    and AssignmentTargetType(LeftHandSideExpression) is not simple.
+flags: [module]
+negative:
+  phase: early
+  type: SyntaxError
+features: [import.meta, destructuring-assignment]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+({a: import.meta} = {});

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-object-rest-destructuring-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-object-rest-destructuring-expr.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-static-semantics-static-semantics-assignmenttargettype
+description: >
+  import.meta is not a valid assignment target.
+info: |
+  Static Semantics: AssignmentTargetType
+
+    ImportMeta:
+      import.meta
+
+    Return invalid.
+
+  12.15.5.1 Static Semantics: Early Errors
+
+    DestructuringAssignmentTarget : LeftHandSideExpression
+
+    It is a Syntax Error if LeftHandSideExpression is neither an ObjectLiteral nor an ArrayLiteral
+    and AssignmentTargetType(LeftHandSideExpression) is not simple.
+flags: [module]
+negative:
+  phase: early
+  type: SyntaxError
+features: [import.meta, destructuring-assignment, object-rest]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+({...import.meta} = {});

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-update-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-update-expr.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2018 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-static-semantics-static-semantics-assignmenttargettype
+description: >
+  import.meta is not a valid assignment target.
+info: |
+  Static Semantics: AssignmentTargetType
+
+    ImportMeta:
+      import.meta
+
+    Return invalid.
+
+  12.4.1 Static Semantics: Early Errors
+
+    UpdateExpression:
+      LeftHandSideExpression++
+      LeftHandSideExpression--
+
+    It is an early Reference Error if AssignmentTargetType of LeftHandSideExpression is invalid.
+flags: [module]
+negative:
+  phase: early
+  type: ReferenceError
+features: [import.meta]
+---*/
+
+throw "Test262: This statement should not be evaluated.";
+
+import.meta++;


### PR DESCRIPTION
Fixes #1342 

For the most part syntax tests, because the properties, prototype, and extensibility state of the `import.meta` object is implementation-dependent.