### PR TITLE
Import test changes from V8

### DIFF
--- a/implementation-contributed/curation_logs/v8.json
+++ b/implementation-contributed/curation_logs/v8.json
@@ -1,5 +1,5 @@
 {
-  "sourceRevisionAtLastExport": "89eb451c",
-  "targetRevisionAtLastExport": "7519e1b462",
+  "sourceRevisionAtLastExport": "f88d169e",
+  "targetRevisionAtLastExport": "ad1b4aadf8",
   "curatedFiles": {}
 }

--- a/implementation-contributed/v8/mjsunit/code-coverage-block-opt.js
+++ b/implementation-contributed/v8/mjsunit/code-coverage-block-opt.js
@@ -23,7 +23,7 @@ f(); f(); f(); f(); f(); f();             // 0150
 `,
 [{"start":0,"end":199,"count":1},
  {"start":0,"end":33,"count":4},   // TODO(jgruber): Invocation count is off.
- {"start":25,"end":32,"count":16},
+ {"start":25,"end":31,"count":16},
  {"start":50,"end":76,"count":2}]  // TODO(jgruber): Invocation count is off.
 );
 
@@ -45,7 +45,7 @@ TestCoverage("Partial coverage collection",
 }();                                      // 0400
 `,
 [{"start":52,"end":153,"count":0},
- {"start":121,"end":152,"count":1}]
+ {"start":121,"end":137,"count":1}]
 );
 
 %DebugToggleBlockCoverage(false);

--- a/implementation-contributed/v8/mjsunit/code-coverage-block.js
+++ b/implementation-contributed/v8/mjsunit/code-coverage-block.js
@@ -246,8 +246,7 @@ function g() {}                           // 0000
  {"start":224,"end":237,"count":12},
  {"start":273,"end":277,"count":0},
  {"start":412,"end":416,"count":12},
- {"start":462,"end":475,"count":12},
- {"start":620,"end":622,"count":0}]
+ {"start":462,"end":475,"count":12}]
 );
 
 TestCoverage(
@@ -357,7 +356,7 @@ TestCoverage(
  {"start":219,"end":222,"count":0},
  {"start":254,"end":274,"count":0},
  {"start":369,"end":372,"count":0},
- {"start":390,"end":404,"count":0},
+ {"start":403,"end":404,"count":0},
  {"start":513,"end":554,"count":0}]
 );
 
