### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "743b57501b",
-  "targetRevisionAtLastExport": "5ccad79611",
+  "sourceRevisionAtLastExport": "2f2295c3f7",
+  "targetRevisionAtLastExport": "c1b245c4be",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/big-int-out-of-memory-tests.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-out-of-memory-tests.js
@@ -1,0 +1,63 @@
+//@ runDefault("--useBigInt=true", "--useDFGJIT=false")
+
+function assert(a, message) {
+    if (!a)
+        throw new Error(message);
+}
+
+function lshift(y) {
+    let out = 1n;
+    for (let i = 0; i < y; i++) {
+        out *= 340282366920938463463374607431768211456n;
+    }
+
+    return out;
+}
+
+let a = lshift(8064);
+for (let i = 0; i < 256; i++) {
+    a *= 18446744073709551615n;
+}
+
+try {
+    let b = a + 1n;
+    assert(false, "Should throw OutOfMemoryError, but executed without exception");
+} catch(e) {
+    assert(e.message == "Out of memory", "Expected OutOfMemoryError, but got: " + e);
+}
+
+try {
+    let b = a - (-1n);
+    assert(false, "Should throw OutOfMemoryError, but executed without exception");
+} catch(e) {
+    assert(e.message == "Out of memory", "Expected OutOfMemoryError, but got: " + e);
+}
+
+try {
+    let b = a * (-1n);
+    assert(false, "Should throw OutOfMemoryError, but executed without exception");
+} catch(e) {
+    assert(e.message == "Out of memory", "Expected OutOfMemoryError, but got: " + e);
+}
+
+try {
+    let b = a / a;
+    assert(false, "Should throw OutOfMemoryError, but executed without exception");
+} catch(e) {
+    assert(e.message == "Out of memory", "Expected OutOfMemoryError, but got: " + e);
+}
+
+try {
+    let b = -a & -1n;
+    assert(false, "Should throw OutOfMemoryError, but executed without exception");
+} catch(e) {
+    assert(e.message == "Out of memory", "Expected OutOfMemoryError, but got: " + e);
+}
+
+try {
+    let b = a ^ -1n;
+    assert(false, "Should throw OutOfMemoryError, but executed without exception");
+} catch(e) {
+    assert(e.message == "Out of memory", "Expected OutOfMemoryError, but got: " + e);
+}
+

--- a/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow-no-max.js
+++ b/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow-no-max.js
@@ -1,0 +1,34 @@
+//@ skip if $memoryLimited
+let bigArray = new Array(0x7000000);
+bigArray[0] = 1.1;
+bigArray[1] = 1.2;
+
+function foo(array) {
+    var index = array.length;
+    if (index >= bigArray.length || (index - 0x1ffdc01) < 0)
+        return;
+    return bigArray[index - 0x1ffdc01];
+}
+
+noInline(foo);
+
+var okArray = new Uint8Array(0x1ffdc02);
+
+for (var i = 0; i < 10000; ++i)
+    foo(okArray);
+
+var ok = false;
+try {
+    var memory = new WebAssembly.Memory({ initial: 0x1000 });
+    memory.grow(0x7000);
+    var result = foo(new Uint8Array(memory.buffer));
+    if (result !== void 0)
+        throw "Error: bad result at end: " + result;
+    ok = true;
+} catch (e) {
+    if (e.toString() != "Error: Out of memory")
+        throw e;
+}
+
+if (ok)
+    throw "Error: did not throw error";

