### PR TITLE
harness: make $262.agent.waitUntil check if a typed array can be shared before proceeding.

### DIFF
--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -66,24 +66,24 @@ properties of the global scope prior to test execution.
   - **`global`** - a reference to the global object on which `$262` was initially defined
   - **`IsHTMLDDA`** - (present only in implementations that can provide it) an
     object that 1) has an [[IsHTMLDDA]] internal slot, and 2) when called with
-    no arguments or with the single argument `""` returns `null`.  Use this
+    no arguments or with the single argument `""` returns `null`. Use this
     property to test that ECMAScript algorithms aren't mis-implemented to treat
     `document.all` as being `undefined` or of type Undefined (instead of
-    Object).  (The peculiar second requirement permits testing algorithms when
+    Object). (The peculiar second requirement permits testing algorithms when
     they also call `document.all` with such arguments, so that testing for
-    correct behavior requires knowing how the call behaves.  This is rarely
+    correct behavior requires knowing how the call behaves. This is rarely
     necessary.)  Tests using this function must be tagged with the `IsHTMLDDA`
     feature so that only hosts supporting this property will run them.
   - **`agent`** - an ordinary object with the following properties:
     - **`start`** - a function that takes a script source string and runs
-      the script in a concurrent agent.  Will block until that agent is
-      running.  The agent has no representation.  The agent script will be
+      the script in a concurrent agent. Will block until that agent is
+      running. The agent has no representation. The agent script will be
       run in an environment that has an object `$262` with a property `agent`
       with the following properties:
       - **`receiveBroadcast`** - a function that takes a function and
         calls the function when it has received a broadcast from the parent,
         passing it the broadcast as two arguments, a SharedArrayBuffer and
-        an Int32.  This function may return before a broadcast is received
+        an Int32 or BigInt. This function may return before a broadcast is received
         (eg to return to an event loop to await a message) and no code should
         follow the call to this function.
       - **`report`** - a function that accepts a single "message" argument,
@@ -93,10 +93,11 @@ properties of the global scope prior to test execution.
       - **`leaving`** - a function that signals that the agent is done and
         may be terminated (if possible).
       - **`monotonicNow`** - a function that returns a value that conforms to [`DOMHighResTimeStamp`][] and is produced in such a way that its semantics conform to **[Monotonic Clock][]**.
-    - **`broadcast`** - a function that takes a SharedArrayBuffer and an Int32
-        and broadcasts the two values to all concurrent agents.  The function
-        blocks until all agents have retrieved the message.  Note, this assumes
-        that all agents that were started are still running.
+    - **`broadcast`** - a function that takes a SharedArrayBuffer and an 
+        Int32 or BigInt and broadcasts the two values to all concurrent 
+        agents. The function blocks until all agents have retrieved the 
+        message. Note, this assumes that all agents that were started are 
+        still running.
     - **`getReport`** - a function that reads an incoming string from any agent,
       and returns it if it exists, or returns `null` otherwise.
     - **`sleep`** - a function that takes a millisecond argument and

--- a/harness/atomicsHelper.js
+++ b/harness/atomicsHelper.js
@@ -28,6 +28,47 @@ description: >
     return r;
   };
 }
