### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "b3e7775f",
-  "targetRevisionAtLastExport": "2f97eefb43",
+  "sourceRevisionAtLastExport": "cac6b037",
+  "targetRevisionAtLastExport": "4dc4cfd817",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-178790.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-178790.js
@@ -25,6 +25,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// Flags: --stack-size=1200
+
 // Create a regexp in the form of a?a?...a? so that fully
 // traversing the entire graph would be prohibitively expensive.
 // This should not cause time out.


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[b3e7775f](https://github.com///github/blob/b3e7775f) in V8 and all changes made since [2f97eefb43](../blob/2f97eefb43) in
test262.



### 1 File Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-178790.js](../blob/v8-test262-automation-export-2f97eefb43/implementation-contributed/v8/mjsunit/regress/regress-crbug-178790.js)