--- a/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow.js
+++ b/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow.js
@@ -1,0 +1,34 @@
+//@ skip if $memoryLimited
+let bigArray = new Array(0x7000000);
+bigArray[0] = 1.1;
+bigArray[1] = 1.2;
+
+function foo(array) {
+    var index = array.length;
+    if (index >= bigArray.length || (index - 0x1ffdc01) < 0)
+        return;
+    return bigArray[index - 0x1ffdc01];
+}
+
+noInline(foo);
+
+var okArray = new Uint8Array(0x1ffdc02);
+
+for (var i = 0; i < 10000; ++i)
+    foo(okArray);
+
+var ok = false;
+try {
+    var memory = new WebAssembly.Memory({ initial: 0x1000, maximum: 0x8000 });
+    memory.grow(0x7000);
+    var result = foo(new Uint8Array(memory.buffer));
+    if (result !== void 0)
+        throw "Error: bad result at end: " + result;
+    ok = true;
+} catch (e) {
+    if (e.toString() != "Error: Out of memory")
+        throw e;
+}
+
+if (ok)
+    throw "Error: did not throw error";

--- a/implementation-contributed/javascriptcore/stress/big-wasm-memory.js
+++ b/implementation-contributed/javascriptcore/stress/big-wasm-memory.js
@@ -1,0 +1,32 @@
+//@ skip if $memoryLimited
+let bigArray = new Array(0x7000000);
+bigArray[0] = 1.1;
+bigArray[1] = 1.2;
+
+function foo(array) {
+    var index = array.length;
+    if (index >= bigArray.length || (index - 0x1ffdc01) < 0)
+        return;
+    return bigArray[index - 0x1ffdc01];
+}
+
+noInline(foo);
+
+var okArray = new Uint8Array(0x1ffdc02);
+
+for (var i = 0; i < 10000; ++i)
+    foo(okArray);
+
+var ok = false;
+try {
+    var result = foo(new Uint8Array(new WebAssembly.Memory({ initial: 0x8000, maximum: 0x8000 }).buffer));
+    if (result !== void 0)
+        throw "Error: bad result at end: " + result;
+    ok = true;
+} catch (e) {
+    if (e.toString() != "Error: Out of memory")
+        throw e;
+}
+
+if (ok)
+    throw "Error: did not throw error";

--- a/implementation-contributed/javascriptcore/stress/exitok-is-not-the-same-as-mayExit.js
+++ b/implementation-contributed/javascriptcore/stress/exitok-is-not-the-same-as-mayExit.js
@@ -1,0 +1,19 @@
+//@ runDefault("--useAccessInlining=0")
+
+function bar(ranges) {
+    for (const [z] of ranges) {
+        let ys = [];
+        for (y = 0; y <= 100000; y++) {
+            ys[y] = false;
+        }
+    }
+}
+
+function foo() {
+    let iterator = [][Symbol.iterator]();
+    iterator.x = 1;
+}
+
+bar([ [], [], [], [], [], [], [], [], [], [], [] ]);
+foo();
+bar([ [], [] ]);

--- a/implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js
+++ b/implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js
@@ -1,0 +1,40 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+for (var i = 0; i < 10; ++i) {
+    var f = Function('/*) {\n*/', 'return 42');
+    shouldBe(f.toString(),
+`function anonymous(/*) {
+*/) {
+return 42
+}`);
+}
+shouldThrow(() => Function('/*', '*/){\nreturn 42'), `SyntaxError: Parameters should match arguments offered as parameters in Function constructor.`);
+
+shouldThrow(() => Function('/*', '*/){\nreturn 43'), `SyntaxError: Parameters should match arguments offered as parameters in Function constructor.`);
+for (var i = 0; i < 10; ++i) {
+    var f = Function('/*) {\n*/', 'return 43');
+    shouldBe(f.toString(),
+`function anonymous(/*) {
+*/) {
+return 43
+}`);
+}
+

