### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "0039b340",
-  "targetRevisionAtLastExport": "6ddea08809",
+  "sourceRevisionAtLastExport": "0d75b76c",
+  "targetRevisionAtLastExport": "7df6ae12f6",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/intl/segmenter/segment-iterator-ownPropertyDescriptor.js
+++ b/implementation-contributed/v8/intl/segmenter/segment-iterator-ownPropertyDescriptor.js
@@ -29,10 +29,47 @@ for (let func of ["segment", "resolvedOptions"]) {
   assertTrue(descriptor.configurable);
 }
 
-let prototype = Object.getPrototypeOf(seg.segment('text'));
+let segmentIterator = seg.segment('text');
+let prototype = Object.getPrototypeOf(segmentIterator);
 for (let func of ["next", "following", "preceding"]) {
   let descriptor = Object.getOwnPropertyDescriptor(prototype, func);
   assertTrue(descriptor.writable);
   assertFalse(descriptor.enumerable);
   assertTrue(descriptor.configurable);
+}
+
+function checkGetterProperty(prototype, property) {
+  let desc = Object.getOwnPropertyDescriptor(prototype, property);
+  assertEquals(`get ${property}`, desc.get.name);
+  assertEquals('function', typeof desc.get)
+  assertEquals(undefined, desc.set);
+  assertFalse(desc.enumerable);
+  assertTrue(desc.configurable);
+}
+
+// Test the descriptor is correct for properties.
+checkGetterProperty(prototype, 'position');
+checkGetterProperty(prototype, 'breakType');
+
+// Test the SegmentIteratorPrototype methods are called with same
+// receiver and won't throw.
+assertDoesNotThrow(() => prototype.next.call(segmentIterator));
+assertDoesNotThrow(() => prototype.following.call(segmentIterator));
+assertDoesNotThrow(() => prototype.preceding.call(segmentIterator));
+
+// Test the SegmentIteratorPrototype methods are called with a different
+// receiver and correctly throw.
+var otherReceivers = [
+    1, 123.45, undefined, null, "string", true, false,
+    Intl, Intl.Segmenter, Intl.Segmenter.prototype,
+    prototype,
+    new Intl.Segmenter(),
+    new Intl.Collator(),
+    new Intl.DateTimeFormat(),
+    new Intl.NumberFormat(),
+];
+for (let rec of otherReceivers) {
+   assertThrows(() => prototype.next.call(rec), TypeError);
+   assertThrows(() => prototype.following.call(rec), TypeError);
+   assertThrows(() => prototype.preceding.call(rec), TypeError);
 }

--- a/implementation-contributed/v8/mjsunit/array-join-invalid-string-length.js
+++ b/implementation-contributed/v8/mjsunit/array-join-invalid-string-length.js
@@ -1,0 +1,63 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+(function DictionaryStringRepeatFastPath() {
+  const a = new Array(%StringMaxLength());
+  assertTrue(%HasDictionaryElements(a));
+  const sep = '12';
+  assertThrows(() => a.join(sep), RangeError);
+
+  // Verifies cycle detection still works properly after thrown error.
+  assertThrows(() => a.join(sep), RangeError);
+
+  a.length = 3;
+  a[0] = 'a';
+  a[1] = 'b';
+  a[2] = 'c';
+  assertSame('a,b,c', a.join());
+})();
+
+(function SeparatorOverflow() {
+  const a = ['a',,,,,'b'];
+
+  const sep = ','.repeat(%StringMaxLength());
+  assertThrows(() => a.join(sep), RangeError);
+
+  // Verifies cycle detection still works properly after thrown error.
+  assertThrows(() => a.join(sep), RangeError);
+  assertSame('a,,,,,b', a.join());
+})();
+
+(function ElementOverflow() {
+  const el = ','.repeat(%StringMaxLength());
+  const a = [el, el, el, el, el];
+
+  assertThrows(() => a.join(), RangeError);
+
+  // Verifies cycle detection still works properly after thrown error.
+  assertThrows(() => a.join(), RangeError);
+  a[0] = 'a';
+  a[1] = 'b';
+  a[2] = 'c';
+  a[3] = 'd';
+  a[4] = 'e';
+  assertSame('a,b,c,d,e', a.join());
+})();
+
+(function ElementSeparatorOverflow() {
+  const el = ','.repeat(%StringMaxLength());
+  const a = [el, el, el, el];
+
+  assertThrows(() => a.join(el), RangeError);
+
+  // Verifies cycle detection still works properly after thrown error.
+  assertThrows(() => a.join(el), RangeError);
+  a[0] = 'a';
+  a[1] = 'b';
+  a[2] = 'c';
+  a[3] = 'd';
+  assertSame('a,b,c,d', a.join());
+})();

