### PR TITLE
Optimize RegExp character class escape tests

### DIFF
--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Digit class escape, \\d with flags ug
+    Compare range for digit class escape \d with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\d/ug;
 const matchingRange = /[0-9]/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
@@ -37,21 +37,21 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+    loneCodePoints: [],
+    ranges: [
+        [0x0030, 0x0039],
+    ],
+});
 
 const re = /\d/ug;
-const matchingRange = /[0-9]/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Digit class escape, \\d+ with flags ug
+    Compare range for digit class escape \d+ with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\d+/ug;
 const matchingRange = /[0-9]+/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
@@ -37,21 +37,21 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+    loneCodePoints: [],
+    ranges: [
+        [0x0030, 0x0039],
+    ],
+});
 
 const re = /\d+/ug;
-const matchingRange = /[0-9]+/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
@@ -37,21 +37,21 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+    loneCodePoints: [],
+    ranges: [
+        [0x0030, 0x0039],
+    ],
+});
 
 const re = /\d+/g;
-const matchingRange = /[0-9]+/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Digit class escape, \\d+ with flags g
+    Compare range for digit class escape \d+ with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\d+/g;
 const matchingRange = /[0-9]+/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
@@ -37,21 +37,21 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+    loneCodePoints: [],
+    ranges: [
+        [0x0030, 0x0039],
+    ],
+});
 
 const re = /\d/g;
-const matchingRange = /[0-9]/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Digit class escape, \\d with flags g
+    Compare range for digit class escape \d with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\d/g;
 const matchingRange = /[0-9]/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non Digit class escape, \\D with flags ug
+    Compare range for non-digit class escape \D with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\D/ug;
 const matchingRange = /[\0-\/:-\u{10FFFF}]/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
@@ -37,21 +37,22 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+    loneCodePoints: [],
+    ranges: [
+        [0x000000, 0x00002F],
+        [0x00003A, 0x10FFFF],
+    ],
+});
 
 const re = /\D/ug;
-const matchingRange = /[\0-\/:-\u{10FFFF}]/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
@@ -37,21 +37,22 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+  loneCodePoints: [],
+  ranges: [
+      [0x000000, 0x00002F],
+      [0x00003A, 0x10FFFF],
+  ],
+});
 
 const re = /\D+/ug;
-const matchingRange = /[\0-\/:-\u{10FFFF}]+/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non Digit class escape, \\D+ with flags ug
+    Compare range for non-digit class escape \D+ with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\D+/ug;
 const matchingRange = /[\0-\/:-\u{10FFFF}]+/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
@@ -37,21 +37,22 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+  loneCodePoints: [],
+  ranges: [
+      [0x000000, 0x00002F],
+      [0x00003A, 0x00FFFF],
+  ],
+});
 
 const re = /\D+/g;
-const matchingRange = /[\0-\/:-\uFFFF]+/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non Digit class escape, \\D+ with flags g
+    Compare range for non-digit class escape \D+ with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\D+/g;
 const matchingRange = /[\0-\/:-\uFFFF]+/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
@@ -37,21 +37,22 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+  loneCodePoints: [],
+  ranges: [
+      [0x000000, 0x00002F],
+      [0x00003A, 0x00FFFF],
+  ],
+});
 
 const re = /\D/g;
-const matchingRange = /[\0-\/:-\uFFFF]/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non Digit class escape, \\D with flags g
+    Compare range for non-digit class escape \D with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\D/g;
 const matchingRange = /[\0-\/:-\uFFFF]/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
@@ -37,21 +37,33 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+    loneCodePoints: [],
+    ranges: [
+        [0x00DC00, 0x00DFFF],
+        [0x000000, 0x000008],
+        [0x00000E, 0x00001F],
+        [0x000021, 0x00009F],
+        [0x0000A1, 0x00167F],
+        [0x001681, 0x001FFF],
+        [0x00200B, 0x002027],
+        [0x00202A, 0x00202E],
+        [0x002030, 0x00205E],
+        [0x002060, 0x002FFF],
+        [0x003001, 0x00DBFF],
+        [0x00E000, 0x00FEFE],
+        [0x00FF00, 0x10FFFF],
+    ],
+});
 
 const re = /\S/ug;
-const matchingRange = /[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uFEFE\uFF00-\u{10FFFF}]/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non whitespace class escape, \\S with flags ug
+    Compare range for non-whitespace class escape \S with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\S/ug;
 const matchingRange = /[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uFEFE\uFF00-\u{10FFFF}]/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
