### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "4a395137",
-  "targetRevisionAtLastExport": "07b313100e",
+  "sourceRevisionAtLastExport": "9583858e",
+  "targetRevisionAtLastExport": "d420adb9f2",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/intl/collator/constructor-order.js
+++ b/implementation-contributed/v8/intl/collator/constructor-order.js
@@ -1,0 +1,30 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Throws only once during construction.
+// Check for all getters to prevent regression.
+// Preserve the order of getter initialization.
+let getCount = 0;
+
+new Intl.Collator(['en-US'], {
+  get usage() {
+    assertEquals(0, getCount++);
+  },
+  get localeMatcher() {
+    assertEquals(1, getCount++);
+  },
+  get numeric() {
+    assertEquals(2, getCount++);
+  },
+  get caseFirst() {
+    assertEquals(3, getCount++);
+  },
+  get sensitivity() {
+    assertEquals(4, getCount++);
+  },
+  get ignorePunctuation() {
+    assertEquals(5, getCount++);
+  },
+});
+assertEquals(6, getCount);

--- a/implementation-contributed/v8/intl/list-format/constructor-order.js
+++ b/implementation-contributed/v8/intl/list-format/constructor-order.js
@@ -1,0 +1,21 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Throws only once during construction.
+// Check for all getters to prevent regression.
+// Preserve the order of getter initialization.
+let getCount = 0;
+
+new Intl.ListFormat(['en-US'], {
+  get type() {
+    assertEquals(0, getCount++);
+  },
+  get style() {
+    assertEquals(1, getCount++);
+  },
+  get localeMatcher() {
+    assertEquals(2, getCount++);
+  },
+});
+assertEquals(3, getCount);

