### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "60ed1be8cd",
-  "targetRevisionAtLastExport": "31e654a339",
+  "sourceRevisionAtLastExport": "205489c4f0",
+  "targetRevisionAtLastExport": "cab19d71a6",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/big-int-left-shift-general.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-left-shift-general.js
@@ -1,0 +1,103 @@
+//@ runBigIntEnabled
+
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+function assert(a) {
+    if (!a)
+        throw new Error("Bad assertion");
+}
+
+assert.sameValue = function (input, expected, message) {
+    if (input !== expected)
+        throw new Error(message);
+}
+
+assert.sameValue(0n << 0n, 0n, "0n << 0n === 0n");
+assert.sameValue(0b101n << 1n, 0b1010n, "0b101n << 1n === 0b1010n");
+assert.sameValue(0b101n << 2n, 0b10100n, "0b101n << 2n === 0b10100n");
+assert.sameValue(0b101n << 3n, 0b101000n, "0b101n << 3n === 0b101000n");
+assert.sameValue(0b101n << -1n, 0b10n, "0b101n << -1n === 0b10n");
+assert.sameValue(0b101n << -2n, 1n, "0b101n << -2n === 1n");
+assert.sameValue(0b101n << -3n, 0n, "0b101n << -3n === 0n");
+assert.sameValue(0n << 128n, 0n, "0n << 128n === 0n");
+assert.sameValue(0n << -128n, 0n, "0n << -128n === 0n");
+assert.sameValue(0x246n << 0n, 0x246n, "0x246n << 0n === 0x246n");
+assert.sameValue(0x246n << 127n, 0x12300000000000000000000000000000000n, "0x246n << 127n === 0x12300000000000000000000000000000000n");
+assert.sameValue(0x246n << 128n, 0x24600000000000000000000000000000000n, "0x246n << 128n === 0x24600000000000000000000000000000000n");
+assert.sameValue(0x246n << 129n, 0x48c00000000000000000000000000000000n, "0x246n << 129n === 0x48c00000000000000000000000000000000n");
+assert.sameValue(0x246n << -128n, 0n, "0x246n << -128n === 0n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n << 64n, 0x123456789abcdef0fedcba98765432123456780000000000000000n,
+  "0x123456789abcdef0fedcba9876543212345678n << 64n === 0x123456789abcdef0fedcba98765432123456780000000000000000n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n << 32n, 0x123456789abcdef0fedcba987654321234567800000000n,
+  "0x123456789abcdef0fedcba9876543212345678n << 32n === 0x123456789abcdef0fedcba987654321234567800000000n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n << 16n, 0x123456789abcdef0fedcba98765432123456780000n,
+  "0x123456789abcdef0fedcba9876543212345678n << 16n === 0x123456789abcdef0fedcba98765432123456780000n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n << 0n, 0x123456789abcdef0fedcba9876543212345678n,
+  "0x123456789abcdef0fedcba9876543212345678n << 0n === 0x123456789abcdef0fedcba9876543212345678n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n << -16n, 0x123456789abcdef0fedcba987654321234n,
+  "0x123456789abcdef0fedcba9876543212345678n << -16n === 0x123456789abcdef0fedcba987654321234n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n << -32n, 0x123456789abcdef0fedcba98765432n,
+  "0x123456789abcdef0fedcba9876543212345678n << -32n === 0x123456789abcdef0fedcba98765432n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n << -64n, 0x123456789abcdef0fedcban,
+  "0x123456789abcdef0fedcba9876543212345678n << -64n === 0x123456789abcdef0fedcban");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n << -127n, 0x2468acn,
+  "0x123456789abcdef0fedcba9876543212345678n << -127n === 0x2468acn");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n << -128n, 0x123456n,
+  "0x123456789abcdef0fedcba9876543212345678n << -128n === 0x123456n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n << -129n, 0x91a2bn,
+  "0x123456789abcdef0fedcba9876543212345678n << -129n === 0x91a2bn");
+assert.sameValue(-5n << 1n, -0xan, "-5n << 1n === -0xan");
+assert.sameValue(-5n << 2n, -0x14n, "-5n << 2n === -0x14n");
+assert.sameValue(-5n << 3n, -0x28n, "-5n << 3n === -0x28n");
+assert.sameValue(-5n << -1n, -3n, "-5n << -1n === -3n");
+assert.sameValue(-5n << -2n, -2n, "-5n << -2n === -2n");
+assert.sameValue(-5n << -3n, -1n, "-5n << -3n === -1n");
+assert.sameValue(-1n << 128n, -0x100000000000000000000000000000000n, "-1n << 128n === -0x100000000000000000000000000000000n");
+assert.sameValue(-1n << 0n, -1n, "-1n << 0n === -1n");
+assert.sameValue(-1n << -128n, -1n, "-1n << -128n === -1n");
+assert.sameValue(-0x246n << 0n, -0x246n, "-0x246n << 0n === -0x246n");
+assert.sameValue(-0x246n << 127n, -0x12300000000000000000000000000000000n, "-0x246n << 127n === -0x12300000000000000000000000000000000n");
+assert.sameValue(-0x246n << 128n, -0x24600000000000000000000000000000000n, "-0x246n << 128n === -0x24600000000000000000000000000000000n");
+assert.sameValue(-0x246n << 129n, -0x48c00000000000000000000000000000000n, "-0x246n << 129n === -0x48c00000000000000000000000000000000n");
+assert.sameValue(-0x246n << -128n, -1n, "-0x246n << -128n === -1n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n << 64n, -0x123456789abcdef0fedcba98765432123456780000000000000000n,
+  "-0x123456789abcdef0fedcba9876543212345678n << 64n === -0x123456789abcdef0fedcba98765432123456780000000000000000n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n << 32n, -0x123456789abcdef0fedcba987654321234567800000000n,
+  "-0x123456789abcdef0fedcba9876543212345678n << 32n === -0x123456789abcdef0fedcba987654321234567800000000n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n << 16n, -0x123456789abcdef0fedcba98765432123456780000n,
+  "-0x123456789abcdef0fedcba9876543212345678n << 16n === -0x123456789abcdef0fedcba98765432123456780000n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n << 0n, -0x123456789abcdef0fedcba9876543212345678n,
+  "-0x123456789abcdef0fedcba9876543212345678n << 0n === -0x123456789abcdef0fedcba9876543212345678n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n << -16n, -0x123456789abcdef0fedcba987654321235n,
+  "-0x123456789abcdef0fedcba9876543212345678n << -16n === -0x123456789abcdef0fedcba987654321235n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n << -32n, -0x123456789abcdef0fedcba98765433n,
+  "-0x123456789abcdef0fedcba9876543212345678n << -32n === -0x123456789abcdef0fedcba98765433n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n << -64n, -0x123456789abcdef0fedcbbn,
+  "-0x123456789abcdef0fedcba9876543212345678n << -64n === -0x123456789abcdef0fedcbbn");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n << -127n, -0x2468adn,
+  "-0x123456789abcdef0fedcba9876543212345678n << -127n === -0x2468adn");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n << -128n, -0x123457n,
+  "-0x123456789abcdef0fedcba9876543212345678n << -128n === -0x123457n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n << -129n, -0x91a2cn,
+  "-0x123456789abcdef0fedcba9876543212345678n << -129n === -0x91a2cn");