@@ -37,21 +37,33 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+    loneCodePoints: [],
+    ranges: [
+        [0x00DC00, 0x00DFFF],
+        [0x000000, 0x000008],
+        [0x00000E, 0x00001F],
+        [0x000021, 0x00009F],
+        [0x0000A1, 0x00167F],
+        [0x001681, 0x001FFF],
+        [0x00200B, 0x002027],
+        [0x00202A, 0x00202E],
+        [0x002030, 0x00205E],
+        [0x002060, 0x002FFF],
+        [0x003001, 0x00DBFF],
+        [0x00E000, 0x00FEFE],
+        [0x00FF00, 0x10FFFF],
+    ],
+});
 
 const re = /\S+/ug;
-const matchingRange = /[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uFEFE\uFF00-\u{10FFFF}]+/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non whitespace class escape, \\S+ with flags ug
+    Compare range for non-whitespace class escape \S+ with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\S+/ug;
 const matchingRange = /[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uFEFE\uFF00-\u{10FFFF}]+/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
@@ -37,21 +37,33 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+    loneCodePoints: [],
+    ranges: [
+        [0x00DC00, 0x00DFFF],
+        [0x000000, 0x000008],
+        [0x00000E, 0x00001F],
+        [0x000021, 0x00009F],
+        [0x0000A1, 0x00167F],
+        [0x001681, 0x001FFF],
+        [0x00200B, 0x002027],
+        [0x00202A, 0x00202E],
+        [0x002030, 0x00205E],
+        [0x002060, 0x002FFF],
+        [0x003001, 0x00DBFF],
+        [0x00E000, 0x00FEFE],
+        [0x00FF00, 0x00FFFF],
+    ],
+});
 
 const re = /\S+/g;
-const matchingRange = /[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uFEFE\uFF00-\uFFFF]+/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non whitespace class escape, \\S+ with flags g
+    Compare range for non-whitespace class escape \S+ with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\S+/g;
 const matchingRange = /[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uFEFE\uFF00-\uFFFF]+/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non whitespace class escape, \\S with flags g
+    Compare range for non-whitespace class escape \S with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\S/g;
 const matchingRange = /[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uFEFE\uFF00-\uFFFF]/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape.js
@@ -37,21 +37,33 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+    loneCodePoints: [],
+    ranges: [
+        [0x00DC00, 0x00DFFF],
+        [0x000000, 0x000008],
+        [0x00000E, 0x00001F],
+        [0x000021, 0x00009F],
+        [0x0000A1, 0x00167F],
+        [0x001681, 0x001FFF],
+        [0x00200B, 0x002027],
+        [0x00202A, 0x00202E],
+        [0x002030, 0x00205E],
+        [0x002060, 0x002FFF],
+        [0x003001, 0x00DBFF],
+        [0x00E000, 0x00FEFE],
+        [0x00FF00, 0x00FFFF],
+    ],
+});
 
 const re = /\S/g;
