### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "010b5d67",
-  "targetRevisionAtLastExport": "04839204ac",
+  "sourceRevisionAtLastExport": "d540724b",
+  "targetRevisionAtLastExport": "713af1bb14",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/intl/intl.status
+++ b/implementation-contributed/v8/intl/intl.status
@@ -51,5 +51,28 @@
   # Unable to change locale on Android:
   'relative-time-format/default-locale-fr-CA': [FAIL],
   'relative-time-format/default-locale-pt-BR': [FAIL],
+
+  # These tests use some locales which are unsupported on Android.
+  'regress-8413-day': [FAIL],
+  'regress-8413-era': [FAIL],
+  'regress-8413-hour': [FAIL],
+  'regress-8413-minute': [FAIL],
+  'regress-8413-month': [FAIL],
+  'regress-8413-second': [FAIL],
+  'regress-8413-timeZoneName': [FAIL],
+  'regress-8413-weekday': [FAIL],
+  'regress-8413-year': [FAIL],
 }],  # 'system == android'
+['tsan', {
+  # Run for too long under some tsan configs.
+  'regress-8413-day': [PASS, NO_VARIANTS],
+  'regress-8413-era': [PASS, NO_VARIANTS],
+  'regress-8413-hour': [PASS, NO_VARIANTS],
+  'regress-8413-minute': [PASS, NO_VARIANTS],
+  'regress-8413-month': [PASS, NO_VARIANTS],
+  'regress-8413-second': [PASS, NO_VARIANTS],
+  'regress-8413-timeZoneName': [PASS, NO_VARIANTS],
+  'regress-8413-weekday': [PASS, NO_VARIANTS],
+  'regress-8413-year': [PASS, NO_VARIANTS],
+}],  # 'tsan'
 ]

--- a/implementation-contributed/v8/mjsunit/compiler/regress-902608.js
+++ b/implementation-contributed/v8/mjsunit/compiler/regress-902608.js
@@ -1,0 +1,16 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+async function f() {
+  var a = [...new Int8Array([, ...new Uint8Array(65536)])];
+  var p = new Proxy([f], {
+    set: function () { },
+    done: undefined.prototype
+  });
+}
+
+f()
+f();

--- a/implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js
+++ b/implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js
@@ -5,7 +5,7 @@
 // Flags: --harmony-weak-refs
 
 (function TestConstructWeakFactory() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   assertEquals(wf.toString(), "[object WeakFactory]");
   assertNotSame(wf.__proto__, Object.prototype);
   assertSame(wf.__proto__.__proto__, Object.prototype);
@@ -15,7 +15,7 @@
   let caught = false;
   let message = "";
   try {
-    let f = WeakFactory();
+    let f = WeakFactory(() => {});
   } catch (e) {
     message = e.message;
     caught = true;
@@ -25,8 +25,30 @@
   }
 })();
 
