### PR TITLE
Get rid of the leading empty line in info block

### DIFF
--- a/test/built-ins/Object/fromEntries/requires-argument.js
+++ b/test/built-ins/Object/fromEntries/requires-argument.js
@@ -5,7 +5,6 @@
 esid: sec-object.fromentries
 description: Throws when called without an argument.
 info: |
-
   Object.fromEntries ( iterable )
 
   1. Perform ? RequireObjectCoercible(iterable).


### PR DESCRIPTION
This makes v8's _monkeyYaml happy --- without it, the info block never ends, and we fail to parse the `features` key.

An explicit indentation marker isn't used because monkeyYaml doesn't supported it, and adding it might slightly slow things down.

Using PyYAML instead was considered, but after trying it, I don't think it looks viable. [simple test cases](https://gist.github.com/caitp/4a59a67f671907c11051a1b7bd5fdaae)