### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "2b233fa3c0",
-  "targetRevisionAtLastExport": "8e3c6d0484",
+  "sourceRevisionAtLastExport": "8e5433b70f",
+  "targetRevisionAtLastExport": "18bf7976f5",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/StringObject-define-length-getter-rope-string-oom.js
+++ b/implementation-contributed/javascriptcore/stress/StringObject-define-length-getter-rope-string-oom.js
@@ -1,0 +1,5 @@
+try {
+    let char16 = decodeURI('%E7%9A%84');
+    let rope = char16.padEnd(2147483644, 1);
+    rope.__defineGetter__(256, function () {});
+} catch { }

--- a/implementation-contributed/javascriptcore/stress/big-int-boolean-proven-type.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-boolean-proven-type.js
@@ -1,0 +1,21 @@
+//@ runBigIntEnabled
+
+function assert(a) {
+    if (!a)
+        throw new Error("Bad assertion");
+}
+
+function bool(n) {
+    var value = "string";
+    if (n & 0x1)
+        value = 0n;
+    return !!value;
+}
+noInline(bool);
+
+for (let i = 0; i < 1e6; i++) {
+    if (i & 0x1)
+        assert(bool(i) === false);
+    else
+        assert(bool(i) === true);
+}

--- a/implementation-contributed/javascriptcore/stress/big-int-div-jit-osr.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-div-jit-osr.js
@@ -1,0 +1,25 @@
+//@ runBigIntEnabled
+
+let assert = {
+    sameValue: function(i, e, m) {
+        if (i !== e)
+            throw new Error(m);
+    }
+}
+
+function bigIntDiv(x, y) {
+    return x / y;
+}
+noInline(bigIntDiv);
+
+for (let i = 0; i < 10000; i++) {
+    let r = bigIntDiv(30n, 10n);
+    assert.sameValue(r, 3n, 30n + " / " + 10n + " = " + r);
+}
+
+let r = bigIntDiv(30, 10);
+assert.sameValue(r, 3, 3 + " / " + 10 + " = " + r);
+
+r = bigIntDiv("30", "10");
+assert.sameValue(r, 3, 30 + " * " + 10 + " = " + r);
+

--- a/implementation-contributed/javascriptcore/stress/big-int-div-jit-untyped.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-div-jit-untyped.js
@@ -1,0 +1,36 @@
+//@ runBigIntEnabled
+
+let assert = {
+    sameValue: function(i, e, m) {
+        if (i !== e)
+            throw new Error(m);
+    }
+}
+
+function bigIntDiv(x, y) {
+    return x / y;
+}
+noInline(bigIntDiv);
+
+let o =  {valueOf: () => 10n};
+
+for (let i = 0; i < 10000; i++) {
+    let r = bigIntDiv(30n, o);
+    assert.sameValue(r, 3n, 30n + " / {valueOf: () => 10n} = " + r);
+}
+
+o2 =  {valueOf: () => 10000n};
+
+for (let i = 0; i < 10000; i++) {
+    let r = bigIntDiv(o2, o);
+    assert.sameValue(r, 1000n, "{valueOf: () => 10000n} / {valueOf: () => 10n}  = " + r);
+}
+
+o = Object(10n);
+let r = bigIntDiv(30n, o);
+assert.sameValue(r, 3n, 30n + " / Object(10n) = " + r);
+
+o2 = Object(3240n);
+r = bigIntDiv(o2, o);
+assert.sameValue(r, 324n, "Object(3240n) / Object(10n) = " + r);
+

--- a/implementation-contributed/javascriptcore/stress/big-int-mul-jit-osr.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-mul-jit-osr.js
@@ -1,0 +1,25 @@
+//@ runBigIntEnabled
+
+let assert = {
+    sameValue: function(i, e, m) {
+        if (i !== e)
+            throw new Error(m);
+    }
+}
+
+function bigIntMul(x, y) {
+    return x * y;
+}
+noInline(bigIntMul);
+
+for (let i = 0; i < 10000; i++) {
+    let r = bigIntMul(3n, 10n);
+    assert.sameValue(r, 30n, 3n + " * " + 10n + " = " + r);
+}
+
+let r = bigIntMul(3, 10);
+assert.sameValue(r, 30, 3 + " * " + 10 + " = " + r);
+
+r = bigIntMul("3", "10");
+assert.sameValue(r, 30, 3 + " * " + 10 + " = " + r);
+

