### PR TITLE
Update same-line-async-gen-private-field-usage.js

### DIFF
--- a/src/class-elements/private-field-usage.case
+++ b/src/class-elements/private-field-usage.case
@@ -17,7 +17,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: productions
-features: [class-methods-private]
+features: [class-fields-private]
 ---*/
 
 //- elements

--- a/test/language/expressions/class/elements/after-same-line-gen-private-field-usage.js
+++ b/test/language/expressions/class/elements/after-same-line-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, generators, class, class-fields-public]
+features: [class-fields-private, generators, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/after-same-line-method-private-field-usage.js
+++ b/test/language/expressions/class/elements/after-same-line-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/after-same-line-static-async-gen-private-field-usage.js
+++ b/test/language/expressions/class/elements/after-same-line-static-async-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a static async generator in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, async-iteration]
+features: [class-fields-private, class, class-fields-public, async-iteration]
 flags: [generated, async]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/after-same-line-static-async-method-private-field-usage.js
+++ b/test/language/expressions/class/elements/after-same-line-static-async-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a static async method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, async-functions]
+features: [class-fields-private, class, class-fields-public, async-functions]
 flags: [generated, async]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/after-same-line-static-gen-private-field-usage.js
+++ b/test/language/expressions/class/elements/after-same-line-static-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, generators, class, class-fields-public]
+features: [class-fields-private, generators, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/after-same-line-static-method-private-field-usage.js
+++ b/test/language/expressions/class/elements/after-same-line-static-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a static method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/multiple-definitions-private-field-usage.js
+++ b/test/language/expressions/class/elements/multiple-definitions-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (multiple fields definitions)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/multiple-stacked-definitions-private-field-usage.js
+++ b/test/language/expressions/class/elements/multiple-stacked-definitions-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (multiple stacked fields definitions through ASI)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/new-no-sc-line-method-private-field-usage.js
+++ b/test/language/expressions/class/elements/new-no-sc-line-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions followed by a method in a new line without a semicolon)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/new-sc-line-gen-private-field-usage.js
+++ b/test/language/expressions/class/elements/new-sc-line-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions followed by a method in a new line with a semicolon)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, generators]
+features: [class-fields-private, class, class-fields-public, generators]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/new-sc-line-method-private-field-usage.js
+++ b/test/language/expressions/class/elements/new-sc-line-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions followed by a method in a new line with a semicolon)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/regular-definitions-private-field-usage.js
+++ b/test/language/expressions/class/elements/regular-definitions-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (regular fields defintion)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/same-line-async-gen-private-field-usage.js
+++ b/test/language/expressions/class/elements/same-line-async-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after an async generator in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, async-iteration]
+features: [class-fields-private, class, class-fields-public, async-iteration]
 flags: [generated, async]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/same-line-async-method-private-field-usage.js
+++ b/test/language/expressions/class/elements/same-line-async-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after an async method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, async-functions]
+features: [class-fields-private, class, class-fields-public, async-functions]
 flags: [generated, async]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/same-line-gen-private-field-usage.js
+++ b/test/language/expressions/class/elements/same-line-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions followed by a generator method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, generators]
+features: [class-fields-private, class, class-fields-public, generators]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/same-line-method-private-field-usage.js
+++ b/test/language/expressions/class/elements/same-line-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions followed by a method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/expressions/class/elements/wrapped-in-sc-private-field-usage.js
+++ b/test/language/expressions/class/elements/wrapped-in-sc-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (fields definition wrapped in semicolons)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/after-same-line-gen-private-field-usage.js
+++ b/test/language/statements/class/elements/after-same-line-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a generator in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, generators, class, class-fields-public]
+features: [class-fields-private, generators, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/after-same-line-method-private-field-usage.js
+++ b/test/language/statements/class/elements/after-same-line-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/after-same-line-static-async-gen-private-field-usage.js
+++ b/test/language/statements/class/elements/after-same-line-static-async-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a static async generator in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, async-iteration]
+features: [class-fields-private, class, class-fields-public, async-iteration]
 flags: [generated, async]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/after-same-line-static-async-method-private-field-usage.js
+++ b/test/language/statements/class/elements/after-same-line-static-async-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a static async method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, async-functions]
+features: [class-fields-private, class, class-fields-public, async-functions]
 flags: [generated, async]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/after-same-line-static-gen-private-field-usage.js
+++ b/test/language/statements/class/elements/after-same-line-static-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a static generator in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, generators, class, class-fields-public]
+features: [class-fields-private, generators, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/after-same-line-static-method-private-field-usage.js
+++ b/test/language/statements/class/elements/after-same-line-static-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after a static method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/multiple-definitions-private-field-usage.js
+++ b/test/language/statements/class/elements/multiple-definitions-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (multiple fields definitions)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/multiple-stacked-definitions-private-field-usage.js
+++ b/test/language/statements/class/elements/multiple-stacked-definitions-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (multiple stacked fields definitions through ASI)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/new-no-sc-line-method-private-field-usage.js
+++ b/test/language/statements/class/elements/new-no-sc-line-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions followed by a method in a new line without a semicolon)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/new-sc-line-gen-private-field-usage.js
+++ b/test/language/statements/class/elements/new-sc-line-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions followed by a method in a new line with a semicolon)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, generators]
+features: [class-fields-private, class, class-fields-public, generators]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/new-sc-line-method-private-field-usage.js
+++ b/test/language/statements/class/elements/new-sc-line-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions followed by a method in a new line with a semicolon)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/regular-definitions-private-field-usage.js
+++ b/test/language/statements/class/elements/regular-definitions-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (regular fields defintion)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/same-line-async-gen-private-field-usage.js
+++ b/test/language/statements/class/elements/same-line-async-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after an async generator in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, async-iteration]
+features: [class-fields-private, class, class-fields-public, async-iteration]
 flags: [generated, async]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/same-line-async-method-private-field-usage.js
+++ b/test/language/statements/class/elements/same-line-async-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions after an async method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, async-functions]
+features: [class-fields-private, class, class-fields-public, async-functions]
 flags: [generated, async]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/same-line-gen-private-field-usage.js
+++ b/test/language/statements/class/elements/same-line-gen-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions followed by a generator method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public, generators]
+features: [class-fields-private, class, class-fields-public, generators]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/same-line-method-private-field-usage.js
+++ b/test/language/statements/class/elements/same-line-method-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (field definitions followed by a method in the same line)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 includes: [propertyHelper.js]
 info: |

--- a/test/language/statements/class/elements/wrapped-in-sc-private-field-usage.js
+++ b/test/language/statements/class/elements/wrapped-in-sc-private-field-usage.js
@@ -4,7 +4,7 @@
 /*---
 description: PrivateName CallExpression usage (private field) (fields definition wrapped in semicolons)
 esid: prod-FieldDefinition
-features: [class-methods-private, class, class-fields-public]
+features: [class-fields-private, class, class-fields-public]
 flags: [generated]
 info: |
     Updated Productions


### PR DESCRIPTION
I caught this because it was failing in Babel's tests.