+
+/**
+ *
+ * Share a given Int32Array or BigInt64Array to all running agents. Ensure that the
+ * provided TypedArray is a "shared typed array".
+ *
+ * NOTE: Migrating all tests to this API is necessary to prevent tests from hanging
+ * indefinitely when a SAB is sent to a worker but the code in the worker attempts to
+ * create a non-sharable TypedArray (something that is not Int32Array or BigInt64Array).
+ * When that scenario occurs, an exception is thrown and the agent worker can no
+ * longer communicate with any other threads that control the SAB. If the main
+ * thread happens to be spinning in the $262.agent.waitUntil() while loop, it will never
+ * meet its termination condition and the test will hang indefinitely.
+ *
+ * Because we've defined $262.agent.broadcast(SAB) in
+ * https://github.com/tc39/test262/blob/master/INTERPRETING.md, there are host implementations
+ * that assume compatibility, which must be maintained.
+ *
+ *
+ * $262.agent.safeBroadcast(TA) should not be included in
+ * https://github.com/tc39/test262/blob/master/INTERPRETING.md
+ *
+ *
+ * @param {(Int32Array|BigInt64Array)} typedArray An Int32Array or BigInt64Array with a SharedArrayBuffer
+ */
+$262.agent.safeBroadcast = function(typedArray) {
+  let Constructor = Object.getPrototypeOf(typedArray).constructor;
+  let temp = new Constructor(
+    new SharedArrayBuffer(Constructor.BYTES_PER_ELEMENT)
+  );
+  try {
+    // This will never actually wait, but that's fine because we only
+    // want to ensure that this typedArray CAN be waited on and is shareable.
+    Atomics.wait(temp, 0, Constructor === Int32Array ? 1 : BigInt(1));
+  } catch (error) {
+    $ERROR(`${Constructor.name} cannot be used as a shared typed array. (${error})`);
+  }
+
+  $262.agent.broadcast(typedArray.buffer);
+};
+
 /**
  * With a given Int32Array or BigInt64Array, wait until the expected number of agents have
  * reported themselves by calling:
@@ -39,6 +80,7 @@ description: >
  * @param {number} expected The number of agents that are expected to report as active.
  */
 $262.agent.waitUntil = function(typedArray, index, expected) {
+
   var agents = 0;
   while ((agents = Atomics.load(typedArray, index)) !== expected) {
     /* nothing */
@@ -76,7 +118,7 @@ $262.agent.waitUntil = function(typedArray, index, expected) {
  *       $262.agent.leaving();
  *     });
  *   `);
- *   $262.agent.broadcast(i32a.buffer);
+ *   $262.agent.safeBroadcast(i32a.buffer);
  *
  *   // Wait until the agent was started and then try to yield control to increase
  *   // the likelihood the agent has called `Atomics.wait` and is now waiting.
@@ -106,7 +148,7 @@ $262.agent.waitUntil = function(typedArray, index, expected) {
  *       });
  *     `);
  *   }
- *   $262.agent.broadcast(i32a.buffer);
+ *   $262.agent.safeBroadcast(i32a.buffer);
  *
  *   // Wait until the agents were started and then try to yield control to increase
  *   // the likelihood the agents have called `Atomics.wait` and are now waiting.
@@ -151,7 +193,7 @@ $262.agent.waitUntil = function(typedArray, index, expected) {
  *       });
  *     `);
  *   }
- *   $262.agent.broadcast(i32a.buffer);
+ *   $262.agent.safeBroadcast(i32a.buffer);
  *
  *   // Wait until the agents were started and then try to yield control to increase
  *   // the likelihood the agents have called `Atomics.wait` and are now waiting.
@@ -204,7 +246,7 @@ $262.agent.timeouts = {
  *       $262.agent.leaving();
  *     });
  *   `);
- *   $262.agent.broadcast(i32a.buffer);
+ *   $262.agent.safeBroadcast(i32a.buffer);
  *
  *   // Wait until agent was started and then try to yield control.
  *   $262.agent.waitUntil(i32a, RUNNING, 1);

--- a/test/built-ins/Atomics/notify/bigint/notify-all-on-loc.js
+++ b/test/built-ins/Atomics/notify/bigint/notify-all-on-loc.js
@@ -22,6 +22,10 @@ const BUFFER_SIZE = 4;
 // `Atomics.notify`.
 const TIMEOUT = $262.agent.timeouts.long;
 
