### PR TITLE
remove "TypeError: Cannot convert a Symbol value to a string"

### DIFF
--- a/test/intl402/RelativeTimeFormat/constructor/constructor/locales-invalid.js
+++ b/test/intl402/RelativeTimeFormat/constructor/constructor/locales-invalid.js
@@ -14,7 +14,5 @@ features: [Intl.RelativeTimeFormat]
 assert.sameValue(typeof Intl.RelativeTimeFormat, "function");
 
 for (const [locales, expectedError] of getInvalidLocaleArguments()) {
-    assert.throws(expectedError, function() {
-        new Intl.RelativeTimeFormat(locales)
-    }, `using ${String(locales)} expects ${expectedError}`);
+    assert.throws(expectedError, function() { new Intl.RelativeTimeFormat(locales) });
 }


### PR DESCRIPTION
Fix "TypeError: Cannot convert a Symbol value to a string" problem caused by 
printing ${String(locales)}
in https://github.com/tc39/test262/pull/2001
@leobalter @rwaldron 