+(function TestConstructWeakFactoryCleanupNotCallable() {
+  let message = "WeakFactory: cleanup must be callable";
+  assertThrows(() => { let wf = new WeakFactory(); }, TypeError, message);
+  assertThrows(() => { let wf = new WeakFactory(1); }, TypeError, message);
+  assertThrows(() => { let wf = new WeakFactory(null); }, TypeError, message);
+})();
+
+(function TestConstructWeakFactoryWithCallableProxyAsCleanup() {
+  let handler = {};
+  let obj = () => {};
+  let proxy = new Proxy(obj, handler);
+  let wf = new WeakFactory(proxy);
+})();
+
+(function TestConstructWeakFactoryWithNonCallableProxyAsCleanup() {
+  let message = "WeakFactory: cleanup must be callable";
+  let handler = {};
+  let obj = {};
+  let proxy = new Proxy(obj, handler);
+  assertThrows(() => { let wf = new WeakFactory(proxy); }, TypeError, message);
+})();
+
 (function TestMakeCell() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let wc = wf.makeCell({});
   assertEquals(wc.toString(), "[object WeakCell]");
   assertNotSame(wc.__proto__, Object.prototype);
@@ -46,7 +68,7 @@
 })();
 
 (function TestMakeCellWithHoldings() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let obj = {a: 1};
   let holdings = {b: 2};
   let wc = wf.makeCell(obj, holdings);
@@ -54,7 +76,7 @@
 })();
 
 (function TestMakeCellWithHoldingsSetHoldings() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let obj = {a: 1};
   let holdings = {b: 2};
   let wc = wf.makeCell(obj, holdings);
@@ -65,7 +87,7 @@
 
 (function TestMakeCellWithHoldingsSetHoldingsStrict() {
   "use strict";
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let obj = {a: 1};
   let holdings = {b: 2};
   let wc = wf.makeCell(obj, holdings);
@@ -75,8 +97,8 @@
 })();
 
 (function TestMakeCellWithNonObject() {
-  let wf = new WeakFactory();
-  let message = "WeakFactory.makeCell: target must be an object";
+  let wf = new WeakFactory(() => {});
+  let message = "WeakFactory.prototype.makeCell: target must be an object";
   assertThrows(() => wf.makeCell(), TypeError, message);
   assertThrows(() => wf.makeCell(1), TypeError, message);
   assertThrows(() => wf.makeCell(false), TypeError, message);
@@ -90,16 +112,16 @@
   let handler = {};
   let obj = {};
   let proxy = new Proxy(obj, handler);
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let wc = wf.makeCell(proxy);
 })();
 
 (function TestMakeCellTargetAndHoldingsSameValue() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let obj = {a: 1};
   // SameValue(target, holdings) not ok
   assertThrows(() => wf.makeCell(obj, obj), TypeError,
-               "WeakFactory.makeCell: target and holdings must not be same");
+               "WeakFactory.prototype.makeCell: target and holdings must not be same");
   let holdings = {a: 1};
   let wc = wf.makeCell(obj, holdings);
 })();
@@ -107,12 +129,12 @@
 (function TestMakeCellWithoutWeakFactory() {
   assertThrows(() => WeakFactory.prototype.makeCell.call({}, {}), TypeError);
   // Does not throw:
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   WeakFactory.prototype.makeCell.call(wf, {});
 })();
 
 (function TestHoldingsWithoutWeakCell() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let wc = wf.makeCell({});
   let holdings_getter = Object.getOwnPropertyDescriptor(wc.__proto__, "holdings").get;
   assertThrows(() => holdings_getter.call({}), TypeError);
@@ -121,7 +143,7 @@
 })();
 
 (function TestClearWithoutWeakCell() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let wc = wf.makeCell({});
   let clear = Object.getOwnPropertyDescriptor(wc.__proto__, "clear").value;
   assertThrows(() => clear.call({}), TypeError);
@@ -130,7 +152,7 @@
 })();
 
 (function TestMakeRef() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let wr = wf.makeRef({});
   let wc = wf.makeCell({});
   assertEquals(wr.toString(), "[object WeakRef]");
@@ -145,7 +167,7 @@
 })();
 
 (function TestMakeRefWithHoldings() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let obj = {a: 1};
   let holdings = {b: 2};
   let wr = wf.makeRef(obj, holdings);
@@ -153,7 +175,7 @@
 })();
 
 (function TestMakeRefWithHoldingsSetHoldings() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let obj = {a: 1};
   let holdings = {b: 2};
   let wr = wf.makeRef(obj, holdings);
@@ -164,7 +186,7 @@
 
 (function TestMakeRefWithHoldingsSetHoldingsStrict() {
   "use strict";
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let obj = {a: 1};
   let holdings = {b: 2};
   let wr = wf.makeRef(obj, holdings);
@@ -174,8 +196,8 @@
 })();
 
 (function TestMakeRefWithNonObject() {
-  let wf = new WeakFactory();
-  let message = "WeakFactory.makeRef: target must be an object";
+  let wf = new WeakFactory(() => {});
+  let message = "WeakFactory.prototype.makeRef: target must be an object";
   assertThrows(() => wf.makeRef(), TypeError, message);
   assertThrows(() => wf.makeRef(1), TypeError, message);
   assertThrows(() => wf.makeRef(false), TypeError, message);
@@ -189,16 +211,16 @@
   let handler = {};
   let obj = {};
   let proxy = new Proxy(obj, handler);
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let wr = wf.makeRef(proxy);
 })();
 
 (function TestMakeRefTargetAndHoldingsSameValue() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let obj = {a: 1};
   // SameValue(target, holdings) not ok
   assertThrows(() => wf.makeRef(obj, obj), TypeError,
-               "WeakFactory.makeRef: target and holdings must not be same");
+               "WeakFactory.prototype.makeRef: target and holdings must not be same");
   let holdings = {a: 1};
   let wr = wf.makeRef(obj, holdings);
 })();