--- a/implementation-contributed/v8/intl/list-format/constructor.js
+++ b/implementation-contributed/v8/intl/list-format/constructor.js
@@ -88,22 +88,3 @@ assertDoesNotThrow(
 
 assertDoesNotThrow(
     () => new Intl.ListFormat(['sr'], {type: 'unit', style: 'narrow'}));
-
-// Throws only once during construction.
-// Check for all getters to prevent regression.
-// Preserve the order of getter initialization.
-let getCount = 0;
-let style = -1;
-let type = -1;
-
-new Intl.ListFormat(['en-US'], {
-  get style() {
-    style = ++getCount;
-  },
-  get type() {
-    type = ++getCount;
-  }
-});
-
-assertEquals(1, type);
-assertEquals(2, style);

--- a/implementation-contributed/v8/intl/number-format/constructor-order.js
+++ b/implementation-contributed/v8/intl/number-format/constructor-order.js
@@ -1,0 +1,42 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Throws only once during construction.
+// Check for all getters to prevent regression.
+// Preserve the order of getter initialization.
+let getCount = 0;
+
+new Intl.NumberFormat(['en-US'], {
+  get localeMatcher() {
+    assertEquals(0, getCount++);
+  },
+  get style() {
+    assertEquals(1, getCount++);
+  },
+  get currency() {
+    assertEquals(2, getCount++);
+  },
+  get currencyDisplay() {
+    assertEquals(3, getCount++);
+  },
+  get minimumIntegerDigits() {
+    assertEquals(4, getCount++);
+  },
+  get minimumFractionDigits() {
+    assertEquals(5, getCount++);
+  },
+  get maximumFractionDigits() {
+    assertEquals(6, getCount++);
+  },
+  get minimumSignificantDigits() {
+    assertEquals(7, getCount++);
+  },
+  get maximumSignificantDigits() {
+    assertEquals(8, getCount++);
+  },
+  get useGrouping() {
+    assertEquals(9, getCount++);
+  },
+});
+assertEquals(10, getCount);

--- a/implementation-contributed/v8/intl/plural-rules/constructor-order.js
+++ b/implementation-contributed/v8/intl/plural-rules/constructor-order.js
@@ -1,0 +1,33 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Throws only once during construction.
+// Check for all getters to prevent regression.
+// Preserve the order of getter initialization.
+let getCount = 0;
+
+new Intl.PluralRules(['en-US'], {
+  get localeMatcher() {
+    assertEquals(0, getCount++);
+  },
+  get type() {
+    assertEquals(1, getCount++);
+  },
+  get minimumIntegerDigits() {
+    assertEquals(2, getCount++);
+  },
+  get minimumFractionDigits() {
+    assertEquals(3, getCount++);
+  },
+  get maximumFractionDigits() {
+    assertEquals(4, getCount++);
+  },
+  get minimumSignificantDigits() {
+    assertEquals(5, getCount++);
+  },
+  get maximumSignificantDigits() {
+    assertEquals(6, getCount++);
+  },
+});
+assertEquals(7, getCount);

--- a/implementation-contributed/v8/intl/relative-time-format/constructor-order.js
+++ b/implementation-contributed/v8/intl/relative-time-format/constructor-order.js
@@ -1,0 +1,21 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Throws only once during construction.
+// Check for all getters to prevent regression.
+// Preserve the order of getter initialization.
+let getCount = 0;
+
+new Intl.RelativeTimeFormat(['en-US'], {
+  get localeMatcher() {
+    assertEquals(0, getCount++);
+  },
+  get style() {
+    assertEquals(1, getCount++);
+  },
+  get numeric() {
+    assertEquals(2, getCount++);
+  },
+});
+assertEquals(3, getCount);

--- a/implementation-contributed/v8/intl/relative-time-format/constructor.js
+++ b/implementation-contributed/v8/intl/relative-time-format/constructor.js
@@ -77,27 +77,3 @@ assertDoesNotThrow(
 assertThrows(
     () => new Intl.RelativeTimeFormat('sr', {numeric: 'never'}),
     RangeError);
-
-// Throws only once during construction.
-// Check for all getters to prevent regression.
-// Preserve the order of getter initialization.
-let getCount = 0;
-let localeMatcher = -1;
-let style = -1;
-let numeric = -1;
-
-new Intl.RelativeTimeFormat('en-US', {
-  get localeMatcher() {
-    localeMatcher = ++getCount;
-  },
-  get style() {
-    style = ++getCount;
-  },
-  get numeric() {
-    numeric = ++getCount;
-  }
-});
-
-assertEquals(1, localeMatcher);
-assertEquals(2, style);
-assertEquals(3, numeric);

--- a/implementation-contributed/v8/intl/segmenter/constructor-order.js
+++ b/implementation-contributed/v8/intl/segmenter/constructor-order.js
@@ -1,0 +1,23 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-intl-segmenter
+
+// Throws only once during construction.
+// Check for all getters to prevent regression.
+// Preserve the order of getter initialization.
+let getCount = 0;
+
+new Intl.Segmenter(['en-US'], {
+  get localeMatcher() {
+    assertEquals(0, getCount++);
+  },
+  get lineBreakStyle() {
+    assertEquals(1, getCount++);
+  },
+  get granularity() {
+    assertEquals(2, getCount++);
+  },
+});
+assertEquals(3, getCount);

--- a/implementation-contributed/v8/mjsunit/harmony/bigint/regressions.js
+++ b/implementation-contributed/v8/mjsunit/harmony/bigint/regressions.js
@@ -19,8 +19,8 @@ assertTrue(0n === 0n);
 
 // crbug.com/818277: Must throw without DCHECK failures.
 // In order to run acceptably fast in Debug mode, this test assumes that
-// we allow at least 2 billion bits in a BigInt.
-var close_to_limit = 2n ** 2000000000n;
+// we allow at least 1 billion bits in a BigInt.
+var close_to_limit = 2n ** 1000000000n;
 assertThrows(() => close_to_limit ** 100n, RangeError);
 
 // Check boundary conditions of the power-of-two fast path.

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-909614.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-909614.js
@@ -1,0 +1,9 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+let just_under = 2n ** 30n - 1n;
+let just_above = 2n ** 30n;
+
+assertDoesNotThrow(() => { var dummy = 2n ** just_under; });
+assertThrows(() => { var dummy = 2n ** just_above; });

--- a/implementation-contributed/v8/wasm-js/wasm-js.status
+++ b/implementation-contributed/v8/wasm-js/wasm-js.status
@@ -14,5 +14,11 @@
   'module/customSections': [FAIL],
   'global/constructor': [FAIL],
   'global/value-get-set': [FAIL],
-}] # ALWAYS
+}], # ALWAYS
+
+['arch == s390 or arch == s390x or system == aix', {
+  # https://bugs.chromium.org/p/v8/issues/detail?id=8402
+  'instance/constructor': [SKIP],
+}],  # 'arch == s390 or arch == s390x or system == aix'
+
 ]


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[4a395137](https://github.com///github/blob/4a395137) in V8 and all changes made since [07b313100e](../blob/07b313100e) in
test262.



### 5 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/intl/list-format/constructor.js](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/intl/list-format/constructor.js)
 - [implementation-contributed/v8/intl/relative-time-format/constructor.js](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/intl/relative-time-format/constructor.js)
 - [implementation-contributed/v8/intl/segmenter/constructor.js](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/intl/segmenter/constructor.js)
 - [implementation-contributed/v8/mjsunit/harmony/bigint/regressions.js](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/mjsunit/harmony/bigint/regressions.js)
 - [implementation-contributed/v8/wasm-js/wasm-js.status](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/wasm-js/wasm-js.status)









### 7 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/intl/collator/constructor-order.js](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/intl/collator/constructor-order.js)
 - [implementation-contributed/v8/intl/list-format/constructor-order.js](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/intl/list-format/constructor-order.js)
 - [implementation-contributed/v8/intl/number-format/constructor-order.js](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/intl/number-format/constructor-order.js)
 - [implementation-contributed/v8/intl/plural-rules/constructor-order.js](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/intl/plural-rules/constructor-order.js)
 - [implementation-contributed/v8/intl/relative-time-format/constructor-order.js](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/intl/relative-time-format/constructor-order.js)
 - [implementation-contributed/v8/intl/segmenter/constructor-order.js](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/intl/segmenter/constructor-order.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-909614.js](../blob/v8-test262-automation-export-07b313100e/implementation-contributed/v8/mjsunit/regress/regress-crbug-909614.js)