### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "8e5433b70f",
-  "targetRevisionAtLastExport": "18bf7976f5",
+  "sourceRevisionAtLastExport": "51c20fe3ea",
+  "targetRevisionAtLastExport": "f8bd9710a3",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/array-unshift-should-not-race-against-compiler-thread.js
+++ b/implementation-contributed/javascriptcore/stress/array-unshift-should-not-race-against-compiler-thread.js
@@ -1,0 +1,7 @@
+let x = [];
+for (let i = 0; i < 30; ++i) {
+    for (let j = 0; j < 20000; ++j) {
+        x[0]
+        x.unshift(undefined);
+    }
+}

--- a/implementation-contributed/javascriptcore/stress/elidable-new-object-roflcopter-then-exit.js
+++ b/implementation-contributed/javascriptcore/stress/elidable-new-object-roflcopter-then-exit.js
@@ -1,0 +1,25 @@
+//@ skip if $architecture != "arm64" and $architecture != "x86-64"
+
+function sumOfArithSeries(limit) {
+    return limit * (limit + 1) / 2;
+}
+
+var n = 1000000;
+
+var array = [42, "hello"];
+
+function foo() {
+    var result = 0;
+    var q;
+    for (var i = 0; i < n; ++i) {
+        var o = {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: i}}}}}}}}}}}}}}}}}}};
+        var p = {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: {f: i + 1}}}}}}}}}}}}}}}}}}};
+        q = array[(i > n - 100) | 0] + 1;
+        result += o.f.f.f.f.f.f.f.f.f.f.f.f.f.f.f.f.f.f.f + p.f.f.f.f.f.f.f.f.f.f.f.f.f.f.f.f.f.f.f;
+    }
+    return q + result;
+}
+
+var result = foo();
+if (result != "hello" + 1 + (sumOfArithSeries(n - 1) + sumOfArithSeries(n)))
+    throw "Error: bad result: " + result;

--- a/implementation-contributed/javascriptcore/stress/force-string-arrayMode-on-originalNonArray-array-class.js
+++ b/implementation-contributed/javascriptcore/stress/force-string-arrayMode-on-originalNonArray-array-class.js
@@ -1,0 +1,16 @@
+//@ requireOptions("--jitPolicyScale=0.1")
+
+function foo(a) {
+    a.length;
+}
+
+for (let i = 0; i < 100; i++) {
+    let a = i % 2 ? new Uint8Array() : new Uint16Array();
+
+    for (let j = 0; j < 2; j++)
+        foo(a);
+
+    gc();
+    foo('');
+    foo(a);
+}

--- a/implementation-contributed/javascriptcore/stress/materialize-regexp-cyclic-regexp.js
+++ b/implementation-contributed/javascriptcore/stress/materialize-regexp-cyclic-regexp.js
@@ -1,0 +1,48 @@
+//@ skip if $architecture != "arm64" and $architecture != "x86-64"
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(num)
+{
+    var regexp = /hello world/;
+    var world = /World/;
+    regexp.lastIndex = world;
+    world.lastIndex = regexp;
+    if (num === 0)
+        return regexp;
+    if (num === 1)
+        return regexp.lastIndex;
+    return regexp.lastIndex.lastIndex;
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    var num = i % 3;
+    switch (num) {
+    case 0:
+        var regexp = test(num);
+        shouldBe(regexp instanceof RegExp, true);
+        shouldBe(regexp.toString(), "/hello world/");
+        shouldBe(regexp.lastIndex instanceof RegExp, true);
+        shouldBe(regexp.lastIndex.toString(), "/World/");
+        break;
+    case 1:
+        var regexp = test(num);
+        shouldBe(regexp instanceof RegExp, true);
+        shouldBe(regexp.toString(), "/World/");
+        shouldBe(regexp.lastIndex instanceof RegExp, true);
+        shouldBe(regexp.lastIndex.toString(), "/hello world/");
+        break;
+    case 2:
+        var regexp = test(num);
+        shouldBe(regexp instanceof RegExp, true);
+        shouldBe(regexp.toString(), "/hello world/");
+        shouldBe(regexp.lastIndex instanceof RegExp, true);
+        shouldBe(regexp.lastIndex.toString(), "/World/");
+        break;
+    }
+}

--- a/implementation-contributed/javascriptcore/stress/materialized-regexp-has-correct-last-index-set-by-match.js
+++ b/implementation-contributed/javascriptcore/stress/materialized-regexp-has-correct-last-index-set-by-match.js
@@ -1,0 +1,30 @@
+//@ skip if $architecture != "arm64" and $architecture != "x86-64"
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(flag, string)
+{
+    var regexp = /hello/g;
+    regexp.lastIndex = "Cocoa";
+    var result = string.match(regexp);
+    if (flag)
+        return [result, regexp];
+    return regexp.lastIndex;
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    if (i & 0x1) {
+        var [result, regexp] = test(true, "hellohello");
+        shouldBe(regexp instanceof RegExp, true);
+        shouldBe(regexp.lastIndex, 0);
+        shouldBe(result.length, 2);
+        shouldBe(result[0], "hello");
+        shouldBe(result[1], "hello");
+    } else
+        shouldBe(test(false, "hellohello"), 0);
+}