--- a/implementation-contributed/javascriptcore/stress/big-int-mul-jit-untyped.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-mul-jit-untyped.js
@@ -1,0 +1,36 @@
+//@ runBigIntEnabled
+
+let assert = {
+    sameValue: function(i, e, m) {
+        if (i !== e)
+            throw new Error(m);
+    }
+}
+
+function bigIntMul(x, y) {
+    return x * y;
+}
+noInline(bigIntMul);
+
+let o =  {valueOf: () => 10n};
+
+for (let i = 0; i < 10000; i++) {
+    let r = bigIntMul(3n, o);
+    assert.sameValue(r, 30n, 3n + " * {valueOf: () => 10n} = " + r);
+}
+
+o2 =  {valueOf: () => 10000n};
+
+for (let i = 0; i < 10000; i++) {
+    let r = bigIntMul(o2, o);
+    assert.sameValue(r, 100000n, "{valueOf: () => 10000n} * {valueOf: () => 10n}  = " + r);
+}
+
+o = Object(10n);
+let r = bigIntMul(3n, o);
+assert.sameValue(r, 30n, 3n + " * Object(10n) = " + r);
+
+o2 = Object(3241n);
+r = bigIntMul(o2, o);
+assert.sameValue(r, 32410n, "Object(32410n) * Object(10n) = " + r);
+

--- a/implementation-contributed/javascriptcore/stress/big-int-type-of-proven-type-non-constant-including-symbol.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-type-of-proven-type-non-constant-including-symbol.js
@@ -1,0 +1,33 @@
+//@ runBigIntEnabled
+
+function assert(a) {
+    if (!a)
+        throw new Error("Bad assertion");
+}
+
+function typeOf(n) {
+    var value = "string";
+    var dispatcher = n % 3;
+    if (dispatcher === 0)
+        value = 1n;
+    else if (dispatcher === 1)
+        value = "string";
+    else
+        value = Symbol("symbol");
+    return typeof value;
+}
+noInline(typeOf);
+
+for (let i = 0; i < 1e6; i++) {
+    switch (i % 3) {
+    case 0:
+        assert(typeOf(i) === "bigint");
+        break;
+    case 1:
+        assert(typeOf(i) === "string");
+        break;
+    case 2:
+        assert(typeOf(i) === "symbol");
+        break;
+    }
+}

--- a/implementation-contributed/javascriptcore/stress/big-int-type-of-proven-type-non-constant.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-type-of-proven-type-non-constant.js
@@ -1,0 +1,21 @@
+//@ runBigIntEnabled
+
+function assert(a) {
+    if (!a)
+        throw new Error("Bad assertion");
+}
+
+function typeOf(n) {
+    var value = "string";
+    if (n & 0x1)
+        value = 1n;
+    return typeof value;
+}
+noInline(typeOf);
+
+for (let i = 0; i < 1e6; i++) {
+    if (i & 0x1)
+        assert(typeOf(i) === "bigint");
+    else
+        assert(typeOf(i) === "string");
+}

--- a/implementation-contributed/javascriptcore/stress/big-int-type-of.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-type-of.js
@@ -1,0 +1,34 @@
+//@ runBigIntEnabled
+
+function assert(a) {
+    if (!a)
+        throw new Error("Bad assertion");
+}
+
+assert(typeof 0n === "bigint");
+assert(typeof 1n !== "object");
+
+function typeOf(value)
+{
+    return typeof value;
+}
+noInline(typeOf);
+
+var object = {};
+var func = function () { };
+var bigInt = 1n;
+var number = 0;
+var string = "String";
+var symbol = Symbol("Symbol");
+
+for (var i = 0; i < 1e6; ++i) {
+    assert(typeOf(object) === "object");
+    assert(typeOf(func) === "function");
+    assert(typeOf(bigInt) === "bigint");
+    assert(typeOf(number) === "number");
+    assert(typeOf(string) === "string");
+    assert(typeOf(symbol) === "symbol");
+    assert(typeOf(null) === "object");
+    assert(typeOf(undefined) === "undefined");
+    assert(typeOf(true) === "boolean");
+}