-const matchingRange = /[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uFEFE\uFF00-\uFFFF]/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non Word class escape, \\W with flags ug
+    Compare range for non-word class escape \W with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\W/ug;
 const matchingRange = /[\0-\/:-@\[-\^`\{-\u{10FFFF}]/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
@@ -37,21 +37,26 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+    loneCodePoints: [0x000060],
+    ranges: [
+        [0x00DC00, 0x00DFFF],
+        [0x000000, 0x00002F],
+        [0x00003A, 0x000040],
+        [0x00005B, 0x00005E],
+        [0x00007B, 0x00DBFF],
+        [0x00E000, 0x10FFFF],
+    ],
+});
 
 const re = /\W/ug;
-const matchingRange = /[\0-\/:-@\[-\^`\{-\u{10FFFF}]/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non Word class escape, \\W+ with flags ug
+    Compare range for non-word class escape \W+ with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\W+/ug;
 const matchingRange = /[\0-\/:-@\[-\^`\{-\u{10FFFF}]+/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
@@ -37,21 +37,26 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+    loneCodePoints: [0x000060],
+    ranges: [
+        [0x00DC00, 0x00DFFF],
+        [0x000000, 0x00002F],
+        [0x00003A, 0x000040],
+        [0x00005B, 0x00005E],
+        [0x00007B, 0x00DBFF],
+        [0x00E000, 0x10FFFF],
+    ],
+});
 
 const re = /\W+/ug;
-const matchingRange = /[\0-\/:-@\[-\^`\{-\u{10FFFF}]+/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
@@ -37,21 +37,26 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+    loneCodePoints: [0x000060],
+    ranges: [
+        [0x00DC00, 0x00DFFF],
+        [0x000000, 0x00002F],
+        [0x00003A, 0x000040],
+        [0x00005B, 0x00005E],
+        [0x00007B, 0x00DBFF],
+        [0x00E000, 0x00FFFF],
+    ],
+});
 
 const re = /\W+/g;
-const matchingRange = /[\0-\/:-@\[-\^`\{-\uFFFF]+/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non Word class escape, \\W+ with flags g
+    Compare range for non-word class escape \W+ with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\W+/g;
 const matchingRange = /[\0-\/:-@\[-\^`\{-\uFFFF]+/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape.js
@@ -37,21 +37,26 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+    loneCodePoints: [0x000060],
+    ranges: [
+        [0x00DC00, 0x00DFFF],
+        [0x000000, 0x00002F],
+        [0x00003A, 0x000040],
+        [0x00005B, 0x00005E],
+        [0x00007B, 0x00DBFF],
+        [0x00E000, 0x00FFFF],
+    ],
+});
 
 const re = /\W/g;
-const matchingRange = /[\0-\/:-@\[-\^`\{-\uFFFF]/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Non Word class escape, \\W with flags g
+    Compare range for non-word class escape \W with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\W/g;
 const matchingRange = /[\0-\/:-@\[-\^`\{-\uFFFF]/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Whitespace class escape, \\s with flags ug
+    Compare range for whitespace class escape \s with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\s/ug;
 const matchingRange = /[\t-\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
@@ -37,21 +37,31 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+    loneCodePoints: [
+        0x000020,
+        0x0000A0,
+        0x001680,
+        0x00202F,
+        0x00205F,
+        0x003000,
+        0x00FEFF,
+    ],
+    ranges: [
+        [0x000009, 0x00000D],
+        [0x002000, 0x00200A],
+        [0x002028, 0x002029],
+    ],
+});
 
 const re = /\s/ug;
-const matchingRange = /[\t-\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Whitespace class escape, \\s+ with flags ug
+    Compare range for whitespace class escape \s+ with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\s+/ug;
 const matchingRange = /[\t-\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]+/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
@@ -37,21 +37,31 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+    loneCodePoints: [
+        0x000020,
+        0x0000A0,
+        0x001680,
+        0x00202F,
+        0x00205F,
+        0x003000,
+        0x00FEFF,
+    ],
+    ranges: [
+        [0x000009, 0x00000D],
+        [0x002000, 0x00200A],
+        [0x002028, 0x002029],
+    ],
+});
 
 const re = /\s+/ug;
-const matchingRange = /[\t-\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]+/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Whitespace class escape, \\s+ with flags g
+    Compare range for whitespace class escape \s+ with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\s+/g;
 const matchingRange = /[\t-\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]+/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
@@ -37,21 +37,31 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+    loneCodePoints: [
+        0x000020,
+        0x0000A0,
+        0x001680,
+        0x00202F,
+        0x00205F,
+        0x003000,
+        0x00FEFF,
+    ],
+    ranges: [
+        [0x000009, 0x00000D],
+        [0x002000, 0x00200A],
+        [0x002028, 0x002029],
+    ],
+});
 
 const re = /\s+/g;
-const matchingRange = /[\t-\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]+/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Whitespace class escape, \\s with flags g
+    Compare range for whitespace class escape \s with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\s/g;
 const matchingRange = /[\t-\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape.js
@@ -37,21 +37,31 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+    loneCodePoints: [
+        0x000020,
+        0x0000A0,
+        0x001680,
+        0x00202F,
+        0x00205F,
+        0x003000,
+        0x00FEFF,
+    ],
+    ranges: [
+        [0x000009, 0x00000D],
+        [0x002000, 0x00200A],
+        [0x002028, 0x002029],
+    ],
+});
 
 const re = /\s/g;
-const matchingRange = /[\t-\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Word class escape, \\w with flags ug
+    Compare range for word class escape \w with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\w/ug;
 const matchingRange = /[0-9A-Z_a-z]/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-flags-u.js
@@ -37,21 +37,23 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+    loneCodePoints: [0x00005F],
+    ranges: [
+        [0x000030, 0x000039],
+        [0x000041, 0x00005A],
+        [0x000061, 0x00007A],
+    ],
+});
 
 const re = /\w/ug;
