### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "801a7d15df",
-  "targetRevisionAtLastExport": "8f629cd87f",
+  "sourceRevisionAtLastExport": "344dd04163",
+  "targetRevisionAtLastExport": "4146be1823",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/stack-overflow-frame-for-construct-arityCheck-should-use-construct-codeBlock.js
+++ b/implementation-contributed/javascriptcore/stress/stack-overflow-frame-for-construct-arityCheck-should-use-construct-codeBlock.js
@@ -1,0 +1,27 @@
+//@ requireOptions("--maxPerThreadStackUsage=1572864")
+
+function foo(a, b, c) {
+    try {
+        throw new Error();
+    } catch {
+        hello();
+    }
+};
+
+function Bar(d, e) {
+    hello();
+}
+
+function hello(f) {
+    new Bar(0);
+};
+
+var exception;
+try {
+    foo();
+} catch(e) {
+    exception = e;
+}
+
+if (exception != "RangeError: Maximum call stack size exceeded.")
+    throw "FAILED";


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[801a7d15df](https://github.com///github/blob/801a7d15df) in JavaScriptCore and all changes made since [8f629cd87f](../blob/8f629cd87f) in
test262.













### 1 New File Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/stack-overflow-frame-for-construct-arityCheck-should-use-construct-codeBlock.js](../blob/javascriptcore-test262-automation-export-8f629cd87f/implementation-contributed/javascriptcore/stress/stack-overflow-frame-for-construct-arityCheck-should-use-construct-codeBlock.js)