### PR TITLE
intl: increase coverage for DateTimeFormat

### DIFF
--- a/test/intl402/DateTimeFormat/constructor-default-value.js
+++ b/test/intl402/DateTimeFormat/constructor-default-value.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2018 Ujjwal Sharma. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-initializedatetimeformat
+description: >
+  Tests that the constructor for Intl.DateTimeFormat uses appropriate default
+  values for its arguments (locales and options).
+---*/
+
+const actual = new Intl.DateTimeFormat().resolvedOptions();
+const expected = new Intl.DateTimeFormat(
+  [],
+  Object.create(null)
+).resolvedOptions();
+
+assert.sameValue(actual.locale, expected.locale);
+assert.sameValue(actual.calendar, expected.calendar);
+assert.sameValue(actual.day, expected.day);
+assert.sameValue(actual.month, expected.month);
+assert.sameValue(actual.year, expected.year);
+assert.sameValue(actual.numberingSystem, expected.numberingSystem);
+assert.sameValue(actual.timeZone, expected.timeZone);


### PR DESCRIPTION
Increase coverage for the Intl.DateTimeFormat constructor by adding a
test that checks for the default values.

/cc @gsathya @rwaldron @littledan