### PR TITLE
Fix a couple of minor issues in dynamic-import tests

### DIFF
--- a/test/language/expressions/dynamic-import/indirect-resolution-1_FIXTURE.js
+++ b/test/language/expressions/dynamic-import/indirect-resolution-1_FIXTURE.js
@@ -1,4 +1,4 @@
 // Copyright (C) 2018 Leo Balter. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-export default import('indirect-resolution-2_FIXTURE.js');
+export default import('./indirect-resolution-2_FIXTURE.js');

--- a/test/language/expressions/dynamic-import/namespace/default-property-not-set-own.js
+++ b/test/language/expressions/dynamic-import/namespace/default-property-not-set-own.js
@@ -5,7 +5,7 @@
 description: The default property is not set the if the module doesn't export any default
 esid: sec-finishdynamicimport
 features: [dynamic-import]
-flags: [async]
+flags: [async, module]
 info: |
     Runtime Semantics: FinishDynamicImport ( referencingScriptOrModule, specifier, promiseCapability, completion )
 

--- a/test/language/expressions/dynamic-import/namespace/default-property-not-set-own.js
+++ b/test/language/expressions/dynamic-import/namespace/default-property-not-set-own.js
@@ -5,7 +5,7 @@
 description: The default property is not set the if the module doesn't export any default
 esid: sec-finishdynamicimport
 features: [dynamic-import]
-flags: [async, module]
+flags: [async]
 info: |
     Runtime Semantics: FinishDynamicImport ( referencingScriptOrModule, specifier, promiseCapability, completion )
 
@@ -26,7 +26,7 @@ info: |
         5. Return namespace.
 ---*/
 
-import('./default-property-not-set-own.js').then(ns => {
+import('./empty_FIXTURE.js').then(ns => {
 
     assert.sameValue(Object.prototype.hasOwnProperty.call(ns, 'default'), false);
 


### PR DESCRIPTION
Hi,

This is to fix what I think are a couple of minor issues in the new dynamic import tests:

 - indirect-resolution-1_FIXTURE.js has a bare import specifier.  This should be a relative specifier to find the indirect-resolution-2_FIXTURE.js module.

 - default-property-not-set-own.js should be marked as a module, so that when it imports itself it doesn't get run again.  If this happens $DONE will complain about being called twice.