### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "1966f6a0b8",
-  "targetRevisionAtLastExport": "ffcc3dc767",
+  "sourceRevisionAtLastExport": "e7f9d46220",
+  "targetRevisionAtLastExport": "0210918f1e",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/bit-not-must-generate.js
+++ b/implementation-contributed/javascriptcore/stress/bit-not-must-generate.js
@@ -1,0 +1,26 @@
+function assert(a, e) {
+    if (a !== e) {
+        throw new Error("Bad!");
+    }
+}
+
+function foo(a) {
+    let loc = ~a;
+    return a + 2;
+}
+noInline(foo);
+
+let b = 0;
+let o = {
+    valueOf: function () {
+        b++;
+        return 2;
+    }
+};
+
+for (let i = 0; i < 100000; i++) {
+    assert(foo(o), 4);
+}
+
+assert(b, 200000)
+

--- a/implementation-contributed/javascriptcore/stress/bitwise-not-no-int32.js
+++ b/implementation-contributed/javascriptcore/stress/bitwise-not-no-int32.js
@@ -1,0 +1,30 @@
+function assert(a, e, m) {
+    if (a !== e)
+        throw new Error("Expected to be: " + e + " but got: " + a);
+}
+
+function bitNot(a) {
+    return ~a;
+}
+noInline(bitNot);
+
+for (let i = 0; i < 10000; i++) {
+    let r = bitNot("0");
+    assert(r, -1);
+    r = bitNot("1");
+    assert(r, -2);
+    r = bitNot("-1");
+    assert(r, 0);
+    r = bitNot("-2");
+    assert(r, 1);
+
+    r = bitNot({ valueOf: () => 0 });
+    assert(r, -1);
+    r = bitNot({ valueOf: () => 1 });
+    assert(r, -2);
+    r = bitNot({ valueOf: () => -1 });
+    assert(r, 0);
+    r = bitNot({ valueOf: () => -2 });
+    assert(r, 1);
+}
+

--- a/implementation-contributed/javascriptcore/stress/r238510-bad-loop.js
+++ b/implementation-contributed/javascriptcore/stress/r238510-bad-loop.js
@@ -1,0 +1,10 @@
+function foo() {
+    return function () {
+        eval();
+    }
+}
+noInline(foo);
+
+for (let i = 0; i < 100000; ++i) {
+    foo();    
+}


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[1966f6a0b8](https://github.com///github/blob/1966f6a0b8) in JavaScriptCore and all changes made since [ffcc3dc767](../blob/ffcc3dc767) in
test262.













### 3 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/bit-not-must-generate.js](../blob/javascriptcore-test262-automation-export-ffcc3dc767/implementation-contributed/javascriptcore/stress/bit-not-must-generate.js)
 - [implementation-contributed/javascriptcore/stress/bitwise-not-no-int32.js](../blob/javascriptcore-test262-automation-export-ffcc3dc767/implementation-contributed/javascriptcore/stress/bitwise-not-no-int32.js)
 - [implementation-contributed/javascriptcore/stress/r238510-bad-loop.js](../blob/javascriptcore-test262-automation-export-ffcc3dc767/implementation-contributed/javascriptcore/stress/r238510-bad-loop.js)