-const matchingRange = /[0-9A-Z_a-z]/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
@@ -37,21 +37,23 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
+const str = buildString({
+    loneCodePoints: [0x00005F],
+    ranges: [
+        [0x000030, 0x000039],
+        [0x000041, 0x00005A],
+        [0x000061, 0x00007A],
+    ],
+});
 
 const re = /\w+/ug;
-const matchingRange = /[0-9A-Z_a-z]+/ug;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Word class escape, \\w+ with flags ug
+    Compare range for word class escape \w+ with flags ug
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0x10FFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0x10FFFF]] });
 
 const re = /\w+/ug;
 const matchingRange = /[0-9A-Z_a-z]+/ug;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
@@ -37,21 +37,23 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+    loneCodePoints: [0x00005F],
+    ranges: [
+        [0x000030, 0x000039],
+        [0x000041, 0x00005A],
+        [0x000061, 0x00007A],
+    ],
+});
 
 const re = /\w+/g;
-const matchingRange = /[0-9A-Z_a-z]+/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Word class escape, \\w+ with flags g
+    Compare range for word class escape \w+ with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\w+/g;
 const matchingRange = /[0-9A-Z_a-z]+/g;

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape.js
@@ -37,21 +37,23 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
+const str = buildString({
+    loneCodePoints: [0x00005F],
+    ranges: [
+        [0x000030, 0x000039],
+        [0x000041, 0x00005A],
+        [0x000061, 0x00007A],
+    ],
+});
 
 const re = /\w/g;
-const matchingRange = /[0-9A-Z_a-z]/g;
 
 const errors = [];
 
-function matching(str) {
-    return str.replace(re, '') === str.replace(matchingRange, '');
-}
-
-if (!matching(str)) {
+if (!re.test(str)) {
     // Error, let's find out where
     for (const char of str) {
-        if (!matching(char)) {
+        if (!re.test(char)) {
             errors.push('0x' + char.codePointAt(0).toString(16));
         }
     }

--- a/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape.js
+++ b/test/built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape.js
@@ -4,9 +4,10 @@
 /*---
 esid: prod-CharacterClassEscape
 description: >
-    Compare range for Word class escape, \\w with flags g
+    Compare range for word class escape \w with flags g
 info: |
-    This is a generated test, please checkout https://github.com/bocoup/test262-regexp-generator
+    This is a generated test. Please check out
+    https://github.com/bocoup/test262-regexp-generator
     for any changes.
 
     CharacterClassEscape[U] ::
@@ -18,7 +19,7 @@ info: |
         W
 
     21.2.2.12 CharacterClassEscape
-    
+
     The production CharacterClassEscape :: d evaluates as follows:
         Return the ten-element set of characters containing the characters 0 through 9 inclusive.
     The production CharacterClassEscape :: D evaluates as follows:
@@ -36,7 +37,7 @@ features: [String.fromCodePoint]
 includes: [regExpUtils.js]
 ---*/
 
-const str = buildString({loneCodePoints: [], ranges: [[0, 0xFFFF]]});
+const str = buildString({ loneCodePoints: [], ranges: [[0, 0xFFFF]] });
 
 const re = /\w/g;
 const matchingRange = /[0-9A-Z_a-z]/g;


### PR DESCRIPTION
Previously, these tests simply compared against an equivalent regular expression pattern by generating a large string containing either all code points up to U+FFFF or U+10FFFF, depending on the `u` flag, and then performing:

```js
str.replace(re, '') === str.replace(otherRe, '');
```

These two `String#replace` calls can be optimized into a single `RegExp#test` call by following the pattern used in the property escapes tests at https://github.com/mathiasbynens/unicode-property-escapes-tests. Furthermore, the strings to be tested can be made smaller by only testing the relevant characters for the particular pattern; the inverse pattern is tested separately anyhow.

--- 

```sh
time test262-harness --test262Dir="$HOME/projects/test262" --hostPath="$HOME/.jsvu/v8" --hostType=d8 test/built-ins/RegExp/CharacterClassEscapes/*.js
```

Before this change:

```
real	0m7.700s
user	0m6.106s
sys	0m2.360s
```

After applying this change:

```
real	0m5.359s
user	0m3.691s
sys	0m1.931s
```