### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "995333da",
-  "targetRevisionAtLastExport": "ccadd02f2b",
+  "sourceRevisionAtLastExport": "89eb451c",
+  "targetRevisionAtLastExport": "7519e1b462",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/intl/locale/locale-canonicalization.js
+++ b/implementation-contributed/v8/intl/locale/locale-canonicalization.js
@@ -19,6 +19,6 @@ let locale = new Intl.Locale('sr-cyrl-rs-t-ja-u-ca-islamic-x-whatever', {
 });
 
 let expected =
-    'sr-Cyrl-RS-t-ja-u-ca-buddhist-co-phonebk-hc-h23-kf-upper-kn-true-nu-roman-x-whatever';
+    'sr-Cyrl-RS-t-ja-u-ca-buddhist-co-phonebk-hc-h23-kf-upper-kn-nu-roman-x-whatever';
 
 assertEquals(expected, locale.toString());

--- a/implementation-contributed/v8/mjsunit/es6/array-prototype-values.js
+++ b/implementation-contributed/v8/mjsunit/es6/array-prototype-values.js
@@ -1,8 +1,6 @@
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-//
-// Flags: --harmony-array-prototype-values
 
 // Functionality of the values iterator is tested elsewhere; this test
 // merely verifies that the 'values' property is set up correctly.

--- a/implementation-contributed/v8/mjsunit/es8/async-function-stacktrace.js
+++ b/implementation-contributed/v8/mjsunit/es8/async-function-stacktrace.js
@@ -81,21 +81,19 @@ async function runTests() {
     try { await reject(); } catch (e) { throw new Error("FAIL"); }
   } }).c4, ["c4"]);
 
-  // TODO(caitp): We should infer anonymous async functions as the empty
-  // string, not as the name of a function they're passed as a parameter to.
   await test(async x => { throw new Error("FAIL") },
-             ["test", "test", "runTests"]);
+             ["test", "runTests"]);
   await test(async() => { throw new Error("FAIL") },
-             ["test", "test", "runTests"]);
+             ["test", "runTests"]);
   await test(async(a) => { throw new Error("FAIL") },
-             ["test", "test", "runTests"]);
+             ["test", "runTests"]);
   await test(async(a, b) => { throw new Error("FAIL") },
-             ["test", "test", "runTests"]);
+             ["test", "runTests"]);
 
-  await test(async x => { await 1; throw new Error("FAIL") }, ["test"]);
-  await test(async() => { await 1; throw new Error("FAIL") }, ["test"]);
-  await test(async(a) => { await 1; throw new Error("FAIL") }, ["test"]);
-  await test(async(a, b) => { await 1; throw new Error("FAIL") }, ["test"]);
+  await test(async x => { await 1; throw new Error("FAIL") }, []);
+  await test(async() => { await 1; throw new Error("FAIL") }, []);
+  await test(async(a) => { await 1; throw new Error("FAIL") }, []);
+  await test(async(a, b) => { await 1; throw new Error("FAIL") }, []);
 
   await test(async x => {
     await 1;
@@ -104,7 +102,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, ["test"]);
+  }, []);
 
   await test(async() => {
     await 1;
@@ -113,7 +111,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, ["test"]);
+  }, []);
 
   await test(async(a) => {
     await 1;
@@ -122,7 +120,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, ["test"]);
+  }, []);
 
   await test(async(a, b) => {
     await 1;
@@ -131,7 +129,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, ["test"]);
+  }, []);
 
   await test(async x => {
     await 1;
@@ -140,7 +138,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, ["test"]);
+  }, []);
 
   await test(async() => {
     await 1;
@@ -149,7 +147,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, ["test"]);
+  }, []);
 
   await test(async(a) => {
     await 1;
@@ -158,7 +156,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, ["test"]);
+  }, []);
 
   await test(async(a, b) => {
     await 1;
@@ -167,7 +165,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, ["test"]);
+  }, []);
 }
 
 runTests().catch(e => {

--- a/implementation-contributed/v8/mjsunit/mjsunit.status
+++ b/implementation-contributed/v8/mjsunit/mjsunit.status
@@ -322,6 +322,35 @@
 }],  # 'gc_stress == True'
 
 ##############################################################################