+const i64a = new BigInt64Array(
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
+);
+
 for (var i = 0; i < NUMAGENT; i++) {
   $262.agent.start(`
     $262.agent.receiveBroadcast(function(sab) {
@@ -52,10 +56,6 @@ $262.agent.start(`
     $262.agent.leaving();
   });
 `);
-
-const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
-);
 
 $262.agent.safeBroadcast(i64a);
 

--- a/test/built-ins/Atomics/notify/bigint/notify-all-on-loc.js
+++ b/test/built-ins/Atomics/notify/bigint/notify-all-on-loc.js
@@ -57,7 +57,7 @@ const i64a = new BigInt64Array(
   new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 
 // Wait for agents to be running.
 $262.agent.waitUntil(i64a, RUNNING, BigInt(NUMAGENT + 1));

--- a/test/built-ins/Atomics/notify/count-defaults-to-infinity-missing.js
+++ b/test/built-ins/Atomics/notify/count-defaults-to-infinity-missing.js
@@ -43,7 +43,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
 
 // An agent may have been interrupted between reporting its initial report

--- a/test/built-ins/Atomics/notify/count-defaults-to-infinity-undefined.js
+++ b/test/built-ins/Atomics/notify/count-defaults-to-infinity-undefined.js
@@ -41,7 +41,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
 
 // An agent may have been interrupted between reporting its initial report

--- a/test/built-ins/Atomics/notify/negative-count.js
+++ b/test/built-ins/Atomics/notify/negative-count.js
@@ -26,7 +26,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/notify/notify-all-on-loc.js
+++ b/test/built-ins/Atomics/notify/notify-all-on-loc.js
@@ -57,7 +57,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 
 // Wait for agents to be running.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT + 1);

--- a/test/built-ins/Atomics/notify/notify-all.js
+++ b/test/built-ins/Atomics/notify/notify-all.js
@@ -30,7 +30,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 
 // Wait for agents to be running.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);

--- a/test/built-ins/Atomics/notify/notify-in-order-one-time.js
+++ b/test/built-ins/Atomics/notify/notify-in-order-one-time.js
@@ -42,7 +42,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 
 // Wait for agents to be running.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);

--- a/test/built-ins/Atomics/notify/notify-in-order.js
+++ b/test/built-ins/Atomics/notify/notify-in-order.js
@@ -42,7 +42,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 
 // Wait for agents to be running.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);

--- a/test/built-ins/Atomics/notify/notify-nan.js
+++ b/test/built-ins/Atomics/notify/notify-nan.js
@@ -26,7 +26,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/notify/notify-one.js
+++ b/test/built-ins/Atomics/notify/notify-one.js
@@ -34,7 +34,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 
 // Wait for agents to be running.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);

--- a/test/built-ins/Atomics/notify/notify-renotify-noop.js
+++ b/test/built-ins/Atomics/notify/notify-renotify-noop.js
@@ -26,7 +26,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 
 $262.agent.waitUntil(i32a, RUNNING, 1);
 

--- a/test/built-ins/Atomics/notify/notify-two.js
+++ b/test/built-ins/Atomics/notify/notify-two.js
@@ -34,7 +34,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 
 // Wait for agents to be running.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);

--- a/test/built-ins/Atomics/notify/notify-with-no-agents-waiting.js
+++ b/test/built-ins/Atomics/notify/notify-with-no-agents-waiting.js
@@ -24,7 +24,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // There are ZERO agents waiting to notify...

--- a/test/built-ins/Atomics/notify/notify-with-no-matching-agents-waiting.js
+++ b/test/built-ins/Atomics/notify/notify-with-no-matching-agents-waiting.js
@@ -10,7 +10,7 @@ includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 
-const RUNNING = 1;
+const RUNNING = 0;
 
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {

--- a/test/built-ins/Atomics/notify/notify-with-no-matching-agents-waiting.js
+++ b/test/built-ins/Atomics/notify/notify-with-no-matching-agents-waiting.js
@@ -24,7 +24,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // There are ZERO matching agents waiting on index 1

--- a/test/built-ins/Atomics/notify/notify-zero.js
+++ b/test/built-ins/Atomics/notify/notify-zero.js
@@ -34,7 +34,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * BUFFER_SIZE)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 
 // Wait for agents to be running.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);

--- a/test/built-ins/Atomics/notify/undefined-index-defaults-to-zero.js
+++ b/test/built-ins/Atomics/notify/undefined-index-defaults-to-zero.js
@@ -50,7 +50,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 
 // Wait until both agents started.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);

--- a/test/built-ins/Atomics/wait/bigint/false-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/bigint/false-for-timeout-agent.js
@@ -16,6 +16,10 @@ includes: [atomicsHelper.js]
 features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
 
+const i64a = new BigInt64Array(
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
+);
+
 const RUNNING = 1;
 
 $262.agent.start(`
@@ -46,11 +50,7 @@ $262.agent.start(`
   });
 `);
 
-const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
-);
-
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/nan-for-timeout.js
+++ b/test/built-ins/Atomics/wait/bigint/nan-for-timeout.js
@@ -33,7 +33,7 @@ const i64a = new BigInt64Array(
   new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/nan-for-timeout.js
+++ b/test/built-ins/Atomics/wait/bigint/nan-for-timeout.js
@@ -17,6 +17,10 @@ includes: [atomicsHelper.js]
 features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
 
+const i64a = new BigInt64Array(
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
+);
+
 const RUNNING = 1;
 
 $262.agent.start(`
@@ -28,10 +32,6 @@ $262.agent.start(`
     $262.agent.leaving();
   });
 `);
-
-const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
-);
 
 $262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);

--- a/test/built-ins/Atomics/wait/bigint/negative-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/bigint/negative-timeout-agent.js
@@ -25,7 +25,7 @@ const i64a = new BigInt64Array(
   new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/negative-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/bigint/negative-timeout-agent.js
@@ -9,6 +9,10 @@ includes: [atomicsHelper.js]
 features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
 
+const i64a = new BigInt64Array(
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
+);
+
 const RUNNING = 1;
 
 $262.agent.start(`
