### PR TITLE
Consistently use spaces in features lists

### DIFF
--- a/test/annexB/built-ins/String/prototype/trimLeft/name.js
+++ b/test/annexB/built-ins/String/prototype/trimLeft/name.js
@@ -11,7 +11,7 @@ info: >
   The function object that is the initial value of  String.prototype.trimLeft is the same function object that is the initial value of  String.prototype.trimStart.
 
 includes: [propertyHelper.js]
-features: [string-trimming,String.prototype.trimStart]
+features: [string-trimming, String.prototype.trimStart]
 ---*/
 
 verifyProperty(String.prototype.trimLeft, "name", {

--- a/test/annexB/built-ins/String/prototype/trimRight/name.js
+++ b/test/annexB/built-ins/String/prototype/trimRight/name.js
@@ -10,7 +10,7 @@ info: >
 
   The function object that is the initial value of  String.prototype.trimRight is the same function object that is the initial value of  String.prototype.trimEnd.
 includes: [propertyHelper.js]
-features: [string-trimming,String.prototype.trimEnd]
+features: [string-trimming, String.prototype.trimEnd]
 ---*/
 
 verifyProperty(String.prototype.trimRight, "name", {

--- a/test/built-ins/ArrayBuffer/Symbol.species/symbol-species.js
+++ b/test/built-ins/ArrayBuffer/Symbol.species/symbol-species.js
@@ -8,7 +8,7 @@ esid: sec-get-arraybuffer-@@species
 es6id: 24.1.3.3
 author: Sam Mikes
 description: ArrayBuffer[Symbol.species] exists per spec
-features: [ ArrayBuffer, Symbol.species ]
+features: [ArrayBuffer, Symbol.species]
 includes: [propertyHelper.js]
 ---*/
 

--- a/test/built-ins/Object/is/symbol-object-is-same-value.js
+++ b/test/built-ins/Object/is/symbol-object-is-same-value.js
@@ -4,7 +4,7 @@
 esid: sec-object.is
 description: >
     Object.is/SameValue: Symbol
-features: [Object.is,Symbol]
+features: [Object.is, Symbol]
 ---*/
 var symA = Symbol('66');
 var symB = Symbol('66');

--- a/test/language/statements/for-of/body-dstr-assign-error.js
+++ b/test/language/statements/for-of/body-dstr-assign-error.js
@@ -18,7 +18,7 @@ info: |
     If iterationKind is enumerate, then
       Return status.
 
-features: [destructuring-assignment,for-of,Symbol.iterator]
+features: [destructuring-assignment, for-of, Symbol.iterator]
 ---*/
 
 var callCount = 0;

--- a/test/language/statements/for-of/body-dstr-assign.js
+++ b/test/language/statements/for-of/body-dstr-assign.js
@@ -11,7 +11,7 @@ info: |
       Let status be the result of performing DestructuringAssignmentEvaluation of
       assignmentPattern using nextValue as the argument.
 
-features: [destructuring-assignment,for-of]
+features: [destructuring-assignment, for-of]
 ---*/
 
 var iterationCount = 0;

--- a/test/language/statements/for-of/body-put-error.js
+++ b/test/language/statements/for-of/body-put-error.js
@@ -17,7 +17,7 @@ info: |
       Let status be PutValue(lhsRef, nextValue).
   ...
 
-features: [for-of,Symbol.iterator]
+features: [for-of, Symbol.iterator]
 ---*/
 
 var callCount = 0;


### PR DESCRIPTION
I think this is all of the tests now - they all work with my really basic parser:

`line[len("features: ["):-2].split(", ")`