### PR TITLE
Fix formatToParts expectation @ RelativeTimeFormat

### DIFF
--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-numeric-always.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-numeric-always.js
@@ -36,7 +36,9 @@ assert.sameValue(typeof rtf.formatToParts, "function", "formatToParts should be 
 for (const unit of units) {
   verifyFormatParts(rtf.formatToParts(1000, unit), [
     { "type": "literal", "value": "in " },
-    { "type": "integer", "value": "1,000", "unit": unit },
+    { "type": "integer", "value": "1", "unit": unit },
+    { "type": "group", "value": ",", "unit": unit },
+    { "type": "integer", "value": "000", "unit": unit },
     { "type": "literal", "value": ` ${unit}s` },
   ], `formatToParts(1000, ${unit})`);
 
@@ -85,7 +87,19 @@ for (const unit of units) {
   ], `formatToParts(-10, ${unit})`);
 
   verifyFormatParts(rtf.formatToParts(-1000, unit), [
-    { "type": "integer", "value": "1,000", "unit": unit },
+    { "type": "integer", "value": "1", "unit": unit },
+    { "type": "group", "value": ",", "unit": unit },
+    { "type": "integer", "value": "000", "unit": unit },
     { "type": "literal", "value": ` ${unit}s ago` },
   ], `formatToParts(-1000, ${unit})`);
+
+  verifyFormatParts(rtf.formatToParts(123456.78, unit), [
+    { "type": "literal", "value": "in " },
+    { "type": "integer", "value": "123", "unit": unit },
+    { "type": "group", "value": ",", "unit": unit },
+    { "type": "integer", "value": "456", "unit": unit },
+    { "type": "decimal", "value": ".", "unit": unit },
+    { "type": "fraction", "value": "78", "unit": unit },
+    { "type": "literal", "value": ` ${unit}s` },
+  ], `formatToParts(123456.78, ${unit})`);
 }

--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-numeric-auto.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-numeric-auto.js
@@ -79,7 +79,9 @@ assert.sameValue(typeof rtf.formatToParts, "function", "formatToParts should be 
 for (const unit of units) {
   verifyFormatParts(rtf.formatToParts(1000, unit), [
     { "type": "literal", "value": "in " },
-    { "type": "integer", "value": "1,000", "unit": unit },
+    { "type": "integer", "value": "1", "unit": unit },
+    { "type": "group", "value": ",", "unit": unit },
+    { "type": "integer", "value": "000", "unit": unit },
     { "type": "literal", "value": ` ${unit}s` },
   ], `formatToParts(1000, ${unit})`);
 
@@ -128,7 +130,19 @@ for (const unit of units) {
   ], `formatToParts(-10, ${unit})`);
 
   verifyFormatParts(rtf.formatToParts(-1000, unit), [
-    { "type": "integer", "value": "1,000", "unit": unit },
+    { "type": "integer", "value": "1", "unit": unit },
+    { "type": "group", "value": ",", "unit": unit },
+    { "type": "integer", "value": "000", "unit": unit },
     { "type": "literal", "value": ` ${unit}s ago` },
   ], `formatToParts(-1000, ${unit})`);
+
+  verifyFormatParts(rtf.formatToParts(123456.78, unit), [
+    { "type": "literal", "value": "in " },
+    { "type": "integer", "value": "123", "unit": unit },
+    { "type": "group", "value": ",", "unit": unit },
+    { "type": "integer", "value": "456", "unit": unit },
+    { "type": "decimal", "value": ".", "unit": unit },
+    { "type": "fraction", "value": "78", "unit": unit },
+    { "type": "literal", "value": ` ${unit}s` },
+  ], `formatToParts(123456.78, ${unit})`);
 }

--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-style-short.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-style-short.js
@@ -40,7 +40,9 @@ for (const [unitArgument, unitStrings] of Object.entries(units)) {
 
   verifyFormatParts(rtf.formatToParts(1000, unitArgument), [
     { "type": "literal", "value": "in " },
-    { "type": "integer", "value": "1,000", "unit": unitArgument },
+    { "type": "integer", "value": "1", "unit": unitArgument },
+    { "type": "group", "value": ",", "unit": unitArgument },
+    { "type": "integer", "value": "000", "unit": unitArgument },
     { "type": "literal", "value": ` ${plural}` },
   ], `formatToParts(1000, ${unitArgument})`);
 
@@ -89,7 +91,19 @@ for (const [unitArgument, unitStrings] of Object.entries(units)) {
   ], `formatToParts(-10, ${unitArgument})`);
 
   verifyFormatParts(rtf.formatToParts(-1000, unitArgument), [
-    { "type": "integer", "value": "1,000", "unit": unitArgument },
+    { "type": "integer", "value": "1", "unit": unitArgument },
+    { "type": "group", "value": ",", "unit": unitArgument },
+    { "type": "integer", "value": "000", "unit": unitArgument },
     { "type": "literal", "value": ` ${plural} ago` },
   ], `formatToParts(-1000, ${unitArgument})`);
