### PR TITLE
Remove test of extlang and 4 letter language

### DIFF
--- a/test/intl402/Locale/constructor-options-language-valid-undefined.js
+++ b/test/intl402/Locale/constructor-options-language-valid-undefined.js
@@ -40,4 +40,4 @@ assert.sameValue(
   `new Intl.Locale('en-US', {language: undefined}).toString() returns "en-US"`
 );
 
-assert.throws(RangeError, () => new Intl.Locale('en-els', {language: undefined}).toString());
+assert.throws(RangeError, () => new Intl.Locale('en-els', {language: undefined}));

--- a/test/intl402/Locale/constructor-options-language-valid-undefined.js
+++ b/test/intl402/Locale/constructor-options-language-valid-undefined.js
@@ -13,15 +13,9 @@ info: |
     12. Set tag to ? ApplyOptionsToTag(tag, options).
 
     ApplyOptionsToTag( tag, options )
+
+    2. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
     ...
-    9. Set tag to CanonicalizeLanguageTag(tag).
-
-    CanonicalizeLanguageTag( tag )
-
-    The CanonicalizeLanguageTag abstract operation returns the canonical and
-    case-regularized form of the locale argument (which must be a String value
-    that is a structurally valid Unicode BCP 47 Locale Identifier as verified by
-    the IsStructurallyValidLanguageTag abstract operation).
 
     IsStructurallyValidLanguageTag ( locale )
 

--- a/test/intl402/Locale/constructor-options-language-valid-undefined.js
+++ b/test/intl402/Locale/constructor-options-language-valid-undefined.js
@@ -14,9 +14,22 @@ info: |
 
     ApplyOptionsToTag( tag, options )
     ...
-    9. If tag matches neither the privateuse nor the grandfathered production, then
-        b. If language is not undefined, then
-            i. Set tag to tag with the substring corresponding to the language production replaced by the string language.
+    9. Set tag to CanonicalizeLanguageTag(tag).
+
+    CanonicalizeLanguageTag( tag )
+
+    The CanonicalizeLanguageTag abstract operation returns the canonical and
+    case-regularized form of the locale argument (which must be a String value
+    that is a structurally valid Unicode BCP 47 Locale Identifier as verified by
+    the IsStructurallyValidLanguageTag abstract operation).
+
+    IsStructurallyValidLanguageTag ( locale )
+
+    The IsStructurallyValidLanguageTag abstract operation verifies that the
+    locale argument (which must be a String value)
+
+    represents a well-formed Unicode BCP 47 Locale Identifier" as specified in
+    Unicode Technical Standard 35 section 3.2, or successor,
 
 features: [Intl.Locale]
 ---*/
@@ -32,3 +45,5 @@ assert.sameValue(
   'en-US',
   `new Intl.Locale('en-US', {language: undefined}).toString() returns "en-US"`
 );
+
+assert.throws(RangeError, () => new Intl.Locale('en-els', {language: undefined}).toString());

--- a/test/intl402/Locale/constructor-options-language-valid-undefined.js
+++ b/test/intl402/Locale/constructor-options-language-valid-undefined.js
@@ -32,9 +32,3 @@ assert.sameValue(
   'en-US',
   `new Intl.Locale('en-US', {language: undefined}).toString() returns "en-US"`
 );
-
-assert.sameValue(
-  new Intl.Locale('en-els', {language: undefined}).toString(),
-  'en-els',
-  `new Intl.Locale('en-els', {language: undefined}).toString() returns "en-els"`
-);

--- a/test/intl402/Locale/constructor-options-language-valid.js
+++ b/test/intl402/Locale/constructor-options-language-valid.js
@@ -25,7 +25,6 @@ const validLanguageOptions = [
   [null, 'null'],
   ['zh-cmn', 'cmn'],
   ['ZH-CMN', 'cmn'],
-  ['abcd', 'abcd'],
   [{ toString() { return 'de' } }, 'de'],
 ];
 for (const [language, expected] of validLanguageOptions) {
@@ -42,12 +41,5 @@ for (const [language, expected] of validLanguageOptions) {
     new Intl.Locale('en-US', {language}).toString(),
     expect,
     `new Intl.Locale('en-US', {language: "${language}"}).toString() returns "${expect}"`
-  );
-
-  expect = expected || 'en-els';
-  assert.sameValue(
-    new Intl.Locale('en-els', {language}).toString(),
-    expect,
-    `new Intl.Locale('en-els', {language: "${language}"}).toString() returns "${expect}"`
   );
 }