@@ -20,10 +24,6 @@ $262.agent.start(`
     $262.agent.leaving();
   });
 `);
-
-const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
-);
 
 $262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-no-operation.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-no-operation.js
@@ -38,7 +38,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-add.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-add.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-and.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-and.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-compareExchange.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-compareExchange.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-exchange.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-exchange.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-or.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-or.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-store.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-store.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-sub.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-sub.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-xor.js
+++ b/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-xor.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/value-not-equal.js
+++ b/test/built-ins/Atomics/wait/bigint/value-not-equal.js
@@ -19,8 +19,11 @@ features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
 
 const RUNNING = 1;
-
 const value = "42n";
+
+const i64a = new BigInt64Array(
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
+);
 
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
@@ -32,10 +35,6 @@ $262.agent.start(`
     $262.agent.leaving();
   });
 `);
-
-const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
-);
 
 // NB: We don't actually explicitly need to wait for the agent to start in this
 // test case, we only do it for consistency with other test cases which do

--- a/test/built-ins/Atomics/wait/bigint/value-not-equal.js
+++ b/test/built-ins/Atomics/wait/bigint/value-not-equal.js
@@ -41,7 +41,7 @@ const i64a = new BigInt64Array(
 // test case, we only do it for consistency with other test cases which do
 // require the main agent to wait and yield control.
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/bigint/waiterlist-block-indexedposition-wake.js
+++ b/test/built-ins/Atomics/wait/bigint/waiterlist-block-indexedposition-wake.js
@@ -51,7 +51,7 @@ const i64a = new BigInt64Array(
   new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 5)
 );
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 
 // Wait until all agents started.
 $262.agent.waitUntil(i64a, RUNNING, BigInt(NUMAGENT));

--- a/test/built-ins/Atomics/wait/bigint/waiterlist-block-indexedposition-wake.js
+++ b/test/built-ins/Atomics/wait/bigint/waiterlist-block-indexedposition-wake.js
@@ -25,6 +25,10 @@ features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 var NUMAGENT = 2;
 var RUNNING = 4;
 
+const i64a = new BigInt64Array(
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 5)
+);
+
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
@@ -46,10 +50,6 @@ $262.agent.start(`
     $262.agent.leaving();
   });
 `);
-
-const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 5)
-);
 
 $262.agent.safeBroadcast(i64a);
 

--- a/test/built-ins/Atomics/wait/bigint/waiterlist-order-of-operations-is-fifo.js
+++ b/test/built-ins/Atomics/wait/bigint/waiterlist-order-of-operations-is-fifo.js
@@ -16,11 +16,14 @@ includes: [atomicsHelper.js]
 features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 ---*/
 
-var NUMAGENT = 3;
-
 var WAIT_INDEX = 0;
 var RUNNING = 1;
 var LOCK_INDEX = 2;