+
+  verifyFormatParts(rtf.formatToParts(123456.78, unitArgument), [
+    { "type": "literal", "value": "in " },
+    { "type": "integer", "value": "123", "unit": unitArgument },
+    { "type": "group", "value": ",", "unit": unitArgument },
+    { "type": "integer", "value": "456", "unit": unitArgument },
+    { "type": "decimal", "value": ".", "unit": unitArgument },
+    { "type": "fraction", "value": "78", "unit": unitArgument },
+    { "type": "literal", "value": ` ${plural}` },
+  ], `formatToParts(123456.78, ${unitArgument})`);
 }

--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-long.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-long.js
@@ -23,6 +23,7 @@ function regular(s) {
     "many": s,
     "few": s + "y",
     "one": s + "ę",
+    "other": s + "y",
   }
 }
 
@@ -35,27 +36,32 @@ const units = {
     "many": "dni",
     "few": "dni",
     "one": "dzień",
+    "other": "dnia",
   },
   "week": {
     "many": "tygodni",
     "few": "tygodnie",
     "one": "tydzień",
+    "other": "tygodnia",
   },
   "month": {
     1000: "miesięcy",
     "many": "miesięcy",
     "few": "miesiące",
     "one": "miesiąc",
+    "other": "miesiąca",
   },
   "quarter": {
     "many": "kwartałów",
     "few": "kwartały",
     "one": "kwartał",
+    "other": "kwartału",
   },
   "year": {
     "many": "lat",
     "few": "lata",
     "one": "rok",
+    "other": "roku",
   },
 };
 
@@ -68,7 +74,9 @@ assert.sameValue(typeof rtf.formatToParts, "function", "formatToParts should be 
 for (const [unitArgument, expected] of Object.entries(units)) {
   verifyFormatParts(rtf.formatToParts(1000, unitArgument), [
     { "type": "literal", "value": "za " },
-    { "type": "integer", "value": "1\u00a0000", "unit": unitArgument },
+    { "type": "integer", "value": "1", "unit": unitArgument },
+    { "type": "group", "value": "\u00a0", "unit": unitArgument },
+    { "type": "integer", "value": "000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many}` },
   ], `formatToParts(1000, ${unitArgument})`);
 
@@ -117,7 +125,19 @@ for (const [unitArgument, expected] of Object.entries(units)) {
   ], `formatToParts(-10, ${unitArgument})`);
 
   verifyFormatParts(rtf.formatToParts(-1000, unitArgument), [
-    { "type": "integer", "value": "1\u00a0000", "unit": unitArgument },
+    { "type": "integer", "value": "1", "unit": unitArgument },
+    { "type": "group", "value": "\u00a0", "unit": unitArgument },
+    { "type": "integer", "value": "000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many} temu` },
   ], `formatToParts(-1000, ${unitArgument})`);
+
+  verifyFormatParts(rtf.formatToParts(123456.78, unitArgument), [
+    { "type": "literal", "value": "za " },
+    { "type": "integer", "value": "123", "unit": unitArgument },
+    { "type": "group", "value": "\u00a0", "unit": unitArgument },
+    { "type": "integer", "value": "456", "unit": unitArgument },
+    { "type": "decimal", "value": ",", "unit": unitArgument },
+    { "type": "fraction", "value": "78", "unit": unitArgument },
+    { "type": "literal", "value": ` ${expected.other}` },
+  ], `formatToParts(123456.78, ${unitArgument})`);
 }

--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-narrow.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-narrow.js
@@ -23,6 +23,7 @@ function always(s) {
     "many": s,
     "few": s,
     "one": s,
+    "other": s,
   }
 }
 
@@ -35,11 +36,13 @@ const units = {
     "many": "dni",
     "few": "dni",
     "one": "dzień",
+    "other": "dnia",
   },
   "week": {
     "many": "tyg.",
     "few": "tyg.",
     "one": "tydz.",
+    "other": "tyg.",
   },
   "month": always("mies."),
   "quarter": always("kw."),
@@ -47,6 +50,7 @@ const units = {
     "many": "lat",
     "few": "lata",
     "one": "rok",
+    "other": "roku",
   },
 };
 
