### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "205489c4f0",
-  "targetRevisionAtLastExport": "cab19d71a6",
+  "sourceRevisionAtLastExport": "2b233fa3c0",
+  "targetRevisionAtLastExport": "8e3c6d0484",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/big-int-branch-usage.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-branch-usage.js
@@ -1,0 +1,23 @@
+//@ runBigIntEnabled
+
+function assert(a, e) {
+    if (a !== e) {
+        throw new Error("Bad!");
+    }
+}
+
+function branchTest(a) {
+    if (a)
+        return a;
+    else
+        return false;
+}
+noInline(branchTest);
+
+for (let i = 0; i < 100000; i++) {
+    assert(branchTest(10n), 10n);
+    assert(branchTest(1n), 1n);
+    assert(branchTest(0n), false);
+    assert(branchTest(-1n), -1n);
+}
+

--- a/implementation-contributed/javascriptcore/stress/big-int-logical-and.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-logical-and.js
@@ -1,0 +1,20 @@
+//@ runBigIntEnabled
+
+function assert(a, e) {
+    if (a !== e) {
+        throw new Error("Bad!");
+    }
+}
+
+function logicalAnd(a, b) {
+    return a && b;
+}
+noInline(logicalAnd);
+
+for (let i = 0; i < 100000; i++) {
+    assert(logicalAnd(1n, 10n), 10n);
+    assert(logicalAnd(1n, 1n), 1n);
+    assert(logicalAnd(1n, 0n), 0n);
+    assert(logicalAnd(1n, -1n), -1n);
+}
+

--- a/implementation-contributed/javascriptcore/stress/big-int-logical-not.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-logical-not.js
@@ -1,0 +1,20 @@
+//@ runBigIntEnabled
+
+function assert(a, e) {
+    if (a !== e) {
+        throw new Error("Bad!");
+    }
+}
+
+function logicalNot(a) {
+    return !a;
+}
+noInline(logicalNot);
+
+for (let i = 0; i < 100000; i++) {
+    assert(logicalNot(10n), false);
+    assert(logicalNot(1n), false);
+    assert(logicalNot(0n), true);
+    assert(logicalNot(-1n), false);
+}
+

--- a/implementation-contributed/javascriptcore/stress/big-int-logical-or.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-logical-or.js
@@ -1,0 +1,20 @@
+//@ runBigIntEnabled
+
+function assert(a, e) {
+    if (a !== e) {
+        throw new Error("Bad!");
+    }
+}
+
+function logicalOr(a, b) {
+    return a || b;
+}
+noInline(logicalOr);
+
+for (let i = 0; i < 100000; i++) {
+    assert(logicalOr(10n, "abc"), 10n);
+    assert(logicalOr(1n, "abc"), 1n);
+    assert(logicalOr(0n, "abc"), "abc");
+    assert(logicalOr(-1n, "abc"), -1n);
+}
+

--- a/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow-no-max.js
+++ b/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow-no-max.js
@@ -1,34 +1,45 @@
 //@ skip if $memoryLimited
-let bigArray = new Array(0x7000000);
-bigArray[0] = 1.1;
-bigArray[1] = 1.2;
 