@@ -376,10 +375,10 @@ TestCoverage("try/catch/finally statements with early return",
 [{"start":0,"end":449,"count":1},
  {"start":1,"end":151,"count":1},
  {"start":67,"end":70,"count":0},
- {"start":89,"end":150,"count":0},
+ {"start":91,"end":150,"count":0},
  {"start":201,"end":401,"count":1},
  {"start":267,"end":270,"count":0},
- {"start":319,"end":400,"count":0}]
+ {"start":321,"end":400,"count":0}]
 );
 
 TestCoverage(
@@ -411,11 +410,11 @@ TestCoverage(
 [{"start":0,"end":1099,"count":1},
  {"start":1,"end":151,"count":1},
  {"start":67,"end":70,"count":0},
- {"start":89,"end":150,"count":0},
+ {"start":91,"end":150,"count":0},
  {"start":201,"end":351,"count":1},
- {"start":284,"end":350,"count":0},
+ {"start":286,"end":350,"count":0},
  {"start":401,"end":701,"count":1},
- {"start":569,"end":700,"count":0},
+ {"start":603,"end":700,"count":0},
  {"start":561,"end":568,"count":0},  // TODO(jgruber): Sorting.
  {"start":751,"end":1051,"count":1},
  {"start":817,"end":820,"count":0},
@@ -437,7 +436,7 @@ TestCoverage(
 [{"start":0,"end":399,"count":1},
  {"start":1,"end":351,"count":1},
  {"start":154,"end":204,"count":0},
- {"start":226,"end":303,"count":0}]
+ {"start":226,"end":350,"count":0}]
 );
 
 TestCoverage(
@@ -467,11 +466,7 @@ TestCoverage(
 [{"start":0,"end":999,"count":1},
  {"start":1,"end":951,"count":1},
  {"start":152,"end":202,"count":0},
- {"start":285,"end":353,"count":0},
- {"start":472,"end":503,"count":0},
- {"start":626,"end":653,"count":0},
- {"start":768,"end":803,"count":0},
- {"start":867,"end":869,"count":0}]
+ {"start":285,"end":353,"count":0}]
 );
 
 TestCoverage(
@@ -496,11 +491,8 @@ TestCoverage(
 [{"start":0,"end":749,"count":1},
  {"start":1,"end":701,"count":1},
  {"start":87,"end":153,"count":2},
- {"start":125,"end":153,"count":0},
  {"start":271,"end":403,"count":2},
- {"start":379,"end":403,"count":0},
- {"start":509,"end":653,"count":2},
- {"start":621,"end":653,"count":0}]
+ {"start":509,"end":653,"count":2}]
 );
 
 TestCoverage(
@@ -570,6 +562,7 @@ try {                                     // 0200
 } catch (e) {}                            // 0450
 `,
 [{"start":0,"end":499,"count":1},
+ {"start":451,"end":452,"count":0},
  {"start":12,"end":101,"count":3},
  {"start":60,"end":100,"count":0},
  {"start":264,"end":353,"count":3},
@@ -648,6 +641,7 @@ try {                                     // 0200
 } catch (e) {}                            // 0450
 `,
 [{"start":0,"end":499,"count":1},
+ {"start":451,"end":452,"count":0},
  {"start":12,"end":101,"count":3},
  {"start":65,"end":100,"count":0},
  {"start":264,"end":353,"count":3},
@@ -846,8 +840,7 @@ Util.escape("foo.bar");                   // 0400
 `,
 [{"start":0,"end":449,"count":1},
  {"start":64,"end":351,"count":1},
- {"start":112,"end":203,"count":0},
- {"start":268,"end":350,"count":0}]
+ {"start":112,"end":203,"count":0}]
 );
 
 TestCoverage(
@@ -879,17 +872,136 @@ TestCoverage(
  {"start":1,"end":151,"count":1},
  {"start":118,"end":137,"count":0},
  {"start":201,"end":351,"count":1},
- {"start":277,"end":318,"count":0},
+ {"start":279,"end":318,"count":0},
  {"start":401,"end":525,"count":1},
  {"start":475,"end":486,"count":0},
  {"start":503,"end":523,"count":0},
  {"start":551,"end":651,"count":1},
  {"start":622,"end":639,"count":0},
  {"start":701,"end":801,"count":1},
- {"start":773,"end":791,"count":0},
+ {"start":774,"end":791,"count":0},
  {"start":851,"end":1001,"count":1},
  {"start":920,"end":928,"count":0},
  {"start":929,"end":965,"count":0}]
+);
+
+TestCoverage(
+"terminal break statement",
+`
+while (true) {                            // 0000
+  const b = false                         // 0050
+  break                                   // 0100
+}                                         // 0150
+let stop = false                          // 0200
+while (true) {                            // 0250
+  if (stop) {                             // 0300
+    break                                 // 0350
+  }                                       // 0400
+  stop = true                             // 0450
+}                                         // 0500
+`,
+[{"start":0,"end":549,"count":1},
+ {"start":263,"end":501,"count":2},
+ {"start":312,"end":501,"count":1}]
+);
+
+TestCoverage(
+"terminal return statement",
+`
+function a () {                           // 0000
+  const b = false                         // 0050
+  return 1                                // 0100
+}                                         // 0150
+const b = (early) => {                    // 0200
+  if (early) {                            // 0250
+    return 2                              // 0300
+  }                                       // 0350
+  return 3                                // 0400
+}                                         // 0450
+const c = () => {                         // 0500
+  if (true) {                             // 0550
+    return                                // 0600
+  }                                       // 0650
+}                                         // 0700
+a(); b(false); b(true); c()               // 0750
+`,
+[{"start":0,"end":799,"count":1},
+ {"start":0,"end":151,"count":1},
+ {"start":210,"end":451,"count":2},
+ {"start":263,"end":450,"count":1},
+ {"start":510,"end":701,"count":1}]
+);
+
+TestCoverage(
+"terminal blocks",
+`
+function a () {                           // 0000
+  {                                       // 0050
+    return 'a'                            // 0100
+  }                                       // 0150
+}                                         // 0200
+function b () {                           // 0250
+  {                                       // 0300
+    {                                     // 0350
+      return 'b'                          // 0400
+    }                                     // 0450
+  }                                       // 0500
+}                                         // 0550
+a(); b()                                  // 0600
+`,
+[{"start":0,"end":649,"count":1},
+ {"start":0,"end":201,"count":1},
+ {"start":250,"end":551,"count":1}]
+);
+
+TestCoverage(
+"terminal if statements",
+`
+function a (branch) {                     // 0000
+  if (branch) {                           // 0050
+    return 'a'                            // 0100
+  } else {                                // 0150
+    return 'b'                            // 0200
+  }                                       // 0250
+}                                         // 0300
+function b (branch) {                     // 0350
+  if (branch) {                           // 0400
+    if (branch) {                         // 0450
+      return 'c'                          // 0500
+    }                                     // 0550
+  }                                       // 0600
+}                                         // 0650
+function c (branch) {                     // 0700
+  if (branch) {                           // 0750
+    return 'c'                            // 0800
+  } else {                                // 0850
+    return 'd'                            // 0900
+  }                                       // 0950
+}                                         // 1000
+function d (branch) {                     // 1050
+  if (branch) {                           // 1100
+    if (!branch) {                        // 1150
+      return 'e'                          // 1200
+    } else {                              // 1250
+      return 'f'                          // 1300
+    }                                     // 1350
+  } else {                                // 1400
+    // noop                               // 1450
+  }                                       // 1500
+}                                         // 1550
+a(true); a(false); b(true); b(false)      // 1600
+c(true); d(true);                         // 1650
+`,
+[{"start":0,"end":1699,"count":1},
+ {"start":0,"end":301,"count":2},
+ {"start":64,"end":253,"count":1},
+ {"start":350,"end":651,"count":2},
+ {"start":414,"end":603,"count":1},
+ {"start":700,"end":1001,"count":1},
+ {"start":853,"end":953,"count":0},
+ {"start":1050,"end":1551,"count":1},
+ {"start":1167,"end":1255,"count":0},
+ {"start":1403,"end":1503,"count":0}]
 );
 
 %DebugToggleBlockCoverage(false);

--- a/implementation-contributed/v8/mjsunit/es8/async-function-stacktrace.js
+++ b/implementation-contributed/v8/mjsunit/es8/async-function-stacktrace.js
@@ -81,19 +81,21 @@ async function runTests() {
     try { await reject(); } catch (e) { throw new Error("FAIL"); }
   } }).c4, ["c4"]);
 
+  // TODO(caitp): We should infer anonymous async functions as the empty
+  // string, not as the name of a function they're passed as a parameter to.
   await test(async x => { throw new Error("FAIL") },
-             ["test", "runTests"]);
+             ["test", "test", "runTests"]);
   await test(async() => { throw new Error("FAIL") },
-             ["test", "runTests"]);
+             ["test", "test", "runTests"]);
   await test(async(a) => { throw new Error("FAIL") },
-             ["test", "runTests"]);
+             ["test", "test", "runTests"]);
   await test(async(a, b) => { throw new Error("FAIL") },
-             ["test", "runTests"]);
+             ["test", "test", "runTests"]);
 
-  await test(async x => { await 1; throw new Error("FAIL") }, []);
-  await test(async() => { await 1; throw new Error("FAIL") }, []);
-  await test(async(a) => { await 1; throw new Error("FAIL") }, []);
-  await test(async(a, b) => { await 1; throw new Error("FAIL") }, []);
+  await test(async x => { await 1; throw new Error("FAIL") }, ["test"]);
+  await test(async() => { await 1; throw new Error("FAIL") }, ["test"]);
+  await test(async(a) => { await 1; throw new Error("FAIL") }, ["test"]);
+  await test(async(a, b) => { await 1; throw new Error("FAIL") }, ["test"]);
 
   await test(async x => {
     await 1;
@@ -102,7 +104,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, []);
+  }, ["test"]);
 
   await test(async() => {
     await 1;
@@ -111,7 +113,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, []);
+  }, ["test"]);
 
   await test(async(a) => {
     await 1;
@@ -120,7 +122,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, []);
+  }, ["test"]);
 
   await test(async(a, b) => {
     await 1;
@@ -129,7 +131,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, []);
+  }, ["test"]);
 
   await test(async x => {
     await 1;
@@ -138,7 +140,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, []);
+  }, ["test"]);
 
   await test(async() => {
     await 1;
@@ -147,7 +149,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, []);
+  }, ["test"]);
 
   await test(async(a) => {
     await 1;
@@ -156,7 +158,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, []);
+  }, ["test"]);
 
   await test(async(a, b) => {
     await 1;
@@ -165,7 +167,7 @@ async function runTests() {
     } catch (e) {
       throw new Error("FAIL");
     }
-  }, []);
+  }, ["test"]);
 }
 
 runTests().catch(e => {

--- a/implementation-contributed/v8/mjsunit/regexp.js
+++ b/implementation-contributed/v8/mjsunit/regexp.js
@@ -808,3 +808,19 @@ assertFalse(/^[\d-X-Z]*$/.test("234-XYZ-432"));
 
 assertFalse(/\uDB88|\uDBEC|aa/.test(""));
 assertFalse(/\uDB88|\uDBEC|aa/u.test(""));
+
+// EscapeRegExpPattern
+assertEquals("\\n", /\n/.source);
+assertEquals("\\n", new RegExp("\n").source);
+assertEquals("\\n", new RegExp("\\n").source);
+assertEquals("\\\\n", /\\n/.source);
+assertEquals("\\r", /\r/.source);
+assertEquals("\\r", new RegExp("\r").source);
+assertEquals("\\r", new RegExp("\\r").source);
+assertEquals("\\\\r", /\\r/.source);
+assertEquals("\\u2028", /\u2028/.source);
+assertEquals("\\u2028", new RegExp("\u2028").source);
+assertEquals("\\u2028", new RegExp("\\u2028").source);
+assertEquals("\\u2029", /\u2029/.source);
+assertEquals("\\u2029", new RegExp("\u2029").source);
+assertEquals("\\u2029", new RegExp("\\u2029").source);

--- a/implementation-contributed/v8/mjsunit/regress/regress-1199637.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-1199637.js
@@ -32,44 +32,53 @@
 var NONE = 0;
 var READ_ONLY = 1;
 
+function AddNamedProperty(object, name, value, attrs) {
+  Object.defineProperty(object, name, {
+      value,
+      configurable: true,
+      enumerable: true,
+      writable: (attrs & READ_ONLY) === 0
+  });
+}
+
 // Use DeclareGlobal...
-%AddNamedProperty(this.__proto__, "a", 1234, NONE);
+AddNamedProperty(this.__proto__, "a", 1234, NONE);
 assertEquals(1234, a);
 eval("var a = 5678;");
 assertEquals(5678, a);
 
-%AddNamedProperty(this.__proto__, "b", 1234, NONE);
+AddNamedProperty(this.__proto__, "b", 1234, NONE);
 assertEquals(1234, b);
 eval("var b = 5678;");
 assertEquals(5678, b);
 
-%AddNamedProperty(this.__proto__, "c", 1234, READ_ONLY);
+AddNamedProperty(this.__proto__, "c", 1234, READ_ONLY);
 assertEquals(1234, c);
 eval("var c = 5678;");
 assertEquals(5678, c);
 
-%AddNamedProperty(this.__proto__, "d", 1234, READ_ONLY);
+AddNamedProperty(this.__proto__, "d", 1234, READ_ONLY);
 assertEquals(1234, d);
 eval("var d = 5678;");
 assertEquals(5678, d);
 
 // Use DeclareContextSlot...
-%AddNamedProperty(this.__proto__, "x", 1234, NONE);
+AddNamedProperty(this.__proto__, "x", 1234, NONE);
 assertEquals(1234, x);
 eval("with({}) { var x = 5678; }");
 assertEquals(5678, x);
 
-%AddNamedProperty(this.__proto__, "y", 1234, NONE);
+AddNamedProperty(this.__proto__, "y", 1234, NONE);
 assertEquals(1234, y);
 eval("with({}) { var y = 5678; }");
 assertEquals(5678, y);
 
-%AddNamedProperty(this.__proto__, "z", 1234, READ_ONLY);
+AddNamedProperty(this.__proto__, "z", 1234, READ_ONLY);
 assertEquals(1234, z);
 eval("with({}) { var z = 5678; }");
 assertEquals(5678, z);
 
-%AddNamedProperty(this.__proto__, "w", 1234, READ_ONLY);
+AddNamedProperty(this.__proto__, "w", 1234, READ_ONLY);
 assertEquals(1234, w);
 eval("with({}) { var w = 5678; }");
 assertEquals(5678, w);

--- a/implementation-contributed/v8/mjsunit/regress/regress-334.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-334.js
@@ -33,14 +33,23 @@ var READ_ONLY   = 1;
 var DONT_ENUM   = 2;
 var DONT_DELETE = 4;
 
+function AddNamedProperty(object, name, value, attrs) {
+  Object.defineProperty(object, name, {
+      value,
+      configurable: (attrs & DONT_DELETE) === 0,
+      enumerable: (attrs & DONT_ENUM) === 0,
+      writable: (attrs & READ_ONLY) === 0
+  });
+}
+
 function func1(){}
 function func2(){}
 
 var object = {__proto__:{}};
-%AddNamedProperty(object, "foo", func1, DONT_ENUM | DONT_DELETE);
-%AddNamedProperty(object, "bar", func1, DONT_ENUM | READ_ONLY);
-%AddNamedProperty(object, "baz", func1, DONT_DELETE | READ_ONLY);
-%AddNamedProperty(object.__proto__, "bif", func1, DONT_ENUM | DONT_DELETE);
+AddNamedProperty(object, "foo", func1, DONT_ENUM | DONT_DELETE);
+AddNamedProperty(object, "bar", func1, DONT_ENUM | READ_ONLY);
+AddNamedProperty(object, "baz", func1, DONT_DELETE | READ_ONLY);
+AddNamedProperty(object.__proto__, "bif", func1, DONT_ENUM | DONT_DELETE);
 object.bif = func2;
 
 function enumerable(obj) {

--- a/implementation-contributed/v8/mjsunit/regress/regress-cntl-descriptors-enum.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-cntl-descriptors-enum.js
@@ -27,13 +27,16 @@
 
 // Flags: --allow-natives-syntax --expose-gc
 
-DontEnum = 2;
-
 var o = {};
-%AddNamedProperty(o, "a", 0, DontEnum);
+Object.defineProperty(o, "a", {
+    value: 0, configurable: true, writable: true, enumerable: false
+});
 
 var o2 = {};
-%AddNamedProperty(o2, "a", 0, DontEnum);
+Object.defineProperty(o2, "a", {
+    value: 0, configurable: true, writable: true, enumerable: false
+});
+
 
 assertTrue(%HaveSameMap(o, o2));
 

--- a/implementation-contributed/v8/mjsunit/regress/wasm/regress-910824.js
+++ b/implementation-contributed/v8/mjsunit/regress/wasm/regress-910824.js
@@ -1,0 +1,37 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+load('test/mjsunit/wasm/wasm-constants.js');
+load('test/mjsunit/wasm/wasm-module-builder.js');
+
+const builder = new WasmModuleBuilder();
+builder.addGlobal(kWasmI32, 1);
+builder.addGlobal(kWasmF32, 1);
+builder.addType(makeSig([kWasmI32, kWasmF32, kWasmF32, kWasmF64], [kWasmI32]));
+builder.addFunction(undefined, 0 /* sig */)
+  .addLocals({i32_count: 504})
+  .addBody([
+kExprGetGlobal, 0x00,
+kExprSetLocal, 0x04,
+kExprGetLocal, 0x04,
+kExprI32Const, 0x01,
+kExprI32Sub,
+kExprGetGlobal, 0x00,
+kExprI32Const, 0x00,
+kExprI32Eqz,
+kExprGetGlobal, 0x00,
+kExprI32Const, 0x01,
+kExprI32Const, 0x01,
+kExprI32Sub,
+kExprGetGlobal, 0x00,
+kExprI32Const, 0x00,
+kExprI32Eqz,
+kExprGetGlobal, 0x00,
+kExprI32Const, 0x00,
+kExprI32Const, 0x01,
+kExprI32Sub,
+kExprGetGlobal, 0x01,
+kExprUnreachable,
+]);
+builder.instantiate();

--- a/implementation-contributed/v8/test262/test262.status
+++ b/implementation-contributed/v8/test262/test262.status
@@ -479,9 +479,6 @@
   'built-ins/TypedArrayConstructors/internals/Set/key-is-out-of-bounds': [FAIL],
   'built-ins/TypedArrayConstructors/internals/Set/BigInt/key-is-out-of-bounds': [FAIL],
 
-  # https://bugs.chromium.org/p/v8/issues/detail?id=5329
-  'built-ins/RegExp/prototype/source/value-line-terminator': [FAIL],
-
   # https://bugs.chromium.org/p/v8/issues/detail?id=5112
   'annexB/language/eval-code/direct/func-block-decl-eval-func-no-skip-try': [FAIL],
   'annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-no-skip-try': [FAIL],

--- a/implementation-contributed/v8/test262/testcfg.py
+++ b/implementation-contributed/v8/test262/testcfg.py
@@ -44,6 +44,8 @@ from testrunner.outproc import test262
 FEATURE_FLAGS = {
   'class-fields-public': '--harmony-public-fields',
   'class-static-fields-public': '--harmony-class-fields',
+  'class-fields-private': '--harmony-private-fields',
+  'class-static-fields-private': '--harmony-private-fields',
   'Array.prototype.flat': '--harmony-array-flat',
   'Array.prototype.flatMap': '--harmony-array-flat',
   'String.prototype.matchAll': '--harmony-string-matchall',
@@ -60,9 +62,7 @@ FEATURE_FLAGS = {
   'Object.fromEntries': '--harmony-object-from-entries',
 }
 
-SKIPPED_FEATURES = set(['class-fields-private',
-                        'class-static-fields-private',
-                        'class-methods-private',
+SKIPPED_FEATURES = set(['class-methods-private',
                         'class-static-methods-private',
                         'Intl.NumberFormat-unified'])
 


### PR DESCRIPTION
# Import JavaScript Test Changes from V8

Changes imported in this pull request include all changes made since
[89eb451c](https://github.com///github/blob/89eb451c) in V8 and all changes made since [7519e1b462](../blob/7519e1b462) in
test262.



### 9 Files Updated From V8

These files have been modified in V8.

 - [implementation-contributed/v8/mjsunit/code-coverage-block-opt.js](../blob/v8-test262-automation-export-7519e1b462/implementation-contributed/v8/mjsunit/code-coverage-block-opt.js)
 - [implementation-contributed/v8/mjsunit/code-coverage-block.js](../blob/v8-test262-automation-export-7519e1b462/implementation-contributed/v8/mjsunit/code-coverage-block.js)
 - [implementation-contributed/v8/mjsunit/es8/async-function-stacktrace.js](../blob/v8-test262-automation-export-7519e1b462/implementation-contributed/v8/mjsunit/es8/async-function-stacktrace.js)
 - [implementation-contributed/v8/mjsunit/regexp.js](../blob/v8-test262-automation-export-7519e1b462/implementation-contributed/v8/mjsunit/regexp.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-1199637.js](../blob/v8-test262-automation-export-7519e1b462/implementation-contributed/v8/mjsunit/regress/regress-1199637.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-334.js](../blob/v8-test262-automation-export-7519e1b462/implementation-contributed/v8/mjsunit/regress/regress-334.js)
 - [implementation-contributed/v8/mjsunit/regress/regress-cntl-descriptors-enum.js](../blob/v8-test262-automation-export-7519e1b462/implementation-contributed/v8/mjsunit/regress/regress-cntl-descriptors-enum.js)
 - [implementation-contributed/v8/test262/test262.status](../blob/v8-test262-automation-export-7519e1b462/implementation-contributed/v8/test262/test262.status)
 - [implementation-contributed/v8/test262/testcfg.py](../blob/v8-test262-automation-export-7519e1b462/implementation-contributed/v8/test262/testcfg.py)









### 1 New File Added in V8

These are new files added in V8 and have been synced to the
`implementation-contributed/v8` directory.

 - [implementation-contributed/v8/mjsunit/regress/wasm/regress-910824.js](../blob/v8-test262-automation-export-7519e1b462/implementation-contributed/v8/mjsunit/regress/wasm/regress-910824.js)