### PR TITLE
Add tests for Hashbang comments

### DIFF
--- a/test/language/comments/hashbang-encoded-bang.js
+++ b/test/language/comments/hashbang-encoded-bang.js
@@ -1,0 +1,10 @@
+#\u0021
+/*---
+esid: pending
+description: >
+    Hashbang comments should not be allowed to have encoded characters
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+flags: [raw]
+---*/

--- a/test/language/comments/hashbang-encoded-hash.js
+++ b/test/language/comments/hashbang-encoded-hash.js
@@ -1,0 +1,10 @@
+\u0023!
+/*---
+esid: pending
+description: >
+    Hashbang comments should not be allowed to have encoded characters
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+flags: [raw]
+---*/

--- a/test/language/comments/hashbang-encoded-hashbang.js
+++ b/test/language/comments/hashbang-encoded-hashbang.js
@@ -1,0 +1,10 @@
+\u0023\u0021
+/*---
+esid: pending
+description: >
+    Hashbang comments should not be allowed to have encoded characters
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+flags: [raw]
+---*/

--- a/test/language/comments/hashbang-eval.js
+++ b/test/language/comments/hashbang-eval.js
@@ -1,0 +1,10 @@
+/*---
+esid: pending
+description: >
+    Hashbang comments should be available in Script evaluator contexts.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+---*/
+
+eval('#!\n');

--- a/test/language/comments/hashbang-eval.js
+++ b/test/language/comments/hashbang-eval.js
@@ -7,4 +7,4 @@ info: |
       #! SingleLineCommentChars[opt]
 ---*/
 
-eval('#!\n');
+assert.sameValue(eval('#!\n'), undefined);

--- a/test/language/comments/hashbang-function-body.js
+++ b/test/language/comments/hashbang-function-body.js
@@ -1,0 +1,14 @@
+/*---
+esid: pending
+description: >
+    Hashbang comments should only be allowed at the start of source texts and should not be allowed within function bodies.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+flags: [raw]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+function fn() {#!
+}

--- a/test/language/comments/hashbang-function-constructor.js
+++ b/test/language/comments/hashbang-function-constructor.js
@@ -16,8 +16,8 @@ for (ctor of [
   GeneratorFunction,
   AsyncGeneratorFunction,
 ]) {
-  assert.throws(SyntaxError, () => ctor('#!\n_',''));
-  assert.throws(SyntaxError, () => ctor('#!\n_'));
-  assert.throws(SyntaxError, () => new ctor('#!\n_',''));
-  assert.throws(SyntaxError, () => new ctor('#!\n_'));
+  assert.throws(SyntaxError, () => ctor('#!\n_',''), `${ctor.name} Call argument`);
+  assert.throws(SyntaxError, () => ctor('#!\n_'), `${ctor.name} Call body`);
+  assert.throws(SyntaxError, () => new ctor('#!\n_',''), `${ctor.name} Construct argument`);
+  assert.throws(SyntaxError, () => new ctor('#!\n_'), `${ctor.name} Construct body`);
 }

--- a/test/language/comments/hashbang-function-constructor.js
+++ b/test/language/comments/hashbang-function-constructor.js
@@ -5,7 +5,6 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
-flags: [module]
 ---*/
 const AsyncFunction = (async function (){}).constructor;
 const GeneratorFunction = (function *(){}).constructor;

--- a/test/language/comments/hashbang-function-constructor.js
+++ b/test/language/comments/hashbang-function-constructor.js
@@ -1,0 +1,23 @@
+/*---
+esid: pending
+description: >
+    Hashbang comments should not be allowed in function evaluator contexts.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+flags: [module]
+---*/
+const AsyncFunction = (async function (){}).constructor;
+const GeneratorFunction = (function *(){}).constructor;
+const AsyncGeneratorFunction = (async function *(){}).constructor;
+for (ctor of [
+  Function,
+  AsyncFunction,
+  GeneratorFunction,
+  AsyncGeneratorFunction,
+]) {
+  assert.throws(SyntaxError, () => ctor('#!\n_',''));
+  assert.throws(SyntaxError, () => ctor('#!\n_'));
+  assert.throws(SyntaxError, () => new ctor('#!\n_',''));
+  assert.throws(SyntaxError, () => new ctor('#!\n_'));
+}

--- a/test/language/comments/hashbang-module.js
+++ b/test/language/comments/hashbang-module.js
@@ -1,0 +1,10 @@
+#!
+/*---
+esid: pending
+description: >
+    Hashbang comments should be allowed in Modules.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+flags: [module]
+---*/

--- a/test/language/comments/hashbang-multi-line-comment.js
+++ b/test/language/comments/hashbang-multi-line-comment.js
@@ -1,0 +1,15 @@
+#!/*
+these characters should not be considered within a comment
+*/
+/*---
+esid: pending
+description: >
+    Hashbang comments should not interpret multi-line comments.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+
+negative:
+  phase: parse
+  type: SyntaxError
+---*/

--- a/test/language/comments/hashbang-multi-line-comment.js
+++ b/test/language/comments/hashbang-multi-line-comment.js
@@ -8,7 +8,7 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
-
+flags: [raw]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/comments/hashbang-no-line-separator.js
+++ b/test/language/comments/hashbang-no-line-separator.js
@@ -5,6 +5,7 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
+flags: [raw]
 ---*/
 
 eval('#!');

--- a/test/language/comments/hashbang-no-line-separator.js
+++ b/test/language/comments/hashbang-no-line-separator.js
@@ -1,0 +1,10 @@
+/*---
+esid: pending
+description: >
+    Hashbang comments should not require a newline afterwards
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+---*/
+
+eval('#!');