+['lite_mode == True', {
+  # Skip tests not suitable for lite_mode.
+
+  # TODO(8596): We cache the templates in the feedback vector. In lite mode
+  # without feedback vectors we need to implement some other mechanism to cache
+  # them. Enable this test after fixing it.
+  'es6/templates': [SKIP],
+
+  # code coverage needs feedback vectors
+  'code-coverage-ad-hoc': [SKIP],
+  'code-coverage-class-fields': [SKIP],
+  'code-coverage-block-noopt': [SKIP],
+  'code-coverage-block': [SKIP],
+  'code-coverage-precise': [SKIP],
+
+  # Needs feedback vector - tests for allocation sites
+  'array-constructor-feedback': [SKIP],
+  'regress/regress-trap-allocation-memento': [SKIP],
+  'regress/regress-4121': [SKIP],
+
+  # Slow tests without feedback vectors
+  # TODO(mythria): Investigate why they are slow and either fix if
+  # possible are update the reason why they are slow.
+  'spread-large-string': [SKIP],
+  'spread-large-array': [SKIP],
+
+}],  # 'lite_mode == True'
+
+##############################################################################
 ['byteorder == big', {
   # Emscripten requires little-endian, skip all tests on big endian platforms.
   'asm/embenchen/*': [SKIP],

--- a/implementation-contributed/v8/mjsunit/regress/regress-8607.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-8607.js
@@ -5,3 +5,4 @@
 assertThrows("[({ p: this }), [][0]] = x", SyntaxError);
 assertThrows("[...a, [][0]] = []", SyntaxError);
 assertThrows("[...o=1,[][0]] = []", SyntaxError);
+assertThrows("({x(){},y:[][0]} = {})", SyntaxError);

--- a/implementation-contributed/v8/mjsunit/regress/regress-crbug-916288.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-crbug-916288.js
@@ -1,0 +1,5 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+assertThrows("(a()=0)=>0", SyntaxError)

--- a/implementation-contributed/v8/mjsunit/regress/wasm/regress-916869.js
+++ b/implementation-contributed/v8/mjsunit/regress/wasm/regress-916869.js
@@ -1,0 +1,14 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+load('test/mjsunit/wasm/wasm-constants.js');
+load('test/mjsunit/wasm/wasm-module-builder.js');
+
+const builder = new WasmModuleBuilder();
+const sig = builder.addType(makeSig([kWasmI32, kWasmI32, kWasmI32], [kWasmI32]));
+builder.addFunction('main', sig)
+    .addBody([kExprI32Const, 0x01, kExprI32SExtendI8])
+    .exportFunc();
+const instance = builder.instantiate();
+assertEquals(1, instance.exports.main());

--- a/implementation-contributed/v8/mjsunit/try-catch-default-destructuring.js
+++ b/implementation-contributed/v8/mjsunit/try-catch-default-destructuring.js
@@ -1,0 +1,24 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+function f1() {
+  let y = 200;
+  try {
+    throw {}
+  } catch ({x=()=>y, y=300}) {
+    return x()
+  }
+}
+assertEquals(300, f1());
+
+function f2() {
+  let y = 200;
+  try {
+    throw {}
+  } catch ({x=()=>y}) {
+    let y = 300;
+    return x()
+  }
+}
+assertEquals(200, f2());

--- a/implementation-contributed/v8/test262/test262.status
+++ b/implementation-contributed/v8/test262/test262.status
@@ -406,9 +406,6 @@
   'language/literals/regexp/u-unicode-esc-non-hex': [FAIL_PHASE_ONLY],
   'language/literals/regexp/unicode-escape-nls-err': [FAIL_PHASE_ONLY],
 
-  # https://bugs.chromium.org/p/v8/issues/detail?id=7828
-  'language/statements/try/early-catch-function': [FAIL],
-
   # https://bugs.chromium.org/p/v8/issues/detail?id=7829
   'language/block-scope/syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function': [FAIL],
 
@@ -473,10 +470,6 @@
   'language/statements/try/tco-catch-finally': [SKIP],
   'language/statements/try/tco-finally': [SKIP],
   'language/statements/while/tco-body': [SKIP],
-
-  # https://bugs.chromium.org/p/v8/issues/detail?id=5064
-  'language/expressions/arrow-function/dflt-params-duplicates': [FAIL],
-  'language/expressions/async-arrow-function/dflt-params-duplicates': [FAIL],
 
   # https://bugs.chromium.org/p/v8/issues/detail?id=5327
   'built-ins/TypedArrayConstructors/internals/Set/key-is-minus-zero': [FAIL],
@@ -587,12 +580,6 @@
   # https://bugs.chromium.org/p/v8/issues/detail?id=7669
   'intl402/Intl/getCanonicalLocales/canonicalized-tags': [FAIL],
 
-  # Tests assume that the sort order of "same elements" (comparator returns 0)
-  # is deterministic.
-  # https://crbug.com/v8/7808
-  'intl402/String/prototype/localeCompare/returns-same-results-as-Collator': [SKIP],
-  'intl402/Collator/prototype/compare/bound-to-collator-instance': [SKIP],
-
   # https://github.com/tc39/ecma402/issues/223
   'intl402/Collator/missing-unicode-ext-value-defaults-to-true': [FAIL],
 
@@ -630,10 +617,6 @@
   'intl402/Locale/extensions-grandfathered': [FAIL],
   'intl402/Locale/getters-grandfathered': [FAIL],
   'intl402/Locale/likely-subtags-grandfathered': [FAIL],
-
-  # Wrong test see https://github.com/tc39/test262/pull/1835
-  'intl402/Locale/constructor-options-numeric-valid': [FAIL],
-  'intl402/Locale/constructor-options-numeric-undefined': [FAIL],
 
   # https://bugs.chromium.org/p/v8/issues/detail?id=6705
   'built-ins/Object/assign/strings-and-symbol-order': [FAIL],


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[995333da](https://github.com///github/blob/995333da) in V8 and all changes made since [ccadd02f2b](../blob/ccadd02f2b) in
test262.



### 6 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/intl/locale/locale-canonicalization.js](../blob/v8-test262-automation-export-ccadd02f2b/implementation-contributed/v8/intl/locale/locale-canonicalization.js)
 - [implementation-contributed/v8/mjsunit/es6/array-prototype-values.js](../blob/v8-test262-automation-export-ccadd02f2b/implementation-contributed/v8/mjsunit/es6/array-prototype-values.js)
 - [implementation-contributed/v8/mjsunit/es8/async-function-stacktrace.js](../blob/v8-test262-automation-export-ccadd02f2b/implementation-contributed/v8/mjsunit/es8/async-function-stacktrace.js)
 - [implementation-contributed/v8/mjsunit/mjsunit.status](../blob/v8-test262-automation-export-ccadd02f2b/implementation-contributed/v8/mjsunit/mjsunit.status)
 - [implementation-contributed/v8/mjsunit/regress/regress-8607.js](../blob/v8-test262-automation-export-ccadd02f2b/implementation-contributed/v8/mjsunit/regress/regress-8607.js)
 - [implementation-contributed/v8/test262/test262.status](../blob/v8-test262-automation-export-ccadd02f2b/implementation-contributed/v8/test262/test262.status)









### 3 New Files Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/regress/regress-crbug-916288.js](../blob/v8-test262-automation-export-ccadd02f2b/implementation-contributed/v8/mjsunit/regress/regress-crbug-916288.js)
 - [implementation-contributed/v8/mjsunit/regress/wasm/regress-916869.js](../blob/v8-test262-automation-export-ccadd02f2b/implementation-contributed/v8/mjsunit/regress/wasm/regress-916869.js)
 - [implementation-contributed/v8/mjsunit/try-catch-default-destructuring.js](../blob/v8-test262-automation-export-ccadd02f2b/implementation-contributed/v8/mjsunit/try-catch-default-destructuring.js)