### PR TITLE
Remove no-longer supported privae tag

### DIFF
--- a/test/intl402/Locale/likely-subtags.js
+++ b/test/intl402/Locale/likely-subtags.js
@@ -37,9 +37,6 @@ const testDataMaximal = {
     "und-419": "es-Latn-419",
     "und-150": "ru-Cyrl-RU",
     "und-AT": "de-Latn-AT",
-
-    // privateuse only.
-    "x-private": "x-private",
 };
 
 const testDataMinimal = {
@@ -65,9 +62,6 @@ const testDataMinimal = {
     "es-Latn-419": "es-419",
     "ru-Cyrl-RU": "ru",
     "de-Latn-AT": "de-AT",
-
-    // privateuse only.
-    "x-private": "x-private",
 };
 
 // Add variants, extensions, and privateuse subtags and ensure they don't


### PR DESCRIPTION
Per https://github.com/tc39/proposal-intl-locale/pull/66
private tags are no longer supported. Remove them from tests.