### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "5d90d70a",
-  "targetRevisionAtLastExport": "7a46296123",
+  "sourceRevisionAtLastExport": "7551e526",
+  "targetRevisionAtLastExport": "8d2e4f0a64",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/intl/segmenter/segment-grapheme-next.js
+++ b/implementation-contributed/v8/intl/segmenter/segment-grapheme-next.js
@@ -1,0 +1,40 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-intl-segmenter
+
+const seg = new Intl.Segmenter([], {granularity: "grapheme"})
+for (const text of [
+    "Hello world!", // English
+    " Hello world! ",  // English with space before/after
+    " Hello world? Foo bar!", // English
+    "Jedovatou mambu objevila žena v zahrádkářské kolonii.", // Czech
+    "Việt Nam: Nhất thể hóa sẽ khác Trung Quốc?",  // Vietnamese
+    "Σοβαρές ενστάσεις Κομισιόν για τον προϋπολογισμό της Ιταλίας", // Greek
+    "Решение Индии о покупке российских С-400 расценили как вызов США",  // Russian
+    "הרופא שהציל נשים והנערה ששועבדה ע",  // Hebrew,
+    "ترامب للملك سلمان: أنا جاد للغاية.. عليك دفع المزيد", // Arabic
+    "भारत की एस 400 मिसाइल के मुकाबले पाक की थाड, जानें कौन कितना ताकतवर",  //  Hindi
+    "ரெட் அலர்ட் எச்சரிக்கை; புதுச்சேரியில் நாளை அரசு விடுமுறை!", // Tamil
+    "'ఉత్తర్వులు అందే వరకు ఓటర్ల తుది జాబితాను వెబ్‌సైట్లో పెట్టవద్దు'", // Telugu
+    "台北》抹黑柯P失敗？朱學恒酸：姚文智氣pupu嗆大老闆", // Chinese
+    "วัดไทรตีระฆังเบาลงช่วงเข้าพรรษา เจ้าอาวาสเผยคนร้องเรียนรับผลกรรมแล้ว",  // Thai
+    "九州北部の一部が暴風域に入りました(日直予報士 2018年10月06日) - 日本気象協会 tenki.jp",  // Japanese
+    "법원 “다스 지분 처분권·수익권 모두 MB가 보유”", // Korean
+    ]) {
+  const iter = seg.segment(text);
+  let segments = [];
+  let oldPos = -1;
+  for (let result = iter.next(); !result.done; result = iter.next()) {
+    const v = result.value;
+    assertEquals(undefined, v.breakType);
+    assertEquals("string", typeof v.segment);
+    assertTrue(v.segment.length > 0);
+    segments.push(v.segment);
+    assertEquals("number", typeof v.position);
+    assertTrue(oldPos < v.position);
+    oldPos = v.position;
+  }
+  assertEquals(text, segments.join(''));
+}

--- a/implementation-contributed/v8/intl/segmenter/segment-iterator-ownPropertyDescriptor.js
+++ b/implementation-contributed/v8/intl/segmenter/segment-iterator-ownPropertyDescriptor.js
@@ -73,3 +73,19 @@ for (let rec of otherReceivers) {
    assertThrows(() => prototype.following.call(rec), TypeError);
    assertThrows(() => prototype.preceding.call(rec), TypeError);
 }
+
+// Check the property of the return object of next()
+let nextReturn = segmentIterator.next();
+
+function checkProperty(obj, property) {
+  let desc = Object.getOwnPropertyDescriptor(obj, property);
+  assertTrue(desc.writable);
+  assertTrue(desc.enumerable);
+  assertTrue(desc.configurable);
+}
+
+checkProperty(nextReturn, 'done');
+checkProperty(nextReturn, 'value');
+checkProperty(nextReturn.value, 'segment');
+checkProperty(nextReturn.value, 'breakType');
+checkProperty(nextReturn.value, 'position');

