### PR TITLE
Fix various bugs in test cases

### DIFF
--- a/src/class-elements/prod-private-async-method.case
+++ b/src/class-elements/prod-private-async-method.case
@@ -17,7 +17,7 @@ async #m() { return 42; }
 //- constructor
 assert.sameValue(this.#m.name, '#m', 'function name inside constructor');
 ctorPromise = this.#m().then(value => {
-    assert.sameValue(this.#m(), 42, 'already defined in the ctor');
+    assert.sameValue(value, 42, 'already defined in the ctor');
 }, $DONE);
 
 //- assertions

--- a/test/built-ins/Array/prototype/flatMap/non-callable-argument-throws.js
+++ b/test/built-ins/Array/prototype/flatMap/non-callable-argument-throws.js
@@ -7,7 +7,7 @@ description: >
 features: [Array.prototype.flatMap]
 ---*/
 
-assert(Array.prototype.flatMap);
+assert.sameValue(typeof Array.prototype.flatMap, "function");
 
 assert.throws(TypeError, function() {
   [].flatMap({});

--- a/test/built-ins/Reflect/ownKeys/return-on-corresponding-order-large-index.js
+++ b/test/built-ins/Reflect/ownKeys/return-on-corresponding-order-large-index.js
@@ -15,10 +15,10 @@ info: |
   9.1.12 [[OwnPropertyKeys]] ( )
 
   1. Let keys be a new empty List.
-  2. For each own property key P of O that is an integer index, in ascending
+  2. For each own property key P of O that is an array index, in ascending
   numeric index order
     a. Add P as the last element of keys.
-  3. For each own property key P of O that is a String but is not an integer
+  3. For each own property key P of O that is a String but is not an array
   index, in property creation order
     a. Add P as the last element of keys.
   4. For each own property key P of O that is a Symbol, in property creation
@@ -36,18 +36,22 @@ var o1 = {
   [Number.MAX_SAFE_INTEGER]: true,
   [Symbol.for('z')]: true,
   12345678901: true,
+  4294967294: true,
+  4294967295: true,
 };
 
 var result = Reflect.ownKeys(o1);
 
-assert.sameValue(result.length, 7);
+assert.sameValue(result.length, 9);
 assert.sameValue(result[0], '1');
-assert.sameValue(result[1], '12345678900');
-assert.sameValue(result[2], '12345678901');
-assert.sameValue(result[3], String(Number.MAX_SAFE_INTEGER));
-assert.sameValue(result[4], 'b');
-assert.sameValue(result[5], 'a');
-assert.sameValue(result[6], Symbol.for('z'));
+assert.sameValue(result[1], '4294967294');
+assert.sameValue(result[2], '12345678900');
+assert.sameValue(result[3], 'b');
+assert.sameValue(result[4], 'a');
+assert.sameValue(result[5], String(Number.MAX_SAFE_INTEGER));
+assert.sameValue(result[6], '12345678901');
+assert.sameValue(result[7], '4294967295');
+assert.sameValue(result[8], Symbol.for('z'));
 
 var o2 = {};
 
@@ -58,15 +62,19 @@ o2.a = true;
 o2[Number.MAX_SAFE_INTEGER] = true;
 o2[Symbol.for('z')] = true;
 o2[12345678901] = true;
+o2[4294967294] = true;
+o2[4294967295] = true;
 
 
 result = Reflect.ownKeys(o2);
 
-assert.sameValue(result.length, 7);
+assert.sameValue(result.length, 9);
 assert.sameValue(result[0], '1');
-assert.sameValue(result[1], '12345678900');
-assert.sameValue(result[2], '12345678901');
-assert.sameValue(result[3], String(Number.MAX_SAFE_INTEGER));
-assert.sameValue(result[4], 'b');
-assert.sameValue(result[5], 'a');
-assert.sameValue(result[6], Symbol.for('z'));
+assert.sameValue(result[1], '4294967294');
+assert.sameValue(result[2], '12345678900');
+assert.sameValue(result[3], 'b');
+assert.sameValue(result[4], 'a');
+assert.sameValue(result[5], String(Number.MAX_SAFE_INTEGER));
+assert.sameValue(result[6], '12345678901');
+assert.sameValue(result[7], '4294967295');
+assert.sameValue(result[8], Symbol.for('z'));

--- a/test/intl402/NumberFormat/currencyDisplay-unit.js
+++ b/test/intl402/NumberFormat/currencyDisplay-unit.js
@@ -7,7 +7,7 @@ description: Checks handling of valid values for the numeric option to the Relat
 info: |
     SetNumberFormatUnitOptions ( intlObj, options )
 
-    6. Let currencyDisplay be ? GetOption(options, "currencyDisplay", "string", « "code", "symbol", "narrowSymbol", "name" », "symbol").
+    6. Let currencyDisplay be ? GetOption(options, "currencyDisplay", "string", « "code", "symbol", "narrow-symbol", "name" », "symbol").
     11. If style is "currency", then
         f. Set intlObj.[[CurrencyDisplay]] to currencyDisplay.
 
@@ -16,8 +16,8 @@ features: [Intl.NumberFormat-unified]
 
 const validOptions = [
   [undefined, "symbol"],
-  ["narrowSymbol", "narrowSymbol"],
-  [{ toString() { return "narrowSymbol"; } }, "narrowSymbol"],
+  ["narrow-symbol", "narrow-symbol"],
+  [{ toString() { return "narrow-symbol"; } }, "narrow-symbol"],
 ];
 
 for (const [validOption, expected] of validOptions) {

--- a/test/intl402/NumberFormat/style-unit.js
+++ b/test/intl402/NumberFormat/style-unit.js
@@ -20,7 +20,7 @@ const validOptions = [
 ];
 
 for (const [validOption, expected] of validOptions) {
-  const nf = new Intl.NumberFormat([], {"style": validOption});
+  const nf = new Intl.NumberFormat([], {"style": validOption, "unit": "generic"});
   const resolvedOptions = nf.resolvedOptions();
   assert.sameValue(resolvedOptions.style, expected);
 }

--- a/test/intl402/Segmenter/iterator/following.js
+++ b/test/intl402/Segmenter/iterator/following.js
@@ -25,7 +25,7 @@ const tests = [
 ];
 
 for (const [input, position] of tests) {
-  assert.sameValue(iter.following(0 | input), false);
+  assert.sameValue(iter.following(input), false);
   assert.sameValue(iter.position, position, String(input));
 }
 

--- a/test/intl402/Segmenter/iterator/granularity.js
+++ b/test/intl402/Segmenter/iterator/granularity.js
@@ -14,9 +14,5 @@ for (const granularity of ["grapheme", "word", "sentence", "line"]) {
 
   assert.sameValue(typeof iter.position, "number");
   assert.sameValue(iter.position, 0);
-  if (granularity === "grapheme") {
-    assert.sameValue(iter.breakType, undefined);
-  } else {
-    assert.sameValue(typeof iter.breakType, "string");
-  }
+  assert.sameValue(iter.breakType, undefined);
 }

--- a/test/intl402/Segmenter/iterator/preceding.js
+++ b/test/intl402/Segmenter/iterator/preceding.js
@@ -23,13 +23,12 @@ const tests = [
 ];
 
 for (const [input, position] of tests) {
-  assert.sameValue(iter.preceding(0 | input), false);
+  assert.sameValue(iter.preceding(input), false);
   assert.sameValue(iter.position, position, String(input));
 }
 
 assert.throws(RangeError, () => iter.preceding("ABC"));
 assert.throws(RangeError, () => iter.preceding(null));
-assert.throws(RangeError, () => iter.preceding(1.4));
 assert.throws(RangeError, () => iter.preceding(-3));
 
 // 1.5.3.3 %SegmentIteratorPrototype%.preceding( [ from ] )

--- a/test/intl402/Segmenter/prototype/segment/segment-line.js
+++ b/test/intl402/Segmenter/prototype/segment/segment-line.js
@@ -29,6 +29,6 @@ for (const text of [
     "법원 “다스 지분 처분권·수익권 모두 MB가 보유”", // Korean
     ]) {
   const iter = seg.segment(text);
-  assert(["soft", "hard"].includes(iter.breakType), iter.breakType);
+  assert.sameValue(undefined, iter.breakType);
   assert.sameValue(0, iter.position);
 }

--- a/test/intl402/Segmenter/prototype/segment/segment-sentence.js
+++ b/test/intl402/Segmenter/prototype/segment/segment-sentence.js
@@ -29,6 +29,6 @@ for (const text of [
     "법원 “다스 지분 처분권·수익권 모두 MB가 보유”", // Korean
     ]) {
   const iter = seg.segment(text);
-  assert(["sep", "term"].includes(iter.breakType), iter.breakType);
+  assert.sameValue(undefined, iter.breakType);
   assert.sameValue(0, iter.position);
 }

--- a/test/intl402/Segmenter/prototype/segment/segment-word.js
+++ b/test/intl402/Segmenter/prototype/segment/segment-word.js
@@ -29,6 +29,6 @@ for (const text of [
     "법원 “다스 지분 처분권·수익권 모두 MB가 보유”", // Korean
     ]) {
   const iter = seg.segment(text);
-  assert(["word", "none"].includes(iter.breakType), iter.breakType);
+  assert.sameValue(undefined, iter.breakType);
   assert.sameValue(0, iter.position);
 }

--- a/test/language/expressions/class/private-methods/prod-private-async-method.js
+++ b/test/language/expressions/class/private-methods/prod-private-async-method.js
@@ -99,7 +99,7 @@ var C = class {
 
     assert.sameValue(this.#m.name, '#m', 'function name inside constructor');
     ctorPromise = this.#m().then(value => {
-        assert.sameValue(this.#m(), 42, 'already defined in the ctor');
+        assert.sameValue(value, 42, 'already defined in the ctor');
     }, $DONE);
 
   }

--- a/test/language/statements/class/private-methods/prod-private-async-method.js
+++ b/test/language/statements/class/private-methods/prod-private-async-method.js
@@ -98,7 +98,7 @@ class C {
 
     assert.sameValue(this.#m.name, '#m', 'function name inside constructor');
     ctorPromise = this.#m().then(value => {
-        assert.sameValue(this.#m(), 42, 'already defined in the ctor');
+        assert.sameValue(value, 42, 'already defined in the ctor');
     }, $DONE);
 
   }


### PR DESCRIPTION
- src/class-elements/prod-private-async-method.case
- test/language/expressions/class/private-methods/prod-private-async-method.js
- test/language/statements/class/private-methods/prod-private-async-method.js
  - Use the `value` argument instead of calling `#m()` again, because the latter returns a new Promise object.

- test/built-ins/Array/prototype/flatMap/non-callable-argument-throws.js
  - `assert(...)` requires a boolean argument, switch to `assert.sameValue(...)`

- test/built-ins/Reflect/ownKeys/return-on-corresponding-order-large-index.js
  - Update test case per https://github.com/tc39/ecma262/pull/1242
  - Also add `4294967294` (maximum array index) and `4294967295` (not an array index) while there.

- test/intl402/NumberFormat/currencyDisplay-unit.js
  - The option value is "narrow-symbol" instead of "narrowSymbol".

- test/intl402/NumberFormat/style-unit.js
  - "unit" style without a unit value leads to a TypeError, use the "generic" unit here.

- test/intl402/Segmenter/iterator/following.js
- test/intl402/Segmenter/iterator/preceding.js
  - Remove `| 0` to ensure we actually test the `ToIndex` operation in the `following` resp. `preceding` methods.
  - ToIndex(1.4) is 1, so don't expect a TypeError for `iter.preceding(1.4)`

- test/intl402/Segmenter/iterator/granularity.js
- test/intl402/Segmenter/prototype/segment/segment-line.js
- test/intl402/Segmenter/prototype/segment/segment-sentence.js
- test/intl402/Segmenter/prototype/segment/segment-word.js
  - The initial value for `breakType` is always `undefined`.


