### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "7551e526",
-  "targetRevisionAtLastExport": "8d2e4f0a64",
+  "sourceRevisionAtLastExport": "5ba032b3",
+  "targetRevisionAtLastExport": "41874187df",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/mjsunit/async-stack-traces-promise-all.js
+++ b/implementation-contributed/v8/mjsunit/async-stack-traces-promise-all.js
@@ -1,0 +1,38 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --async-stack-traces
+
+// Basic test with Promise.all().
+(function() {
+  async function fine() { }
+
+  async function thrower() {
+    await fine();
+    throw new Error();
+  }
+
+  async function driver() {
+    await Promise.all([fine(), fine(), thrower(), thrower()]);
+  }
+
+  async function test(f) {
+    try {
+      await f();
+      assertUnreachable();
+    } catch (e) {
+      assertInstanceof(e, Error);
+      assertMatches(/Error.+at thrower.+at async Promise.all \(index 2\).+at async driver.+at async test/ms, e.stack);
+    }
+  }
+
+  assertPromiseResult((async () => {
+    await test(driver);
+    await test(driver);
+    %OptimizeFunctionOnNextCall(thrower);
+    await test(driver);
+    %OptimizeFunctionOnNextCall(driver);
+    await test(driver);
+  })());
+})();

--- a/implementation-contributed/v8/mjsunit/elements-kind.js
+++ b/implementation-contributed/v8/mjsunit/elements-kind.js
@@ -241,12 +241,17 @@ for (var i = 0; i < 3; i++) {
 }
 convert_mixed(construct_smis(), "three", elements_kind.fast);
 convert_mixed(construct_doubles(), "three", elements_kind.fast);
+
+if (%ICsAreEnabled()) {
+  // Test that allocation sites allocate correct elements kind initially based
+  // on previous transitions.
   %OptimizeFunctionOnNextCall(convert_mixed);
-smis = construct_smis();
-doubles = construct_doubles();
-convert_mixed(smis, 1, elements_kind.fast);
-convert_mixed(doubles, 1, elements_kind.fast);
-assertTrue(%HaveSameMap(smis, doubles));
+  smis = construct_smis();
+  doubles = construct_doubles();
+  convert_mixed(smis, 1, elements_kind.fast);
+  convert_mixed(doubles, 1, elements_kind.fast);
+  assertTrue(%HaveSameMap(smis, doubles));
+}
 
 // Crankshaft support for smi-only elements in dynamic array literals.
 function get(foo) { return foo; }  // Used to generate dynamic values.

--- a/implementation-contributed/v8/mjsunit/es6/typedarray-from-next-overridden.js
+++ b/implementation-contributed/v8/mjsunit/es6/typedarray-from-next-overridden.js
@@ -1,0 +1,29 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+var typedArrayConstructors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Uint8ClampedArray,
+  Float32Array,
+  Float64Array
+];
+
+for (var constructor of typedArrayConstructors) {
+  let ta = new constructor([1, 2, 3]);
+  let it = ta[Symbol.iterator]();
+  let original_next = it.__proto__["next"];
+  Object.defineProperty(it.__proto__, "next", {
+    value: function() {
+      return {value: undefined, done: true};
+    },
+    configurable: true
+  });
+  assertEquals(0, constructor.from(ta).length);
+  Object.defineProperty(it.__proto__, "next", original_next);
+}

--- a/implementation-contributed/v8/mjsunit/es6/typedarray-from-nonfunction-iterator.js
+++ b/implementation-contributed/v8/mjsunit/es6/typedarray-from-nonfunction-iterator.js
@@ -1,0 +1,11 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+let ta = new Uint8Array([1, 2, 3]);
+
+ta[Symbol.iterator] = 1;
+assertThrows(function() { Uint8Array.from(ta); }, TypeError);
+
+ta[Symbol.iterator] = "bad";
+assertThrows(function() { Uint8Array.from(ta); }, TypeError);

--- a/implementation-contributed/v8/mjsunit/mjsunit.status
+++ b/implementation-contributed/v8/mjsunit/mjsunit.status
@@ -210,10 +210,10 @@
 
   # TODO(vogelheim): big-object-literal exceeds the stack in debug builds,
   #                  which makes the test useless.