--- a/implementation-contributed/v8/intl/segmenter/segment-line-next.js
+++ b/implementation-contributed/v8/intl/segmenter/segment-line-next.js
@@ -1,0 +1,40 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-intl-segmenter
+
+const seg = new Intl.Segmenter([], {granularity: "line"})
+for (const text of [
+    "Hello world!", // English
+    " Hello world! ",  // English with space before/after
+    " Hello world? Foo bar!", // English
+    "Jedovatou mambu objevila žena v zahrádkářské kolonii.", // Czech
+    "Việt Nam: Nhất thể hóa sẽ khác Trung Quốc?",  // Vietnamese
+    "Σοβαρές ενστάσεις Κομισιόν για τον προϋπολογισμό της Ιταλίας", // Greek
+    "Решение Индии о покупке российских С-400 расценили как вызов США",  // Russian
+    "הרופא שהציל נשים והנערה ששועבדה ע",  // Hebrew,
+    "ترامب للملك سلمان: أنا جاد للغاية.. عليك دفع المزيد", // Arabic
+    "भारत की एस 400 मिसाइल के मुकाबले पाक की थाड, जानें कौन कितना ताकतवर",  //  Hindi
+    "ரெட் அலர்ட் எச்சரிக்கை; புதுச்சேரியில் நாளை அரசு விடுமுறை!", // Tamil
+    "'ఉత్తర్వులు అందే వరకు ఓటర్ల తుది జాబితాను వెబ్‌సైట్లో పెట్టవద్దు'", // Telugu
+    "台北》抹黑柯P失敗？朱學恒酸：姚文智氣pupu嗆大老闆", // Chinese
+    "วัดไทรตีระฆังเบาลงช่วงเข้าพรรษา เจ้าอาวาสเผยคนร้องเรียนรับผลกรรมแล้ว",  // Thai
+    "九州北部の一部が暴風域に入りました(日直予報士 2018年10月06日) - 日本気象協会 tenki.jp",  // Japanese
+    "법원 “다스 지분 처분권·수익권 모두 MB가 보유”", // Korean
+    ]) {
+  const iter = seg.segment(text);
+  let segments = [];
+  let oldPos = -1;
+  for (let result = iter.next(); !result.done; result = iter.next()) {
+    const v = result.value;
+    assertTrue(["soft", "hard"].includes(iter.breakType), iter.breakType);
+    assertEquals("string", typeof v.segment);
+    assertTrue(v.segment.length > 0);
+    segments.push(v.segment);
+    assertEquals("number", typeof v.position);
+    assertTrue(oldPos < v.position);
+    oldPos = v.position;
+  }
+  assertEquals(text, segments.join(''));
+}

--- a/implementation-contributed/v8/intl/segmenter/segment-sentence-next.js
+++ b/implementation-contributed/v8/intl/segmenter/segment-sentence-next.js
@@ -1,0 +1,40 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-intl-segmenter
+
+const seg = new Intl.Segmenter([], {granularity: "sentence"})
+for (const text of [
+    "Hello world!", // English
+    " Hello world! ",  // English with space before/after
+    " Hello world? Foo bar!", // English
+    "Jedovatou mambu objevila žena v zahrádkářské kolonii.", // Czech
+    "Việt Nam: Nhất thể hóa sẽ khác Trung Quốc?",  // Vietnamese
+    "Σοβαρές ενστάσεις Κομισιόν για τον προϋπολογισμό της Ιταλίας", // Greek
+    "Решение Индии о покупке российских С-400 расценили как вызов США",  // Russian
+    "הרופא שהציל נשים והנערה ששועבדה ע",  // Hebrew,
+    "ترامب للملك سلمان: أنا جاد للغاية.. عليك دفع المزيد", // Arabic
+    "भारत की एस 400 मिसाइल के मुकाबले पाक की थाड, जानें कौन कितना ताकतवर",  //  Hindi
+    "ரெட் அலர்ட் எச்சரிக்கை; புதுச்சேரியில் நாளை அரசு விடுமுறை!", // Tamil
+    "'ఉత్తర్వులు అందే వరకు ఓటర్ల తుది జాబితాను వెబ్‌సైట్లో పెట్టవద్దు'", // Telugu
+    "台北》抹黑柯P失敗？朱學恒酸：姚文智氣pupu嗆大老闆", // Chinese
+    "วัดไทรตีระฆังเบาลงช่วงเข้าพรรษา เจ้าอาวาสเผยคนร้องเรียนรับผลกรรมแล้ว",  // Thai
+    "九州北部の一部が暴風域に入りました(日直予報士 2018年10月06日) - 日本気象協会 tenki.jp",  // Japanese
+    "법원 “다스 지분 처분권·수익권 모두 MB가 보유”", // Korean
+    ]) {
+  const iter = seg.segment(text);
+  let segments = [];
+  let oldPos = -1;
+  for (let result = iter.next(); !result.done; result = iter.next()) {
+    const v = result.value;
+    assertTrue(["sep", "term"].includes(iter.breakType), iter.breakType);
+    assertEquals("string", typeof v.segment);
+    assertTrue(v.segment.length > 0);
+    segments.push(v.segment);
+    assertEquals("number", typeof v.position);
+    assertTrue(oldPos < v.position);
+    oldPos = v.position;
+  }
+  assertEquals(text, segments.join(''));
+}