-function foo(array) {
-    var index = array.length;
-    if (index >= bigArray.length || (index - 0x1ffdc01) < 0)
+function test() {
+
+    // We don't support WebAssembly everywhere, so check for its existance before doing anything else.
+    if (!this.WebAssembly)
         return;
-    return bigArray[index - 0x1ffdc01];
+
+    let bigArray = new Array(0x7000000);
+    bigArray[0] = 1.1;
+    bigArray[1] = 1.2;
+
+    function foo(array) {
+        var index = array.length;
+        if (index >= bigArray.length || (index - 0x1ffdc01) < 0)
+            return;
+        return bigArray[index - 0x1ffdc01];
+    }
+
+    noInline(foo);
+
+    var okArray = new Uint8Array(0x1ffdc02);
+
+    for (var i = 0; i < 10000; ++i)
+        foo(okArray);
+
+    var ok = false;
+    try {
+        var memory = new WebAssembly.Memory({ initial: 0x1000 });
+        memory.grow(0x7000);
+        var result = foo(new Uint8Array(memory.buffer));
+        if (result !== void 0)
+            throw "Error: bad result at end: " + result;
+        ok = true;
+    } catch (e) {
+        if (e.toString() != "Error: Out of memory")
+            throw e;
+    }
+
+    if (ok)
+        throw "Error: did not throw error";
+
 }
 
-noInline(foo);
-
-var okArray = new Uint8Array(0x1ffdc02);
-
-for (var i = 0; i < 10000; ++i)
-    foo(okArray);
-
-var ok = false;
-try {
-    var memory = new WebAssembly.Memory({ initial: 0x1000 });
-    memory.grow(0x7000);
-    var result = foo(new Uint8Array(memory.buffer));
-    if (result !== void 0)
-        throw "Error: bad result at end: " + result;
-    ok = true;
-} catch (e) {
-    if (e.toString() != "Error: Out of memory")
-        throw e;
-}
-
-if (ok)
-    throw "Error: did not throw error";
+test();

--- a/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow.js
+++ b/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow.js
@@ -1,34 +1,45 @@
 //@ skip if $memoryLimited
-let bigArray = new Array(0x7000000);
-bigArray[0] = 1.1;
-bigArray[1] = 1.2;
 
-function foo(array) {
-    var index = array.length;
-    if (index >= bigArray.length || (index - 0x1ffdc01) < 0)
+function test() {
+
+    // We don't support WebAssembly everywhere, so check for its existance before doing anything else.
+    if (!this.WebAssembly)
         return;
-    return bigArray[index - 0x1ffdc01];
+
+    let bigArray = new Array(0x7000000);
+    bigArray[0] = 1.1;
+    bigArray[1] = 1.2;
+
+    function foo(array) {
+        var index = array.length;
+        if (index >= bigArray.length || (index - 0x1ffdc01) < 0)
+            return;
+        return bigArray[index - 0x1ffdc01];
+    }
+
+    noInline(foo);
+
+    var okArray = new Uint8Array(0x1ffdc02);
+
+    for (var i = 0; i < 10000; ++i)
+        foo(okArray);
+
+    var ok = false;
+    try {
+        var memory = new WebAssembly.Memory({ initial: 0x1000, maximum: 0x8000 });
+        memory.grow(0x7000);
+        var result = foo(new Uint8Array(memory.buffer));
+        if (result !== void 0)
+            throw "Error: bad result at end: " + result;
+        ok = true;
+    } catch (e) {
+        if (e.toString() != "Error: Out of memory")
+            throw e;
+    }
+
+    if (ok)
+        throw "Error: did not throw error";
+
 }
 
-noInline(foo);
-
-var okArray = new Uint8Array(0x1ffdc02);
-
-for (var i = 0; i < 10000; ++i)
-    foo(okArray);
-
-var ok = false;
-try {
-    var memory = new WebAssembly.Memory({ initial: 0x1000, maximum: 0x8000 });
-    memory.grow(0x7000);
-    var result = foo(new Uint8Array(memory.buffer));
-    if (result !== void 0)
-        throw "Error: bad result at end: " + result;
-    ok = true;
-} catch (e) {
-    if (e.toString() != "Error: Out of memory")
-        throw e;
-}
-
-if (ok)
-    throw "Error: did not throw error";
+test();

--- a/implementation-contributed/javascriptcore/stress/big-wasm-memory.js
+++ b/implementation-contributed/javascriptcore/stress/big-wasm-memory.js
@@ -1,32 +1,43 @@
 //@ skip if $memoryLimited
-let bigArray = new Array(0x7000000);
-bigArray[0] = 1.1;
-bigArray[1] = 1.2;
 
-function foo(array) {
-    var index = array.length;
-    if (index >= bigArray.length || (index - 0x1ffdc01) < 0)
+function test() {
+
+    // We don't support WebAssembly everywhere, so check for its existance before doing anything else.
+    if (!this.WebAssembly)
         return;
-    return bigArray[index - 0x1ffdc01];
+
+    let bigArray = new Array(0x7000000);
+    bigArray[0] = 1.1;
+    bigArray[1] = 1.2;
+
+    function foo(array) {
+        var index = array.length;
+        if (index >= bigArray.length || (index - 0x1ffdc01) < 0)
+            return;
+        return bigArray[index - 0x1ffdc01];
+    }
+
+    noInline(foo);
+
+    var okArray = new Uint8Array(0x1ffdc02);
+
+    for (var i = 0; i < 10000; ++i)
+        foo(okArray);
+
+    var ok = false;
+    try {
+        var result = foo(new Uint8Array(new WebAssembly.Memory({ initial: 0x8000, maximum: 0x8000 }).buffer));
+        if (result !== void 0)
+            throw "Error: bad result at end: " + result;
+        ok = true;
+    } catch (e) {
+        if (e.toString() != "Error: Out of memory")
+            throw e;
+    }
+
+    if (ok)
+        throw "Error: did not throw error";
+
 }
 
-noInline(foo);
-
-var okArray = new Uint8Array(0x1ffdc02);
-
-for (var i = 0; i < 10000; ++i)
-    foo(okArray);
-
-var ok = false;
-try {
-    var result = foo(new Uint8Array(new WebAssembly.Memory({ initial: 0x8000, maximum: 0x8000 }).buffer));
-    if (result !== void 0)
-        throw "Error: bad result at end: " + result;
-    ok = true;
-} catch (e) {
-    if (e.toString() != "Error: Out of memory")
-        throw e;
-}
-
-if (ok)
-    throw "Error: did not throw error";
+test();

--- a/implementation-contributed/javascriptcore/stress/regress-192386.js
+++ b/implementation-contributed/javascriptcore/stress/regress-192386.js
@@ -1,0 +1,12 @@
+//@ requireOptions("--jitPolicyScale=0")
+
+function foo(x) {
+    try {
+        new x();
+    } catch {
+    }
+}
+
+foo(function() {});
+for (let i = 0; i < 10000; ++i)
+    foo(() => undefined);

--- a/implementation-contributed/javascriptcore/stress/regress-192441.js
+++ b/implementation-contributed/javascriptcore/stress/regress-192441.js
@@ -1,0 +1,12 @@
+//@ requireOptions("--jitPolicyScale=0")
+
+// This test passes if it does not crash.
+
+let x = {}
+let enUS = ['en', 'US'].join('-')
+for (let i=0; i<100; i++) {
+    Intl.NumberFormat(enUS)
+}
+for (let i=0; i<10000; i++) {
+    x[enUS]
+};


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[205489c4f0](https://github.com///github/blob/205489c4f0) in JavaScriptCore and all changes made since [cab19d71a6](../blob/cab19d71a6) in
test262.



### 3 Files Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/big-wasm-memory-grow-no-max.js](../blob/javascriptcore-test262-automation-export-cab19d71a6/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow-no-max.js)
 - [implementation-contributed/javascriptcore/stress/big-wasm-memory-grow.js](../blob/javascriptcore-test262-automation-export-cab19d71a6/implementation-contributed/javascriptcore/stress/big-wasm-memory-grow.js)
 - [implementation-contributed/javascriptcore/stress/big-wasm-memory.js](../blob/javascriptcore-test262-automation-export-cab19d71a6/implementation-contributed/javascriptcore/stress/big-wasm-memory.js)









### 6 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/big-int-branch-usage.js](../blob/javascriptcore-test262-automation-export-cab19d71a6/implementation-contributed/javascriptcore/stress/big-int-branch-usage.js)
 - [implementation-contributed/javascriptcore/stress/big-int-logical-and.js](../blob/javascriptcore-test262-automation-export-cab19d71a6/implementation-contributed/javascriptcore/stress/big-int-logical-and.js)
 - [implementation-contributed/javascriptcore/stress/big-int-logical-not.js](../blob/javascriptcore-test262-automation-export-cab19d71a6/implementation-contributed/javascriptcore/stress/big-int-logical-not.js)
 - [implementation-contributed/javascriptcore/stress/big-int-logical-or.js](../blob/javascriptcore-test262-automation-export-cab19d71a6/implementation-contributed/javascriptcore/stress/big-int-logical-or.js)
 - [implementation-contributed/javascriptcore/stress/regress-192386.js](../blob/javascriptcore-test262-automation-export-cab19d71a6/implementation-contributed/javascriptcore/stress/regress-192386.js)
 - [implementation-contributed/javascriptcore/stress/regress-192441.js](../blob/javascriptcore-test262-automation-export-cab19d71a6/implementation-contributed/javascriptcore/stress/regress-192441.js)