--- a/implementation-contributed/javascriptcore/stress/big-int-left-shift-range-error.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-left-shift-range-error.js
@@ -1,0 +1,22 @@
+//@ runBigIntEnabled
+
+function assert(a, message) {
+    if (!a)
+        throw new Error(message);
+}
+
+function assertThrowRangeError(a, b, message) {
+    try {
+        let n = a << b;
+        assert(false, message + ": Should throw RangeError, but executed without exception");
+    } catch (e) {
+        assert(e instanceof RangeError, message + ": expected RangeError, got: " + e);
+    }
+}
+
+let a = 1n << 64n;
+assertThrowRangeError(1n, a, "Left shift by " + a);
+
+a = 1n << 30n;
+assertThrowRangeError(1n, a, "Left shift by " + a);
+

--- a/implementation-contributed/javascriptcore/stress/big-int-left-shift-type-error.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-left-shift-type-error.js
@@ -1,0 +1,104 @@
+//@ runBigIntEnabled
+
+function assert(a, message) {
+    if (!a)
+        throw new Error(message);
+}
+
+function assertThrowTypeError(a, b, message) {
+    try {
+        let n = a << b;
+        assert(false, message + ": Should throw TypeError, but executed without exception");
+    } catch (e) {
+        assert(e instanceof TypeError, message + ": expected TypeError, got: " + e);
+    }
+}
+
+assertThrowTypeError(30n, "foo", "BigInt << String");
+assertThrowTypeError("bar", 18757382984821n, "String << BigInt");
+assertThrowTypeError(30n, Symbol("foo"), "BigInt << Symbol");
+assertThrowTypeError(Symbol("bar"), 18757382984821n, "Symbol << BigInt");
+assertThrowTypeError(30n, 3320, "BigInt << Int32");
+assertThrowTypeError(33256, 18757382984821n, "Int32 << BigInt");
+assertThrowTypeError(30n, 0.543, "BigInt << Double");
+assertThrowTypeError(230.19293, 18757382984821n, "Double << BigInt");
+assertThrowTypeError(30n, NaN, "BigInt << NaN");
+assertThrowTypeError(NaN, 18757382984821n, "NaN << BigInt");
+assertThrowTypeError(30n, +Infinity, "BigInt << +Infinity");
+assertThrowTypeError(+Infinity, 18757382984821n, "+Infinity << BigInt");
+assertThrowTypeError(30n, -Infinity, "BigInt << -Infinity");
+assertThrowTypeError(-Infinity, 18757382984821n, "-Infinity << BigInt");
+assertThrowTypeError(30n, null, "BigInt << null");
+assertThrowTypeError(null, 18757382984821n, "null << BigInt");
+assertThrowTypeError(30n, undefined, "BigInt << undefined");
+assertThrowTypeError(undefined, 18757382984821n, "undefined << BigInt");
+assertThrowTypeError(30n, true, "BigInt << true");
+assertThrowTypeError(true, 18757382984821n, "true << BigInt");
+assertThrowTypeError(30n, false, "BigInt << false");
+assertThrowTypeError(false, 18757382984821n, "false << BigInt");
+
+// Error when returning from object
+
+let o = {
+    valueOf: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt << Object.valueOf returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Symbol << BigInt");
+
+o = {
+    valueOf: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt << Object.valueOf returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Int32 << BigInt");
+
+o = {
+    valueOf: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt << Object.valueOf returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Double << BigInt");
+
+o = {
+    toString: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt << Object.toString returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Symbol << BigInt");
+
+o = {
+    toString: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt << Object.toString returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Int32 << BigInt");
+
+o = {
+    toString: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt << Object.toString returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Double << BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt << Object.@@toPrimitive returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Symbol << BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt << Object.@@toPrimitive returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Int32 << BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt << Object.@@toPrimitive returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Double << BigInt");
+

--- a/implementation-contributed/javascriptcore/stress/big-int-left-shift-wrapped-value.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-left-shift-wrapped-value.js
@@ -1,0 +1,36 @@
+//@ runBigIntEnabled
+
+assert = {
+    sameValue: function (input, expected, message) {
+        if (input !== expected)
+            throw new Error(message);
+    }
+};
+
+function testLeftShift(x, y, z, message) {
+    assert.sameValue(x << y, z, message);
+}
+
+testLeftShift(Object(0b10n), 1n, 0b100n, "ToPrimitive: unbox object with internal slot");
+
+let o = {
+    [Symbol.toPrimitive]: function() {
+        return 0b10n;
+    }
+};
+testLeftShift(o, 0b01n, 0b100n, "ToPrimitive: @@toPrimitive");
+
+o = {
+    valueOf: function() {
+        return 0b10n;
+    }
+};
+testLeftShift(o, 0b01n, 0b100n, "ToPrimitive: valueOf");
+
+o = {
+    toString: function() {
+        return 0b10n;
+    }
+}
+testLeftShift(o, 0b01n, 0b100n, "ToPrimitive: toString");
+

--- a/implementation-contributed/javascriptcore/stress/big-int-out-of-memory-tests.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-out-of-memory-tests.js
@@ -5,19 +5,8 @@ function assert(a, message) {
         throw new Error(message);
 }
 
-function lshift(y) {
-    let out = 1n;
-    for (let i = 0; i < y; i++) {
-        out *= 340282366920938463463374607431768211456n;
-    }
-
-    return out;
-}
-
-let a = lshift(8064);
-for (let i = 0; i < 256; i++) {
-    a *= 18446744073709551615n;
-}
+let a = (1n << 1048575n) - 1n;
+a = (a << 1n) | 1n;
 
 try {
     let b = a + 1n;

--- a/implementation-contributed/javascriptcore/stress/big-int-right-shift-general.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-right-shift-general.js
@@ -1,0 +1,104 @@
+//@ runBigIntEnabled
+
+// Copyright (C) 2017 Josh Wolfe. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+function assert(a) {
+    if (!a)
+        throw new Error("Bad assertion");
+}
+
+assert.sameValue = function (input, expected, message) {
+    if (input !== expected)
+        throw new Error(message);
+}
+
+assert.sameValue(0n >> 0n, 0n, "0n >> 0n === 0n");
+assert.sameValue(0b101n >> -1n, 0b1010n, "0b101n >> -1n === 0b1010n");
+assert.sameValue(0b101n >> -2n, 0b10100n, "0b101n >> -2n === 0b10100n");
+assert.sameValue(0b101n >> -3n, 0b101000n, "0b101n >> -3n === 0b101000n");
+assert.sameValue(0b101n >> 1n, 0b10n, "0b101n >> 1n === 0b10n");
+assert.sameValue(0b101n >> 2n, 1n, "0b101n >> 2n === 1n");
+assert.sameValue(0b101n >> 3n, 0n, "0b101n >> 3n === 0n");
+assert.sameValue(0n >> -128n, 0n, "0n >> -128n === 0n");
+assert.sameValue(0n >> 128n, 0n, "0n >> 128n === 0n");
+assert.sameValue(0x246n >> 0n, 0x246n, "0x246n >> 0n === 0x246n");
+assert.sameValue(0x246n >> -127n, 0x12300000000000000000000000000000000n, "0x246n >> -127n === 0x12300000000000000000000000000000000n");
+assert.sameValue(0x246n >> -128n, 0x24600000000000000000000000000000000n, "0x246n >> -128n === 0x24600000000000000000000000000000000n");
+assert.sameValue(0x246n >> -129n, 0x48c00000000000000000000000000000000n, "0x246n >> -129n === 0x48c00000000000000000000000000000000n");
+assert.sameValue(0x246n >> 128n, 0n, "0x246n >> 128n === 0n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n >> -64n, 0x123456789abcdef0fedcba98765432123456780000000000000000n,
+  "0x123456789abcdef0fedcba9876543212345678n >> -64n === 0x123456789abcdef0fedcba98765432123456780000000000000000n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n >> -32n, 0x123456789abcdef0fedcba987654321234567800000000n,
+  "0x123456789abcdef0fedcba9876543212345678n >> -32n === 0x123456789abcdef0fedcba987654321234567800000000n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n >> -16n, 0x123456789abcdef0fedcba98765432123456780000n,
+  "0x123456789abcdef0fedcba9876543212345678n >> -16n === 0x123456789abcdef0fedcba98765432123456780000n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n >> 0n, 0x123456789abcdef0fedcba9876543212345678n,
+  "0x123456789abcdef0fedcba9876543212345678n >> 0n === 0x123456789abcdef0fedcba9876543212345678n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n >> 16n, 0x123456789abcdef0fedcba987654321234n,
+  "0x123456789abcdef0fedcba9876543212345678n >> 16n === 0x123456789abcdef0fedcba987654321234n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n >> 32n, 0x123456789abcdef0fedcba98765432n,
+  "0x123456789abcdef0fedcba9876543212345678n >> 32n === 0x123456789abcdef0fedcba98765432n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n >> 64n, 0x123456789abcdef0fedcban,
+  "0x123456789abcdef0fedcba9876543212345678n >> 64n === 0x123456789abcdef0fedcban");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n >> 127n, 0x2468acn,
+  "0x123456789abcdef0fedcba9876543212345678n >> 127n === 0x2468acn");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n >> 128n, 0x123456n,
+  "0x123456789abcdef0fedcba9876543212345678n >> 128n === 0x123456n");
+assert.sameValue(
+  0x123456789abcdef0fedcba9876543212345678n >> 129n, 0x91a2bn,
+  "0x123456789abcdef0fedcba9876543212345678n >> 129n === 0x91a2bn");
+assert.sameValue(-5n >> -1n, -0xan, "-5n >> -1n === -0xan");
+assert.sameValue(-5n >> -2n, -0x14n, "-5n >> -2n === -0x14n");
+assert.sameValue(-5n >> -3n, -0x28n, "-5n >> -3n === -0x28n");
+assert.sameValue(-5n >> 1n, -3n, "-5n >> 1n === -3n");
+assert.sameValue(-5n >> 2n, -2n, "-5n >> 2n === -2n");
+assert.sameValue(-5n >> 3n, -1n, "-5n >> 3n === -1n");
+assert.sameValue(-1n >> -128n, -0x100000000000000000000000000000000n, "-1n >> -128n === -0x100000000000000000000000000000000n");
+assert.sameValue(-1n >> 0n, -1n, "-1n >> 0n === -1n");
+assert.sameValue(-1n >> 128n, -1n, "-1n >> 128n === -1n");
+assert.sameValue(-0x246n >> 0n, -0x246n, "-0x246n >> 0n === -0x246n");
+assert.sameValue(-0x246n >> -127n, -0x12300000000000000000000000000000000n, "-0x246n >> -127n === -0x12300000000000000000000000000000000n");
+assert.sameValue(-0x246n >> -128n, -0x24600000000000000000000000000000000n, "-0x246n >> -128n === -0x24600000000000000000000000000000000n");
+assert.sameValue(-0x246n >> -129n, -0x48c00000000000000000000000000000000n, "-0x246n >> -129n === -0x48c00000000000000000000000000000000n");
+assert.sameValue(-0x246n >> 128n, -1n, "-0x246n >> 128n === -1n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n >> -64n, -0x123456789abcdef0fedcba98765432123456780000000000000000n,
+  "-0x123456789abcdef0fedcba9876543212345678n >> -64n === -0x123456789abcdef0fedcba98765432123456780000000000000000n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n >> -32n, -0x123456789abcdef0fedcba987654321234567800000000n,
+  "-0x123456789abcdef0fedcba9876543212345678n >> -32n === -0x123456789abcdef0fedcba987654321234567800000000n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n >> -16n, -0x123456789abcdef0fedcba98765432123456780000n,
+  "-0x123456789abcdef0fedcba9876543212345678n >> -16n === -0x123456789abcdef0fedcba98765432123456780000n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n >> 0n, -0x123456789abcdef0fedcba9876543212345678n,
+  "-0x123456789abcdef0fedcba9876543212345678n >> 0n === -0x123456789abcdef0fedcba9876543212345678n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n >> 16n, -0x123456789abcdef0fedcba987654321235n,
+  "-0x123456789abcdef0fedcba9876543212345678n >> 16n === -0x123456789abcdef0fedcba987654321235n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n >> 32n, -0x123456789abcdef0fedcba98765433n,
+  "-0x123456789abcdef0fedcba9876543212345678n >> 32n === -0x123456789abcdef0fedcba98765433n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n >> 64n, -0x123456789abcdef0fedcbbn,
+  "-0x123456789abcdef0fedcba9876543212345678n >> 64n === -0x123456789abcdef0fedcbbn");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n >> 127n, -0x2468adn,
+  "-0x123456789abcdef0fedcba9876543212345678n >> 127n === -0x2468adn");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n >> 128n, -0x123457n,
+  "-0x123456789abcdef0fedcba9876543212345678n >> 128n === -0x123457n");
+assert.sameValue(
+  -0x123456789abcdef0fedcba9876543212345678n >> 129n, -0x91a2cn,
+  "-0x123456789abcdef0fedcba9876543212345678n >> 129n === -0x91a2cn");
+

--- a/implementation-contributed/javascriptcore/stress/big-int-right-shift-type-error.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-right-shift-type-error.js
@@ -1,0 +1,104 @@
+//@ runBigIntEnabled
+
+function assert(a, message) {
+    if (!a)
+        throw new Error(message);
+}
+
+function assertThrowTypeError(a, b, message) {
+    try {
+        let n = a >> b;
+        assert(false, message + ": Should throw TypeError, but executed without exception");
+    } catch (e) {
+        assert(e instanceof TypeError, message + ": expected TypeError, got: " + e);
+    }
+}
+
+assertThrowTypeError(30n, "foo", "BigInt >> String");
+assertThrowTypeError("bar", 18757382984821n, "String >> BigInt");
+assertThrowTypeError(30n, Symbol("foo"), "BigInt >> Symbol");
+assertThrowTypeError(Symbol("bar"), 18757382984821n, "Symbol >> BigInt");
+assertThrowTypeError(30n, 3320, "BigInt >> Int32");
+assertThrowTypeError(33256, 18757382984821n, "Int32 >> BigInt");
+assertThrowTypeError(30n, 0.543, "BigInt >> Double");
+assertThrowTypeError(230.19293, 18757382984821n, "Double >> BigInt");
+assertThrowTypeError(30n, NaN, "BigInt >> NaN");
+assertThrowTypeError(NaN, 18757382984821n, "NaN >> BigInt");
+assertThrowTypeError(30n, +Infinity, "BigInt >> +Infinity");
+assertThrowTypeError(+Infinity, 18757382984821n, "+Infinity >> BigInt");
+assertThrowTypeError(30n, -Infinity, "BigInt >> -Infinity");
+assertThrowTypeError(-Infinity, 18757382984821n, "-Infinity >> BigInt");
+assertThrowTypeError(30n, null, "BigInt >> null");
+assertThrowTypeError(null, 18757382984821n, "null >> BigInt");
+assertThrowTypeError(30n, undefined, "BigInt >> undefined");
+assertThrowTypeError(undefined, 18757382984821n, "undefined >> BigInt");
+assertThrowTypeError(30n, true, "BigInt >> true");
+assertThrowTypeError(true, 18757382984821n, "true >> BigInt");
+assertThrowTypeError(30n, false, "BigInt >> false");
+assertThrowTypeError(false, 18757382984821n, "false >> BigInt");
+
+// Error when returning from object
+
+let o = {
+    valueOf: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt >> Object.valueOf returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Symbol >> BigInt");
+
+o = {
+    valueOf: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt >> Object.valueOf returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Int32 >> BigInt");
+
+o = {
+    valueOf: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt >> Object.valueOf returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.valueOf returning Double >> BigInt");
+
+o = {
+    toString: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt >> Object.toString returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Symbol >> BigInt");
+
+o = {
+    toString: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt >> Object.toString returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Int32 >> BigInt");
+
+o = {
+    toString: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt >> Object.toString returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.toString returning Double >> BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return Symbol("Foo"); }
+};
+
+assertThrowTypeError(30n, o, "BigInt >> Object.@@toPrimitive returning Symbol");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Symbol >> BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return 33256; }
+};
+
+assertThrowTypeError(30n, o, "BigInt >> Object.@@toPrimitive returning Int32");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Int32 >> BigInt");
+
+o = {
+    [Symbol.toPrimitive]: function () { return 0.453; }
+};
+
+assertThrowTypeError(30n, o, "BigInt >> Object.@@toPrimitive returning Double");
+assertThrowTypeError(o, 18757382984821n, "Object.@@toPrimitive returning Double >> BigInt");
+

--- a/implementation-contributed/javascriptcore/stress/big-int-right-shift-wrapped-value.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-right-shift-wrapped-value.js
@@ -1,0 +1,36 @@
+//@ runBigIntEnabled
+
+assert = {
+    sameValue: function (input, expected, message) {
+        if (input !== expected)
+            throw new Error(message);
+    }
+};
+
+function testRightShift(x, y, z, message) {
+    assert.sameValue(x >> y, z, message);
+}
+
+testRightShift(Object(0b10n), 1n, 0b1n, "ToPrimitive: unbox object with internal slot");
+
+let o = {
+    [Symbol.toPrimitive]: function() {
+        return 0b10n;
+    }
+};
+testRightShift(o, 0b01n, 0b1n, "ToPrimitive: @@toPrimitive");
+
+o = {
+    valueOf: function() {
+        return 0b10n;
+    }
+};
+testRightShift(o, 0b01n, 0b1n, "ToPrimitive: valueOf");
+
+o = {
+    toString: function() {
+        return 0b10n;
+    }
+}
+testRightShift(o, 0b01n, 0b1n, "ToPrimitive: toString");
+

--- a/implementation-contributed/javascriptcore/stress/left-shift-to-primitive-precedence.js
+++ b/implementation-contributed/javascriptcore/stress/left-shift-to-primitive-precedence.js
@@ -1,0 +1,29 @@
+//@ runBigIntEnabled
+
+assert = {
+    sameValue: function (input, expected, message) {
+        if (input !== expected)
+            throw new Error(message);
+    }
+};
+
+let o = {
+    [Symbol.toPrimitive]: function() {
+        throw new Error("Bad");
+    }
+};
+
+try{
+    o << Symbol("2");
+    assert.sameValue(true, false, "Exception expected to be throwed, but executed without error");
+} catch (e) {
+    assert.sameValue(e.message, "Bad", "Expected to throw Error('Bad'), but got: " + e);
+}
+
+try{
+    Symbol("2") << o;
+    assert.sameValue(true, false, "Exception expected to be throwed, but executed without error");
+} catch (e) {
+    assert.sameValue(e instanceof TypeError, true, "Expected to throw TypeError, but got: " + e)
+}
+

--- a/implementation-contributed/javascriptcore/stress/right-shift-to-primitive-precedence.js
+++ b/implementation-contributed/javascriptcore/stress/right-shift-to-primitive-precedence.js
@@ -1,0 +1,29 @@
+//@ runBigIntEnabled
+
+assert = {
+    sameValue: function (input, expected, message) {
+        if (input !== expected)
+            throw new Error(message);
+    }
+};
+
+let o = {
+    [Symbol.toPrimitive]: function() {
+        throw new Error("Bad");
+    }
+};
+
+try{
+    o >> Symbol("2");
+    assert.sameValue(true, false, "Exception expected to be throwed, but executed without error");
+} catch (e) {
+    assert.sameValue(e.message, "Bad", "Expected to throw Error('Bad'), but got: " + e);
+}
+
+try{
+    Symbol("2") >> o;
+    assert.sameValue(true, false, "Exception expected to be throwed, but executed without error");
+} catch (e) {
+    assert.sameValue(e instanceof TypeError, true, "Expected to throw TypeError, but got: " + e)
+}
+

--- a/implementation-contributed/javascriptcore/stress/simple-module.mjs
+++ b/implementation-contributed/javascriptcore/stress/simple-module.mjs
@@ -1,0 +1,2 @@
+if (this !== undefined)
+    throw new Error("this === undefined in module code");

--- a/implementation-contributed/javascriptcore/stress/simple-script.js
+++ b/implementation-contributed/javascriptcore/stress/simple-script.js
@@ -1,0 +1,2 @@
+if (this === undefined)
+    throw new Error("this !== undefined in script code");


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[60ed1be8cd](https://github.com///github/blob/60ed1be8cd) in JavaScriptCore and all changes made since [31e654a339](../blob/31e654a339) in
test262.



### 1 File Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/big-int-out-of-memory-tests.js](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/big-int-out-of-memory-tests.js)









### 11 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/big-int-left-shift-general.js](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/big-int-left-shift-general.js)
 - [implementation-contributed/javascriptcore/stress/big-int-left-shift-range-error.js](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/big-int-left-shift-range-error.js)
 - [implementation-contributed/javascriptcore/stress/big-int-left-shift-type-error.js](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/big-int-left-shift-type-error.js)
 - [implementation-contributed/javascriptcore/stress/big-int-left-shift-wrapped-value.js](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/big-int-left-shift-wrapped-value.js)
 - [implementation-contributed/javascriptcore/stress/big-int-right-shift-general.js](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/big-int-right-shift-general.js)
 - [implementation-contributed/javascriptcore/stress/big-int-right-shift-type-error.js](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/big-int-right-shift-type-error.js)
 - [implementation-contributed/javascriptcore/stress/big-int-right-shift-wrapped-value.js](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/big-int-right-shift-wrapped-value.js)
 - [implementation-contributed/javascriptcore/stress/left-shift-to-primitive-precedence.js](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/left-shift-to-primitive-precedence.js)
 - [implementation-contributed/javascriptcore/stress/right-shift-to-primitive-precedence.js](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/right-shift-to-primitive-precedence.js)
 - [implementation-contributed/javascriptcore/stress/simple-module.mjs](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/simple-module.mjs)
 - [implementation-contributed/javascriptcore/stress/simple-script.js](../blob/javascriptcore-test262-automation-export-31e654a339/implementation-contributed/javascriptcore/stress/simple-script.js)