### PR TITLE
add async-iteration flag

### DIFF
--- a/test/built-ins/Function/prototype/toString/proxy-async-generator-function.js
+++ b/test/built-ins/Function/prototype/toString/proxy-async-generator-function.js
@@ -14,7 +14,7 @@ info: |
   NativeFunction:
     function IdentifierName_opt ( FormalParameters ) { [ native code ] }
 
-features: [async-functions, generators, Proxy]
+features: [async-iteration, Proxy]
 includes: [nativeFunctionMatcher.js]
 ---*/
 

--- a/test/built-ins/Function/prototype/toString/proxy-async-generator-method-definition.js
+++ b/test/built-ins/Function/prototype/toString/proxy-async-generator-method-definition.js
@@ -14,7 +14,7 @@ info: |
   NativeFunction:
     function IdentifierName_opt ( FormalParameters ) { [ native code ] }
 
-features: [async-functions, generators, Proxy]
+features: [async-iteration, Proxy]
 includes: [nativeFunctionMatcher.js]
 ---*/
 

--- a/test/language/expressions/await/async-generator-interleaved.js
+++ b/test/language/expressions/await/async-generator-interleaved.js
@@ -8,7 +8,7 @@ description: >
   Await on async generator functions and builtin Promises are properly
   interleaved, meaning await takes only 1 tick on the microtask queue.
 flags: [async]
-features: [async-functions]
+features: [async-functions, async-iteration]
 includes: [compareArray.js]
 ---*/
 


### PR DESCRIPTION
These tests use async generators, which I understand are meant to be included in the `async-iteration` flag.