### PR TITLE
More cases for private methods

### DIFF
--- a/src/class-elements/private-async-generator-cannot-escape-token.case
+++ b/src/class-elements/private-async-generator-cannot-escape-token.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: The pound signal in the private async generator cannot be escaped
+template: syntax/invalid
+info: |
+  PrivateName::
+    # IdentifierName
+
+  U+0023 is the escape sequence for #
+features: [class-methods-private, async-iteration]
+---*/
+
+//- elements
+async * \u0023m() { return 42; }

--- a/src/class-elements/private-async-method-cannot-escape-token.case
+++ b/src/class-elements/private-async-method-cannot-escape-token.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: The pound signal in the private async method cannot be escaped
+template: syntax/invalid
+info: |
+  PrivateName::
+    # IdentifierName
+
+  U+0023 is the escape sequence for #
+features: [class-methods-private, async-functions]
+---*/
+
+//- elements
+async \u0023m() { return 42; }

--- a/src/class-elements/private-call-exp-cannot-escape-token.case
+++ b/src/class-elements/private-call-exp-cannot-escape-token.case
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: The pound signal in the private reference cannot be escaped
+template: syntax/invalid
+info: |
+  PrivateName ::
+    # IdentifierName
+
+  MemberExpression :
+    MemberExpression . PrivateName
+
+  CallExpression :
+    CallExpression . PrivateName
+
+  U+0023 is the escape sequence for #
+features: [class-fields-private]
+---*/
+
+//- elements
+method() {
+  foo().\u0023field;
+}

--- a/src/class-elements/private-field-cannot-escape-token.case
+++ b/src/class-elements/private-field-cannot-escape-token.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: The pound signal in the private field cannot be escaped
+template: syntax/invalid
+info: |
+  PrivateName::
+    # IdentifierName
+
+  U+0023 is the escape sequence for #
+features: [class-fields-private]
+---*/
+
+//- elements
+\u0023field;

--- a/src/class-elements/private-generator-cannot-escape-token.case
+++ b/src/class-elements/private-generator-cannot-escape-token.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: The pound signal in the private generator cannot be escaped
+template: syntax/invalid
+info: |
+  PrivateName::
+    # IdentifierName
+
+  U+0023 is the escape sequence for #
+features: [class-methods-private, generators]
+---*/
+
+//- elements
+* \u0023m() { return 42; }

--- a/src/class-elements/private-member-exp-cannot-escape-token.case
+++ b/src/class-elements/private-member-exp-cannot-escape-token.case
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: The pound signal in the private reference cannot be escaped
+template: syntax/invalid
+info: |
+  PrivateName ::
+    # IdentifierName
+
+  MemberExpression :
+    MemberExpression . PrivateName
+
+  CallExpression :
+    CallExpression . PrivateName
+
+  U+0023 is the escape sequence for #
+features: [class-fields-private]
+---*/
+
+//- elements
+method() {
+  this.\u0023field;
+}

--- a/src/class-elements/private-method-cannot-escape-token.case
+++ b/src/class-elements/private-method-cannot-escape-token.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: The pound signal in the private method cannot be escaped
+template: syntax/invalid
+info: |
+  PrivateName::
+    # IdentifierName
+
+  U+0023 is the escape sequence for #
+features: [class-methods-private]
+---*/
+
+//- elements
+\u0023m() { return 42; }