--- a/test/intl402/Locale/constructor-options-language-valid.js
+++ b/test/intl402/Locale/constructor-options-language-valid.js
@@ -14,9 +14,23 @@ info: |
 
     ApplyOptionsToTag( tag, options )
     ...
-    9. If tag matches neither the privateuse nor the grandfathered production, then
-        b. If language is not undefined, then
-            i. Set tag to tag with the substring corresponding to the language production replaced by the string language.
+
+    9. Set tag to CanonicalizeLanguageTag(tag).
+
+    CanonicalizeLanguageTag( tag )
+
+    The CanonicalizeLanguageTag abstract operation returns the canonical and
+    case-regularized form of the locale argument (which must be a String value
+    that is a structurally valid Unicode BCP 47 Locale Identifier as verified by
+    the IsStructurallyValidLanguageTag abstract operation).
+
+    IsStructurallyValidLanguageTag ( locale )
+
+    The IsStructurallyValidLanguageTag abstract operation verifies that the
+    locale argument (which must be a String value)
+
+    represents a well-formed Unicode BCP 47 Locale Identifier" as specified in
+    Unicode Technical Standard 35 section 3.2, or successor,
 
 features: [Intl.Locale]
 ---*/
@@ -42,4 +56,16 @@ for (const [language, expected] of validLanguageOptions) {
     expect,
     `new Intl.Locale('en-US', {language: "${language}"}).toString() returns "${expect}"`
   );
+
+  assert.throws(RangeError, () => new Intl.Locale('en-els', {language}).toString());
+
+}
+
+const invalidLanguageOptions = [
+    'abcd',
+];
+for (const language of invalidLanguageOptions) {
+  assert.throws(RangeError, () => new Intl.Locale('en', {language}).toString());
+  assert.throws(RangeError, () => new Intl.Locale('en-US', {language}).toString());
+  assert.throws(RangeError, () => new Intl.Locale('en-els', {language}).toString());
 }

--- a/test/intl402/Locale/constructor-options-language-valid.js
+++ b/test/intl402/Locale/constructor-options-language-valid.js
@@ -14,15 +14,7 @@ info: |
 
     ApplyOptionsToTag( tag, options )
     ...
-
-    9. Set tag to CanonicalizeLanguageTag(tag).
-
-    CanonicalizeLanguageTag( tag )
-
-    The CanonicalizeLanguageTag abstract operation returns the canonical and
-    case-regularized form of the locale argument (which must be a String value
-    that is a structurally valid Unicode BCP 47 Locale Identifier as verified by
-    the IsStructurallyValidLanguageTag abstract operation).
+    2. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
 
     IsStructurallyValidLanguageTag ( locale )
 

--- a/test/intl402/Locale/constructor-options-language-valid.js
+++ b/test/intl402/Locale/constructor-options-language-valid.js
@@ -49,7 +49,7 @@ for (const [language, expected] of validLanguageOptions) {
     `new Intl.Locale('en-US', {language: "${language}"}).toString() returns "${expect}"`
   );
 
-  assert.throws(RangeError, () => new Intl.Locale('en-els', {language}).toString());
+  assert.throws(RangeError, () => new Intl.Locale('en-els', {language}));
 
 }
 
@@ -57,7 +57,7 @@ const invalidLanguageOptions = [
     'abcd',
 ];
 for (const language of invalidLanguageOptions) {
-  assert.throws(RangeError, () => new Intl.Locale('en', {language}).toString());
-  assert.throws(RangeError, () => new Intl.Locale('en-US', {language}).toString());
-  assert.throws(RangeError, () => new Intl.Locale('en-els', {language}).toString());
+  assert.throws(RangeError, () => new Intl.Locale('en', {language}));
+  assert.throws(RangeError, () => new Intl.Locale('en-US', {language}));
+  assert.throws(RangeError, () => new Intl.Locale('en-els', {language}));
 }


### PR DESCRIPTION
Per https://github.com/tc39/proposal-intl-locale/pull/66 we switch to support Unicode Locale Identifier. And therefore the following in RFC 5646 are no longer supportive:
2*3ALPHA "-" extlang           ; shortest ISO 639 code followed by extended language subtags
and
4ALPHA
in "langage"
While "extlang" is 
" extlang       = 3ALPHA              ; selected ISO 639 codes
                 *2("-" 3ALPHA)      ; permanently reserved"

in UTS35, unicode_language_subtag is only
unicode_language_subtag = alpha{2,3} | alpha{5,8};

So this PR remove the test of language as 2*3ALPHA "-" extlang  or 4ALPHA

