### PR TITLE
Integration tests: Membrane (Proxy, WeakMap, Reflect, Map).

### DIFF
--- a/harness/features.yml
+++ b/harness/features.yml
@@ -4,3 +4,4 @@ testAtomics.js: [ArrayBuffer, Atomics, DataView, SharedArrayBuffer, Symbol, Type
 testBigIntTypedArray.js: [BigInt, TypedArray]
 testTypedArray.js: [TypedArray]
 isConstructor.js: [Reflect.construct]
+integration/Membrane.js: [Proxy, WeakMap, Reflect, Map]

--- a/harness/integration-Membrane.js
+++ b/harness/integration-Membrane.js
@@ -1,0 +1,273 @@
+/**
+ * @fileoverview This tests how multiple features of ECMAScript work together.
+ * Specifically, Proxy, WeakMap, Reflect, and Map.  Membranes, the primary
+ * motivation behind both Proxy and WeakMap, require plenty of overhead to work.
+ *
+ * For an introduction to Membranes, read https://tvcutsem.github.io/js-membranes .
+ */
+
+const ORIGIN_GRAPH = Symbol("Origin graph");
+
+/**
+ * @constructor
+ */
+function Membrane() {
+  /**
+   * @private
+   */
+  this.graphs = new Map(/*
+    name: new ObjectGraph(name, this)
+  */);
+
+  /**
+   * @private
+   */
+  this.mappings = new WeakMap(/*
+    object: new Map(
+      string or symbol: { proxy, revoke }
+    )
+  */);
+}
+
+/**
+ * Get a named object graph.  Create it if necessary.
+ *
+ * @param name       {String|Symbol} The name to use.
+ * @param mustCreate {Boolean}       True if we should create the graph.
+ *
+ * @returns {ObjectGraph}
+ */
+Membrane.prototype.getObjectGraph = function(name, mustCreate = false) {
+  if (!this.graphs.has(name) && mustCreate)
+    this.graphs.set(name, new ObjectGraph(name, this));
+  return this.graphs.get(name);
+};
+
+/**
+ * Get the object graph for the original value a shadow target reflects.
+ *
+ * @param shadowTarget {Object} The shadow target.
+ *
+ * @returns {ObjectGraph}
+ */
+Membrane.prototype.originGraph = function(shadowTarget) {
+  const map = this.mappings.get(shadowTarget);
+  if (!map)
+    throw new Error("originGraph called with unknown shadowTarget");
+  return map.get(ORIGIN_GRAPH);
+};
+
+/**
+ * Get a Proxy (or original value).
+ *
+ * @param value       {Object}      The value to convert.
+ * @param targetGraph {ObjectGraph} The destination object graph.
+ * @param isOrigin    {Boolean}     True if we're simply registering the value in the membrane.
+ *
+ * @return {Object} The proxy or original value.
+ */
+Membrane.prototype.convertToProxy = function(value, targetGraph, isOrigin = false) {
+  {
+    const t = typeof value;
+    if ((t !== "object") && (t !== "function"))
+      return value;
+  }
+  if (value === null)
+    return value;
+
+  if (!this.mappings.has(value)) {
+    this.mappings.set(value, new Map());
+  }
+
+  const map = this.mappings.get(value);
+  if (!map.has(targetGraph.name)) {
+    let payload;
+    if (isOrigin) {
+      payload = { proxy: value };
+      map.set(targetGraph.name, payload);
+      map.set(ORIGIN_GRAPH, targetGraph);
+    }
+
+    else {
+      if (!map.has(ORIGIN_GRAPH))
+        throw new Error("You must set an origin graph for the value first");
+
+      /* The shadow is for bookkeeping of properties, prototype.  In particular,
+       * it stores proxies as properties, in the same object graph.  This
+       * forces a lot of complications, yes, but they're necessary.
+       */
+      let shadow; 
+      if (Array.isArray(value))
+        shadow = [];
+      else if (typeof value == "object")
+        shadow = {};
+      else if (typeof value == "function")
+        shadow = function() {};
+
+      /* This Membrane implementation started with using Proxy.revocable, but
+       * none of the tests exercise that, and a revocation for the origin graph
+       * would be a "distortion" which isn't really an integration test of more
+       * than one feature... so I dropped the Proxy.revocable call.
+       */
+      payload = {
+        proxy: new Proxy(shadow, targetGraph)
+      };
+      map.set(targetGraph.name, payload);
+
+      this.mappings.set(shadow, map); // necessary so we can look up the original value
+      this.mappings.set(payload.proxy, map);
+    }
+  }
+
+  return map.get(targetGraph.name).proxy;
+};
+
+/**
+ * Convert a property descriptor from one object graph to another.
+ *
+ * @param desc {Object}             The starting property descriptor.
+ * @param sourceGraph {ObjectGraph} The object graph the descriptor came from.
+ * @param targetGraph {ObjectGraph} The object graph we're sending the descriptor to.
+ *
+ * @returns {Object} The replacement property descriptor.
+ */
+Membrane.prototype.wrapDescriptor = function(desc, sourceGraph, targetGraph) {
+  if (desc === undefined)
+    return desc;
+
+  var keys = Object.keys(desc);
+
+  var wrappedDesc = {
+    configurable: Boolean(desc.configurable)
+  };
+  if ("enumerable" in desc)
+    wrappedDesc.enumerable = Boolean(desc.enumerable);
+  if (keys.includes("writable"))
+    wrappedDesc.writable = Boolean(desc.writable);
+
+  ["value", "get", "set"].forEach(function(descProp) {
+    if (!keys.includes(descProp))
+      return;
+    this.convertToProxy(desc[descProp], sourceGraph, true);
+    wrappedDesc[descProp] = this.convertToProxy(desc[descProp], targetGraph);
+  }, this);
+
+  return wrappedDesc;
+};
+
+/**
+ * @param name     {String|Symbol} The name of the object graph.
+ * @param membrane {Membrane}      The membrane owning this graph.
+ *
+ * @constructor
+ * @extends ProxyHandler
+ */
+function ObjectGraph(name, membrane) {
+  this.name = name;
+  this.membrane = membrane;
+}
+
+Reflect.ownKeys(Reflect).forEach(function(keyName) {
+  Reflect.defineProperty(
+    ObjectGraph.prototype,
+    keyName,
+    {
+      value: function(shadowTarget, ...args) {
+        const originGraph = this.membrane.originGraph(shadowTarget);
+        args.unshift(this.membrane.convertToProxy(shadowTarget, originGraph));
+
+        // Argument conversions.
+        switch (keyName) {
+          case "get":
+            this.membrane.convertToProxy(args[2], this, true);
+            args[2] = this.membrane.convertToProxy(args[2], originGraph);
+            break;
+
+          case "defineProperty":
+            args[2] = this.membrane.wrapDescriptor(args[2], this, originGraph);
+            break;
+
+          case "set":
+            this.membrane.convertToProxy(args[2], this, true);
+            args[2] = this.membrane.convertToProxy(args[2], originGraph);
+            this.membrane.convertToProxy(args[3], this, true);
+            args[3] = this.membrane.convertToProxy(args[3], originGraph);
+            break;
+
+          case "setPrototypeOf":
+            this.membrane.convertToProxy(args[1], this, true);
+            args[1] = this.membrane.convertToProxy(args[1], originGraph);
+            break;
+
+          case "apply":
+            this.membrane.convertToProxy(args[1], this, true);
+            args[1] = this.membrane.convertToProxy(args[1], originGraph);
+
+            args[2] = args[2].map((arg) => {
+              this.membrane.convertToProxy(arg, this, true);
+              return this.membrane.convertToProxy(arg, originGraph);
+            });
+            break;
+
+          case "construct":
+            args[1] = args[1].map((arg) => {
+              this.membrane.convertToProxy(arg, this, true);
+              return this.membrane.convertToProxy(arg, originGraph);
+            });
+
+            this.membrane.convertToProxy(args[2], this);
+            args[2] = this.membrane.convertToProxy(args[2], originGraph);
+            break;
+        }
+
+        // Run the command.  Exception handling and wrapping is not supported.
+        let rv = Reflect[keyName].apply(Reflect, args);
+
+        // Return value conversions.
+        switch (keyName) {
+          case "getOwnPropertyDescriptor":
+            rv = this.membrane.wrapDescriptor(rv, originGraph, this);
+            break;
+
+          case "ownKeys":
+            this.membrane.convertToProxy(rv, originGraph, true);
+            rv = this.membrane.convertToProxy(rv, this);
+            break;
+
+          default:
+            this.membrane.convertToProxy(rv, originGraph, true);
+            rv = this.membrane.convertToProxy(rv, this);
+            break;
+        }
+
+        // Book-keeping: Update the shadow proxy.
+        switch (keyName) {
+          case "ownKeys":
+            /* Don't create proxies for all the properties.  We're not testing
+             * sealed objects at this time, which causes headaches for proxies
+             * under construction.
+             */
+            rv.forEach((property) => {
+              if (!Reflect.getOwnPropertyDescriptor(shadowTarget, property)) {
+                shadowTarget[property] = undefined;
+              }
+            });
+            break;
+    
+          case "getOwnPropertyDescriptor":
+            if (rv)
+              Reflect.defineProperty(shadowTarget, args[1], rv);
+            break;
+
+          case "preventExtensions":
+            if (rv)
+              rv = Reflect.preventExtensions(shadowTarget);
+        }
+        return rv;
+      },
+      enumerable: true,
+      writable: false,
+      configurable: false,
+    }
+  );
+});

--- a/test/integration/Membrane/accessor-descriptor.js
+++ b/test/integration/Membrane/accessor-descriptor.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Test an accessor descriptor of a Membrane proxy.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+let cachedValue = { toString: () => "original value" };
+let expectedValue = { toString: () => "expected" };
+
+const rawObject = {
+  toString: () => "membrane object",
+};
+Reflect.defineProperty(rawObject, "accessor", {
+  enumerable: true,
+  configurable: false,
+  get: function() { return cachedValue; },
+  set: function(value) {
+    cachedValue = value;
+    return value;
+  }
+});
+
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+
+M.convertToProxy(cachedValue, wetGraph, true);
+const dryCached = M.convertToProxy(cachedValue, dryGraph);
+
+M.convertToProxy(expectedValue, wetGraph, true);
+const dryExpected = M.convertToProxy(expectedValue, dryGraph);
+
+assert.sameValue(
+  dryCached,
+  dryObject.accessor,
+  "Getting an accessor property through a Membrane proxy should be wrapped"
+);
+
+dryObject.accessor = dryExpected;
+
+assert.sameValue(
+  dryExpected,
+  dryObject.accessor,
+  "Setting an accessor property, and then getting it, should work through a Membrane"
+);
+
+// In unwrapping, we switched to the wet object graph.
+assert.sameValue(
+  expectedValue,
+  cachedValue,
+  "Setting an accessor property should unwrap the property"
+);

--- a/test/integration/Membrane/accessor-descriptor.js
+++ b/test/integration/Membrane/accessor-descriptor.js
@@ -4,7 +4,7 @@
 /*---
  description: Test an accessor descriptor of a Membrane proxy.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js]
 ---*/
 

--- a/test/integration/Membrane/call-constructor.js
+++ b/test/integration/Membrane/call-constructor.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Ensure wrapping and unwrapping of constructors and instances is correct.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+let thisObj, firstArg;
+
+const rawObject = function(arg) {
+  thisObj = this;
+  firstArg = arg;
+  this.firstArg = arg;
+};
+rawObject.prototype.toString = () => "object prototype";
+
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+
+const wetArgument = M.convertToProxy({ toString: () => "argument" }, wetGraph, true);
+const dryArgument = M.convertToProxy(wetArgument, dryGraph);
+
+const dryInstance = new dryObject(dryArgument);
+
+// In unwrapping, we switched to the wet object graph.
+assert.sameValue(
+  dryInstance,
+  M.convertToProxy(thisObj, dryGraph),
+  "Constructor should receive a Proxy as this."
+);
+
+assert.sameValue(
+  dryArgument,
+  dryInstance.firstArg,
+  "Constructor should correctly wrap its arguments."
+);
+
+assert.sameValue(
+  wetArgument,
+  firstArg,
+  "First argument to constructor should have been unwrapped."
+);
+
+/* XXX ajvincent I'm not testing Reflect.construct here.  The receiver argument
+ * confuses me every time I look at it.  Feel free to write a test for it here.
+ */

--- a/test/integration/Membrane/call-constructor.js
+++ b/test/integration/Membrane/call-constructor.js
@@ -4,7 +4,7 @@
 /*---
  description: Ensure wrapping and unwrapping of constructors and instances is correct.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js]
 ---*/
 

--- a/test/integration/Membrane/call-method.js
+++ b/test/integration/Membrane/call-method.js
@@ -4,7 +4,7 @@
 /*---
  description: Call a method of a Membrane proxy.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js]
 ---*/
 

--- a/test/integration/Membrane/call-method.js
+++ b/test/integration/Membrane/call-method.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Call a method of a Membrane proxy.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+let thisObj, firstArg;
+
+const rawObject = {
+  toString: () => "membrane object",
+  property1: { toString: () => "property1" },
+  retval: { toString: () => "retval" },
+  method: function(arg) {
+    thisObj = this;
+    firstArg = arg;
+    return this.retval;
+  },
+};
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+
+const methodCall = dryObject.method(dryObject.property1);
+assert.sameValue(
+  dryObject.retval,
+  methodCall
+);
+
+// In unwrapping, we switched to the wet object graph.
+assert.sameValue(
+  wetObject,
+  thisObj
+);
+
+assert.sameValue(
+  wetObject.property1,
+  firstArg
+);

--- a/test/integration/Membrane/delete-property.js
+++ b/test/integration/Membrane/delete-property.js
@@ -4,7 +4,7 @@
 /*---
  description: Membrane proxies must support isExtensible and preventExtensions.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js]
 ---*/
 

--- a/test/integration/Membrane/delete-property.js
+++ b/test/integration/Membrane/delete-property.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Membrane proxies must support isExtensible and preventExtensions.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+const rawObject = {
+  toString: () => "rawObject",
+  son: { toString: () => "son" },
+};
+Reflect.defineProperty(rawObject, "daughter", {
+  value: { toString: () => "daughter" },
+  writable: false,
+  enumerable: true,
+  configurable: false,
+});
+
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+
+assert.sameValue(
+  true,
+  Reflect.deleteProperty(dryObject, "son"),
+  "Deleting a configurable property should work on a Proxy"
+);
+
+assert.sameValue(
+  false,
+  Reflect.ownKeys(dryObject).includes("son"),
+  "Deleting a configurable property on a Proxy should really delete it"
+);
+
+assert.sameValue(
+  false,
+  Reflect.deleteProperty(dryObject, "daughter"),
+  "Deleting a non-configurable property should not work on a Proxy"
+);
+
+assert.sameValue(
+  true,
+  Reflect.ownKeys(dryObject).includes("daughter"),
+  "Deleting a non-configurable property on a Proxy should have no effect on ownKeys"
+);

--- a/test/integration/Membrane/direct-wrap.js
+++ b/test/integration/Membrane/direct-wrap.js
@@ -4,7 +4,7 @@
 /*---
  description: Exercise the conversion, via WeakMap, of an object into a Proxy and back.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js]
 ---*/
 

--- a/test/integration/Membrane/direct-wrap.js
+++ b/test/integration/Membrane/direct-wrap.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Exercise the conversion, via WeakMap, of an object into a Proxy and back.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+const rawObject = {toString: () => "membrane object"};
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+assert.sameValue(
+  wetObject,
+  rawObject,
+  "M.convertToProxy should've returned the same value for originals"
+);
+
+assert.sameValue(
+  M.convertToProxy(wetObject, wetGraph),
+  rawObject,
+  "M.convertToProxy is violating identity"
+);
+
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+assert(Boolean(dryObject), "M.convertToProxy should've returned a Proxy");
+assert.notSameValue(
+  dryObject,
+  rawObject,
+  "M.convertToProxy should've returned a Proxy for non-originals"
+);
+
+assert.sameValue(
+  M.convertToProxy(dryObject, wetGraph),
+  wetObject,
+  "M.convertToProxy should get back the original value when going to the original graph"
+);
+
+assert.sameValue(
+  dryObject.toString(),
+  "membrane object"
+);

--- a/test/integration/Membrane/lookup-null.js
+++ b/test/integration/Membrane/lookup-null.js
@@ -4,7 +4,7 @@
 /*---
  description: Membrane proxies must correctly report null on demand.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js]
 ---*/
 

--- a/test/integration/Membrane/lookup-null.js
+++ b/test/integration/Membrane/lookup-null.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Membrane proxies must correctly report null on demand.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+const rawObject = {
+  toString: () => "rawObject",
+  son: null
+};
+
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+
+const expected = dryObject.son;
+assert.sameValue(
+  null,
+  expected,
+  "Looking up a null property of a Membrane proxy should work"
+);

--- a/test/integration/Membrane/not-configurable-nor-writable.js
+++ b/test/integration/Membrane/not-configurable-nor-writable.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Membrane proxies must return the same property on different lookups to the same name.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js,propertyHelper.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+const rawObject = {
+  toString: () => "rawObject",
+};
+const son = {
+  toString: () => "son"
+};
+
+Reflect.defineProperty(rawObject, "son", {
+  value: son,
+  writable: false,
+  enumerable: true,
+  configurable: false
+});
+
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+
+const wrappedSon = dryObject.son;
+assert.sameValue(
+  wrappedSon,
+  dryObject.son,
+  "Non-configurable, non-writable properties should respect the identity property of Membranes"
+);
+
+const wrappedDesc = {
+  value: wrappedSon,
+  writable: false,
+  enumerable: true,
+  configurable: false
+};
+
+verifyProperty(dryObject, "son", wrappedDesc);

--- a/test/integration/Membrane/not-configurable-nor-writable.js
+++ b/test/integration/Membrane/not-configurable-nor-writable.js
@@ -4,7 +4,7 @@
 /*---
  description: Membrane proxies must return the same property on different lookups to the same name.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js,propertyHelper.js]
 ---*/
 

--- a/test/integration/Membrane/property-cycle-lookup.js
+++ b/test/integration/Membrane/property-cycle-lookup.js
@@ -4,7 +4,7 @@
 /*---
  description: Membrane proxies must correctly recreate a tree of properties from the objects they emulate.  This includes property cycles.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js]
 ---*/
 

--- a/test/integration/Membrane/property-cycle-lookup.js
+++ b/test/integration/Membrane/property-cycle-lookup.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Membrane proxies must correctly recreate a tree of properties from the objects they emulate.  This includes property cycles.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+const rawObject = {
+  toString: () => "rawObject",
+  son: {
+    toString: () => "son",
+    daughter: {
+      toString: () => "daughter"
+    }
+  }
+};
+rawObject.son.daughter.grandParent = rawObject;
+
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+
+assert.sameValue(
+  dryObject.son.daughter.grandParent,
+  dryObject,
+  "Looking up a cycle of properties through a Membrane proxy should work"
+);

--- a/test/integration/Membrane/property-identity.js
+++ b/test/integration/Membrane/property-identity.js
@@ -4,7 +4,7 @@
 /*---
  description: Membrane proxies must return the same property on different lookups to the same name.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js]
 ---*/
 

--- a/test/integration/Membrane/property-identity.js
+++ b/test/integration/Membrane/property-identity.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Membrane proxies must return the same property on different lookups to the same name.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+const rawObject = {
+  toString: () => "rawObject",
+  son: {
+    toString: () => "son"
+  }
+};
+
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+
+assert.sameValue(
+  dryObject.son,
+  dryObject.son,
+  "Looking up a cycle of properties through a Membrane proxy should work"
+);

--- a/test/integration/Membrane/prototype.js
+++ b/test/integration/Membrane/prototype.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Ensure wrapping and unwrapping of object prototypes is correct.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+const rawObject = function() {};
+rawObject.prototype = {
+  toString: () => "object prototype (original)",
+};
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+
+/* Ideally, this wouldn't be necessary beforehand... but I think the sample
+ * Membrane implementation in harness/integration-Membrane.js would require it.
+ */
+M.convertToProxy(wetObject.prototype, wetGraph, true);
+const dryProto = M.convertToProxy(wetObject.prototype, dryGraph);
+
+const dryInstance = new dryObject();
+assert.sameValue(
+  dryProto,
+  Reflect.getPrototypeOf(dryInstance)
+);
+// Inheritance test
+assert.sameValue(
+  "object prototype (original)",
+  dryInstance.toString(),
+  "object prototype inheritance works before modification"
+);
+assert.sameValue(
+  false,
+  Reflect.ownKeys(dryInstance).includes("toString"),
+  "toString should be on the proxy's prototype, not the proxy itself."
+);
+
+const newProto = M.convertToProxy({
+  toString: () => "object prototype (modified)",
+}, wetGraph, true);
+const dryNewProto = M.convertToProxy(newProto, dryGraph);
+
+assert.sameValue(
+  true,
+  Reflect.setPrototypeOf(dryInstance, dryNewProto),
+  "Setting a prototype works"
+);
+// Inheritance test
+assert.sameValue(
+  "object prototype (modified)",
+  dryInstance.toString(),
+  "object prototype inheritance works after modification"
+);
+assert.sameValue(
+  false,
+  Reflect.ownKeys(dryInstance).includes("toString"),
+  "toString should be on the proxy's prototype, not the proxy itself."
+);

--- a/test/integration/Membrane/prototype.js
+++ b/test/integration/Membrane/prototype.js
@@ -4,7 +4,7 @@
 /*---
  description: Ensure wrapping and unwrapping of object prototypes is correct.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js]
 ---*/
 

--- a/test/integration/Membrane/same-graph-setter.js
+++ b/test/integration/Membrane/same-graph-setter.js
@@ -4,7 +4,7 @@
 /*---
  description: Membrane proxies must by default pass through setters, with proper wrapping.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js]
 ---*/
 

--- a/test/integration/Membrane/same-graph-setter.js
+++ b/test/integration/Membrane/same-graph-setter.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Membrane proxies must by default pass through setters, with proper wrapping.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+const rawObject = {
+  toString: () => "rawObject",
+  son: {
+    toString: () => "son",
+  }
+};
+const daughter = {
+  toString: () => "daughter",
+  grandParent: rawObject
+};
+
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+
+M.convertToProxy(daughter, wetGraph, true);
+
+{
+  const x = dryObject.son;
+  const y = M.convertToProxy(daughter, dryGraph);
+  x.daughter = y;
+}
+
+assert.sameValue(
+  wetObject.son.daughter.grandParent,
+  wetObject,
+  "Looking up a cycle of properties through a Membrane proxy should work"
+);

--- a/test/integration/Membrane/set-property-extensible.js
+++ b/test/integration/Membrane/set-property-extensible.js
@@ -4,7 +4,7 @@
 /*---
  description: Membrane proxies must support isExtensible and preventExtensions.
  esid: pending
- features: Proxy,WeakMap,Reflect,Map
+ features: [Proxy,WeakMap,Reflect,Map]
  includes: [integration-Membrane.js]
 ---*/
 

--- a/test/integration/Membrane/set-property-extensible.js
+++ b/test/integration/Membrane/set-property-extensible.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2019 Alexander J. Vincent. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+ description: Membrane proxies must support isExtensible and preventExtensions.
+ esid: pending
+ features: Proxy,WeakMap,Reflect,Map
+ includes: [integration-Membrane.js]
+---*/
+
+const M = new Membrane();
+const wetGraph = M.getObjectGraph("wet", true);
+const dryGraph = M.getObjectGraph("dry", true);
+
+const rawObject = {
+  toString: () => "rawObject",
+};
+
+const wetObject = M.convertToProxy(rawObject, wetGraph, true);
+const dryObject = M.convertToProxy(wetObject, dryGraph);
+
+assert.sameValue(
+  true,
+  Reflect.isExtensible(dryObject),
+  "Membrane proxies should forward their extensibility (true)"
+);
+
+assert.sameValue(
+  true,
+  Reflect.preventExtensions(dryObject),
+  "Membrane proxies should allow Reflect.preventExtensions"
+);
+
+assert.sameValue(
+  false,
+  Reflect.isExtensible(dryObject),
+  "Membrane proxies should forward their extensibility (true)"
+);
+
+const son = M.convertToProxy({
+  toString: () => "son"
+}, wetGraph, true);
+const drySon = M.convertToProxy(son, dryGraph);
+
+assert.sameValue(
+  false,
+  Reflect.defineProperty(
+    dryObject,
+    "son",
+    {
+      value: drySon,
+      writable: true,
+      enumerable: true,
+      configurable: true
+    }
+  ),
+  "Proxies which had preventExtensions called on them should fail to set new properties"
+);
+
+assert.sameValue(
+  undefined,
+  Reflect.getOwnPropertyDescriptor(dryObject, "son"),
+  "Prevented extensions on a membrane proxy should disallow setting properties"
+);


### PR DESCRIPTION
See #1026 - this is a first set of integration tests.

A few trouble spots:

- I didn't pick out a specific esid for any of the tests.  It's a required field for the tests' frontmatter... but these are integration tests, so no single section of ECMAScript is being tested.  I suggest an "integration-tests(section, section, ...)" esid format, for clarity.
- In the [recommended test-262 web runner](https://bakkot.github.io/test262-web-runner/), I couldn't put the integration-Membrane.js file into a subdirectory of harness/ .  (This is also the only test runner I actually used to develop and run these tests.)
- This is, I believe, my first contribution to test-262, and of course it's in a new area entirely.  So it needs to be more carefully reviewed, for both design and correctness.  At TC39 in July 2018, it was suggested that test-262 might not be the right repository for integration tests, but this is just a starting point.
