### PR TITLE
Remove extra spaces from features list

### DIFF
--- a/test/language/expressions/object/method-definition/generator-super-prop-param.js
+++ b/test/language/expressions/object/method-definition/generator-super-prop-param.js
@@ -7,7 +7,7 @@ info: |
 es6id: 14.4.1
 author: Sam Mikes
 description: GeneratorMethod uses SuperProperty (allowed)
-features: [ default-parameters, generators, super ]
+features: [default-parameters, generators, super]
 ---*/
 
 var obj = {


### PR DESCRIPTION
This broke my (admittedly terrible) feature parser. Although I guess the requirement is that it is valid YAML, which it currently is. Still, the formatting is very consistent except for this case.