### PR TITLE
Fix incorrect expectation of resolvedOptions.locale while no "hour" in options

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/resolved-locale-with-hc-unicode.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/resolved-locale-with-hc-unicode.js
@@ -49,7 +49,7 @@ function assertLocale(locale, expectedLocale, options, message) {
     hour12: options.hour12,
     hourCycle: options.hourCycle,
   }).resolvedOptions();
-  assert.sameValue(resolved.locale, expectedLocale, message + " (Without hour option.)");
+  assert.sameValue(resolved.locale, locale, message + " (Without hour option.)");
 }
 
 assertLocale(defaultLocaleWithHourCycle, defaultLocale, {


### PR DESCRIPTION
Notice the comment stated:
  // Also test the case when no hour option is present at all.
  // The resolved options don't include hour12 and hourCycle if the date-time
  // formatter doesn't include an hour option. This restriction doesn't apply
  // to the hc Unicode extension value.

If so, for that test without hour: in options, the resolved locale should equal to locale, not expectedLocale
@littledan @anba @Ms2ger 