### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "cac6b037",
-  "targetRevisionAtLastExport": "4dc4cfd817",
+  "sourceRevisionAtLastExport": "4a395137",
+  "targetRevisionAtLastExport": "07b313100e",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/mjsunit/apply.js
+++ b/implementation-contributed/v8/mjsunit/apply.js
@@ -122,10 +122,7 @@ for (var j = 1; j < 0x400000; j <<= 1) {
     a[j - 1] = 42;
     assertEquals(42 + j, al.apply(345, a));
   } catch (e) {
-    assertTrue(
-        e.toString().indexOf('Maximum call stack size exceeded') != -1 ||
-        e.toString().indexOf(
-            'Too many arguments in function call (only 65534 allowed)') != -1);
+    assertTrue(e.toString().indexOf("Maximum call stack size exceeded") != -1);
     for (; j < 0x400000; j <<= 1) {
       var caught = false;
       try {
@@ -136,10 +133,7 @@ for (var j = 1; j < 0x400000; j <<= 1) {
         assertUnreachable("Apply of array with length " + a.length +
                           " should have thrown");
       } catch (e) {
-        assertTrue(
-          e.toString().indexOf('Maximum call stack size exceeded') != -1 ||
-          e.toString().indexOf(
-            'Too many arguments in function call (only 65534 allowed)') != -1);
+        assertTrue(e.toString().indexOf("Maximum call stack size exceeded") != -1);
         caught = true;
       }
       assertTrue(caught, "exception not caught");

--- a/implementation-contributed/v8/mjsunit/es6/collections-constructor-custom-iterator.js
+++ b/implementation-contributed/v8/mjsunit/es6/collections-constructor-custom-iterator.js
@@ -4,6 +4,8 @@
 
 // Flags: --allow-natives-syntax --opt
 
+var global;
+
 function TestSetWithCustomIterator(ctor) {
   const k1 = {};
   const k2 = {};
@@ -19,6 +21,9 @@ function TestSetWithCustomIterator(ctor) {
   assertFalse(set.has(k1));
   assertTrue(set.has(k2));
   assertEquals(2, callCount);
+  // Keep entries alive to avoid collection of the weakly held map in optimized
+  // code which causes the code to deopt.
+  global = entries;
 }
 TestSetWithCustomIterator(Set);
 TestSetWithCustomIterator(Set);
@@ -49,6 +54,9 @@ function TestMapWithCustomIterator(ctor) {
   assertFalse(map.has(k1));
   assertEquals(2, map.get(k2));
   assertEquals(2, callCount);
+  // Keep entries alive to avoid collection of the weakly held map in optimized
+  // code which causes the code to deopt.
+  global = entries;
 }
 TestMapWithCustomIterator(Map);
 TestMapWithCustomIterator(Map);

--- a/implementation-contributed/v8/mjsunit/mjsunit.status
+++ b/implementation-contributed/v8/mjsunit/mjsunit.status
@@ -897,12 +897,13 @@
 }], # arch != x64 or deopt_fuzzer
 
 ##############################################################################
-# Liftoff is currently only sufficiently implemented on x64, ia32 and arm64.
+# Liftoff is currently only sufficiently implemented on x64, ia32, arm64 and
+# arm.
 # TODO(clemensh): Implement on all other platforms (crbug.com/v8/6600).
-['arch != x64 and arch != ia32 and arch != arm64', {
+['arch != x64 and arch != ia32 and arch != arm64 and arch != arm', {
   'wasm/liftoff': [SKIP],
   'wasm/tier-up-testing-flag': [SKIP],
-}], # arch != x64 and arch != ia32 and arch != arm64
+}], # arch != x64 and arch != ia32 and arch != arm64 and arch != arm
 
 ##############################################################################
 ['variant == slow_path and gc_stress', {

--- a/implementation-contributed/v8/mjsunit/regress/regress-3027.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-3027.js
@@ -30,7 +30,7 @@
 
 function boom() {
   var args = [];
-  for (var i = 0; i < 65534; i++) {
+  for (var i = 0; i < 125000; i++) {
     args.push(i);
   }
   return Array.apply(Array, args);
@@ -38,5 +38,5 @@ function boom() {
 
 var array = boom();
 
-assertEquals(65534, array.length);
-assertEquals(65533, array[65533]);
+assertEquals(125000, array.length);
+assertEquals(124999, array[124999]);

--- a/implementation-contributed/v8/mjsunit/regress/regress-331444.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-331444.js
@@ -29,7 +29,7 @@
 
 function boom() {
   var args = [];
-  for (var i = 0; i < 65534; i++)
+  for (var i = 0; i < 125000; i++)
     args.push(i);
   return Array.apply(Array, args);
 }

--- a/implementation-contributed/v8/mjsunit/regress/regress-358090.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-358090.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-var x = Array(65534);
+var x = Array(100000);
 y =  Array.apply(Array, x);
 y.unshift(4);
 y.shift();

--- a/implementation-contributed/v8/mjsunit/regress/regress-732836.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-732836.js
@@ -4,7 +4,7 @@
 
 function boom() {
   var args = [];
-  for (var i = 0; i < 65534; i++)
+  for (var i = 0; i < 125000; i++)
     args.push(1.1);
   return Array.apply(Array, args);
 }

--- a/implementation-contributed/v8/mjsunit/regress/regress-803750.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-803750.js
@@ -3,5 +3,5 @@
 // found in the LICENSE file.
 
 // Verify that very large arrays can be constructed.
-assertEquals(Array.isArray(Array.of.apply(Array, Array(65534))), true);
-assertEquals(Array.isArray(Array.of.apply(null, Array(65534))), true);
+assertEquals(Array.isArray(Array.of.apply(Array, Array(65536))), true);
+assertEquals(Array.isArray(Array.of.apply(null, Array(65536))), true);

--- a/implementation-contributed/v8/mjsunit/regress/regress-869735.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-869735.js
@@ -10,5 +10,5 @@ function f() {
 
 var a = [];
 %OptimizeFunctionOnNextCall(f);
-a.length = 65534;
+a.length = 81832;
 f(...a);

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-614727.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-614727.js
@@ -7,7 +7,10 @@
 function f(a, b, c) { return arguments }
 function g(...args) { return args }
 
-var length = 65534;
+// On 64-bit machine this produces a 768K array which is sufficiently small to
+// not cause a stack overflow, but big enough to move the allocated arguments
+// object into large object space (kMaxRegularHeapObjectSize == 600K).
+var length = Math.pow(2, 15) * 3;
 var args = new Array(length);
 assertEquals(length, f.apply(null, args).length);
 assertEquals(length, g.apply(null, args).length);

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-813450.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-813450.js
@@ -4,7 +4,7 @@
 
 // Flags: --allow-natives-syntax
 
-var constructorArgs = new Array(65534);
+var constructorArgs = new Array(0x10100);
 var constructor = function() {};
 var target = new Proxy(constructor, {
   construct: function() {

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-906043.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-906043.js
@@ -15,7 +15,7 @@ function fun(arg) {
 }
 
 var a1, a2;
-var a3 = [1.1,2.2];
+var a3 = [1.1, 2.2];
 a3.length = 0x11000;
 a3.fill(3.3);
 
@@ -25,30 +25,9 @@ for (let i = 0; i < 3; i++) fun(...a4);
 %OptimizeFunctionOnNextCall(fun);
 fun(...a4);
 
-assertThrows(() => fun(...a3), RangeError);
-assertThrows(() => fun.apply(null, a3), RangeError);
+res = fun(...a3);
 
-const kMaxArguments = 65534;
-let big_array = [];
-for (let i = 0; i < kMaxArguments + 1; i++) big_array.push(i);
-assertThrows(() => fun(...big_array), RangeError);
-assertThrows(() => new fun(...big_array), RangeError);
-assertThrows(() => fun.apply(null, big_array), RangeError);
-assertThrows(() => Reflect.construct(fun, big_array), RangeError);
-assertThrows(() => Reflect.apply(fun, undefined, big_array), RangeError);
-
-big_array = [];
-for (let i = 0; i < kMaxArguments + 1; i++) big_array.push(i + 0.1);
-assertThrows(() => fun(...big_array), RangeError);
-assertThrows(() => new fun(...big_array), RangeError);
-assertThrows(() => fun.apply(null, big_array), RangeError);
-assertThrows(() => Reflect.construct(fun, big_array), RangeError);
-assertThrows(() => Reflect.apply(fun, undefined, big_array), RangeError);
-
-big_array = [];
-for (let i = 0; i < kMaxArguments + 1; i++) big_array.push({i: i});
-assertThrows(() => fun(...big_array), RangeError);
-assertThrows(() => new fun(...big_array), RangeError);
-assertThrows(() => fun.apply(null, big_array), RangeError);
-assertThrows(() => Reflect.construct(fun, big_array), RangeError);
-assertThrows(() => Reflect.apply(fun, undefined, big_array), RangeError);
+assertEquals(16, a2.length);
+for (let i = 8; i < 32; i++) {
+  assertEquals(undefined, a2[i]);
+}

--- a/implementation-contributed/v8/mjsunit/regress/regress-v8-6716.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-v8-6716.js
@@ -3,5 +3,5 @@
 // found in the LICENSE file.
 
 function f() {}
-var a = Array(65534);
+var a = Array(2 ** 16);  // Elements in large-object-space.
 f.bind(...a);

--- a/implementation-contributed/v8/mjsunit/string-indexof-1.js
+++ b/implementation-contributed/v8/mjsunit/string-indexof-1.js
@@ -133,7 +133,7 @@ assertEquals(-1, asciiString.indexOf("\x2061"));
 
 // Search in string containing many non-ASCII chars.
 var allCodePoints = [];
-for (var i = 0; i < 65534; i++) allCodePoints[i] = i;
+for (var i = 0; i < 65536; i++) allCodePoints[i] = i;
 var allCharsString = String.fromCharCode.apply(String, allCodePoints);
 // Search for string long enough to trigger complex search with ASCII pattern
 // and UC16 subject.


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[cac6b037](https://github.com///github/blob/cac6b037) in V8 and all changes made since [4dc4cfd817](../blob/4dc4cfd817) in
test262.



### 14 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/mjsunit/apply.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/apply.js)
 - [implementation-contributed/v8/mjsunit/es6/collections-constructor-custom-iterator.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/es6/collections-constructor-custom-iterator.js)
 - [implementation-contributed/v8/mjsunit/mjsunit.status](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/mjsunit.status)
 - [implementation-contributed/v8/mjsunit/regress/regress-3027.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/regress/regress-3027.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-331444.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/regress/regress-331444.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-358090.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/regress/regress-358090.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-732836.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/regress/regress-732836.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-803750.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/regress/regress-803750.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-869735.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/regress/regress-869735.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-614727.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/regress/regress-crbug-614727.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-813450.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/regress/regress-crbug-813450.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-906043.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/regress/regress-crbug-906043.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-v8-6716.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/regress/regress-v8-6716.js)
 - [implementation-contributed/v8/mjsunit/string-indexof-1.js](../blob/v8-test262-automation-export-4dc4cfd817/implementation-contributed/v8/mjsunit/string-indexof-1.js)