@@ -59,7 +63,9 @@ assert.sameValue(typeof rtf.formatToParts, "function", "formatToParts should be 
 for (const [unitArgument, expected] of Object.entries(units)) {
   verifyFormatParts(rtf.formatToParts(1000, unitArgument), [
     { "type": "literal", "value": "za " },
-    { "type": "integer", "value": "1\u00a0000", "unit": unitArgument },
+    { "type": "integer", "value": "1", "unit": unitArgument },
+    { "type": "group", "value": "\u00a0", "unit": unitArgument },
+    { "type": "integer", "value": "000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many}` },
   ], `formatToParts(1000, ${unitArgument})`);
 
@@ -108,7 +114,19 @@ for (const [unitArgument, expected] of Object.entries(units)) {
   ], `formatToParts(-10, ${unitArgument})`);
 
   verifyFormatParts(rtf.formatToParts(-1000, unitArgument), [
-    { "type": "integer", "value": "1\u00a0000", "unit": unitArgument },
+    { "type": "integer", "value": "1", "unit": unitArgument },
+    { "type": "group", "value": "\u00a0", "unit": unitArgument },
+    { "type": "integer", "value": "000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many} temu` },
   ], `formatToParts(-1000, ${unitArgument})`);
+
+  verifyFormatParts(rtf.formatToParts(123456.78, unitArgument), [
+    { "type": "literal", "value": "za " },
+    { "type": "integer", "value": "123", "unit": unitArgument },
+    { "type": "group", "value": "\u00a0", "unit": unitArgument },
+    { "type": "integer", "value": "456", "unit": unitArgument },
+    { "type": "decimal", "value": ",", "unit": unitArgument },
+    { "type": "fraction", "value": "78", "unit": unitArgument },
+    { "type": "literal", "value": ` ${expected.other}` },
+  ], `formatToParts(123456.78, ${unitArgument})`);
 }

--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-short.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-short.js
@@ -23,6 +23,7 @@ function always(s) {
     "many": s,
     "few": s,
     "one": s,
+    "other": s,
   }
 }
 
@@ -35,11 +36,13 @@ const units = {
     "many": "dni",
     "few": "dni",
     "one": "dzień",
+    "other": "dnia",
   },
   "week": {
     "many": "tyg.",
     "few": "tyg.",
     "one": "tydz.",
+    "other": "tyg.",
   },
   "month": always("mies."),
   "quarter": always("kw."),
@@ -47,6 +50,7 @@ const units = {
     "many": "lat",
     "few": "lata",
     "one": "rok",
+    "other": "roku",
   },
 };
 
@@ -59,7 +63,9 @@ assert.sameValue(typeof rtf.formatToParts, "function", "formatToParts should be 
 for (const [unitArgument, expected] of Object.entries(units)) {
   verifyFormatParts(rtf.formatToParts(1000, unitArgument), [
     { "type": "literal", "value": "za " },
-    { "type": "integer", "value": "1\u00a0000", "unit": unitArgument },
+    { "type": "integer", "value": "1", "unit": unitArgument },
+    { "type": "group", "value": "\u00a0", "unit": unitArgument },
+    { "type": "integer", "value": "000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many}` },
   ], `formatToParts(1000, ${unitArgument})`);
 
@@ -108,7 +114,19 @@ for (const [unitArgument, expected] of Object.entries(units)) {
   ], `formatToParts(-10, ${unitArgument})`);
 
   verifyFormatParts(rtf.formatToParts(-1000, unitArgument), [
-    { "type": "integer", "value": "1\u00a0000", "unit": unitArgument },
+    { "type": "integer", "value": "1", "unit": unitArgument },
+    { "type": "group", "value": "\u00a0", "unit": unitArgument },
+    { "type": "integer", "value": "000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many} temu` },
   ], `formatToParts(-1000, ${unitArgument})`);
+
+  verifyFormatParts(rtf.formatToParts(123456.78, unitArgument), [
+    { "type": "literal", "value": "za " },
+    { "type": "integer", "value": "123", "unit": unitArgument },
+    { "type": "group", "value": "\u00a0", "unit": unitArgument },
+    { "type": "integer", "value": "456", "unit": unitArgument },
+    { "type": "decimal", "value": ",", "unit": unitArgument },
+    { "type": "fraction", "value": "78", "unit": unitArgument },
+    { "type": "literal", "value": ` ${expected.other}` },
+  ], `formatToParts(123456.78, ${unitArgument})`);
 }


### PR DESCRIPTION
Fix wrong expectations of
Intl.RelativeTimeFormat.prototype.formatToParts
Add tests to cover "group", "decimal" and "fraction".
Close https://github.com/tc39/test262/issues/1910