--- a/implementation-contributed/javascriptcore/stress/regress-191993.js
+++ b/implementation-contributed/javascriptcore/stress/regress-191993.js
@@ -1,0 +1,13 @@
+function foo(o) {
+    return o.r.input;
+}
+noInline(foo);
+
+Object.assign({}, RegExp);
+
+for (let i = 0; i < 10000; i++)
+    foo({r: RegExp});
+
+let input = foo({r: RegExp});
+if (typeof input !== "string")
+    throw "FAILED";

--- a/implementation-contributed/javascriptcore/stress/regress-192626.js
+++ b/implementation-contributed/javascriptcore/stress/regress-192626.js
@@ -1,0 +1,23 @@
+var a = {};
+
+function foo() {
+    return Array.prototype.splice.apply([], a);
+}
+noInline(foo);
+
+function bar(b) {
+    with({});
+    a = arguments;
+    a.__defineGetter__("length", String.prototype.valueOf);
+    foo();
+}
+
+var exception;
+try {
+    bar();
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "TypeError: Type error")
+    throw "FAIL";

--- a/implementation-contributed/javascriptcore/stress/regress-192717.js
+++ b/implementation-contributed/javascriptcore/stress/regress-192717.js
@@ -1,0 +1,16 @@
+//@ runDefault("--useLLInt=false", "--forceCodeBlockToJettisonDueToOldAge=true", "--maxPerThreadStackUsage=200000", "--exceptionStackTraceLimit=1", "--defaultErrorStackTraceLimit=1")
+//@ skip if $memoryLimited or $buildType == "debug"
+
+let foo = 'let a';
+for (let i = 0; i < 400000; i++)
+  foo += ',a' + i;
+
+var exception;
+try {
+    new Function(foo)();
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "RangeError: Maximum call stack size exceeded.")
+    throw "FAILED";

--- a/implementation-contributed/javascriptcore/stress/symbol-description-identity.js
+++ b/implementation-contributed/javascriptcore/stress/symbol-description-identity.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(description)
+{
+    return Symbol(description);
+}
+noInline(test);
+
+var set = new Set;
+for (var i = 0; i < 1e4; ++i) {
+    var description = String(i);
+    var symbol = test(description);
+    set.add(symbol);
+    shouldBe(set.size, i + 1);
+    shouldBe(symbol.description, description);
+}

--- a/implementation-contributed/javascriptcore/stress/symbol-identity.js
+++ b/implementation-contributed/javascriptcore/stress/symbol-identity.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test()
+{
+    return Symbol();
+}
+noInline(test);
+
+var set = new Set;
+for (var i = 0; i < 1e4; ++i) {
+    var symbol = test();
+    set.add(symbol);
+    shouldBe(set.size, i + 1);
+    shouldBe(symbol.description, undefined);
+}

--- a/implementation-contributed/javascriptcore/stress/symbol-with-description-throw-error.js
+++ b/implementation-contributed/javascriptcore/stress/symbol-with-description-throw-error.js
@@ -1,0 +1,52 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+function test(description)
+{
+    return Symbol(description);
+}
+noInline(test);
+
+var count = 0;
+var flag = false;
+var object = {
+    toString()
+    {
+        count++;
+        if (flag) {
+            throw new Error("out");
+        }
+        return "Cocoa";
+    }
+};
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(test(object).description, "Cocoa");
+    shouldBe(count, i + 1);
+}
+flag = true;
+
+shouldThrow(() => {
+    shouldBe(test(object).description, "Cocoa");
+    shouldBe(count, 1e4 + 1);
+}, `Error: out`);