--- a/src/class-elements/private-methods/cls-decl.template
+++ b/src/class-elements/private-methods/cls-decl.template
@@ -90,6 +90,7 @@ class C {
     hasProp(this, '#m', false, 'private methods are defined in an special internal slot and cannot be found as own properties');
     assert.sameValue(typeof this.#m, 'function');
     assert.sameValue(this.ref, this.#m, 'returns the same value');
+    assert.sameValue(this.#m, (() => this)().#m, 'memberexpression and call expression forms');
 
     /*{ constructor }*/
   }

--- a/src/class-elements/private-methods/cls-expr.template
+++ b/src/class-elements/private-methods/cls-expr.template
@@ -91,6 +91,7 @@ var C = class {
     hasProp(this, '#m', false, 'private methods are defined in an special internal slot and cannot be found as own properties');
     assert.sameValue(typeof this.#m, 'function');
     assert.sameValue(this.ref, this.#m, 'returns the same value');
+    assert.sameValue(this.#m, (() => this)().#m, 'memberexpression and call expression forms');
 
     /*{ constructor }*/
   }

--- a/test/language/expressions/class/private-methods/prod-private-async-generator.js
+++ b/test/language/expressions/class/private-methods/prod-private-async-generator.js
@@ -95,6 +95,7 @@ var C = class {
     hasProp(this, '#m', false, 'private methods are defined in an special internal slot and cannot be found as own properties');
     assert.sameValue(typeof this.#m, 'function');
     assert.sameValue(this.ref, this.#m, 'returns the same value');
+    assert.sameValue(this.#m, (() => this)().#m, 'memberexpression and call expression forms');
 
     var ctorIter = this.#m();
     var p = ctorIter.next();

--- a/test/language/expressions/class/private-methods/prod-private-async-method.js
+++ b/test/language/expressions/class/private-methods/prod-private-async-method.js
@@ -95,6 +95,7 @@ var C = class {
     hasProp(this, '#m', false, 'private methods are defined in an special internal slot and cannot be found as own properties');
     assert.sameValue(typeof this.#m, 'function');
     assert.sameValue(this.ref, this.#m, 'returns the same value');
+    assert.sameValue(this.#m, (() => this)().#m, 'memberexpression and call expression forms');
 
     assert.sameValue(this.#m.name, '#m', 'function name inside constructor');
     ctorPromise = this.#m().then(value => {

--- a/test/language/expressions/class/private-methods/prod-private-generator.js
+++ b/test/language/expressions/class/private-methods/prod-private-generator.js
@@ -93,6 +93,7 @@ var C = class {
     hasProp(this, '#m', false, 'private methods are defined in an special internal slot and cannot be found as own properties');
     assert.sameValue(typeof this.#m, 'function');
     assert.sameValue(this.ref, this.#m, 'returns the same value');
+    assert.sameValue(this.#m, (() => this)().#m, 'memberexpression and call expression forms');
 
     var res = this.#m().next();
     assert.sameValue(res.value, 42, 'return from generator method, inside ctor');

--- a/test/language/expressions/class/private-methods/prod-private-method.js
+++ b/test/language/expressions/class/private-methods/prod-private-method.js
@@ -93,6 +93,7 @@ var C = class {
     hasProp(this, '#m', false, 'private methods are defined in an special internal slot and cannot be found as own properties');
     assert.sameValue(typeof this.#m, 'function');
     assert.sameValue(this.ref, this.#m, 'returns the same value');
+    assert.sameValue(this.#m, (() => this)().#m, 'memberexpression and call expression forms');
 
     assert.sameValue(this.#m(), 42, 'already defined in the ctor');
     assert.sameValue(this.#m.name, '#m', 'function name inside constructor');

--- a/test/language/expressions/class/syntax/early-errors/private-async-generator-cannot-escape-token.js
+++ b/test/language/expressions/class/syntax/early-errors/private-async-generator-cannot-escape-token.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-async-generator-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private async generator cannot be escaped (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, async-iteration, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName::
+      # IdentifierName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  async * \u0023m() { return 42; }
+};

--- a/test/language/expressions/class/syntax/early-errors/private-async-method-cannot-escape-token.js
+++ b/test/language/expressions/class/syntax/early-errors/private-async-method-cannot-escape-token.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-async-method-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private async method cannot be escaped (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, async-functions, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName::
+      # IdentifierName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  async \u0023m() { return 42; }
+};

--- a/test/language/expressions/class/syntax/early-errors/private-call-exp-cannot-escape-token.js
+++ b/test/language/expressions/class/syntax/early-errors/private-call-exp-cannot-escape-token.js
@@ -1,0 +1,33 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-call-exp-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private reference cannot be escaped (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName ::
+      # IdentifierName
+
+    MemberExpression :
+      MemberExpression . PrivateName
+
+    CallExpression :
+      CallExpression . PrivateName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  method() {
+    foo().\u0023field;
+  }
+};

--- a/test/language/expressions/class/syntax/early-errors/private-field-cannot-escape-token.js
+++ b/test/language/expressions/class/syntax/early-errors/private-field-cannot-escape-token.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-field-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private field cannot be escaped (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName::
+      # IdentifierName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  \u0023field;
+};

--- a/test/language/expressions/class/syntax/early-errors/private-generator-cannot-escape-token.js
+++ b/test/language/expressions/class/syntax/early-errors/private-generator-cannot-escape-token.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-generator-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private generator cannot be escaped (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, generators, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName::
+      # IdentifierName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  * \u0023m() { return 42; }
+};

--- a/test/language/expressions/class/syntax/early-errors/private-member-exp-cannot-escape-token.js
+++ b/test/language/expressions/class/syntax/early-errors/private-member-exp-cannot-escape-token.js
@@ -1,0 +1,33 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-member-exp-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private reference cannot be escaped (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName ::
+      # IdentifierName
+
+    MemberExpression :
+      MemberExpression . PrivateName
+
+    CallExpression :
+      CallExpression . PrivateName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  method() {
+    this.\u0023field;
+  }
+};

--- a/test/language/expressions/class/syntax/early-errors/private-method-cannot-escape-token.js
+++ b/test/language/expressions/class/syntax/early-errors/private-method-cannot-escape-token.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private method cannot be escaped (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName::
+      # IdentifierName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  \u0023m() { return 42; }
+};

--- a/test/language/expressions/object/method-definition/private-name-early-error-async-fn-inside-class.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-async-fn-inside-class.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name even
+  inside a class body (async method).
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private, async-functions, class, class-fields-public]
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  field = {
+    async #m() {}
+  }
+}

--- a/test/language/expressions/object/method-definition/private-name-early-error-async-fn.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-async-fn.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name
+  (async method).
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private, async-functions]
+---*/
+
+$DONOTEVALUATE();
+
+var o = {
+  async #m() {}
+};

--- a/test/language/expressions/object/method-definition/private-name-early-error-async-gen-inside-class.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-async-gen-inside-class.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name even
+  inside a class body. (async generator)
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private, async-iteration, class, class-fields-public]
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  field = {
+    async * #m() {}
+  }
+}

--- a/test/language/expressions/object/method-definition/private-name-early-error-async-gen.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-async-gen.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name.
+  (async generator)
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private, async-iteration]
+---*/
+
+$DONOTEVALUATE();
+
+var o = {
+  async * #m() {}
+};

--- a/test/language/expressions/object/method-definition/private-name-early-error-gen-inside-class.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-gen-inside-class.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name even
+  inside a class body. (generator)
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private, generators, class, class-fields-public]
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  field = {
+    * #m() {}
+  }
+}

--- a/test/language/expressions/object/method-definition/private-name-early-error-gen.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-gen.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name.
+  (generator)
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private, generators]
+---*/
+
+$DONOTEVALUATE();
+
+var o = {
+  * #m() {}
+};

--- a/test/language/expressions/object/method-definition/private-name-early-error-get-method-inside-class.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-get-method-inside-class.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name even
+  inside a class body. (getter method)
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private, class, class-fields-public]
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  field = {
+    get #m() {}
+  }
+}

--- a/test/language/expressions/object/method-definition/private-name-early-error-get-method.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-get-method.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name.
+  (getter method)
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private]
+---*/
+
+$DONOTEVALUATE();
+
+var o = {
+  get #m() {}
+};

--- a/test/language/expressions/object/method-definition/private-name-early-error-method-inside-class.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-method-inside-class.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name even
+  inside a class body. (ordinary method)
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private, class, class-fields-public]
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  field = {
+    #m() {}
+  }
+}

--- a/test/language/expressions/object/method-definition/private-name-early-error-method.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-method.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name.
+  (ordinary method)
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private]
+---*/
+
+$DONOTEVALUATE();
+
+var o = {
+  #m() {}
+};

--- a/test/language/expressions/object/method-definition/private-name-early-error-set-method-inside-class.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-set-method-inside-class.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name even
+  inside a class body. (getter method)
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private, class, class-fields-public]
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  field = {
+    set #m(x) {}
+  }
+}

--- a/test/language/expressions/object/method-definition/private-name-early-error-set-method.js
+++ b/test/language/expressions/object/method-definition/private-name-early-error-set-method.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-method-definitions-static-semantics-early-errors
+description: >
+  Throws an early SyntaxError if a method definition has a private name.
+  (getter method)
+info: |
+  Static Semantics: Early Errors
+
+  PropertyDefinition : MethodDefinition
+    It is a Syntax Error if PrivateBoundNames of MethodDefinition is non-empty.
+negative:
+  phase: parse
+  type: SyntaxError
+features: [class-methods-private]
+---*/
+
+$DONOTEVALUATE();
+
+var o = {
+  set #m(x) {}
+};

--- a/test/language/statements/class/private-methods/prod-private-async-generator.js
+++ b/test/language/statements/class/private-methods/prod-private-async-generator.js
@@ -94,6 +94,7 @@ class C {
     hasProp(this, '#m', false, 'private methods are defined in an special internal slot and cannot be found as own properties');
     assert.sameValue(typeof this.#m, 'function');
     assert.sameValue(this.ref, this.#m, 'returns the same value');
+    assert.sameValue(this.#m, (() => this)().#m, 'memberexpression and call expression forms');
 
     var ctorIter = this.#m();
     var p = ctorIter.next();

--- a/test/language/statements/class/private-methods/prod-private-async-method.js
+++ b/test/language/statements/class/private-methods/prod-private-async-method.js
@@ -94,6 +94,7 @@ class C {
     hasProp(this, '#m', false, 'private methods are defined in an special internal slot and cannot be found as own properties');
     assert.sameValue(typeof this.#m, 'function');
     assert.sameValue(this.ref, this.#m, 'returns the same value');
+    assert.sameValue(this.#m, (() => this)().#m, 'memberexpression and call expression forms');
 
     assert.sameValue(this.#m.name, '#m', 'function name inside constructor');
     ctorPromise = this.#m().then(value => {

--- a/test/language/statements/class/private-methods/prod-private-generator.js
+++ b/test/language/statements/class/private-methods/prod-private-generator.js
@@ -92,6 +92,7 @@ class C {
     hasProp(this, '#m', false, 'private methods are defined in an special internal slot and cannot be found as own properties');
     assert.sameValue(typeof this.#m, 'function');
     assert.sameValue(this.ref, this.#m, 'returns the same value');
+    assert.sameValue(this.#m, (() => this)().#m, 'memberexpression and call expression forms');
 
     var res = this.#m().next();
     assert.sameValue(res.value, 42, 'return from generator method, inside ctor');

--- a/test/language/statements/class/private-methods/prod-private-method.js
+++ b/test/language/statements/class/private-methods/prod-private-method.js
@@ -92,6 +92,7 @@ class C {
     hasProp(this, '#m', false, 'private methods are defined in an special internal slot and cannot be found as own properties');
     assert.sameValue(typeof this.#m, 'function');
     assert.sameValue(this.ref, this.#m, 'returns the same value');
+    assert.sameValue(this.#m, (() => this)().#m, 'memberexpression and call expression forms');
 
     assert.sameValue(this.#m(), 42, 'already defined in the ctor');
     assert.sameValue(this.#m.name, '#m', 'function name inside constructor');

--- a/test/language/statements/class/syntax/early-errors/private-async-generator-cannot-escape-token.js
+++ b/test/language/statements/class/syntax/early-errors/private-async-generator-cannot-escape-token.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-async-generator-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private async generator cannot be escaped (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, async-iteration, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName::
+      # IdentifierName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  async * \u0023m() { return 42; }
+}

--- a/test/language/statements/class/syntax/early-errors/private-async-method-cannot-escape-token.js
+++ b/test/language/statements/class/syntax/early-errors/private-async-method-cannot-escape-token.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-async-method-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private async method cannot be escaped (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, async-functions, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName::
+      # IdentifierName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  async \u0023m() { return 42; }
+}

--- a/test/language/statements/class/syntax/early-errors/private-call-exp-cannot-escape-token.js
+++ b/test/language/statements/class/syntax/early-errors/private-call-exp-cannot-escape-token.js
@@ -1,0 +1,33 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-call-exp-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private reference cannot be escaped (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName ::
+      # IdentifierName
+
+    MemberExpression :
+      MemberExpression . PrivateName
+
+    CallExpression :
+      CallExpression . PrivateName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  method() {
+    foo().\u0023field;
+  }
+}

--- a/test/language/statements/class/syntax/early-errors/private-field-cannot-escape-token.js
+++ b/test/language/statements/class/syntax/early-errors/private-field-cannot-escape-token.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-field-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private field cannot be escaped (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName::
+      # IdentifierName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  \u0023field;
+}

--- a/test/language/statements/class/syntax/early-errors/private-generator-cannot-escape-token.js
+++ b/test/language/statements/class/syntax/early-errors/private-generator-cannot-escape-token.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-generator-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private generator cannot be escaped (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, generators, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName::
+      # IdentifierName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  * \u0023m() { return 42; }
+}

--- a/test/language/statements/class/syntax/early-errors/private-member-exp-cannot-escape-token.js
+++ b/test/language/statements/class/syntax/early-errors/private-member-exp-cannot-escape-token.js
@@ -1,0 +1,33 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-member-exp-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private reference cannot be escaped (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName ::
+      # IdentifierName
+
+    MemberExpression :
+      MemberExpression . PrivateName
+
+    CallExpression :
+      CallExpression . PrivateName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  method() {
+    this.\u0023field;
+  }
+}

--- a/test/language/statements/class/syntax/early-errors/private-method-cannot-escape-token.js
+++ b/test/language/statements/class/syntax/early-errors/private-method-cannot-escape-token.js
@@ -1,0 +1,25 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-cannot-escape-token.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: The pound signal in the private method cannot be escaped (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    PrivateName::
+      # IdentifierName
+
+    U+0023 is the escape sequence for #
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  \u0023m() { return 42; }
+}


### PR DESCRIPTION
Covering:

- tests for private method/fields unnescapable token
- memberexpression and call expression forms to access private names
- early error for private names in method definitions