--- a/implementation-contributed/v8/mjsunit/array-natives-elements.js
+++ b/implementation-contributed/v8/mjsunit/array-natives-elements.js
@@ -112,15 +112,19 @@ function array_natives_test() {
   assertEquals([2], a2.slice(1,2));
   a2 = [1.1,2,3];
   assertTrue(%HasDoubleElements(a2.slice()));
-  assertTrue(%HasDoubleElements(a2.slice(1)));
-  assertTrue(%HasDoubleElements(a2.slice(1, 2)));
+  assertTrue(%HasDoubleElements(a2.slice(1)) ||
+             %HasSmiElements(a2.slice(1)));
+  assertTrue(%HasDoubleElements(a2.slice(1, 2)) ||
+            %HasSmiElements(a2.slice(1, 2)));
   assertEquals([1.1,2,3], a2.slice());
   assertEquals([2,3], a2.slice(1));
   assertEquals([2], a2.slice(1,2));
   a2 = [{},2,3];
   assertTrue(%HasObjectElements(a2.slice()));
-  assertTrue(%HasObjectElements(a2.slice(1)));
-  assertTrue(%HasObjectElements(a2.slice(1, 2)));
+  assertTrue(%HasObjectElements(a2.slice(1)) ||
+             %HasSmiElements(a2.slice(1)));
+  assertTrue(%HasObjectElements(a2.slice(1, 2)) ||
+             %HasSmiElements(a2.slice(1, 2)));
   assertEquals([{},2,3], a2.slice());
   assertEquals([2,3], a2.slice(1));
   assertEquals([2], a2.slice(1,2));

--- a/implementation-contributed/v8/mjsunit/code-coverage-block-opt.js
+++ b/implementation-contributed/v8/mjsunit/code-coverage-block-opt.js
@@ -5,6 +5,11 @@
 // Flags: --allow-natives-syntax --no-always-opt --opt
 // Files: test/mjsunit/code-coverage-utils.js
 
+if (isNeverOptimizeLiteMode()) {
+  print("Warning: skipping test that requires optimization in Lite mode.");
+  quit(0);
+}
+
 %DebugToggleBlockCoverage(true);
 
 TestCoverage(

--- a/implementation-contributed/v8/mjsunit/compiler/native-context-specialization-hole-check.js
+++ b/implementation-contributed/v8/mjsunit/compiler/native-context-specialization-hole-check.js
@@ -27,6 +27,11 @@
 
 // Flags: --allow-natives-syntax --opt --no-always-opt
 
+if (isNeverOptimizeLiteMode()) {
+  print("Warning: skipping test that requires optimization in Lite mode.");
+  quit(0);
+}
+
 function f() {
   Array.prototype[10] = 2;
   var arr = new Array();

--- a/implementation-contributed/v8/mjsunit/d8/d8-arguments.js
+++ b/implementation-contributed/v8/mjsunit/d8/d8-arguments.js
@@ -1,0 +1,7 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: -- 1 2 3
+
+assertEquals(["1", "2", "3"], arguments);

--- a/implementation-contributed/v8/mjsunit/d8/d8-no-arguments.js
+++ b/implementation-contributed/v8/mjsunit/d8/d8-no-arguments.js
@@ -1,0 +1,5 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+assertEquals(undefined, Object.getOwnPropertyDescriptor(this, "arguments"));

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js
@@ -32,11 +32,17 @@
   assertNotSame(wc.__proto__, Object.prototype);
   assertSame(wc.__proto__.__proto__, Object.prototype);
   assertEquals(wc.holdings, undefined);
-  let desc = Object.getOwnPropertyDescriptor(wc.__proto__, "holdings");
-  assertEquals(true, desc.configurable);
-  assertEquals(false, desc.enumerable);
-  assertEquals("function", typeof desc.get);
-  assertEquals(undefined, desc.set);
+
+  let holdings_desc = Object.getOwnPropertyDescriptor(wc.__proto__, "holdings");
+  assertEquals(true, holdings_desc.configurable);
+  assertEquals(false, holdings_desc.enumerable);
+  assertEquals("function", typeof holdings_desc.get);
+  assertEquals(undefined, holdings_desc.set);
+
+  let clear_desc = Object.getOwnPropertyDescriptor(wc.__proto__, "clear");
+  assertEquals(true, clear_desc.configurable);
+  assertEquals(false, clear_desc.enumerable);
+  assertEquals("function", typeof clear_desc.value);
 })();
 
 (function TestMakeCellWithHoldings() {
@@ -111,4 +117,13 @@
   assertThrows(() => holdings_getter.call({}), TypeError);
   // Does not throw:
   holdings_getter.call(wc);
+})();
+
+(function TestClearWithoutWeakCell() {
+  let wf = new WeakFactory();
+  let wc = wf.makeCell({});
+  let clear = Object.getOwnPropertyDescriptor(wc.__proto__, "clear").value;
+  assertThrows(() => clear.call({}), TypeError);
+  // Does not throw:
+  clear.call(wc);
 })();

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-after-cleanup.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-after-cleanup.js
@@ -1,0 +1,46 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+let cleanup_call_count = 0;
+let cleanup_weak_cell_count = 0;
+let cleanup = function(iter) {
+  for (wc of iter) {
+    assertSame(wc, weak_cell);
+    ++cleanup_weak_cell_count;
+  }
+  ++cleanup_call_count;
+}
+
+let wf = new WeakFactory(cleanup);
+// Create an object and a WeakCell pointing to it. The object needs to be inside
+// a closure so that we can reliably kill them!
+let weak_cell;
+
+(function() {
+  let object = {};
+  weak_cell = wf.makeCell(object);
+
+  // object goes out of scope.
+})();
+
+// This GC will discover dirty WeakCells and schedule cleanup.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function was called and iterated the WeakCell.
+let timeout_func = function() {
+  assertEquals(1, cleanup_call_count);
+  assertEquals(1, cleanup_weak_cell_count);
+
+  // Clear an already iterated over WeakCell.
+  weak_cell.clear();
+
+  // Assert that it didn't do anything.
+  setTimeout(() => { assertEquals(1, cleanup_call_count); }, 0);
+  setTimeout(() => { assertEquals(1, cleanup_weak_cell_count); }, 0);
+}
+
+setTimeout(timeout_func, 0);

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-before-cleanup.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-before-cleanup.js
@@ -1,0 +1,40 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+let cleanup_call_count = 0;
+let cleanup = function(iter) {
+  ++cleanup_call_count;
+}
+
+let wf = new WeakFactory(cleanup);
+// Create an object and a WeakCell pointing to it. The object needs to be inside
+// a closure so that we can reliably kill them!
+let weak_cell;
+
+(function() {
+  let object = {};
+  weak_cell = wf.makeCell(object, "my holdings");
+
+  // Clear the WeakCell before the GC has a chance to discover it.
+  let return_value = weak_cell.clear();
+  assertEquals(undefined, return_value);
+
+  // Assert holdings got cleared too.
+  assertEquals(undefined, weak_cell.holdings);
+
+  // object goes out of scope.
+})();
+
+// This GC will discover dirty WeakCells.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function won't be called, since the WeakCell was cleared.
+let timeout_func = function() {
+  assertEquals(0, cleanup_call_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-called-twice.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-called-twice.js
@@ -1,0 +1,39 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+let cleanup_call_count = 0;
+let cleanup = function(iter) {
+  ++cleanup_call_count;
+}
+
+let wf = new WeakFactory(cleanup);
+// Create an object and a WeakCell pointing to it. The object needs to be inside
+// a closure so that we can reliably kill them!
+let weak_cell;
+
+(function() {
+  let object = {};
+  weak_cell = wf.makeCell(object);
+
+  // Clear the WeakCell before the GC has a chance to discover it.
+  weak_cell.clear();
+
+  // Call clear again (just to assert we handle this gracefully).
+  weak_cell.clear();
+
+  // object goes out of scope.
+})();
+
+// This GC will discover dirty WeakCells.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function won't be called, since the WeakCell was cleared.
+let timeout_func = function() {
+  assertEquals(0, cleanup_call_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-clears-factory-pointer.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-clears-factory-pointer.js
@@ -1,0 +1,49 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+// Test that WeakCell.prototype.clear() also clears the WeakFactory pointer of
+// WeakCell. The only way to observe this is to assert that the WeakCell no
+// longer keeps its WeakFactory alive after clear() has been called.
+
+let weak_cell;
+let weak_cell_pointing_to_factory;
+
+let cleanup1_call_count = 0;
+let cleanup2_call_count = 0;
+
+let cleanup1 = function() {
+  ++cleanup1_call_count;
+}
+
+let cleanup2 = function() {
+  ++cleanup2_call_count;
+}
+
+let wf1 = new WeakFactory(cleanup1);
+
+(function(){
+  let wf2 = new WeakFactory(cleanup2);
+
+  (function() {
+    let object = {};
+    weak_cell = wf2.makeCell(object);
+    // object goes out of scope.
+  })();
+
+  weak_cell_pointing_to_factory = wf1.makeCell(wf2);
+  // wf goes out of scope
+})();
+
+weak_cell.clear();
+gc();
+
+// Assert that weak_cell_pointing_to_factory now got cleared.
+let timeout_func = function() {
+  assertEquals(1, cleanup1_call_count);
+  assertEquals(0, cleanup2_call_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup1.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup1.js
@@ -1,0 +1,41 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+let cleanup_call_count = 0;
+let cleanup_weak_cell_count = 0;
+let cleanup = function(iter) {
+  // Clear the WeakCell before we've iterated through it.
+  weak_cell.clear();
+
+  for (wc of iter) {
+    ++cleanup_weak_cell_count;
+  }
+  ++cleanup_call_count;
+}
+
+let wf = new WeakFactory(cleanup);
+// Create an object and a WeakCell pointing to it. The object needs to be inside
+// a closure so that we can reliably kill them!
+let weak_cell;
+
+(function() {
+  let object = {};
+  weak_cell = wf.makeCell(object);
+
+  // object goes out of scope.
+})();
+
+// This GC will discover dirty WeakCells and schedule cleanup.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function was called, but didn't iterate any weak cells.
+let timeout_func = function() {
+  assertEquals(1, cleanup_call_count);
+  assertEquals(0, cleanup_weak_cell_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup2.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup2.js
@@ -1,0 +1,40 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+let cleanup_call_count = 0;
+let cleanup_weak_cell_count = 0;
+let cleanup = function(iter) {
+  for (wc of iter) {
+    assertSame(wc, weak_cell);
+    wc.clear();
+    ++cleanup_weak_cell_count;
+  }
+  ++cleanup_call_count;
+}
+
+let wf = new WeakFactory(cleanup);
+// Create an object and a WeakCell pointing to it. The object needs to be inside
+// a closure so that we can reliably kill them!
+let weak_cell;
+
+(function() {
+  let object = {};
+  weak_cell = wf.makeCell(object);
+
+  // object goes out of scope.
+})();
+
+// This GC will discover dirty WeakCells and schedule cleanup.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function was called and iterated the WeakCell.
+let timeout_func = function() {
+  assertEquals(1, cleanup_call_count);
+  assertEquals(1, cleanup_weak_cell_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup3.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup3.js
@@ -1,0 +1,41 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+let cleanup_call_count = 0;
+let cleanup_weak_cell_count = 0;
+let cleanup = function(iter) {
+  for (wc of iter) {
+    assertSame(wc, weak_cell);
+    ++cleanup_weak_cell_count;
+  }
+  // Clear an already iterated over WeakCell.
+  weak_cell.clear();
+  ++cleanup_call_count;
+}
+
+let wf = new WeakFactory(cleanup);
+// Create an object and a WeakCell pointing to it. The object needs to be inside
+// a closure so that we can reliably kill them!
+let weak_cell;
+
+(function() {
+  let object = {};
+  weak_cell = wf.makeCell(object);
+
+  // object goes out of scope.
+})();
+
+// This GC will discover dirty WeakCells and schedule cleanup.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function was called and iterated the WeakCell.
+let timeout_func = function() {
+  assertEquals(1, cleanup_call_count);
+  assertEquals(1, cleanup_weak_cell_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup4.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup4.js
@@ -1,0 +1,48 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+let cleanup_call_count = 0;
+let cleanup_weak_cell_count = 0;
+let cleanup = function(iter) {
+  for (wc of iter) {
+    // See which WeakCell we're iterating over and clear the other one.
+    if (wc == weak_cell1) {
+      weak_cell2.clear();
+    } else {
+      assertSame(wc, weak_cell2);
+      weak_cell1.clear();
+    }
+    ++cleanup_weak_cell_count;
+  }
+  ++cleanup_call_count;
+}
+
+let wf = new WeakFactory(cleanup);
+// Create an object and a WeakCell pointing to it. The object needs to be inside
+// a closure so that we can reliably kill them!
+let weak_cell1;
+let weak_cell2;
+
+(function() {
+  let object1 = {};
+  weak_cell1 = wf.makeCell(object1);
+  let object2 = {};
+  weak_cell2 = wf.makeCell(object2);
+
+  // object1 and object2 go out of scope.
+})();
+
+// This GC will discover dirty WeakCells and schedule cleanup.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function was called and iterated one WeakCell (but not the other one).
+let timeout_func = function() {
+  assertEquals(1, cleanup_call_count);
+  assertEquals(1, cleanup_weak_cell_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-when-cleanup-already-scheduled.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-when-cleanup-already-scheduled.js
@@ -1,0 +1,36 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc
+
+let cleanup_call_count = 0;
+let cleanup = function(iter) {
+  ++cleanup_call_count;
+}
+
+let wf = new WeakFactory(cleanup);
+// Create an object and a WeakCell pointing to it. The object needs to be inside
+// a closure so that we can reliably kill them!
+let weak_cell;
+
+(function() {
+  let object = {};
+  weak_cell = wf.makeCell(object);
+
+  // object goes out of scope.
+})();
+
+// This GC will discover dirty WeakCells and schedule cleanup.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Clear the WeakCell before cleanup has ran.
+weak_cell.clear();
+
+// Assert that the cleanup function won't be called, since the WeakCell was cleared.
+let timeout_func = function() {
+  assertEquals(0, cleanup_call_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/implementation-contributed/v8/mjsunit/messages.js
+++ b/implementation-contributed/v8/mjsunit/messages.js
@@ -570,6 +570,10 @@ test(function() {
   "a".repeat(1 << 30);
 }, "Invalid string length", RangeError);
 
+test(function() {
+  new Array(1 << 30).join();
+}, "Invalid string length", RangeError);
+
 // kNormalizationForm
 test(function() {
   "".normalize("ABC");

--- a/implementation-contributed/v8/mjsunit/mjsunit.status
+++ b/implementation-contributed/v8/mjsunit/mjsunit.status
@@ -145,7 +145,7 @@
   'regress/regress-634-debug': [PASS, ['mode == release', SKIP]],
 
   # BUG(v8:2989).
-  'regress/regress-2989': [FAIL, NO_VARIANTS],
+  'regress/regress-2989': [FAIL, NO_VARIANTS, ['lite_mode == True', SKIP]],
 
   # This test variant makes only sense on arm.
   'math-floor-of-div-nosudiv': [PASS, SLOW, ['arch not in [arm, arm64, android_arm, android_arm64]', SKIP]],
@@ -176,6 +176,8 @@
   'wasm/embenchen/*': [PASS, SLOW],
   'wasm/grow-memory': [PASS, SLOW],
   'wasm/unreachable-validation': [PASS, SLOW],
+  'wasm/atomics-stress': [PASS, SLOW, NO_VARIANTS, ['mode != release', SKIP], ['(arch == arm or arch == arm64) and simulator_run', SKIP]],
+  'wasm/atomics64-stress': [PASS, SLOW, NO_VARIANTS, ['mode != release', SKIP], ['(arch == arm or arch == arm64) and simulator_run', SKIP]],
   'wasm/compare-exchange-stress': [PASS, SLOW, NO_VARIANTS],
   'wasm/compare-exchange64-stress': [PASS, SLOW, NO_VARIANTS],
 
@@ -227,11 +229,6 @@
 
   # BUG(v8:8169)
   'external-backing-store-gc': [SKIP],
-
-  # BUG(v8:8332)
-  'wasm/atomics-stress': [SKIP],
-  # BUG(v8:8331)
-  'wasm/atomics64-stress': [SKIP],
 }],  # ALWAYS
 
 ['novfp3 == True', {
@@ -663,6 +660,7 @@
 ['system == macos', {
   # BUG(v8:5333)
   'big-object-literal': [SKIP],
+  'harmony/weakrefs/basics': [SKIP],
 }],  # 'system == macos'
 
 ##############################################################################
@@ -759,6 +757,9 @@
   'd8/enable-tracing': [SKIP],
   # Relies on async compilation which requires background tasks.
   'wasm/streaming-error-position': [SKIP],
+  # Intentionally non-deterministic using shared arraybuffers.
+  'wasm/atomics-stress': [SKIP],
+  'wasm/atomics64-stress': [SKIP],
 }],  # 'predictable == True'
 
 ##############################################################################

--- a/implementation-contributed/v8/mjsunit/regress/regress-2618.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-2618.js
@@ -28,7 +28,11 @@
 // Flags: --use-osr --allow-natives-syntax --ignition-osr --opt
 // Flags: --no-always-opt
 
-// Can't OSR with always-opt.
+// Can't OSR with always-opt or in Lite mode.
+if (isNeverOptimizeLiteMode()) {
+  print("Warning: skipping test that requires optimization in Lite mode.");
+  quit(0);
+}
 assertFalse(isAlwaysOptimize());
 
 function f() {

--- a/implementation-contributed/v8/mjsunit/regress/regress-2989.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-2989.js
@@ -21,7 +21,12 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// Flags: --allow-natives-syntax
+// Flags: --allow-natives-syntax --opt
+
+if (isNeverOptimizeLiteMode()) {
+  print("Warning: skipping test that requires optimization in Lite mode.");
+  quit(0);
+}
 
 (function ArgumentsObjectChange() {
   function f(x) {

--- a/implementation-contributed/v8/mjsunit/regress/regress-778668.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-778668.js
@@ -3,6 +3,22 @@
 // found in the LICENSE file.
 
 (function () {
+  function f() {
+    arguments.length = -5;
+    Array.prototype.slice.call(arguments);
+  }
+  f('a')
+})();
+
+(function () {
+  function f() {
+    arguments.length = 2.3;
+    Array.prototype.slice.call(arguments);
+  }
+  f('a')
+})();
+
+(function () {
   function f( __v_59960) {
     arguments.length = -5;
     Array.prototype.slice.call(arguments);
@@ -13,7 +29,6 @@
 (function () {
   function f( __v_59960) {
     arguments.length = 2.3;
-    print(arguments.length);
     Array.prototype.slice.call(arguments);
   }
   f('a')

--- a/implementation-contributed/v8/mjsunit/regress/regress-8241.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-8241.js
@@ -1,0 +1,6 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+function f(x) { }
+f(x=>x, [x,y] = [1,2]);

--- a/implementation-contributed/v8/mjsunit/regress/regress-897366.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-897366.js
@@ -1,0 +1,15 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --gc-interval=100
+
+let xs = [];
+for (let i = 0; i < 205; ++i) {
+  xs.push(i);
+}
+xs.sort((a, b) => {
+  xs.shift();
+  xs[xs.length] = -246;
+  return a - b;
+});

--- a/implementation-contributed/v8/mjsunit/regress/regress-897815.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-897815.js
@@ -1,0 +1,16 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+(function __f_19350() {
+  function __f_19351() {
+    function __f_19352() {
+    }
+  }
+  try {
+    __f_19350();
+  } catch (e) {}
+    %OptimizeFunctionOnNextCall(__f_19351)
+})();

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-781116-1.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-781116-1.js
@@ -9,7 +9,6 @@ function baz(obj, store) {
 }
 function bar(store) {
   baz(Array.prototype, store);
-  baz(this.arguments, true);
 }
 bar(false);
 bar(false);

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-781116-2.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-781116-2.js
@@ -9,7 +9,6 @@ function baz(obj, store) {
 }
 function bar(store) {
   baz(Object.prototype, store);
-  baz(this.arguments, true);
 }
 bar(false);
 bar(false);

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-897098.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-897098.js
@@ -1,0 +1,8 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const arr = [1.1,2.2,3.3];
+arr.pop();
+const start = {toString: function() {arr.pop();}}
+arr.includes(0, start);

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-897404.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-897404.js
@@ -1,0 +1,20 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+function TestError() {}
+
+// Force slow, generic assess path that will always allocate a temporary fixed
+// array.
+String.prototype.__defineGetter__(0, function() { });
+
+const a = new Array(2**32 - 1);
+
+// Force early exit to avoid an unreasonably long test.
+a[0] = {
+  toString() { throw new TestError(); }
+};
+
+// Verify join throws test error and does not fail due to asserts (Negative
+// length fixed array allocation).
+assertThrows(() => a.join(), TestError);

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-897406.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-897406.js
@@ -1,0 +1,14 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --async-stack-traces --expose-async-hooks
+
+async_hooks.createHook({
+  after() { throw new Error(); }
+}).enable();
+
+(async function() {
+  await 1;
+  await 1;
+})();

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-897514.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-897514.js
@@ -1,0 +1,26 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+// Create transtion => 'get a'.
+let o = {};
+Object.defineProperty(o, 'a', {
+    enumerable: true,
+    configurable: true,
+    get: function() { return 7 }
+});
+
+function spread(o) {
+  let result = { ...o };
+  %HeapObjectVerify(result);
+  return result;
+}
+
+for (let i = 0; i<3; i++) {
+  spread([]);
+  // Use different transition => 'a'.
+  spread({ a:0 });
+  spread("abc");
+}

--- a/implementation-contributed/v8/mjsunit/shared-function-tier-up-turbo.js
+++ b/implementation-contributed/v8/mjsunit/shared-function-tier-up-turbo.js
@@ -6,6 +6,10 @@
 // Flags: --opt --no-always-opt --turbo-filter=*
 
 // If we are always or never optimizing it is useless.
+if (isNeverOptimizeLiteMode()) {
+  print("Warning: skipping test that requires optimization in Lite mode.");
+  quit(0);
+}
 assertFalse(isAlwaysOptimize());
 assertFalse(isNeverOptimize());
 

--- a/implementation-contributed/v8/test262/test262.status
+++ b/implementation-contributed/v8/test262/test262.status
@@ -518,10 +518,6 @@
   'annexB/language/statements/for-await-of/iterator-close-return-emulates-undefined-throws-when-called': [FAIL],
   'annexB/language/statements/for-of/iterator-close-return-emulates-undefined-throws-when-called': [FAIL],
 
-  # https://bugs.chromium.org/p/v8/issues/detail?id=7186
-  'language/statements/class/fields-indirect-eval-err-contains-arguments': [FAIL],
-  'language/expressions/class/fields-indirect-eval-err-contains-arguments': [FAIL],
-
   # https://bugs.chromium.org/p/v8/issues/detail?id=7468
   'language/statements/class/privatename-not-valid-earlyerr-script-8': [FAIL],
 


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[0039b340](https://github.com///github/blob/0039b340) in V8 and all changes made since [6ddea08809](../blob/6ddea08809) in
test262.



### 15 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/intl/segmenter/segment-iterator-ownPropertyDescriptor.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/intl/segmenter/segment-iterator-ownPropertyDescriptor.js)
 - [implementation-contributed/v8/mjsunit/array-natives-elements.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/array-natives-elements.js)
 - [implementation-contributed/v8/mjsunit/code-coverage-block-opt.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/code-coverage-block-opt.js)
 - [implementation-contributed/v8/mjsunit/compiler/native-context-specialization-hole-check.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/compiler/native-context-specialization-hole-check.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js)
 - [implementation-contributed/v8/mjsunit/messages.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/messages.js)
 - [implementation-contributed/v8/mjsunit/mjsunit.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/mjsunit.js)
 - [implementation-contributed/v8/mjsunit/mjsunit.status](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/mjsunit.status)
 - [implementation-contributed/v8/mjsunit/regress/regress-2618.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-2618.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-2989.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-2989.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-778668.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-778668.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-781116-1.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-crbug-781116-1.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-781116-2.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-crbug-781116-2.js)
 - [implementation-contributed/v8/mjsunit/shared-function-tier-up-turbo.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/shared-function-tier-up-turbo.js)
 - [implementation-contributed/v8/test262/test262.status](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/test262/test262.status)









### 19 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/array-join-invalid-string-length.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/array-join-invalid-string-length.js)
 - [implementation-contributed/v8/mjsunit/d8/d8-arguments.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/d8/d8-arguments.js)
 - [implementation-contributed/v8/mjsunit/d8/d8-no-arguments.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/d8/d8-no-arguments.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-after-cleanup.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-after-cleanup.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-before-cleanup.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-before-cleanup.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-called-twice.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-called-twice.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-clears-factory-pointer.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-clears-factory-pointer.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup1.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup1.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup2.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup2.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup3.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup3.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup4.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-inside-cleanup4.js)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-when-cleanup-already-scheduled.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/harmony/weakrefs/clear-when-cleanup-already-scheduled.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-8241.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-8241.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-897366.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-897366.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-897815.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-897815.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-897098.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-crbug-897098.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-897404.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-crbug-897404.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-897406.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-crbug-897406.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-897514.js](../blob/v8-test262-automation-export-6ddea08809/implementation-contributed/v8/mjsunit/regress/regress-crbug-897514.js)