### PR TITLE
private elements: tests for private method semantics usage

### DIFF
--- a/src/class-elements/private-method-multiple-instance-identity-same.case
+++ b/src/class-elements/private-method-multiple-instance-identity-same.case
@@ -1,0 +1,27 @@
+// Copyright (C) 2018 Jaideep Bhoosreddy (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Multiple class instances of PrivateName Private method have same function identity 
+info: |
+  Static Semantics: PrivateStringValue
+    PrivateName::
+      #IdentifierName
+  Return the String value consisting of the sequence of code units corresponding to PrivateName
+
+template: productions
+features: [class-methods-private]
+---*/
+
+//- fields
+#m() {}
+//- privateinspectionfunctions
+method() {
+  return this.#m;
+}
+
+const c1 = new C();
+const c2 = new C();
+
+//- assertions
+assert.sameValue(c1.method(), c2.method());

--- a/src/class-elements/private-method-name-property.case
+++ b/src/class-elements/private-method-name-property.case
@@ -1,0 +1,23 @@
+// Copyright (C) 2018 Jaideep Bhoosreddy (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName IdentifierName PropName StringValue
+info: |
+  Static Semantics: PrivateStringValue
+    PrivateName::
+      #IdentifierName
+  Return the String value consisting of the sequence of code units corresponding to PrivateName
+
+template: productions
+features: [class-methods-private]
+---*/
+
+//- fields
+#foo() {}
+//- privateinspectionfunctions
+method() {
+  return this.#foo;
+}
+//- assertions
+assert.sameValue(c.method().name, '#foo');

--- a/src/class-elements/private-static-method-function-call-access.case
+++ b/src/class-elements/private-static-method-function-call-access.case
@@ -1,0 +1,28 @@
+// Copyright (C) 2018 Jaideep Bhoosreddy (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName IdentifierName PropName StringValue
+info: |
+  Static Semantics: PrivateStringValue
+    PrivateName::
+      #IdentifierName
+  Return the String value consisting of the sequence of code units corresponding to PrivateName
+
+template: productions
+features: [class-methods-private]
+---*/
+
+//- fields
+#foo() { return 'test'; }
+static #bar() { return '262'; }
+//- privateinspectionfunctions
+method1() {
+  return this.#foo.call(C);
+}
+method2() {
+  return C.#bar.call(this);
+}
+//- assertions
+assert.sameValue(c.method1(), 'test');
+assert.sameValue(c.method2(), '262');


### PR DESCRIPTION
Tracking issue: #1343

### Summary of changes:
1. Reading a private method separately from calling it
    + All instances of the class share the same function identity for the private method
2. The .name property of the private method is "#foo"
3. It's OK at parse-time to reference a static private method from an instance method, or vice versa, and you can make use of this at runtime with creative application of Function.prototype.call.