### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "bf5cc562",
-  "targetRevisionAtLastExport": "0a41d10187",
+  "sourceRevisionAtLastExport": "b3e7775f",
+  "targetRevisionAtLastExport": "2f97eefb43",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/mjsunit/regress/regress-748069.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-748069.js
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This test gets very slow with slow asserts.
+// Flags: --noenable-slow-asserts
+
 try {
   var a = 'a'.repeat(1 << 28);
 } catch (e) {

--- a/implementation-contributed/v8/mjsunit/regress/regress-908975.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-908975.js
@@ -1,0 +1,6 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+[] = [];
+a => 0

--- a/implementation-contributed/v8/wasm-js/testharness.js
+++ b/implementation-contributed/v8/wasm-js/testharness.js
@@ -19,7 +19,7 @@ let lastPromise = Promise.resolve();
 
 function test(func, description) {
   let maybeErr;
-  try { func({unreached_func: assert_unreached}); }
+  try { func({unreached_func: unreached_func}); }
   catch(e) { maybeErr = e; }
   if (typeof maybeErr !== 'undefined') {
     console.log(`${description}: FAIL. ${maybeErr}`);
@@ -96,6 +96,12 @@ function assert_array_equals(actual, expected, description) {
         'property ${i}, expected ${expected} but got ${actual}',
         {i: i, expected: expected[i], actual: actual[i]});
   }
+}
+
+function unreached_func(msg) {
+  return function trap() {
+    assert_unreached(msg);
+  };
 }
 
 function assert_unreached(description) {


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[bf5cc562](https://github.com///github/blob/bf5cc562) in V8 and all changes made since [0a41d10187](../blob/0a41d10187) in
test262.



### 2 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/mjsunit/regress/regress-748069.js](../blob/v8-test262-automation-export-0a41d10187/implementation-contributed/v8/mjsunit/regress/regress-748069.js)
 - [implementation-contributed/v8/wasm-js/testharness.js](../blob/v8-test262-automation-export-0a41d10187/implementation-contributed/v8/wasm-js/testharness.js)









### 1 New File Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/regress/regress-908975.js](../blob/v8-test262-automation-export-0a41d10187/implementation-contributed/v8/mjsunit/regress/regress-908975.js)