--- a/test/language/comments/hashbang-not-empty.js
+++ b/test/language/comments/hashbang-not-empty.js
@@ -6,5 +6,6 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
+flags: [raw]
 ---*/
 

--- a/test/language/comments/hashbang-not-empty.js
+++ b/test/language/comments/hashbang-not-empty.js
@@ -1,0 +1,10 @@
+#! these characters should be treated as a comment
+/*---
+esid: pending
+description: >
+    Hashbang comments should be allowed in Scripts and should not be required to be empty.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+---*/
+

--- a/test/language/comments/hashbang-preceding-directive-prologue.js
+++ b/test/language/comments/hashbang-preceding-directive-prologue.js
@@ -7,7 +7,7 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
-
+flags: [raw]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/comments/hashbang-preceding-directive-prologue.js
+++ b/test/language/comments/hashbang-preceding-directive-prologue.js
@@ -1,0 +1,14 @@
+"use strict"
+#!
+/*---
+esid: pending
+description: >
+    Hashbang comments should only be allowed at start of source texts and should not be preceded by DirectivePrologues.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+
+negative:
+  phase: parse
+  type: SyntaxError
+---*/

--- a/test/language/comments/hashbang-preceding-empty-statement.js
+++ b/test/language/comments/hashbang-preceding-empty-statement.js
@@ -6,7 +6,7 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
-
+flags: [raw]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/comments/hashbang-preceding-empty-statement.js
+++ b/test/language/comments/hashbang-preceding-empty-statement.js
@@ -1,0 +1,13 @@
+;#!
+/*---
+esid: pending
+description: >
+    Hashbang comments should only be allowed at the start of source texts and should not be preceded by empty statements.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+
+negative:
+  phase: parse
+  type: SyntaxError
+---*/

--- a/test/language/comments/hashbang-preceding-hashbang.js
+++ b/test/language/comments/hashbang-preceding-hashbang.js
@@ -7,7 +7,7 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
-
+flags: [raw]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/comments/hashbang-preceding-hashbang.js
+++ b/test/language/comments/hashbang-preceding-hashbang.js
@@ -1,0 +1,14 @@
+#!
+#!
+/*---
+esid: pending
+description: >
+    Hashbang comments should only be allowed at the start of source texts and should not be preceded by Hashbang comments.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+
+negative:
+  phase: parse
+  type: SyntaxError
+---*/

--- a/test/language/comments/hashbang-preceding-line-comment.js
+++ b/test/language/comments/hashbang-preceding-line-comment.js
@@ -7,7 +7,7 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
-
+flags: [raw]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/comments/hashbang-preceding-line-comment.js
+++ b/test/language/comments/hashbang-preceding-line-comment.js
@@ -1,0 +1,14 @@
+//
+#!
+/*---
+esid: pending
+description: >
+    Hashbang comments should only be allowed at the start of source texts and should not be preceded by line comments.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+
+negative:
+  phase: parse
+  type: SyntaxError
+---*/

--- a/test/language/comments/hashbang-preceding-multi-line-comment.js
+++ b/test/language/comments/hashbang-preceding-multi-line-comment.js
@@ -1,0 +1,14 @@
+/*
+*/#!
+/*---
+esid: pending
+description: >
+    Hashbang comments should only be allowed at the start of source texts and should not be preceded by multi-line comments.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+
+negative:
+  phase: parse
+  type: SyntaxError
+---*/

--- a/test/language/comments/hashbang-preceding-multi-line-comment.js
+++ b/test/language/comments/hashbang-preceding-multi-line-comment.js
@@ -7,7 +7,7 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
-
+flags: [raw]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/comments/hashbang-preceding-whitespace.js
+++ b/test/language/comments/hashbang-preceding-whitespace.js
@@ -1,0 +1,13 @@
+    #!/bin/sh
+/*---
+esid: pending
+description: >
+    Hashbang comments should only be allowed at the start of source texts and should not be preceded by whitespace.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+
+negative:
+  phase: parse
+  type: SyntaxError
+---*/

--- a/test/language/comments/hashbang-preceding-whitespace.js
+++ b/test/language/comments/hashbang-preceding-whitespace.js
@@ -1,4 +1,4 @@
-    #!/bin/sh
+    #!
 /*---
 esid: pending
 description: >
@@ -6,7 +6,7 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
-
+flags: [raw]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/comments/hashbang-statement-block.js
+++ b/test/language/comments/hashbang-statement-block.js
@@ -5,7 +5,7 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
-
+flags: [raw]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/comments/hashbang-statement-block.js
+++ b/test/language/comments/hashbang-statement-block.js
@@ -1,0 +1,15 @@
+/*---
+esid: pending
+description: >
+    Hashbang comments should only be allowed at the start of source texts and should not be allowed within blocks.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+{
+  #!
+}

--- a/test/language/comments/hashbang-use-strict.js
+++ b/test/language/comments/hashbang-use-strict.js
@@ -6,6 +6,7 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
+flags: [raw]
 ---*/
 
 with ({}) {}

--- a/test/language/comments/hashbang-use-strict.js
+++ b/test/language/comments/hashbang-use-strict.js
@@ -1,0 +1,11 @@
+#!"use strict"
+/*---
+esid: pending
+description: >
+    Hashbang comments should not be interpretted and should not generate DirectivePrologues.
+info: |
+    HashbangComment::
+      #! SingleLineCommentChars[opt]
+---*/
+
+with ({}) {}


### PR DESCRIPTION
This adds tests around https://github.com/tc39/proposal-hashbang which is at Stage 3 but has not been merged nor has an esid. I tried to figure out if templates could work, but I was unsure about how whitespace worked with them so I left them as standalone files.