### PR TITLE
Increase coverage for %TypedArray%.prototype.map with species constructor

### DIFF
--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor-abrupt.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: Return abrupt from SpeciesConstructor's get Constructor
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  3. If C is undefined, return defaultConstructor.
+  ...
+includes: [testBigIntTypedArray.js]
+features: [BigInt, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA([40n, 41n, 42n, 43n]);
+  var callCount = 0;
+
+  Object.defineProperty(sample, "constructor", {
+    get: function() {
+      throw new Test262Error();
+    }
+  });
+
+  assert.throws(Test262Error, function() {
+    sample.map(function() {
+      callCount++;
+    });
+  });
+  assert.sameValue(callCount, 0, "callback should not be called");
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor-inherited.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor-inherited.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: get inherited constructor on SpeciesConstructor
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  3. If C is undefined, return defaultConstructor.
+  ...
+includes: [testBigIntTypedArray.js]
+features: [BigInt, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA([40n, 41n, 42n, 43n]);
+  var calls = 0;
+  var result;
+
+  Object.defineProperty(TA.prototype, "constructor", {
+    get: function() {
+      calls++;
+    }
+  });
+
+  result = sample.map(function() {
+    return 0n;
+  });
+
+  assert.sameValue(calls, 1, "called custom ctor get accessor once");
+
+  assert.sameValue(
+    Object.getPrototypeOf(result),
+    Object.getPrototypeOf(sample),
+    "use defaultCtor on an undefined return - getPrototypeOf check"
+  );
+  assert.sameValue(
+    result.constructor,
+    undefined,
+    "used defaultCtor but still checks the inherited .constructor"
+  );
+
+  calls = 6;
+  result.constructor;
+  assert.sameValue(
+    calls,
+    7,
+    "result.constructor triggers the inherited accessor property"
+  );
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor-returns-throws.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor-returns-throws.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Throws if O.constructor returns a non-Object and non-undefined value
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  3. If C is undefined, return defaultConstructor.
+  4. If Type(C) is not Object, throw a TypeError exception.
+  ...
+includes: [testBigIntTypedArray.js]
+features: [BigInt, Symbol, TypedArray]
+---*/
+
+var callbackfn = function() { return 0n; };
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA([40n, 41n, 42n, 43n]);
+
+  sample.constructor = 42;
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "42");
+
+  sample.constructor = "1";
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "string");
+
+  sample.constructor = null;
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "null");
+
+  sample.constructor = NaN;
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "NaN");
+
+  sample.constructor = false;
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "false");
+
+  sample.constructor = Symbol("1");
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "symbol");
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-ctor.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: get constructor on SpeciesConstructor
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  3. If C is undefined, return defaultConstructor.
+  ...
+includes: [testBigIntTypedArray.js]
+features: [BigInt, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA([40n, 41n, 42n, 43n]);
+  var calls = 0;
+  var result;
+
+  Object.defineProperty(sample, "constructor", {
+    get: function() {
+      calls++;
+    }
+  });
+
+  result = sample.map(function() { return 0n; });
+
+  assert.sameValue(calls, 1, "called custom ctor get accessor once");
+
+  assert.sameValue(
+    Object.getPrototypeOf(result),
+    Object.getPrototypeOf(sample),
+    "use defaultCtor on an undefined return - getPrototypeOf check"
+  );
+  assert.sameValue(
+    result.constructor,
+    TA,
+    "use defaultCtor on an undefined return - .constructor check"
+  );
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-abrupt.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Returns abrupt from get @@species on found constructor
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+includes: [testBigIntTypedArray.js]
+features: [BigInt, Symbol.species, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+
+  sample.constructor = {};
+
+  Object.defineProperty(sample.constructor, Symbol.species, {
+    get: function() {
+      throw new Test262Error();
+    }
+  });
+
+  assert.throws(Test262Error, function() {
+    sample.map(function() { return 0n; });
+  });
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor-invocation.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Verify arguments on custom @@species construct call
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+  7. If IsConstructor(S) is true, return S.
+  ...
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  1. Let newTypedArray be ? Construct(constructor, argumentList).
+  2. Perform ? ValidateTypedArray(newTypedArray).
+  3. If argumentList is a List of a single Number, then
+    ...
+  4. Return newTypedArray.
+includes: [testBigIntTypedArray.js]
+features: [BigInt, Symbol.species, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA([40n, 42n, 42n]);
+  var result, ctorThis;
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = function(count) {
+    result = arguments;
+    ctorThis = this;
+    return new TA(count);
+  };
+
+  sample.map(function(v) { return v === 42n; });
+
+  assert.sameValue(result.length, 1, "called with 1 argument");
+  assert.sameValue(result[0], 3, "[0] is the length");
+
+  assert(
+    ctorThis instanceof sample.constructor[Symbol.species],
+    "`this` value in the @@species fn is an instance of the function itself"
+  );
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Throws a TypeError if new typedArray's length < len
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  ...
+  3. If argumentList is a List of a single Number, then
+    a. If the value of newTypedArray's [[ArrayLength]] internal slot <
+    argumentList[0], throw a TypeError exception.
+  ...
+includes: [testBigIntTypedArray.js]
+features: [BigInt, Symbol.species, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = function() {
+    return new TA();
+  };
+
+  assert.throws(TypeError, function() {
+    sample.map(function() { return 0; });
+  });
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor-length.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor-length.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Does not throw a TypeError if new typedArray's length >= len
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  ...
+  3. If argumentList is a List of a single Number, then
+    a. If the value of newTypedArray's [[ArrayLength]] internal slot <
+    argumentList[0], throw a TypeError exception.
+  ...
+includes: [testBigIntTypedArray.js]
+features: [BigInt, Symbol.species, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+  var customCount, result;
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = function() {
+    return new TA(customCount);
+  };
+
+  customCount = 2;
+  result = sample.map(function() { return 0n; });
+  assert.sameValue(result.length, customCount, "length == count");
+
+  customCount = 5;
+  result = sample.map(function() { return 0n; });
+  assert.sameValue(result.length, customCount, "length > count");
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Custom @@species constructor may return a different TypedArray
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+  7. If IsConstructor(S) is true, return S.
+  ...
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  1. Let newTypedArray be ? Construct(constructor, argumentList).
+  2. Perform ? ValidateTypedArray(newTypedArray).
+  3. If argumentList is a List of a single Number, then
+    ...
+  4. Return newTypedArray.
+includes: [testBigIntTypedArray.js, compareArray.js]
+features: [BigInt, Symbol.species, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA([40n]);
+  var otherTA = TA === BigInt64Array ? BigUint64Array : BigInt64Array;
+  var other = new otherTA([1n, 0n, 1n]);
+  var result;
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = function() {
+    return other;
+  };
+
+  result = sample.map(function(a) { return a + 7n; });
+
+  assert.sameValue(result, other, "returned another typedarray");
+  assert(compareArray(result, [47n, 0n, 1n]), "values are set on returned typedarray");
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor-throws.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor-throws.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Custom @@species constructor throws if it does not return a compatible object
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+  7. If IsConstructor(S) is true, return S.
+  ...
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  1. Let newTypedArray be ? Construct(constructor, argumentList).
+  2. Perform ? ValidateTypedArray(newTypedArray).
+  ...
+includes: [testBigIntTypedArray.js]
+features: [BigInt, Symbol.species, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = Array;
+
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  });
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Use custom @@species constructor if available
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+  7. If IsConstructor(S) is true, return S.
+  ...
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  1. Let newTypedArray be ? Construct(constructor, argumentList).
+  2. Perform ? ValidateTypedArray(newTypedArray).
+  3. If argumentList is a List of a single Number, then
+    ...
+  4. Return newTypedArray.
+includes: [testBigIntTypedArray.js, compareArray.js]
+features: [BigInt, Symbol.species, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA([40n, 41n, 42n]);
+  var calls = 0;
+  var other, result;
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = function(len) {
+    calls++;
+    other = new TA(len);
+    return other;
+  };
+
+  result = sample.map(function(a) { return a + 7n; });
+
+  assert.sameValue(calls, 1, "ctor called once");
+  assert.sameValue(result, other, "return is instance of custom constructor");
+  assert(compareArray(result, [47n, 48n, 49n]), "values are set on the new obj");
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-returns-throws.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-returns-throws.js
@@ -1,0 +1,66 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Throws if returned @@species is not a constructor, null or undefined.
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  6. If S is either undefined or null, return defaultConstructor.
+  7. If IsConstructor(S) is true, return S.
+  8. Throw a TypeError exception.
+  ...
+includes: [testBigIntTypedArray.js]
+features: [BigInt, Symbol.species, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+
+  sample.constructor = {};
+
+  sample.constructor[Symbol.species] = 0;
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "0");
+
+  sample.constructor[Symbol.species] = "string";
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "string");
+
+  sample.constructor[Symbol.species] = {};
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "{}");
+
+  sample.constructor[Symbol.species] = NaN;
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "NaN");
+
+  sample.constructor[Symbol.species] = false;
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "false");
+
+  sample.constructor[Symbol.species] = true;
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "true");
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-use-default-ctor.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-use-default-ctor.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Use defaultConstructor if @@species is either undefined or null
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  6. If S is either undefined or null, return defaultConstructor.
+  ...
+includes: [testBigIntTypedArray.js]
+features: [BigInt, Symbol.species, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+  var result;
+
+  sample.constructor = {};
+
+  result = sample.map(function() { return 0n; });
+
+  assert.sameValue(
+    Object.getPrototypeOf(result),
+    Object.getPrototypeOf(sample),
+    "undefined @@species - prototype check "
+  );
+  assert.sameValue(result.constructor, TA, "undefined @@species - ctor check");
+
+  sample.constructor[Symbol.species] = null;
+  result = sample.map(function() { return 0n; });
+
+  assert.sameValue(
+    Object.getPrototypeOf(result),
+    Object.getPrototypeOf(sample),
+    "null @@species - prototype check "
+  );
+  assert.sameValue(result.constructor, TA, "null @@species - ctor check");
+});