@@ -206,12 +228,12 @@
 (function TestMakeRefWithoutWeakFactory() {
   assertThrows(() => WeakFactory.prototype.makeRef.call({}, {}), TypeError);
   // Does not throw:
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   WeakFactory.prototype.makeRef.call(wf, {});
 })();
 
 (function TestDerefWithoutWeakRef() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let wc = wf.makeCell({});
   let wr = wf.makeRef({});
   let deref = Object.getOwnPropertyDescriptor(wr.__proto__, "deref").value;
@@ -222,7 +244,7 @@
 })();
 
 (function TestWeakRefClearAfterProtoChange() {
-  let wf = new WeakFactory();
+  let wf = new WeakFactory(() => {});
   let wc = wf.makeCell({});
   let wr = wf.makeRef({});
   // Does not throw:

--- a/implementation-contributed/v8/mjsunit/regress/regress-336820.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-336820.js
@@ -33,6 +33,6 @@ assertThrows((function() {
     x = new Array();
     x[0] = s;
     x[1000] = s;
-    x[1000000] = s;
+    x[10000] = s;
     s = x.join("::");
   }}), RangeError);

--- a/implementation-contributed/v8/mjsunit/regress/regress-902552.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-902552.js
@@ -1,0 +1,11 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+var C = class {};
+for (var i = 0; i < 4; ++i) {
+  if (i == 2) %OptimizeOsr();
+  C.prototype.foo = 42;
+}

--- a/implementation-contributed/v8/mjsunit/regress/regress-902810.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-902810.js
@@ -1,0 +1,5 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+assertThrows("((__v_4 = __v_4, __v_0) => eval(__v_4))()", ReferenceError)

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-902395.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-902395.js
@@ -1,0 +1,37 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+function opt() {
+  try{
+    Object.seal({})
+  }finally{
+    try{
+      // Carefully crafted by clusterfuzz to alias the temporary object literal
+      // register with the below dead try block's context register.
+      (
+        {
+          toString(){
+          }
+        }
+      ).apply(-1).x(  )
+    }
+    finally{
+      if(2.2)
+      {
+        return
+      }
+      // This code should be dead.
+      try{
+        Reflect.construct
+      }finally{
+      }
+    }
+  }
+}
+
+opt();
+%OptimizeFunctionOnNextCall(opt);
+opt();

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-902610.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-902610.js
@@ -1,0 +1,11 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+assertThrows(() => {
+  // Make a function with 65535 args. This should throw a SyntaxError because -1
+  // is reserved for the "don't adapt arguments" sentinel.
+  var f_with_65535_args =
+      eval("(function(" + Array(65535).fill("x").join(",") + "){})");
+  f_with_65535_args();
+}, SyntaxError);


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[010b5d67](https://github.com///github/blob/010b5d67) in V8 and all changes made since [04839204ac](../blob/04839204ac) in
test262.



### 3 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/intl/intl.status](../blob/v8-test262-automation-export-04839204ac/implementation-contributed/v8/intl/intl.status)
 - [implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js](../blob/v8-test262-automation-export-04839204ac/implementation-contributed/v8/mjsunit/harmony/weakrefs/basics.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-336820.js](../blob/v8-test262-automation-export-04839204ac/implementation-contributed/v8/mjsunit/regress/regress-336820.js)









### 5 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/compiler/regress-902608.js](../blob/v8-test262-automation-export-04839204ac/implementation-contributed/v8/mjsunit/compiler/regress-902608.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-902552.js](../blob/v8-test262-automation-export-04839204ac/implementation-contributed/v8/mjsunit/regress/regress-902552.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-902810.js](../blob/v8-test262-automation-export-04839204ac/implementation-contributed/v8/mjsunit/regress/regress-902810.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-902395.js](../blob/v8-test262-automation-export-04839204ac/implementation-contributed/v8/mjsunit/regress/regress-crbug-902395.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-902610.js](../blob/v8-test262-automation-export-04839204ac/implementation-contributed/v8/mjsunit/regress/regress-crbug-902610.js)