### PR TITLE
Fix some proxy tests

### DIFF
--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/call-parameters.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/call-parameters.js
@@ -23,7 +23,7 @@ var handler = {
     _handler = this;
     _prop = prop;
 
-    return Object.getOwnPropertyDescriptor(t);
+    return Object.getOwnPropertyDescriptor(t, prop);
   }
 };
 var p = new Proxy(target, handler);

--- a/test/built-ins/Proxy/getOwnPropertyDescriptor/result-type-is-not-object-nor-undefined.js
+++ b/test/built-ins/Proxy/getOwnPropertyDescriptor/result-type-is-not-object-nor-undefined.js
@@ -18,8 +18,7 @@ var target = {
   number: 1,
   symbol: Symbol(),
   string: '',
-  boolean: true,
-  fn: function() {}
+  boolean: true
 };
 var p = new Proxy(target, {
   getOwnPropertyDescriptor: function(t, prop) {
@@ -41,8 +40,4 @@ assert.throws(TypeError, function() {
 
 assert.throws(TypeError, function() {
   Object.getOwnPropertyDescriptor(p, "boolean");
-});
-
-assert.throws(TypeError, function() {
-  Object.getOwnPropertyDescriptor(p, "fn");
 });


### PR DESCRIPTION
- `Proxy/getOwnPropertyDescriptor/call-parameters.js`
  Fixes a call to `Object.getOwnPropertyDescriptor` without the prop
  param. Not actually a huge problem, as the test wasn't depending on
  it.

- `Proxy/getOwnPropertyDescriptor/result-type-is-not-object-nor-undefined`
  This test asserted that `function() {}` should throw with the
  following spec step, which is incorrect, as functions are typed as
  `Object` in the spec.
  `1. If Type(trapResultObj) is neither Object nor Undefined, throw a
    TypeError exception.`