--- a/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  get @@species from found constructor
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+includes: [testBigIntTypedArray.js]
+features: [BigInt, Symbol.species, TypedArray]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+  var calls = 0;
+
+  sample.constructor = {};
+
+  Object.defineProperty(sample.constructor, Symbol.species, {
+    get: function() {
+      calls++;
+    }
+  });
+
+  sample.map(function() { return 0n; });
+
+  assert.sameValue(calls, 1);
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor-abrupt.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: Return abrupt from SpeciesConstructor's get Constructor
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  3. If C is undefined, return defaultConstructor.
+  ...
+includes: [testTypedArray.js]
+features: [TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA([40, 41, 42, 43]);
+  var callCount = 0;
+
+  Object.defineProperty(sample, "constructor", {
+    get: function() {
+      throw new Test262Error();
+    }
+  });
+
+  assert.throws(Test262Error, function() {
+    sample.map(function() {
+      callCount++;
+    });
+  });
+  assert.sameValue(callCount, 0, "callback should not be called");
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor-inherited.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor-inherited.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: get inherited constructor on SpeciesConstructor
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  3. If C is undefined, return defaultConstructor.
+  ...
+includes: [testTypedArray.js]
+features: [TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA([40, 41, 42, 43]);
+  var calls = 0;
+  var result;
+
+  Object.defineProperty(TA.prototype, "constructor", {
+    get: function() {
+      calls++;
+    }
+  });
+
+  result = sample.map(function() {
+    return 0;
+  });
+
+  assert.sameValue(calls, 1, "called custom ctor get accessor once");
+
+  assert.sameValue(
+    Object.getPrototypeOf(result),
+    Object.getPrototypeOf(sample),
+    "use defaultCtor on an undefined return - getPrototypeOf check"
+  );
+  assert.sameValue(
+    result.constructor,
+    undefined,
+    "used defaultCtor but still checks the inherited .constructor"
+  );
+
+  calls = 6;
+  result.constructor;
+  assert.sameValue(
+    calls,
+    7,
+    "result.constructor triggers the inherited accessor property"
+  );
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor-returns-throws.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor-returns-throws.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Throws if O.constructor returns a non-Object and non-undefined value
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  3. If C is undefined, return defaultConstructor.
+  4. If Type(C) is not Object, throw a TypeError exception.
+  ...
+includes: [testTypedArray.js]
+features: [Symbol, TypedArray]
+---*/
+
+var callbackfn = function() { return 0; };
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA([40, 41, 42, 43]);
+
+  sample.constructor = 42;
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "42");
+
+  sample.constructor = "1";
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "string");
+
+  sample.constructor = null;
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "null");
+
+  sample.constructor = NaN;
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "NaN");
+
+  sample.constructor = false;
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "false");
+
+  sample.constructor = Symbol("1");
+  assert.throws(TypeError, function() {
+    sample.map(callbackfn);
+  }, "symbol");
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-ctor.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: get constructor on SpeciesConstructor
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  3. If C is undefined, return defaultConstructor.
+  ...
+includes: [testTypedArray.js]
+features: [TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA([40, 41, 42, 43]);
+  var calls = 0;
+  var result;
+
+  Object.defineProperty(sample, "constructor", {
+    get: function() {
+      calls++;
+    }
+  });
+
+  result = sample.map(function() { return 0; });
+
+  assert.sameValue(calls, 1, "called custom ctor get accessor once");
+
+  assert.sameValue(
+    Object.getPrototypeOf(result),
+    Object.getPrototypeOf(sample),
+    "use defaultCtor on an undefined return - getPrototypeOf check"
+  );
+  assert.sameValue(
+    result.constructor,
+    TA,
+    "use defaultCtor on an undefined return - .constructor check"
+  );
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-abrupt.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-abrupt.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Returns abrupt from get @@species on found constructor
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+includes: [testTypedArray.js]
+features: [Symbol.species, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+
+  sample.constructor = {};
+
+  Object.defineProperty(sample.constructor, Symbol.species, {
+    get: function() {
+      throw new Test262Error();
+    }
+  });
+
+  assert.throws(Test262Error, function() {
+    sample.map(function() { return 0; });
+  });
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor-invocation.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor-invocation.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Verify arguments on custom @@species construct call
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+  7. If IsConstructor(S) is true, return S.
+  ...
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  1. Let newTypedArray be ? Construct(constructor, argumentList).
+  2. Perform ? ValidateTypedArray(newTypedArray).
+  3. If argumentList is a List of a single Number, then
+    ...
+  4. Return newTypedArray.
+includes: [testTypedArray.js]
+features: [Symbol.species, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA([40, 42, 42]);
+  var result, ctorThis;
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = function(count) {
+    result = arguments;
+    ctorThis = this;
+    return new TA(count);
+  };
+
+  sample.map(function(v) { return v === 42; });
+
+  assert.sameValue(result.length, 1, "called with 1 argument");
+  assert.sameValue(result[0], 3, "[0] is the length");
+
+  assert(
+    ctorThis instanceof sample.constructor[Symbol.species],
+    "`this` value in the @@species fn is an instance of the function itself"
+  );
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor-length-throws.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor-length-throws.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Throws a TypeError if new typedArray's length < len
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  ...
+  3. If argumentList is a List of a single Number, then
+    a. If the value of newTypedArray's [[ArrayLength]] internal slot <
+    argumentList[0], throw a TypeError exception.
+  ...
+includes: [testTypedArray.js]
+features: [Symbol.species, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = function() {
+    return new TA();
+  };
+
+  assert.throws(TypeError, function() {
+    sample.map(function() { return 0; });
+  });
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor-length.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor-length.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Does not throw a TypeError if new typedArray's length >= len
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  ...
+  3. If argumentList is a List of a single Number, then
+    a. If the value of newTypedArray's [[ArrayLength]] internal slot <
+    argumentList[0], throw a TypeError exception.
+  ...
+includes: [testTypedArray.js]
+features: [Symbol.species, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+  var customCount, result;
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = function() {
+    return new TA(customCount);
+  };
+
+  customCount = 2;
+  result = sample.map(function() { return 0; });
+  assert.sameValue(result.length, customCount, "length == count");
+
+  customCount = 5;
+  result = sample.map(function() { return 0; });
+  assert.sameValue(result.length, customCount, "length > count");
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Custom @@species constructor may return a different TypedArray
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+  7. If IsConstructor(S) is true, return S.
+  ...
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  1. Let newTypedArray be ? Construct(constructor, argumentList).
+  2. Perform ? ValidateTypedArray(newTypedArray).
+  3. If argumentList is a List of a single Number, then
+    ...
+  4. Return newTypedArray.
+includes: [testTypedArray.js, compareArray.js]
+features: [Symbol.species, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA([40]);
+  var otherTA = TA === Int8Array ? Int16Array : Int8Array;
+  var other = new otherTA([1, 0, 1]);
+  var result;
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = function() {
+    return other;
+  };
+
+  result = sample.map(function(a) { return a + 7; });
+
+  assert.sameValue(result, other, "returned another typedarray");
+  assert(compareArray(result, [47, 0, 1]), "values are set on returned typedarray");
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor-throws.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor-throws.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Custom @@species constructor throws if it does not return a compatible object
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+  7. If IsConstructor(S) is true, return S.
+  ...
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  1. Let newTypedArray be ? Construct(constructor, argumentList).
+  2. Perform ? ValidateTypedArray(newTypedArray).
+  ...
+includes: [testTypedArray.js]
+features: [Symbol.species, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = Array;
+
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  });
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Use custom @@species constructor if available
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  4. Return ? TypedArrayCreate(constructor, argumentList).
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+  7. If IsConstructor(S) is true, return S.
+  ...
+
+  22.2.4.6 TypedArrayCreate ( constructor, argumentList )
+
+  1. Let newTypedArray be ? Construct(constructor, argumentList).
+  2. Perform ? ValidateTypedArray(newTypedArray).
+  3. If argumentList is a List of a single Number, then
+    ...
+  4. Return newTypedArray.
+includes: [testTypedArray.js, compareArray.js]
+features: [Symbol.species, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA([40, 41, 42]);
+  var calls = 0;
+  var other, result;
+
+  sample.constructor = {};
+  sample.constructor[Symbol.species] = function(len) {
+    calls++;
+    other = new TA(len);
+    return other;
+  };
+
+  result = sample.map(function(a) { return a + 7; });
+
+  assert.sameValue(calls, 1, "ctor called once");
+  assert.sameValue(result, other, "return is instance of custom constructor");
+  assert(compareArray(result, [47, 48, 49]), "values are set on the new obj");
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-returns-throws.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-returns-throws.js
@@ -1,0 +1,66 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Throws if returned @@species is not a constructor, null or undefined.
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  6. If S is either undefined or null, return defaultConstructor.
+  7. If IsConstructor(S) is true, return S.
+  8. Throw a TypeError exception.
+  ...
+includes: [testTypedArray.js]
+features: [Symbol.species, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+
+  sample.constructor = {};
+
+  sample.constructor[Symbol.species] = 0;
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "0");
+
+  sample.constructor[Symbol.species] = "string";
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "string");
+
+  sample.constructor[Symbol.species] = {};
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "{}");
+
+  sample.constructor[Symbol.species] = NaN;
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "NaN");
+
+  sample.constructor[Symbol.species] = false;
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "false");
+
+  sample.constructor[Symbol.species] = true;
+  assert.throws(TypeError, function() {
+    sample.map(function() {});
+  }, "true");
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-use-default-ctor.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species-use-default-ctor.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  Use defaultConstructor if @@species is either undefined or null
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  ...
+  5. Let S be ? Get(C, @@species).
+  6. If S is either undefined or null, return defaultConstructor.
+  ...
+includes: [testTypedArray.js]
+features: [Symbol.species, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+  var result;
+
+  sample.constructor = {};
+
+  result = sample.map(function() {});
+
+  assert.sameValue(
+    Object.getPrototypeOf(result),
+    Object.getPrototypeOf(sample),
+    "undefined @@species - prototype check "
+  );
+  assert.sameValue(result.constructor, TA, "undefined @@species - ctor check");
+
+  sample.constructor[Symbol.species] = null;
+  result = sample.map(function() {});
+
+  assert.sameValue(
+    Object.getPrototypeOf(result),
+    Object.getPrototypeOf(sample),
+    "null @@species - prototype check "
+  );
+  assert.sameValue(result.constructor, TA, "null @@species - ctor check");
+});

--- a/test/built-ins/TypedArray/prototype/map/speciesctor-get-species.js
+++ b/test/built-ins/TypedArray/prototype/map/speciesctor-get-species.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2018 Peter Wong. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: >
+  get @@species from found constructor
+info: |
+  22.2.3.19 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] )
+
+  ...
+  6. Let A be ? TypedArraySpeciesCreate(O, « len »).
+  ...
+
+  22.2.4.7 TypedArraySpeciesCreate ( exemplar, argumentList )
+
+  ...
+  3. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
+  ...
+
+  7.3.20 SpeciesConstructor ( O, defaultConstructor )
+
+  1. Assert: Type(O) is Object.
+  2. Let C be ? Get(O, "constructor").
+  ...
+  5. Let S be ? Get(C, @@species).
+  ...
+includes: [testTypedArray.js]
+features: [Symbol.species, TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(2);
+  var calls = 0;
+
+  sample.constructor = {};
+
+  Object.defineProperty(sample.constructor, Symbol.species, {
+    get: function() {
+      calls++;
+    }
+  });
+
+  sample.map(function() {});
+
+  assert.sameValue(calls, 1);
+});


### PR DESCRIPTION
<img width="826" alt="screen shot 2018-12-29 at 5 46 17 pm" src="https://user-images.githubusercontent.com/284734/50543083-152e5700-0b92-11e9-9779-84660fcbedaa.png">

When comparing test coverage between `%TypedArray%.prototype.filter`, I noticed `%TypedArray%.prototype.map` tests didn't cover species constructors.
This PR essentially ports over the test coverage for species constructor from `%TypedArray%.prototype.filter`.