--- a/implementation-contributed/v8/intl/segmenter/segment-word-next.js
+++ b/implementation-contributed/v8/intl/segmenter/segment-word-next.js
@@ -1,0 +1,40 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-intl-segmenter
+
+const seg = new Intl.Segmenter([], {granularity: "word"})
+for (const text of [
+    "Hello world!", // English
+    " Hello world! ",  // English with space before/after
+    " Hello world? Foo bar!", // English
+    "Jedovatou mambu objevila žena v zahrádkářské kolonii.", // Czech
+    "Việt Nam: Nhất thể hóa sẽ khác Trung Quốc?",  // Vietnamese
+    "Σοβαρές ενστάσεις Κομισιόν για τον προϋπολογισμό της Ιταλίας", // Greek
+    "Решение Индии о покупке российских С-400 расценили как вызов США",  // Russian
+    "הרופא שהציל נשים והנערה ששועבדה ע",  // Hebrew,
+    "ترامب للملك سلمان: أنا جاد للغاية.. عليك دفع المزيد", // Arabic
+    "भारत की एस 400 मिसाइल के मुकाबले पाक की थाड, जानें कौन कितना ताकतवर",  //  Hindi
+    "ரெட் அலர்ட் எச்சரிக்கை; புதுச்சேரியில் நாளை அரசு விடுமுறை!", // Tamil
+    "'ఉత్తర్వులు అందే వరకు ఓటర్ల తుది జాబితాను వెబ్‌సైట్లో పెట్టవద్దు'", // Telugu
+    "台北》抹黑柯P失敗？朱學恒酸：姚文智氣pupu嗆大老闆", // Chinese
+    "วัดไทรตีระฆังเบาลงช่วงเข้าพรรษา เจ้าอาวาสเผยคนร้องเรียนรับผลกรรมแล้ว",  // Thai
+    "九州北部の一部が暴風域に入りました(日直予報士 2018年10月06日) - 日本気象協会 tenki.jp",  // Japanese
+    "법원 “다스 지분 처분권·수익권 모두 MB가 보유”", // Korean
+    ]) {
+  const iter = seg.segment(text);
+  let segments = [];
+  let oldPos = -1;
+  for (let result = iter.next(); !result.done; result = iter.next()) {
+    const v = result.value;
+    assertTrue(["word", "none"].includes(iter.breakType), iter.breakType);
+    assertEquals("string", typeof v.segment);
+    assertTrue(v.segment.length > 0);
+    segments.push(v.segment);
+    assertEquals("number", typeof v.position);
+    assertTrue(oldPos < v.position);
+    oldPos = v.position;
+  }
+  assertEquals(text, segments.join(''));
+}

--- a/implementation-contributed/v8/mjsunit/es6/array-spread-large-holey.js
+++ b/implementation-contributed/v8/mjsunit/es6/array-spread-large-holey.js
@@ -1,0 +1,17 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Test spreading of large holey arrays, which are supposedly allocated in
+// LargeObjectSpace. Holes should be replaced with undefined.
+
+var arr = new Array(2e5);
+
+for (var i = 0; i < 10; i++) {
+  arr[i] = i;
+}
+
+var arr2 = [...arr];
+assertTrue(arr2.hasOwnProperty(10));
+assertEquals(undefined, arr2[10]);
+assertEquals(9, arr2[9]);

