### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "3f48fafe3c",
-  "targetRevisionAtLastExport": "5bceb8efa6",
+  "sourceRevisionAtLastExport": "badd645214",
+  "targetRevisionAtLastExport": "0803ae6792",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/op_add.js
+++ b/implementation-contributed/javascriptcore/stress/op_add.js
@@ -1,0 +1,66 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "add";
+var op = "+";
+
+var o1 = {
+    valueOf: function() { return 10; }
+};
+
+var posInfinity = 1 / 0;
+var negInfinity = -1 / 0;
+
+var values = [
+    'o1',
+    'null',
+    'undefined',
+    'true',
+    'false',
+
+    'NaN',
+    'posInfinity',
+    'negInfinity',
+    '100.2', // Some random small double value.
+    '-100.2',
+    '54294967296.2923', // Some random large double value.
+    '-54294967296.2923',
+
+    '0',
+    '-0',
+    '1',
+    '-1',
+    '0x3fff',
+    '-0x3fff',
+    '0x7fff',
+    '-0x7fff',
+    '0x10000',
+    '-0x10000',
+    '0x7ffffff',
+    '-0x7ffffff',
+    '0x100000000',
+    '-0x100000000',
+
+    '"abc"',
+    '"0"',
+    '"-0"',
+    '"1"',
+    '"-1"',
+];
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarVar", values, values);
+generateBinaryTests(tests, opName, op, "VarConst", values, values);
+generateBinaryTests(tests, opName, op, "ConstVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_bitand.js
+++ b/implementation-contributed/javascriptcore/stress/op_bitand.js
@@ -1,0 +1,72 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "bitand";
+var op = "&";
+
+var o1 = {
+    valueOf: function() { return 10; }
+};
+
+var posInfinity = 1 / 0;
+var negInfinity = -1 / 0;
+
+var values = [
+    'o1',
+    'null',
+    'undefined',
+    'true',
+    'false',
+
+    'NaN',
+    'posInfinity',
+    'negInfinity',
+    '100.2', // Some random small double value.
+    '-100.2',
+    '54294967296.2923', // Some random large double value.
+    '-54294967296.2923',
+
+    '0',
+    '-0',
+    '1',
+    '-1',
+    '0x3fff',
+    '-0x3fff',
+    '0x7fff',
+    '-0x7fff',
+    '0x10000',
+    '-0x10000',
+    '0x7fffffff',
+    '-0x7fffffff',
+    '0xa5a5a5a5',
+    '0x100000000',
+    '-0x100000000',
+
+    '"abc"',
+    '"0"',
+    '"-0"',
+    '"1"',
+    '"-1"',
+    '"0x7fffffff"',
+    '"-0x7fffffff"',
+    '"0xa5a5a5a5"',
+    '"0x100000000"',
+    '"-0x100000000"',
+];
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarVar", values, values);
+generateBinaryTests(tests, opName, op, "VarConst", values, values);
+generateBinaryTests(tests, opName, op, "ConstVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_bitor.js
+++ b/implementation-contributed/javascriptcore/stress/op_bitor.js
@@ -1,0 +1,72 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "bitor";
+var op = "|";
+
+var o1 = {
+    valueOf: function() { return 10; }
+};
+
+var posInfinity = 1 / 0;
+var negInfinity = -1 / 0;
+
+var values = [
+    'o1',
+    'null',
+    'undefined',
+    'true',
+    'false',
+
+    'NaN',
+    'posInfinity',
+    'negInfinity',
+    '100.2', // Some random small double value.
+    '-100.2',
+    '54294967296.2923', // Some random large double value.
+    '-54294967296.2923',
+
+    '0',
+    '-0',
+    '1',
+    '-1',
+    '0x3fff',
+    '-0x3fff',
+    '0x7fff',
+    '-0x7fff',
+    '0x10000',
+    '-0x10000',
+    '0x7fffffff',
+    '-0x7fffffff',
+    '0xa5a5a5a5',
+    '0x100000000',
+    '-0x100000000',
+
+    '"abc"',
+    '"0"',
+    '"-0"',
+    '"1"',
+    '"-1"',
+    '"0x7fffffff"',
+    '"-0x7fffffff"',
+    '"0xa5a5a5a5"',
+    '"0x100000000"',
+    '"-0x100000000"',
+];
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarVar", values, values);
+generateBinaryTests(tests, opName, op, "VarConst", values, values);
+generateBinaryTests(tests, opName, op, "ConstVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_bitxor.js
+++ b/implementation-contributed/javascriptcore/stress/op_bitxor.js
@@ -1,0 +1,72 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "bitxor";
+var op = "^";
+
+var o1 = {
+    valueOf: function() { return 10; }
+};
+
+var posInfinity = 1 / 0;
+var negInfinity = -1 / 0;
+
+var values = [
+    'o1',
+    'null',
+    'undefined',
+    'true',
+    'false',
+
+    'NaN',
+    'posInfinity',
+    'negInfinity',
+    '100.2', // Some random small double value.
+    '-100.2',
+    '54294967296.2923', // Some random large double value.
+    '-54294967296.2923',
+
+    '0',
+    '-0',
+    '1',
+    '-1',
+    '0x3fff',
+    '-0x3fff',
+    '0x7fff',
+    '-0x7fff',
+    '0x10000',
+    '-0x10000',
+    '0x7fffffff',
+    '-0x7fffffff',
+    '0xa5a5a5a5',
+    '0x100000000',
+    '-0x100000000',
+
+    '"abc"',
+    '"0"',
+    '"-0"',
+    '"1"',
+    '"-1"',
+    '"0x7fffffff"',
+    '"-0x7fffffff"',
+    '"0xa5a5a5a5"',
+    '"0x100000000"',
+    '"-0x100000000"',
+];
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarVar", values, values);
+generateBinaryTests(tests, opName, op, "VarConst", values, values);
+generateBinaryTests(tests, opName, op, "ConstVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_lshift-ConstVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_lshift-ConstVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "lshift";
+var op = "<<";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "ConstVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_lshift-VarConst.js
+++ b/implementation-contributed/javascriptcore/stress/op_lshift-VarConst.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "lshift";
+var op = "<<";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarConst", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_lshift-VarVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_lshift-VarVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "lshift";
+var op = "<<";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_mod-ConstVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_mod-ConstVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT("--timeoutMultiplier=1.5")
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "mod";
+var op = "%";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "ConstVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_mod-VarConst.js
+++ b/implementation-contributed/javascriptcore/stress/op_mod-VarConst.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT("--timeoutMultiplier=1.5")
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "mod";
+var op = "%";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarConst", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_mod-VarVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_mod-VarVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT("--timeoutMultiplier=1.5")
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "mod";
+var op = "%";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_mul-ConstVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_mul-ConstVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "mul";
+var op = "*";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "ConstVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_mul-VarConst.js
+++ b/implementation-contributed/javascriptcore/stress/op_mul-VarConst.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "mul";
+var op = "*";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarConst", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_mul-VarVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_mul-VarVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "mul";
+var op = "*";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_rshift-ConstVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_rshift-ConstVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "rshift";
+var op = ">>";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "ConstVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_rshift-VarConst.js
+++ b/implementation-contributed/javascriptcore/stress/op_rshift-VarConst.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "rshift";
+var op = ">>";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarConst", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_rshift-VarVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_rshift-VarVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "rshift";
+var op = ">>";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_sub-ConstVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_sub-ConstVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "sub";
+var op = "-";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "ConstVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_sub-VarConst.js
+++ b/implementation-contributed/javascriptcore/stress/op_sub-VarConst.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "sub";
+var op = "-";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarConst", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_sub-VarVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_sub-VarVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "sub";
+var op = "-";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_urshift-ConstVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_urshift-ConstVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "urshift";
+var op = ">>>";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "ConstVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_urshift-VarConst.js
+++ b/implementation-contributed/javascriptcore/stress/op_urshift-VarConst.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "urshift";
+var op = ">>>";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarConst", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/op_urshift-VarVar.js
+++ b/implementation-contributed/javascriptcore/stress/op_urshift-VarVar.js
@@ -1,0 +1,22 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ runFTLNoCJIT
+
+// If all goes well, this test module will terminate silently. If not, it will print
+// errors. See binary-op-test.js for debugging options if needed.
+
+load("./resources/binary-op-test.js");
+
+//============================================================================
+// Test configuration data:
+
+var opName = "urshift";
+var op = ">>>";
+
+load("./resources/binary-op-values.js");
+
+tests = [];
+generateBinaryTests(tests, opName, op, "VarVar", values, values);
+
+run();

--- a/implementation-contributed/javascriptcore/stress/spread-forward-call-varargs-stack-overflow.js
+++ b/implementation-contributed/javascriptcore/stress/spread-forward-call-varargs-stack-overflow.js
@@ -1,0 +1,61 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "arm"
+//@ skip if $architecture == "x86"
+function assert(b) {
+    if (!b)
+        throw new Error("Bad assertion");
+}
+noInline(assert);
+
+function identity(a) { return a; }
+noInline(identity);
+
+function bar(...args) {
+    return args;
+}
+noInline(bar);
+
+function foo(a, ...args) {
+    let arg = identity(a);
+    try {
+        let r = bar(...args, ...args);
+        return r;
+    } catch(e) {
+        return arg;
+    }
+}
+noInline(foo);
+
+for (let i = 0; i < 40000; i++) {
+    let args = [];
+    for (let i = 0; i < 400; i++) {
+        args.push(i);
+    }
+
+    let o = {};
+    let r = foo(o, ...args);
+    let i = 0;
+    for (let arg of args) {
+        assert(r[i] === arg);
+        i++;
+    }
+    for (let arg of args) {
+        assert(r[i] === arg);
+        i++;
+    }
+}
+
+for (let i = 0; i < 20; i++) {
+    let threw = false;
+    let o = {};
+    let args = [];
+    let argCount = maxArguments() * (2/3);
+    argCount = argCount | 0;
+    for (let i = 0; i < argCount; i++) {
+        args.push(i);
+    }
+
+    let r = foo(o, ...args);
+    assert(r === o);
+}

--- a/implementation-contributed/javascriptcore/stress/value-to-boolean.js
+++ b/implementation-contributed/javascriptcore/stress/value-to-boolean.js
@@ -1,0 +1,70 @@
+// FIXME: unskip when this is solved
+// https://bugs.webkit.org/show_bug.cgi?id=191163
+//@ skip if $architecture == "mips" or $architecture == "arm"
+//@ if $buildType == "release" then runDefault else skip end
+
+function assert(b) {
+    if (!b)
+        throw new Error("Bad assertion")
+}
+noInline(assert);
+
+let tests = [
+    [true, true],
+    [false, false],
+    ["", false],
+    ["" + "" + "", false],
+    ["foo", true],
+    ["foo" + "bar", true],
+    [{}, true],
+    [Symbol(), true],
+    [undefined, false],
+    [null, false],
+    [0, false],
+    [-0, false],
+    [+0, false],
+    [NaN, false],
+    [10, true],
+    [10.2012, true],
+    [function() { }, true],
+    [new String("foo"), true],
+    [new String(""), true],
+    [new String, true]
+];
+
+function test1(c) {
+    return !!c;
+}
+noInline(test1);
+
+function test2(c) {
+    if (c)
+        return true;
+    return false;
+}
+noInline(test2);
+
+function test3(c) {
+    if (!c)
+        return false;
+    return true;
+}
+noInline(test3);
+
+let testFunctions = [test1, test2, test3];
+
+for (let testFunction of testFunctions) {
+    for (let i = 0; i < 10000; i++) {
+        let item = tests[i % tests.length];
+        assert(testFunction(item[0]) === item[1]);
+    }
+}
+
+let masquerader = makeMasquerader();
+for (let testFunction of testFunctions) {
+    for (let i = 0; i < 10000; i++) {
+        for (let i = 0; i < 10000; i++) {
+            assert(testFunction(masquerader) === false);
+        }
+    }
+}


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[3f48fafe3c](https://github.com///github/blob/3f48fafe3c) in JavaScriptCore and all changes made since [5bceb8efa6](../blob/5bceb8efa6) in
test262.



### 24 Files Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/op_add.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_add.js)
 - [implementation-contributed/javascriptcore/stress/op_bitand.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_bitand.js)
 - [implementation-contributed/javascriptcore/stress/op_bitor.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_bitor.js)
 - [implementation-contributed/javascriptcore/stress/op_bitxor.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_bitxor.js)
 - [implementation-contributed/javascriptcore/stress/op_lshift-ConstVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_lshift-ConstVar.js)
 - [implementation-contributed/javascriptcore/stress/op_lshift-VarConst.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_lshift-VarConst.js)
 - [implementation-contributed/javascriptcore/stress/op_lshift-VarVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_lshift-VarVar.js)
 - [implementation-contributed/javascriptcore/stress/op_mod-ConstVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_mod-ConstVar.js)
 - [implementation-contributed/javascriptcore/stress/op_mod-VarConst.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_mod-VarConst.js)
 - [implementation-contributed/javascriptcore/stress/op_mod-VarVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_mod-VarVar.js)
 - [implementation-contributed/javascriptcore/stress/op_mul-ConstVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_mul-ConstVar.js)
 - [implementation-contributed/javascriptcore/stress/op_mul-VarConst.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_mul-VarConst.js)
 - [implementation-contributed/javascriptcore/stress/op_mul-VarVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_mul-VarVar.js)
 - [implementation-contributed/javascriptcore/stress/op_rshift-ConstVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_rshift-ConstVar.js)
 - [implementation-contributed/javascriptcore/stress/op_rshift-VarConst.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_rshift-VarConst.js)
 - [implementation-contributed/javascriptcore/stress/op_rshift-VarVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_rshift-VarVar.js)
 - [implementation-contributed/javascriptcore/stress/op_sub-ConstVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_sub-ConstVar.js)
 - [implementation-contributed/javascriptcore/stress/op_sub-VarConst.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_sub-VarConst.js)
 - [implementation-contributed/javascriptcore/stress/op_sub-VarVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_sub-VarVar.js)
 - [implementation-contributed/javascriptcore/stress/op_urshift-ConstVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_urshift-ConstVar.js)
 - [implementation-contributed/javascriptcore/stress/op_urshift-VarConst.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_urshift-VarConst.js)
 - [implementation-contributed/javascriptcore/stress/op_urshift-VarVar.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/op_urshift-VarVar.js)
 - [implementation-contributed/javascriptcore/stress/spread-forward-call-varargs-stack-overflow.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/spread-forward-call-varargs-stack-overflow.js)
 - [implementation-contributed/javascriptcore/stress/value-to-boolean.js](../blob/javascriptcore-test262-automation-export-5bceb8efa6/implementation-contributed/javascriptcore/stress/value-to-boolean.js)