### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "a8673918",
-  "targetRevisionAtLastExport": "fc9d2bbf73",
+  "sourceRevisionAtLastExport": "bf5cc562",
+  "targetRevisionAtLastExport": "0a41d10187",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/mjsunit/date.js
+++ b/implementation-contributed/v8/mjsunit/date.js
@@ -358,3 +358,13 @@ delete Date.prototype.getUTCMilliseconds;
   assertTrue(delete Date.prototype.toString);
   assertTrue('[object Date]' !== Date());
 })();
+
+// Test minimum and maximum date range according to ES6 section 20.3.1.1:
+// "The actual range of times supported by ECMAScript Date objects is slightly
+// smaller: exactly -100,000,000 days to 100,000,000 days measured relative to
+// midnight at the beginning of 01 January, 1970 UTC. This gives a range of
+// 8,640,000,000,000,000 milliseconds to either side of 01 January, 1970 UTC."
+assertEquals(-8640000000000000, Date.parse("-271821-04-20T00:00:00.000Z"));
+assertEquals(8640000000000000, Date.parse("+275760-09-13T00:00:00.000Z"));
+assertTrue(isNaN(Date.parse("-271821-04-19T00:00:00.000Z")));
+assertTrue(isNaN(Date.parse("+275760-09-14T00:00:00.000Z")));

--- a/implementation-contributed/v8/mjsunit/es9/regress/regress-904167.js
+++ b/implementation-contributed/v8/mjsunit/es9/regress/regress-904167.js
@@ -1,0 +1,14 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Previously, spreading in-object properties would always treat double fields
+// as tagged, potentially dereferencing a Float64.
+
+// Ensure that we don't fail an assert from --verify-heap when cloning a
+// MutableHeapNumber in the CloneObjectIC handler case.
+var src, clone;
+for (var i = 0; i < 40000; i++) {
+    src = { ...i, x: -9007199254740991 };
+    clone = { ...src };
+}

--- a/implementation-contributed/v8/mjsunit/mjsunit.status
+++ b/implementation-contributed/v8/mjsunit/mjsunit.status
@@ -717,10 +717,12 @@
   # Tests that fail some assertions due to checking internal state sensitive
   # to GC. We mark PASS,FAIL to not skip those tests on the endurance fuzzer.
   'array-literal-feedback': [PASS, FAIL],
+  'compiler/dataview-neutered': [PASS, FAIL],
   'compiler/native-context-specialization-hole-check': [PASS, FAIL],
   'elements-transition-hoisting': [PASS, FAIL],
   'es6/collections-constructor-custom-iterator': [PASS, FAIL],
   'harmony/weakrefs/clear-clears-factory-pointer': [PASS, FAIL],
+  'ignition/throw-if-not-hole': [PASS, FAIL],
   'keyed-load-with-symbol-key': [PASS, FAIL],
   'object-seal': [PASS, FAIL],
   'regress/regress-3709': [PASS, FAIL],

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-90771.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-90771.js
@@ -1,0 +1,15 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
+// Flags: --allow-natives-syntax
+function target() {};
+
+for (let key of Object.getOwnPropertyNames(this)) {
+  try {
+    let newTarget = this[key];
+    let arg = target;
+    Reflect.construct(target, arg, newTarget);
+  } catch {}
+}

--- a/implementation-contributed/v8/test262/test262.status
+++ b/implementation-contributed/v8/test262/test262.status
@@ -651,9 +651,6 @@
   # https://bugs.chromium.org/p/v8/issues/detail?id=6705
   'built-ins/Object/assign/strings-and-symbol-order': [FAIL],
 
-  # https://bugs.chromium.org/p/v8/issues/detail?id=7781
-  'built-ins/Date/parse/time-value-maximum-range': [FAIL],
-
   # https://bugs.chromium.org/p/v8/issues/detail?id=7831
   'language/statements/generators/generator-created-after-decl-inst': [FAIL],
   'language/expressions/generators/generator-created-after-decl-inst': [FAIL],


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[a8673918](https://github.com///github/blob/a8673918) in V8 and all changes made since [fc9d2bbf73](../blob/fc9d2bbf73) in
test262.



### 3 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/mjsunit/date.js](../blob/v8-test262-automation-export-fc9d2bbf73/implementation-contributed/v8/mjsunit/date.js)
 - [implementation-contributed/v8/mjsunit/mjsunit.status](../blob/v8-test262-automation-export-fc9d2bbf73/implementation-contributed/v8/mjsunit/mjsunit.status)
 - [implementation-contributed/v8/test262/test262.status](../blob/v8-test262-automation-export-fc9d2bbf73/implementation-contributed/v8/test262/test262.status)









### 2 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/es9/regress/regress-904167.js](../blob/v8-test262-automation-export-fc9d2bbf73/implementation-contributed/v8/mjsunit/es9/regress/regress-904167.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-90771.js](../blob/v8-test262-automation-export-fc9d2bbf73/implementation-contributed/v8/mjsunit/regress/regress-crbug-90771.js)