+var NUMAGENT = 3;
+
+const i64a = new BigInt64Array(
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
+);
 
 for (var i = 0; i < NUMAGENT; i++) {
   var agentNum = i;
@@ -49,10 +52,6 @@ for (var i = 0; i < NUMAGENT; i++) {
     });
   `);
 }
-
-const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
-);
 
 $262.agent.safeBroadcast(i64a);
 

--- a/test/built-ins/Atomics/wait/bigint/waiterlist-order-of-operations-is-fifo.js
+++ b/test/built-ins/Atomics/wait/bigint/waiterlist-order-of-operations-is-fifo.js
@@ -54,7 +54,7 @@ const i64a = new BigInt64Array(
   new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 
 // Wait until all agents started.
 $262.agent.waitUntil(i64a, RUNNING, BigInt(NUMAGENT));

--- a/test/built-ins/Atomics/wait/bigint/was-woken-before-timeout.js
+++ b/test/built-ins/Atomics/wait/bigint/was-woken-before-timeout.js
@@ -25,6 +25,10 @@ features: [Atomics, BigInt, SharedArrayBuffer, TypedArray]
 const RUNNING = 1;
 const TIMEOUT = $262.agent.timeouts.huge;
 
+const i64a = new BigInt64Array(
+  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
+);
+
 $262.agent.start(`
   $262.agent.receiveBroadcast(function(sab) {
     const i64a = new BigInt64Array(sab);
@@ -39,10 +43,6 @@ $262.agent.start(`
     $262.agent.leaving();
   });
 `);
-
-const i64a = new BigInt64Array(
-  new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
-);
 
 $262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);

--- a/test/built-ins/Atomics/wait/bigint/was-woken-before-timeout.js
+++ b/test/built-ins/Atomics/wait/bigint/was-woken-before-timeout.js
@@ -44,7 +44,7 @@ const i64a = new BigInt64Array(
   new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i64a.buffer);
+$262.agent.safeBroadcast(i64a);
 $262.agent.waitUntil(i64a, RUNNING, 1n);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/false-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/false-for-timeout-agent.js
@@ -50,7 +50,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/nan-for-timeout.js
+++ b/test/built-ins/Atomics/wait/nan-for-timeout.js
@@ -33,7 +33,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/negative-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/negative-timeout-agent.js
@@ -25,7 +25,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-no-operation.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-no-operation.js
@@ -38,7 +38,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-add.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-add.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-and.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-and.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-compareExchange.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-compareExchange.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-exchange.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-exchange.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-or.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-or.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-store.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-store.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-sub.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-sub.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/no-spurious-wakeup-on-xor.js
+++ b/test/built-ins/Atomics/wait/no-spurious-wakeup-on-xor.js
@@ -31,7 +31,7 @@ $262.agent.start(`
   });
 `);
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/null-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/null-for-timeout-agent.js
@@ -50,7 +50,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/object-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/object-for-timeout-agent.js
@@ -56,7 +56,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/poisoned-object-for-timeout-throws-agent.js
+++ b/test/built-ins/Atomics/wait/poisoned-object-for-timeout-throws-agent.js
@@ -59,7 +59,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/symbol-for-index-throws-agent.js
+++ b/test/built-ins/Atomics/wait/symbol-for-index-throws-agent.js
@@ -72,7 +72,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/symbol-for-timeout-throws-agent.js
+++ b/test/built-ins/Atomics/wait/symbol-for-timeout-throws-agent.js
@@ -47,7 +47,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/symbol-for-value-throws-agent.js
+++ b/test/built-ins/Atomics/wait/symbol-for-value-throws-agent.js
@@ -63,7 +63,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/true-for-timeout-agent.js
+++ b/test/built-ins/Atomics/wait/true-for-timeout-agent.js
@@ -50,7 +50,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/undefined-for-timeout.js
+++ b/test/built-ins/Atomics/wait/undefined-for-timeout.js
@@ -48,7 +48,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/undefined-index-defaults-to-zero.js
+++ b/test/built-ins/Atomics/wait/undefined-index-defaults-to-zero.js
@@ -39,7 +39,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/value-not-equal.js
+++ b/test/built-ins/Atomics/wait/value-not-equal.js
@@ -41,7 +41,7 @@ const i32a = new Int32Array(
 // test case, we only do it for consistency with other test cases which do
 // require the main agent to wait and yield control.
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/wait-index-value-not-equal.js
+++ b/test/built-ins/Atomics/wait/wait-index-value-not-equal.js
@@ -38,7 +38,7 @@ const i32a = new Int32Array(
 // test case, we only do it for consistency with other test cases which do
 // require the main agent to wait and yield control.
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.

--- a/test/built-ins/Atomics/wait/waiterlist-block-indexedposition-wake.js
+++ b/test/built-ins/Atomics/wait/waiterlist-block-indexedposition-wake.js
@@ -51,7 +51,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 5)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 
 // Wait until all agents started.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);

--- a/test/built-ins/Atomics/wait/waiterlist-order-of-operations-is-fifo.js
+++ b/test/built-ins/Atomics/wait/waiterlist-order-of-operations-is-fifo.js
@@ -54,7 +54,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 
 // Wait until all agents started.
 $262.agent.waitUntil(i32a, RUNNING, NUMAGENT);

--- a/test/built-ins/Atomics/wait/was-woken-before-timeout.js
+++ b/test/built-ins/Atomics/wait/was-woken-before-timeout.js
@@ -44,7 +44,7 @@ const i32a = new Int32Array(
   new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
 );
 
-$262.agent.broadcast(i32a.buffer);
+$262.agent.safeBroadcast(i32a);
 $262.agent.waitUntil(i32a, RUNNING, 1);
 
 // Try to yield control to ensure the agent actually started to wait.


### PR DESCRIPTION
Without this check, $262.agent.waitUntil can get stuck forever if the worker fails.