--- a/implementation-contributed/javascriptcore/stress/function-constructor-name.js
+++ b/implementation-contributed/javascriptcore/stress/function-constructor-name.js
@@ -1,0 +1,36 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var GeneratorFunction = function*(){}.constructor;
+var AsyncFunction = async function(){}.constructor;
+var AsyncGeneratorFunction = async function*(){}.constructor;
+
+var f = Function(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(f.toString(),
+`function anonymous() {
+return 42
+}`);
+
+var gf = GeneratorFunction(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(gf.toString(),
+`function* anonymous() {
+return 42
+}`);
+
+var af = AsyncFunction(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(af.toString(),
+`async function anonymous() {
+return 42
+}`);
+
+var agf = AsyncGeneratorFunction(`return 42`);
+shouldBe(typeof anonymous, `undefined`);
+shouldBe(agf.toString(),
+`async function* anonymous() {
+return 42
+}`);

--- a/implementation-contributed/javascriptcore/stress/global-import-function-should-return-a-promise-when-clearing-exceptions.js
+++ b/implementation-contributed/javascriptcore/stress/global-import-function-should-return-a-promise-when-clearing-exceptions.js
@@ -1,0 +1,19 @@
+//@ requireOptions("--maxPerThreadStackUsage=300000", "--exceptionStackTraceLimit=0", "--defaultErrorStackTraceLimit=0")
+
+function bar(v) {
+    !v
+    foo();
+}
+function foo() {
+    eval(`bar(import(0));`);
+}
+
+var exception;
+try {
+    foo();
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "RangeError: Maximum call stack size exceeded.")
+    throw "FAILED";

--- a/implementation-contributed/javascriptcore/stress/json-stringified-overflow-2.js
+++ b/implementation-contributed/javascriptcore/stress/json-stringified-overflow-2.js
@@ -1,0 +1,10 @@
+//@ if $memoryLimited then skip else runDefault end
+
+try {
+    const s = "a".padStart(0x80000000 - 1);
+    JSON.stringify(s);
+} catch(e) {
+    if (e != "Error: Out of memory")
+        throw e;
+}
+

--- a/implementation-contributed/javascriptcore/stress/json-stringified-overflow.js
+++ b/implementation-contributed/javascriptcore/stress/json-stringified-overflow.js
@@ -1,0 +1,9 @@
+//@ if $memoryLimited then skip else runDefault end
+
+try {
+    const s = "123".padStart(1073741823);
+    JSON.stringify(s);
+} catch(e) {
+    if (e != "Error: Out of memory")
+        throw e;
+}

--- a/implementation-contributed/javascriptcore/stress/known-cell-type-check-should-allow-empty-value-to-flow-through.js
+++ b/implementation-contributed/javascriptcore/stress/known-cell-type-check-should-allow-empty-value-to-flow-through.js
@@ -1,0 +1,25 @@
+//@ runDefault("--jitPolicyScale=0", "--useConcurrentJIT=0")
+
+class C extends class {} {
+    constructor(beforeSuper) {
+        let f = () => {
+            for (let j=0; j<10; j++) {
+                try {
+                    this.x
+                } catch (e) {
+                }
+            }
+        };
+        if (beforeSuper) {
+            f();
+            super();
+        } else {
+            super();
+            f();
+        }
+    }
+};
+for (let i = 0; i < 10000; i++) {
+    new C(false);
+    new C(true);
+}

--- a/implementation-contributed/javascriptcore/stress/known-cell-use-needs-type-check-assertion.js
+++ b/implementation-contributed/javascriptcore/stress/known-cell-use-needs-type-check-assertion.js
@@ -1,0 +1,14 @@
+//@ runDefault("--useTypeProfiler=1")
+
+function foo(z) {
+    bar(z);
+}
+function bar(o) {
+    o.x = 0;
+}
+let p = 0;
+let k = {};
+for (var i = 0; i < 100000; ++i) {
+    bar(p);
+    foo(k);
+}

--- a/implementation-contributed/javascriptcore/stress/large-unshift-splice.js
+++ b/implementation-contributed/javascriptcore/stress/large-unshift-splice.js
@@ -1,0 +1,18 @@
+//@ if $memoryLimited then skip else runDefault end
+
+function make_contig_arr(sz)
+{
+    let a = []; 
+    while (a.length < sz / 8)
+        a.push(3.14); 
+    a.length *= 8;
+    return a;
+}
+
+try {
+    let ARRAY_LENGTH = 0x10000000;
+    let a = make_contig_arr(ARRAY_LENGTH);
+    let b = make_contig_arr(0xff00);
+    b.unshift(a.length-0x10000, 0);
+    Array.prototype.splice.apply(a, b);
+} catch (e) {}

--- a/implementation-contributed/javascriptcore/stress/merging-ic-variants-should-bail-if-structures-overlap.js
+++ b/implementation-contributed/javascriptcore/stress/merging-ic-variants-should-bail-if-structures-overlap.js
@@ -1,0 +1,16 @@
+//@ runDefault("--validateGraphAtEachPhase=1", "--useLLInt=0")
+
+let items = [];
+for (let i = 0; i < 8; ++i) {
+    class C {
+    }
+    items.push(new C());
+}
+function foo(x) {
+    x.z = 0;
+}
+for (let i = 0; i < 100000; ++i) {
+    for (let j = 0; j < items.length; ++j) {
+        foo(items[j]);
+    }
+}

--- a/implementation-contributed/javascriptcore/stress/regress-185888.js
+++ b/implementation-contributed/javascriptcore/stress/regress-185888.js
@@ -1,0 +1,12 @@
+//@ if $memoryLimited then skip else runDefault end
+
+var exception;
+try {
+    const str = "a".padStart(0x80000000 - 1);
+    new Date(str);
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "Error: Out of memory")
+    throw "FAILED";

--- a/implementation-contributed/javascriptcore/stress/regress-191856.js
+++ b/implementation-contributed/javascriptcore/stress/regress-191856.js
@@ -1,0 +1,8 @@
+//@ skip
+//@ requireOptions("--watchdog=100")
+
+// FIMXE: skipping this test for now because it takes too long to run until we have a fix
+// for https://bugs.webkit.org/show_bug.cgi?id=191855.
+
+for (let i=0; i<1000; i++)
+    import(0);

--- a/implementation-contributed/javascriptcore/wasm/regress/wasm-memory-requested-more-than-MAX_ARRAY_BUFFER_SIZE-2.js
+++ b/implementation-contributed/javascriptcore/wasm/regress/wasm-memory-requested-more-than-MAX_ARRAY_BUFFER_SIZE-2.js
@@ -1,0 +1,88 @@
+var kWasmH0 = 0;
+var kWasmH1 = 0x61;
+var kWasmH2 = 0x73;
+var kWasmH3 = 0x6d;
+var kWasmV0 = 0x1;
+var kWasmV1 = 0;
+var kWasmV2 = 0;
+var kWasmV3 = 0;
+let kMemorySectionCode = 5;
+
+class Binary extends Array {
+    emit_u8(val) {
+        this.push(val);
+    }
+    emit_u32v(val) {
+        while (true) {
+            let v = val & 0xff;
+            val = val >>> 7;
+            if (val == 0) {
+                this.push(v);
+                break;
+            }
+            this.push(v | 0x80);
+        }
+    }
+
+    emit_header() {
+        this.push(kWasmH0, kWasmH1, kWasmH2, kWasmH3, kWasmV0, kWasmV1, kWasmV2, kWasmV3);
+    }
+    emit_section(section_code, content_generator) {
+        this.emit_u8(section_code);
+        const section = new Binary();
+        content_generator(section);
+        this.emit_u32v(section.length);
+        for (let b of section)
+            this.push(b);
+    }
+}
+
+class WasmModuleBuilder {
+    constructor() { }
+    addMemory(min) {
+        this.memory = { min: min };
+    }
+    toArray() {
+        let binary = new Binary();
+        let wasm = this;
+        binary.emit_header();
+        binary.emit_section(kMemorySectionCode, section => {
+            section.emit_u8(1);
+            const is_shared = wasm.memory.shared !== undefined;
+            if (is_shared) {
+            } else {
+                section.emit_u8();
+            }
+            section.emit_u32v(wasm.memory.min);
+        });
+        return binary;
+    }
+    toBuffer() {
+        let bytes = this.toArray();
+        let buffer = new ArrayBuffer(bytes.length);
+        let view = new Uint8Array(buffer);
+        for (let i = 0; i < bytes.length; i++) {
+            let val = bytes[i];
+            view[i] = val | 0;
+        }
+        return buffer;
+    }
+    instantiate() {
+        let module = new WebAssembly.Module(this.toBuffer());
+        let instance = new WebAssembly.Instance(module);
+    }
+}
+
+var exception;
+try {
+    var module = new WasmModuleBuilder();
+    module.addMemory(32768);
+    module.instantiate();
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "Error: Out of memory") {
+    print(exception);
+    throw "FAILED";
+}

--- a/implementation-contributed/javascriptcore/wasm/regress/wasm-memory-requested-more-than-MAX_ARRAY_BUFFER_SIZE.js
+++ b/implementation-contributed/javascriptcore/wasm/regress/wasm-memory-requested-more-than-MAX_ARRAY_BUFFER_SIZE.js
@@ -1,0 +1,10 @@
+var exception;
+
+try {
+    new WebAssembly.Memory({ initial: 0x8000, maximum: 0x8000 }).buffer;
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "Error: Out of memory")
+    throw "FAILED";


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[743b57501b](https://github.com///github/blob/743b57501b) in JavaScriptCore and all changes made since [5ccad79611](../blob/5ccad79611) in
test262.



### 4 Files Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/json-stringified-overflow-2.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/json-stringified-overflow-2.js)
 - [implementation-contributed/javascriptcore/stress/json-stringified-overflow.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/json-stringified-overflow.js)
 - [implementation-contributed/javascriptcore/stress/large-unshift-splice.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/large-unshift-splice.js)
 - [implementation-contributed/javascriptcore/stress/regress-185888.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/regress-185888.js)









### 14 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/big-int-out-of-memory-tests.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/big-int-out-of-memory-tests.js)
 - [implementation-contributed/javascriptcore/stress/big-wasm-memory-grow-no-max.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow-no-max.js)
 - [implementation-contributed/javascriptcore/stress/big-wasm-memory-grow.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow.js)
 - [implementation-contributed/javascriptcore/stress/big-wasm-memory.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/big-wasm-memory.js)
 - [implementation-contributed/javascriptcore/stress/exitok-is-not-the-same-as-mayExit.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/exitok-is-not-the-same-as-mayExit.js)
 - [implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/function-cache-with-parameters-end-position.js)
 - [implementation-contributed/javascriptcore/stress/function-constructor-name.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/function-constructor-name.js)
 - [implementation-contributed/javascriptcore/stress/global-import-function-should-return-a-promise-when-clearing-exceptions.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/global-import-function-should-return-a-promise-when-clearing-exceptions.js)
 - [implementation-contributed/javascriptcore/stress/known-cell-type-check-should-allow-empty-value-to-flow-through.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/known-cell-type-check-should-allow-empty-value-to-flow-through.js)
 - [implementation-contributed/javascriptcore/stress/known-cell-use-needs-type-check-assertion.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/known-cell-use-needs-type-check-assertion.js)
 - [implementation-contributed/javascriptcore/stress/merging-ic-variants-should-bail-if-structures-overlap.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/merging-ic-variants-should-bail-if-structures-overlap.js)
 - [implementation-contributed/javascriptcore/stress/regress-191856.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/stress/regress-191856.js)
 - [implementation-contributed/javascriptcore/wasm/regress/wasm-memory-requested-more-than-MAX_ARRAY_BUFFER_SIZE-2.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/wasm/regress/wasm-memory-requested-more-than-MAX_ARRAY_BUFFER_SIZE-2.js)
 - [implementation-contributed/javascriptcore/wasm/regress/wasm-memory-requested-more-than-MAX_ARRAY_BUFFER_SIZE.js](../blob/javascriptcore-test262-automation-export-5ccad79611/implementation-contributed/javascriptcore/wasm/regress/wasm-memory-requested-more-than-MAX_ARRAY_BUFFER_SIZE.js)