### PR TITLE
Remove invalid invalid values in the tests

### DIFF
--- a/test/intl402/Collator/ignore-invalid-unicode-ext-values.js
+++ b/test/intl402/Collator/ignore-invalid-unicode-ext-values.js
@@ -24,15 +24,15 @@ var defaultLocale = defaultOptions.locale;
 var defaultSortedArray = testArray.slice(0).sort(defaultCollator.compare);
 
 var keyValues = {
-    "co": ["standard", "search", "invalid"],
-    "ka": ["noignore", "shifted", "invalid"],
-    "kb": ["true", "false", "invalid"],
-    "kc": ["true", "false", "invalid"],
-    "kh": ["true", "false", "invalid"],
-    "kk": ["true", "false", "invalid"],
-    "kr": ["latn-hira-hani", "hani-hira-latn", "invalid"],
-    "ks": ["level1", "level2", "level3", "level4", "identic", "invalid"],
-    "vt": ["1234-5678-9abc-edf0", "invalid"]
+    "co": ["standard", "search"],
+    "ka": ["noignore", "shifted"],
+    "kb": ["true", "false"],
+    "kc": ["true", "false"],
+    "kh": ["true", "false"],
+    "kk": ["true", "false"],
+    "kr": ["latn-hira-hani", "hani-hira-latn"],
+    "ks": ["level1", "level2", "level3", "level4", "identic"],
+    "vt": ["1234-5678-9abc-edf0"]
 };
 
 Object.getOwnPropertyNames(keyValues).forEach(function (key) {

--- a/test/intl402/DateTimeFormat/ignore-invalid-unicode-ext-values.js
+++ b/test/intl402/DateTimeFormat/ignore-invalid-unicode-ext-values.js
@@ -20,9 +20,9 @@ locales.forEach(function (locale) {
     var defaultFormatted = defaultDateTimeFormat.format(input);
 
     var keyValues = {
-        "cu": ["USD", "EUR", "JPY", "CNY", "TWD", "invalid"], // DateTimeFormat internally uses NumberFormat
-        "nu": ["native", "traditio", "finance", "invalid"],
-        "tz": ["usnavajo", "utcw01", "aumel", "uslax", "usnyc", "deber", "invalid"]
+        "cu": ["USD", "EUR", "JPY", "CNY", "TWD"], // DateTimeFormat internally uses NumberFormat
+        "nu": ["native", "traditio", "finance"],
+        "tz": ["usnavajo", "utcw01", "aumel", "uslax", "usnyc", "deber"]
     };
     
     Object.getOwnPropertyNames(keyValues).forEach(function (key) {

--- a/test/intl402/NumberFormat/ignore-invalid-unicode-ext-values.js
+++ b/test/intl402/NumberFormat/ignore-invalid-unicode-ext-values.js
@@ -20,8 +20,8 @@ locales.forEach(function (locale) {
     var defaultFormatted = defaultNumberFormat.format(input);
 
     var keyValues = {
-        "cu": ["USD", "EUR", "JPY", "CNY", "TWD", "invalid"],
-        "nu": ["native", "traditio", "finance", "invalid"]
+        "cu": ["USD", "EUR", "JPY", "CNY", "TWD"],
+        "nu": ["native", "traditio", "finance"]
     };
     
     Object.getOwnPropertyNames(keyValues).forEach(function (key) {


### PR DESCRIPTION
I believe these value of "invalid" in the test to test invalid are not valid. 
There are no where in the ECMA 402 spec mentioned the string "invalid" have to be treated as an invalid value and cannot be a valid value. Therefore, we need to remove them from the test. (or we can add "invalid" as an invalid value to the spec.)