-  'big-object-literal': [PASS, ['mode == debug', SKIP]],
+  'big-object-literal': [PASS, ['mode == debug or dcheck_always_on', SKIP]],
 
   # Runs out of stack space in debug builds.
-  'big-array-literal': [PASS, ['mode == debug', SKIP]],
+  'big-array-literal': [PASS, ['mode == debug or dcheck_always_on', SKIP]],
 
   # BUG(v8:6306).
   'wasm/huge-memory': [SKIP],
@@ -707,6 +707,9 @@
   'code-coverage-ad-hoc': [SKIP],
   'code-coverage-precise': [SKIP],
 
+  # Passes incompatible arguments.
+  'd8/d8-arguments': [SKIP],
+
   # Fails allocation on tsan.
   'es6/classes': [PASS, ['tsan', SKIP]],
 
@@ -793,9 +796,10 @@
 
 ##############################################################################
 ['variant == stress', {
-  'es6/array-iterator-turbo': [SKIP],
-
+  # Slow tests.
   'array-natives-elements': [SKIP],
+  'big-object-literal': [SKIP],
+  'es6/array-iterator-turbo': [SKIP],
   'ignition/regress-599001-verifyheap': [SKIP],
   'unicode-test': [SKIP],
 
@@ -814,9 +818,6 @@
 
   # Too memory hungry on Odroid devices.
   'regress/regress-678917': [PASS, ['arch == arm and not simulator_run', SKIP]],
-
-  # Too slow for verify-csa builds.
-  'big-object-literal': [PASS, ['verify_csa == True', SKIP]],
 }],  # variant == stress
 
 ##############################################################################