--- a/implementation-contributed/v8/mjsunit/mjsunit.status
+++ b/implementation-contributed/v8/mjsunit/mjsunit.status
@@ -176,8 +176,8 @@
   'wasm/embenchen/*': [PASS, SLOW],
   'wasm/grow-memory': [PASS, SLOW],
   'wasm/unreachable-validation': [PASS, SLOW],
-  'wasm/atomics-stress': [PASS, SLOW, NO_VARIANTS, ['mode != release', SKIP], ['(arch == arm or arch == arm64) and simulator_run', SKIP]],
-  'wasm/atomics64-stress': [PASS, SLOW, NO_VARIANTS, ['mode != release', SKIP], ['(arch == arm or arch == arm64) and simulator_run', SKIP]],
+  'wasm/atomics-stress': [PASS, SLOW, NO_VARIANTS, ['mode != release or dcheck_always_on', SKIP], ['(arch == arm or arch == arm64) and simulator_run', SKIP], ['tsan', SKIP]],
+  'wasm/atomics64-stress': [PASS, SLOW, NO_VARIANTS, ['mode != release or dcheck_always_on', SKIP], ['(arch == arm or arch == arm64) and simulator_run', SKIP], ['tsan', SKIP]],
   'wasm/compare-exchange-stress': [PASS, SLOW, NO_VARIANTS],
   'wasm/compare-exchange64-stress': [PASS, SLOW, NO_VARIANTS],
 

--- a/implementation-contributed/v8/mjsunit/regress/regress-897512.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-897512.js
@@ -1,0 +1,24 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Fill up the Array prototype's elements.
+for (let i = 0; i < 100; i++) Array.prototype.unshift(3.14);
+
+// Create a holey double elements array.
+const o31 = [1.1];
+o31[37] = 2.2;
+
+// Concat converts to dictionary elements.
+const o51 = o31.concat(false);
+
+// Set one element to undefined to trigger the movement bug.
+o51[0] = undefined;
+
+assertEquals(o51.length, 39);
+
+// Sort triggers the bug.
+o51.sort();
+
+// TODO(chromium:897512): The length should be 39.
+assertEquals(o51.length, 101);


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[5d90d70a](https://github.com///github/blob/5d90d70a) in V8 and all changes made since [7a46296123](../blob/7a46296123) in
test262.



### 6 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/intl/segmenter/segment-grapheme-next.js](../blob/v8-test262-automation-export-7a46296123/implementation-contributed/v8/intl/segmenter/segment-grapheme-next.js)
 - [implementation-contributed/v8/intl/segmenter/segment-iterator-ownPropertyDescriptor.js](../blob/v8-test262-automation-export-7a46296123/implementation-contributed/v8/intl/segmenter/segment-iterator-ownPropertyDescriptor.js)
 - [implementation-contributed/v8/intl/segmenter/segment-line-next.js](../blob/v8-test262-automation-export-7a46296123/implementation-contributed/v8/intl/segmenter/segment-line-next.js)
 - [implementation-contributed/v8/intl/segmenter/segment-sentence-next.js](../blob/v8-test262-automation-export-7a46296123/implementation-contributed/v8/intl/segmenter/segment-sentence-next.js)
 - [implementation-contributed/v8/intl/segmenter/segment-word-next.js](../blob/v8-test262-automation-export-7a46296123/implementation-contributed/v8/intl/segmenter/segment-word-next.js)
 - [implementation-contributed/v8/mjsunit/mjsunit.status](../blob/v8-test262-automation-export-7a46296123/implementation-contributed/v8/mjsunit/mjsunit.status)









### 2 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/es6/array-spread-large-holey.js](../blob/v8-test262-automation-export-7a46296123/implementation-contributed/v8/mjsunit/es6/array-spread-large-holey.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-897512.js](../blob/v8-test262-automation-export-7a46296123/implementation-contributed/v8/mjsunit/regress/regress-897512.js)