--- a/implementation-contributed/javascriptcore/stress/object-keys-cached-zero.js
+++ b/implementation-contributed/javascriptcore/stress/object-keys-cached-zero.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(object)
+{
+    return Object.keys(object);
+}
+noInline(test);
+
+var object = {};
+for (var i = 0; i < 1e6; ++i) {
+    var result = test(object);
+    shouldBe(result.length, 0);
+    shouldBe(result[0], undefined);
+    result[0] = i;
+    shouldBe(result.length, 1);
+    shouldBe(result[0], i);
+}

--- a/implementation-contributed/javascriptcore/stress/object-keys-changed-attribute.js
+++ b/implementation-contributed/javascriptcore/stress/object-keys-changed-attribute.js
@@ -1,0 +1,28 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(object)
+{
+    return Object.keys(object);
+}
+noInline(test);
+
+var object = { Cocoa: 42 };
+for (var i = 0; i < 1e6; ++i) {
+    var result = test(object);
+    shouldBe(result.length, 1);
+    shouldBe(result[0], 'Cocoa');
+}
+
+Reflect.defineProperty(object, 'Cocoa', {
+    enumerable: false
+});
+
+for (var i = 0; i < 1e6; ++i) {
+    var result = test(object);
+    shouldBe(result.length, 0);
+    shouldBe(result[0], undefined);
+}

--- a/implementation-contributed/javascriptcore/stress/object-keys-changed-index.js
+++ b/implementation-contributed/javascriptcore/stress/object-keys-changed-index.js
@@ -1,0 +1,28 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(object)
+{
+    return Object.keys(object);
+}
+noInline(test);
+
+var object = {};
+for (var i = 0; i < 1e6; ++i) {
+    var result = test(object);
+    shouldBe(result.length, 0);
+    shouldBe(result[0], undefined);
+    result[0] = i;
+    shouldBe(result.length, 1);
+    shouldBe(result[0], i);
+}
+
+object[0] = 42;
+for (var i = 0; i < 1e6; ++i) {
+    var result = test(object);
+    shouldBe(result.length, 1);
+    shouldBe(result[0], '0');
+}

--- a/implementation-contributed/javascriptcore/stress/object-keys-changed.js
+++ b/implementation-contributed/javascriptcore/stress/object-keys-changed.js
@@ -1,0 +1,28 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(object)
+{
+    return Object.keys(object);
+}
+noInline(test);
+
+var object = {};
+for (var i = 0; i < 1e6; ++i) {
+    var result = test(object);
+    shouldBe(result.length, 0);
+    shouldBe(result[0], undefined);
+    result[0] = i;
+    shouldBe(result.length, 1);
+    shouldBe(result[0], i);
+}
+
+object.Cocoa = 42;
+for (var i = 0; i < 1e6; ++i) {
+    var result = test(object);
+    shouldBe(result.length, 1);
+    shouldBe(result[0], 'Cocoa');
+}

--- a/implementation-contributed/javascriptcore/stress/object-keys-indexed-non-cache.js
+++ b/implementation-contributed/javascriptcore/stress/object-keys-indexed-non-cache.js
@@ -1,0 +1,25 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(object)
+{
+    return Object.keys(object);
+}
+noInline(test);
+
+var object = {0: 42};
+for (var i = 0; i < 1e3; ++i) {
+    var result = test(object);
+    shouldBe(result.length, 1);
+    shouldBe(result[0], '0');
+}
+object[1] = 44;
+for (var i = 0; i < 1e3; ++i) {
+    var result = test(object);
+    shouldBe(result.length, 2);
+    shouldBe(result[0], '0');
+    shouldBe(result[1], '1');
+}

--- a/implementation-contributed/javascriptcore/stress/object-keys-overrides-get-property-names.js
+++ b/implementation-contributed/javascriptcore/stress/object-keys-overrides-get-property-names.js
@@ -1,0 +1,57 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(object)
+{
+    return Object.keys(object);
+}
+noInline(test);
+
+{
+    let object = new String("Cocoa");
+    for (let i = 0; i < 1e3; ++i) {
+        let result = test(object);
+        shouldBe(result.length, 5);
+        shouldBe(result[0], '0');
+        shouldBe(result[1], '1');
+        shouldBe(result[2], '2');
+        shouldBe(result[3], '3');
+        shouldBe(result[4], '4');
+    }
+
+    object.Cocoa = 42;
+    let result = test(object);
+    shouldBe(result.length, 6);
+    shouldBe(result[0], '0');
+    shouldBe(result[1], '1');
+    shouldBe(result[2], '2');
+    shouldBe(result[3], '3');
+    shouldBe(result[4], '4');
+    shouldBe(result[5], 'Cocoa');
+}
+
+{
+    let object = new String("Cocoa");
+    for (let i = 0; i < 1e3; ++i) {
+        let result = test(object);
+        shouldBe(result.length, 5);
+        shouldBe(result[0], '0');
+        shouldBe(result[1], '1');
+        shouldBe(result[2], '2');
+        shouldBe(result[3], '3');
+        shouldBe(result[4], '4');
+    }
+
+    object[8] = 42;
+    let result = test(object);
+    shouldBe(result.length, 6);
+    shouldBe(result[0], '0');
+    shouldBe(result[1], '1');
+    shouldBe(result[2], '2');
+    shouldBe(result[3], '3');
+    shouldBe(result[4], '4');
+    shouldBe(result[5], '8');
+}