--- a/implementation-contributed/javascriptcore/stress/value-div-fixup-int32-big-int.js
+++ b/implementation-contributed/javascriptcore/stress/value-div-fixup-int32-big-int.js
@@ -1,0 +1,29 @@
+//@ runBigIntEnabled
+
+function assert(a, e) {
+    if (a !== e)
+        throw new Error("Bad!");
+}
+
+function foo() {
+    let c;
+    do {
+    
+        let a = 2;
+        let b = 3n;
+        for (let i = 0; i < 10000; i++) {
+            c = i;
+        }
+
+        c = a / b; 
+    } while(true);
+
+    return c;
+}
+
+try {
+    foo();
+} catch(e) {
+    assert(e instanceof TypeError, true);
+}
+

--- a/implementation-contributed/javascriptcore/stress/value-mul-fixup-int32-big-int.js
+++ b/implementation-contributed/javascriptcore/stress/value-mul-fixup-int32-big-int.js
@@ -1,0 +1,29 @@
+//@ runBigIntEnabled
+
+function assert(a, e) {
+    if (a !== e)
+        throw new Error("Bad!");
+}
+
+function foo() {
+    let c;
+    do {
+    
+        let a = 2;
+        let b = 3n;
+        for (let i = 0; i < 10000; i++) {
+            c = i;
+        }
+
+        c = a * b; 
+    } while(true);
+
+    return c;
+}
+
+try {
+    foo();
+} catch(e) {
+    assert(e instanceof TypeError, true);
+}
+


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[2b233fa3c0](https://github.com///github/blob/2b233fa3c0) in JavaScriptCore and all changes made since [8e3c6d0484](../blob/8e3c6d0484) in
test262.



### 1 File Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/big-int-type-of.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/big-int-type-of.js)









### 16 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/StringObject-define-length-getter-rope-string-oom.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/StringObject-define-length-getter-rope-string-oom.js)
 - [implementation-contributed/javascriptcore/stress/big-int-boolean-proven-type.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/big-int-boolean-proven-type.js)
 - [implementation-contributed/javascriptcore/stress/big-int-div-jit-osr.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/big-int-div-jit-osr.js)
 - [implementation-contributed/javascriptcore/stress/big-int-div-jit-untyped.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/big-int-div-jit-untyped.js)
 - [implementation-contributed/javascriptcore/stress/big-int-mul-jit-osr.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/big-int-mul-jit-osr.js)
 - [implementation-contributed/javascriptcore/stress/big-int-mul-jit-untyped.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/big-int-mul-jit-untyped.js)
 - [implementation-contributed/javascriptcore/stress/big-int-type-of-proven-type-non-constant-including-symbol.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/big-int-type-of-proven-type-non-constant-including-symbol.js)
 - [implementation-contributed/javascriptcore/stress/big-int-type-of-proven-type-non-constant.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/big-int-type-of-proven-type-non-constant.js)
 - [implementation-contributed/javascriptcore/stress/regress-191993.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/regress-191993.js)
 - [implementation-contributed/javascriptcore/stress/regress-192626.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/regress-192626.js)
 - [implementation-contributed/javascriptcore/stress/regress-192717.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/regress-192717.js)
 - [implementation-contributed/javascriptcore/stress/symbol-description-identity.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/symbol-description-identity.js)
 - [implementation-contributed/javascriptcore/stress/symbol-identity.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/symbol-identity.js)
 - [implementation-contributed/javascriptcore/stress/symbol-with-description-throw-error.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/symbol-with-description-throw-error.js)
 - [implementation-contributed/javascriptcore/stress/value-div-fixup-int32-big-int.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/value-div-fixup-int32-big-int.js)
 - [implementation-contributed/javascriptcore/stress/value-mul-fixup-int32-big-int.js](../blob/javascriptcore-test262-automation-export-8e3c6d0484/implementation-contributed/javascriptcore/stress/value-mul-fixup-int32-big-int.js)