--- a/implementation-contributed/v8/mjsunit/opt-elements-kind.js
+++ b/implementation-contributed/v8/mjsunit/opt-elements-kind.js
@@ -134,11 +134,15 @@ function test1() {
   convert_mixed(construct_smis(), "three", elements_kind.fast);
   convert_mixed(construct_doubles(), "three", elements_kind.fast);
 
-  smis = construct_smis();
-  doubles = construct_doubles();
-  convert_mixed(smis, 1, elements_kind.fast);
-  convert_mixed(doubles, 1, elements_kind.fast);
-  assertTrue(%HaveSameMap(smis, doubles));
+  if (%ICsAreEnabled()) {
+    // Test that allocation sites allocate correct elements kind initially based
+    // on previous transitions.
+    smis = construct_smis();
+    doubles = construct_doubles();
+    convert_mixed(smis, 1, elements_kind.fast);
+    convert_mixed(doubles, 1, elements_kind.fast);
+    assertTrue(%HaveSameMap(smis, doubles));
+  }
 }
 
 function clear_ic_state() {

--- a/implementation-contributed/v8/mjsunit/osr-elements-kind.js
+++ b/implementation-contributed/v8/mjsunit/osr-elements-kind.js
@@ -132,11 +132,15 @@ convert_mixed(doubles, "three", elements_kind.fast);
 convert_mixed(construct_smis(), "three", elements_kind.fast);
 convert_mixed(construct_doubles(), "three", elements_kind.fast);
 
-smis = construct_smis();
-doubles = construct_doubles();
-convert_mixed(smis, 1, elements_kind.fast);
-convert_mixed(doubles, 1, elements_kind.fast);
-assertTrue(%HaveSameMap(smis, doubles));
+if (%ICsAreEnabled()) {
+  // Test that allocation sites allocate correct elements kind initially based
+  // on previous transitions.
+  smis = construct_smis();
+  doubles = construct_doubles();
+  convert_mixed(smis, 1, elements_kind.fast);
+  convert_mixed(doubles, 1, elements_kind.fast);
+  assertTrue(%HaveSameMap(smis, doubles));
+}
 
 // Throw away type information in the ICs for next stress run.
 gc();

--- a/implementation-contributed/v8/mjsunit/regress/regress-898812.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-898812.js
@@ -1,0 +1,5 @@
+// Copyright 2015 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+assertThrows("(async)(a)=>{}", SyntaxError);

--- a/implementation-contributed/v8/mjsunit/regress/regress-898936.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-898936.js
@@ -1,0 +1,5 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+assertThrows("async(...x=e)()=>");

--- a/implementation-contributed/v8/mjsunit/regress/regress-899115.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-899115.js
@@ -1,0 +1,13 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+function foo() {
+  Object.getPrototypeOf([]).includes();
+}
+
+foo();
+%OptimizeFunctionOnNextCall(foo);
+foo();

--- a/implementation-contributed/v8/mjsunit/regress/regress-899133.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-899133.js
@@ -1,0 +1,5 @@
+// Copyright 2015 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+assertThrows("let fun = ({a} = {a: 30}) => {", SyntaxError);

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-898974.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-898974.js
@@ -1,0 +1,34 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+function Module(global, env, buffer) {
+  "use asm";
+  var HEAPF64 = new global.Float64Array(buffer);
+  var HEAPF32 = new global.Float32Array(buffer);
+  var Math_fround = global.Math.fround;
+  function main_d_f() {
+    HEAPF64[0] = Math_fround(+HEAPF64[0]);
+  }
+  function main_d_fq() {
+    HEAPF64[1] = HEAPF32[4096];
+  }
+  function main_f_dq() {
+    HEAPF32[4] = HEAPF64[4096];
+  }
+  return {main_d_f: main_d_f, main_d_fq: main_d_fq, main_f_dq: main_f_dq};
+};
+let buffer = new ArrayBuffer(4096);
+let module = Module(this, undefined, buffer);
+let view64 = new Float64Array(buffer);
+let view32 = new Float32Array(buffer);
+assertEquals(view64[0] = 2.3, view64[0]);
+module.main_d_f();
+module.main_d_fq();
+module.main_f_dq();
+assertTrue(%IsAsmWasmCode(Module));
+assertEquals(Math.fround(2.3), view64[0]);
+assertTrue(isNaN(view64[1]));
+assertTrue(isNaN(view32[4]));

--- a/implementation-contributed/v8/mjsunit/regress/regress-v8-8357.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-v8-8357.js
@@ -1,0 +1,31 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+const s = "Umbridge has been reading your mail, Harry."
+
+{
+  let monkey_called = false;
+  s.__proto__.__proto__[Symbol.replace] =
+    () => { monkey_called = true; };
+  s.replace(s);
+  assertTrue(monkey_called);
+}
+
+{
+  let monkey_called = false;
+  s.__proto__.__proto__[Symbol.search] =
+    () => { monkey_called = true; };
+  s.search(s);
+  assertTrue(monkey_called);
+}
+
+{
+  let monkey_called = false;
+  s.__proto__.__proto__[Symbol.match] =
+    () => { monkey_called = true; };
+  s.match(s);
+  assertTrue(monkey_called);
+}


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[7551e526](https://github.com///github/blob/7551e526) in V8 and all changes made since [8d2e4f0a64](../blob/8d2e4f0a64) in
test262.



### 4 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/mjsunit/elements-kind.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/elements-kind.js)
 - [implementation-contributed/v8/mjsunit/mjsunit.status](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/mjsunit.status)
 - [implementation-contributed/v8/mjsunit/opt-elements-kind.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/opt-elements-kind.js)
 - [implementation-contributed/v8/mjsunit/osr-elements-kind.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/osr-elements-kind.js)









### 10 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-4.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/async-stack-traces-prepare-stacktrace-4.js)
 - [implementation-contributed/v8/mjsunit/async-stack-traces-promise-all.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/async-stack-traces-promise-all.js)
 - [implementation-contributed/v8/mjsunit/es6/typedarray-from-next-overridden.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/es6/typedarray-from-next-overridden.js)
 - [implementation-contributed/v8/mjsunit/es6/typedarray-from-nonfunction-iterator.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/es6/typedarray-from-nonfunction-iterator.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-898812.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/regress/regress-898812.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-898936.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/regress/regress-898936.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-899115.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/regress/regress-899115.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-899133.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/regress/regress-899133.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-898974.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/regress/regress-crbug-898974.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-v8-8357.js](../blob/v8-test262-automation-export-8d2e4f0a64/implementation-contributed/v8/mjsunit/regress/regress-v8-8357.js)