--- a/implementation-contributed/javascriptcore/stress/out-of-frame-stack-accesses-due-to-probe-based-osr-exits.js
+++ b/implementation-contributed/javascriptcore/stress/out-of-frame-stack-accesses-due-to-probe-based-osr-exits.js
@@ -1,0 +1,14 @@
+//@ requireOptions("--useProbeOSRExit=true", "--forceEagerCompilation=true")
+
+// This test passes if it does not crash especially on ASAN builds.
+
+let x = 0;
+function Foo(a) {
+    a === a;
+    '' + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x;
+}
+
+for (let i=0; i<8; i++)
+    new Foo(0);
+
+new Foo({});

--- a/implementation-contributed/javascriptcore/stress/sampling-profiler-should-not-sample-beyond-stack-bounds.js
+++ b/implementation-contributed/javascriptcore/stress/sampling-profiler-should-not-sample-beyond-stack-bounds.js
@@ -1,0 +1,24 @@
+//@ requireOptions("--useSamplingProfiler=true", "--useProbeOSRExit=true", "--useObjectAllocationSinking=false", "--sampleInterval=10")
+
+function foo(ranges) {
+    const CHUNK_SIZE = 95;
+    for (const [start, end] of ranges) {
+        const codePoints = [];
+        for (let length = 0, codePoint = start; codePoint <= end; codePoint++) {
+            codePoints[length++] = codePoint;
+            if (length === CHUNK_SIZE) {
+                length = 0;
+                codePoints.length = 0;
+                String.fromCodePoint(...[]);
+            }
+        }
+        String.fromCodePoint(...codePoints);
+    }
+}
+
+for (let i=0; i<3; i++) {
+    let x = foo([
+        [ 0, 10000 ],
+        [ 68000, 1114111 ]
+    ]);
+}


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[8e5433b70f](https://github.com///github/blob/8e5433b70f) in JavaScriptCore and all changes made since [18bf7976f5](../blob/18bf7976f5) in
test262.



### 3 Files Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/elidable-new-object-roflcopter-then-exit.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/elidable-new-object-roflcopter-then-exit.js)
 - [implementation-contributed/javascriptcore/stress/materialize-regexp-cyclic-regexp.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/materialize-regexp-cyclic-regexp.js)
 - [implementation-contributed/javascriptcore/stress/materialized-regexp-has-correct-last-index-set-by-match.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/materialized-regexp-has-correct-last-index-set-by-match.js)









### 10 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/array-unshift-should-not-race-against-compiler-thread.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/array-unshift-should-not-race-against-compiler-thread.js)
 - [implementation-contributed/javascriptcore/stress/force-string-arrayMode-on-originalNonArray-array-class.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/force-string-arrayMode-on-originalNonArray-array-class.js)
 - [implementation-contributed/javascriptcore/stress/object-keys-cached-zero.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/object-keys-cached-zero.js)
 - [implementation-contributed/javascriptcore/stress/object-keys-changed-attribute.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/object-keys-changed-attribute.js)
 - [implementation-contributed/javascriptcore/stress/object-keys-changed-index.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/object-keys-changed-index.js)
 - [implementation-contributed/javascriptcore/stress/object-keys-changed.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/object-keys-changed.js)
 - [implementation-contributed/javascriptcore/stress/object-keys-indexed-non-cache.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/object-keys-indexed-non-cache.js)
 - [implementation-contributed/javascriptcore/stress/object-keys-overrides-get-property-names.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/object-keys-overrides-get-property-names.js)
 - [implementation-contributed/javascriptcore/stress/out-of-frame-stack-accesses-due-to-probe-based-osr-exits.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/out-of-frame-stack-accesses-due-to-probe-based-osr-exits.js)
 - [implementation-contributed/javascriptcore/stress/sampling-profiler-should-not-sample-beyond-stack-bounds.js](../blob/javascriptcore-test262-automation-export-18bf7976f5/implementation-contributed/javascriptcore/stress/sampling-profiler-should-not-sample-beyond-stack-bounds.js)