### PR TITLE
Import test changes from JavaScriptCore

### DIFF
--- a/implementation-contributed/curation_logs/javascriptcore.json
+++ b/implementation-contributed/curation_logs/javascriptcore.json
@@ -1,6 +1,6 @@
 {
-  "sourceRevisionAtLastExport": "344dd04163",
-  "targetRevisionAtLastExport": "4146be1823",
+  "sourceRevisionAtLastExport": "c0dba7aed4",
+  "targetRevisionAtLastExport": "7a0293f26c",
   "curatedFiles": {
     "/stress/Number-isNaN-basics.js": "DELETED_IN_TARGET",
     "/stress/Object_static_methods_Object.getOwnPropertyDescriptors-proxy.js": "DELETED_IN_TARGET",

--- a/implementation-contributed/javascriptcore/stress/ai-should-perform-array-check-on-get-by-val-constant-folding.js
+++ b/implementation-contributed/javascriptcore/stress/ai-should-perform-array-check-on-get-by-val-constant-folding.js
@@ -1,0 +1,14 @@
+//@ runDefault("--jitPolicyScale=0")
+function compareArray(a, b) {
+    if (b.length !== a.length) {
+        return;
+    }
+    for (var i = 0; i < a.length; i++) {
+        b[0];
+    }
+}
+compareArray([], [0]);
+compareArray([0, 'b'].copyWithin(), ['a', 0]);
+compareArray([0], [1.1]);
+runString('');
+for (var i = 0; i < 1e6; ++i);

--- a/implementation-contributed/javascriptcore/stress/array-species-create-should-handle-masquerader.js
+++ b/implementation-contributed/javascriptcore/stress/array-species-create-should-handle-masquerader.js
@@ -1,0 +1,21 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+for (var i = 0; i < 1e5; ++i) {
+    shouldThrow(() => {
+        new (class extends Array { static get [Symbol.species]() { return makeMasquerader(); } })(1, 2, 3).flat().constructor
+    }, `TypeError: Masquerader is not a constructor`);
+}

--- a/implementation-contributed/javascriptcore/stress/big-int-json-stringify-to-json.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-json-stringify-to-json.js
@@ -1,0 +1,50 @@
+//@ runBigIntEnabled
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+var counter = 0;
+BigInt.prototype.toJSON = function () {
+    ++counter;
+    return Number(String(this));
+};
+
+shouldBe(JSON.stringify(0n), `0`);
+shouldBe(counter, 1);
+
+shouldBe(JSON.stringify([0n]), `[0]`);
+shouldBe(counter, 2);
+
+shouldBe(JSON.stringify({hello:0n}), `{"hello":0}`);
+shouldBe(counter, 3);
+
+var bigIntObject = Object(0n);
+
+shouldBe(JSON.stringify(bigIntObject), `0`);
+shouldBe(counter, 4);
+
+shouldBe(JSON.stringify([bigIntObject]), `[0]`);
+shouldBe(counter, 5);
+
+shouldBe(JSON.stringify({hello:bigIntObject}), `{"hello":0}`);
+shouldBe(counter, 6);

--- a/implementation-contributed/javascriptcore/stress/big-int-json-stringify.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-json-stringify.js
@@ -1,0 +1,52 @@
+//@ runBigIntEnabled
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+shouldThrow(() => {
+    JSON.stringify(0n);
+}, `TypeError: JSON.stringify cannot serialize BigInt.`);
+
+shouldThrow(() => {
+    JSON.stringify([0n]);
+}, `TypeError: JSON.stringify cannot serialize BigInt.`);
+
+shouldThrow(() => {
+    JSON.stringify({hello:0n});
+}, `TypeError: JSON.stringify cannot serialize BigInt.`);
+
+var bigIntObject = Object(0n);
+
+shouldThrow(() => {
+    JSON.stringify(bigIntObject);
+}, `TypeError: JSON.stringify cannot serialize BigInt.`);
+
+shouldThrow(() => {
+    JSON.stringify([bigIntObject]);
+}, `TypeError: JSON.stringify cannot serialize BigInt.`);
+
+shouldThrow(() => {
+    JSON.stringify({hello:bigIntObject});
+}, `TypeError: JSON.stringify cannot serialize BigInt.`);
+
+

--- a/implementation-contributed/javascriptcore/stress/big-int-literal-inside-literal-object.js
+++ b/implementation-contributed/javascriptcore/stress/big-int-literal-inside-literal-object.js
@@ -1,0 +1,21 @@
+//@ runBigIntEnabled
+
+var assert = {
+    sameValue: function (input, expected) {
+        if (input !== expected)
+            throw new Error('Expected: ' + expected + ' but got: ' + input);
+    }
+};
+
+var x = {y:1n}
+assert.sameValue(x.y, 1n);
+
+x = {y:{z:1n}};
+assert.sameValue(x.y.z, 1n);
+
+x = {y:-1212n}
+assert.sameValue(x.y, -1212n);
+
+x = {y:{z:-22312n}};
+assert.sameValue(x.y.z, -22312n);
+

--- a/implementation-contributed/javascriptcore/stress/bit-op-with-object-returning-int32.js
+++ b/implementation-contributed/javascriptcore/stress/bit-op-with-object-returning-int32.js
@@ -1,0 +1,38 @@
+//@ skip if not $jitTests
+function assert(a, e) {
+    if (a !== e)
+        throw new Error("Expected: " + e + " but got: " + a);
+}
+
+function bitAnd(a, b) {
+    return a & b;
+}
+noInline(bitAnd);
+
+var o = { valueOf: () => 0b1101 };
+
+for (var i = 0; i < 10000; i++)
+    assert(bitAnd(0b11, o), 0b1);
+
+assert(numberOfDFGCompiles(bitAnd) <= 1, true);
+
+function bitOr(a, b) {
+    return a | b;
+}
+noInline(bitOr);
+
+for (var i = 0; i < 10000; i++)
+    assert(bitOr(0b11, o), 0b1111);
+
+assert(numberOfDFGCompiles(bitOr) <= 1, true);
+
+function bitXor(a, b) {
+    return a ^ b;
+}
+noInline(bitXor);
+
+for (var i = 0; i < 10000; i++)
+    assert(bitXor(0b0011, o), 0b1110);
+
+assert(numberOfDFGCompiles(bitXor) <= 1, true);
+

--- a/implementation-contributed/javascriptcore/stress/cant-eliminate-string-object-structure-check-when-string-object-is-proven.js
+++ b/implementation-contributed/javascriptcore/stress/cant-eliminate-string-object-structure-check-when-string-object-is-proven.js
@@ -1,0 +1,11 @@
+//@ runDefault("--forceEagerCompilation=1", "--useConcurrentJIT=0")
+
+function foo(x) {
+    x.toString();
+}
+
+var a = new String();
+a.valueOf = 0
+for (var i = 0; i < 5; i++) {
+    foo(a)
+}

--- a/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-ftl.js
+++ b/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-ftl.js
@@ -1,0 +1,49 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+noInline(shouldBe);
+
+function foo() {
+    bar = 4;
+}
+function get() {
+    return bar;
+}
+for (var i = 0; i < 1e6; ++i)
+    foo();
+for (var i = 0; i < 1e6; ++i)
+    shouldBe(get(), 4);
+
+shouldBe(bar, 4);
+$.evalScript('const bar = 3;');
+shouldBe(bar, 3);
+shouldBe(get(), 3);
+
+for (var i = 0; i < 1e6; ++i)
+    shouldBe(get(), 3);
+
+shouldThrow(() => {
+    foo();
+}, `TypeError: Attempted to assign to readonly property.`);
+shouldBe(bar, 3);
+shouldBe(get(), 3);
+
+for (var i = 0; i < 1e6; ++i)
+    shouldBe(get(), 3);

--- a/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-tdz-ftl.js
+++ b/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-tdz-ftl.js
@@ -1,0 +1,53 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+noInline(shouldBe);
+
+function foo() {
+    bar = 4;
+}
+function get() {
+    return bar;
+}
+for (var i = 0; i < 1e6; ++i)
+    foo();
+for (var i = 0; i < 1e6; ++i)
+    shouldBe(get(), 4);
+
+shouldBe(bar, 4);
+shouldThrow(() => {
+    $.evalScript('get(); const bar = 3;');
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    shouldBe(bar, 3);
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    shouldBe(get(), 3);
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    $.evalScript('bar;');
+}, `ReferenceError: Cannot access uninitialized variable.`);
+
+for (var i = 0; i < 1e3; ++i) {
+    shouldThrow(() => {
+        shouldBe(get(), 3);
+    }, `ReferenceError: Cannot access uninitialized variable.`);
+}
+

--- a/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-tdz.js
+++ b/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-tdz.js
@@ -1,0 +1,44 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+noInline(shouldBe);
+
+function foo() {
+    bar = 4;
+}
+function get() {
+    return bar;
+}
+foo();
+shouldBe(get(), 4);
+
+shouldBe(bar, 4);
+shouldThrow(() => {
+    $.evalScript('get(); const bar = 3;');
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    shouldBe(bar, 3);
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    shouldBe(get(), 3);
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    $.evalScript('bar;');
+}, `ReferenceError: Cannot access uninitialized variable.`);

--- a/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property.js
+++ b/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property.js
@@ -1,0 +1,33 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+noInline(shouldBe);
+
+function foo() {
+    bar = 4;
+}
+foo();
+shouldBe(bar, 4);
+$.evalScript('const bar = 3;');
+shouldBe(bar, 3);
+shouldThrow(() => {
+    foo();
+}, `TypeError: Attempted to assign to readonly property.`);
+shouldBe(bar, 3);

--- a/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadowing-global-properties-and-eval-injection.js
+++ b/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadowing-global-properties-and-eval-injection.js
@@ -1,0 +1,36 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+noInline(shouldBe);
+
+bar = 0;
+function foo(code) {
+    eval(code);
+    return (function () {
+        return bar;
+    }());
+}
+shouldBe(foo(`42`), 0);
+
+$.evalScript(`const bar = 42`);
+shouldBe(foo(`42`), 42);
+
+shouldBe(foo(`var bar = 1`), 1);
+shouldBe(foo(`42`), 42);

--- a/implementation-contributed/javascriptcore/stress/constructing-builtin-functions-with-getter-prototype-should-only-call-getter-once-per-new-1.js
+++ b/implementation-contributed/javascriptcore/stress/constructing-builtin-functions-with-getter-prototype-should-only-call-getter-once-per-new-1.js
@@ -1,0 +1,15 @@
+var invokeCount = 0;
+
+Object.defineProperty(Function.prototype, 'prototype', {
+    get: function () {
+        invokeCount++;
+    }
+});
+
+new Promise(resolve => {
+    for (var i = 0; i < 10000; ++i)
+        new resolve();
+
+    if (invokeCount != 10000)
+        $vm.crash();
+});

--- a/implementation-contributed/javascriptcore/stress/constructing-builtin-functions-with-getter-prototype-should-only-call-getter-once-per-new-2.js
+++ b/implementation-contributed/javascriptcore/stress/constructing-builtin-functions-with-getter-prototype-should-only-call-getter-once-per-new-2.js
@@ -1,0 +1,15 @@
+new Promise(resolve => {
+    var invokeCount = 0;
+
+    Object.defineProperty(resolve, 'prototype', {
+        get: function () {
+            invokeCount++;
+        }
+    });
+
+    for (var i = 0; i < 10000; ++i)
+        new resolve();
+
+    if (invokeCount != 10000)
+        $vm.crash();
+});

--- a/implementation-contributed/javascriptcore/stress/dfg-combined-liveness-consider-terminal-blocks-bytecode-liveness.js
+++ b/implementation-contributed/javascriptcore/stress/dfg-combined-liveness-consider-terminal-blocks-bytecode-liveness.js
@@ -1,0 +1,19 @@
+//@ runDefault("--useConcurrentJIT=0", "--usePutStackSinking=0")
+
+function foo() {
+    var args1 = function () {
+        return arguments;
+    }();
+    var args2 = function () {
+        var result = arguments;
+        result.length = 1;
+        return result;
+    }(1);
+    for (var i = 0; i < 10000000; ++i) {
+        args1.length;
+        args2.length;
+    }
+}
+foo();
+foo();
+foo();

--- a/implementation-contributed/javascriptcore/stress/get-by-id-change-mode.js
+++ b/implementation-contributed/javascriptcore/stress/get-by-id-change-mode.js
@@ -1,0 +1,12 @@
+//@ runDefault("--useConcurrentJIT=0")
+
+forEach({ length: 5 }, function() {
+    for (var i = 0; i < 10; i++) {
+        forEach([1], function() {});
+    }
+});
+
+function forEach(a, b) {
+    for (var c = 0; c < a.length; c++)
+        b();
+}

--- a/implementation-contributed/javascriptcore/stress/global-add-function-should-not-be-shadowed-by-lexical-bindings.js
+++ b/implementation-contributed/javascriptcore/stress/global-add-function-should-not-be-shadowed-by-lexical-bindings.js
@@ -1,0 +1,18 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+shouldThrow(() => {
+    $.evalScript(`const shouldThrow = 42`);
+}, `SyntaxError: Can't create duplicate variable that shadows a global property: 'shouldThrow'`);

--- a/implementation-contributed/javascriptcore/stress/global-static-variables-should-not-be-shadowed-by-lexical-bindings.js
+++ b/implementation-contributed/javascriptcore/stress/global-static-variables-should-not-be-shadowed-by-lexical-bindings.js
@@ -1,0 +1,18 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+shouldThrow(() => {
+    $.evalScript(`const NaN = 42`);
+}, `SyntaxError: Can't create duplicate variable that shadows a global property: 'NaN'`);

--- a/implementation-contributed/javascriptcore/stress/is-undefined-or-null-builtin.js
+++ b/implementation-contributed/javascriptcore/stress/is-undefined-or-null-builtin.js
@@ -1,0 +1,26 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+var isUndefinedOrNull = $vm.createBuiltin(`(function (value) { return @isUndefinedOrNull(value); })`);
+noInline(isUndefinedOrNull);
+
+var masquerader = makeMasquerader();
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(isUndefinedOrNull(null), true);
+    shouldBe(isUndefinedOrNull(undefined), true);
+    shouldBe(isUndefinedOrNull("Hello"), false);
+    shouldBe(isUndefinedOrNull(Symbol("Hello")), false);
+    shouldBe(isUndefinedOrNull(42), false);
+    shouldBe(isUndefinedOrNull(-42), false);
+    shouldBe(isUndefinedOrNull(0), false);
+    shouldBe(isUndefinedOrNull(-0), false);
+    shouldBe(isUndefinedOrNull(42.2), false);
+    shouldBe(isUndefinedOrNull(-42.2), false);
+    shouldBe(isUndefinedOrNull({}), false);
+    shouldBe(isUndefinedOrNull([]), false);
+    shouldBe(isUndefinedOrNull(true), false);
+    shouldBe(isUndefinedOrNull(masquerader), false);
+}

--- a/implementation-contributed/javascriptcore/stress/jsfunction-cannot-use-allocation-profile-with-builtin-functions-with-no-prototype.js
+++ b/implementation-contributed/javascriptcore/stress/jsfunction-cannot-use-allocation-profile-with-builtin-functions-with-no-prototype.js
@@ -1,0 +1,9 @@
+Object.defineProperty(Function.prototype, 'prototype', {
+    get: function () {
+        throw new Error('hello');
+    }
+});
+
+new Promise(resolve => {
+    new resolve();
+});

--- a/implementation-contributed/javascriptcore/stress/json-surrogate-pair.js
+++ b/implementation-contributed/javascriptcore/stress/json-surrogate-pair.js
@@ -1,0 +1,14 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+shouldBe(JSON.stringify('𝌆'), `"𝌆"`);
+shouldBe(JSON.stringify('\uD834\uDF06'), `"𝌆"`);
+shouldBe(JSON.stringify('\uD834'), `"\\ud834"`);
+shouldBe(JSON.stringify('\uDF06'), `"\\udf06"`);
+shouldBe(JSON.stringify('\uDF06\uD834'), `"\\udf06\\ud834"`);
+shouldBe(JSON.stringify('\uDEAD'), `"\\udead"`);
+shouldBe(JSON.stringify('\uD834\uD834\uDF06'), `"\\ud834𝌆"`);
+shouldBe(JSON.stringify('\uD834a'), `"\\ud834a"`);
+shouldBe(JSON.stringify('\uD834\u0400'), `"\\ud834Ѐ"`);

--- a/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-ftl.js
+++ b/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-ftl.js
@@ -1,0 +1,47 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+noInline(shouldBe);
+
+function foo() {
+    bar = 4;
+}
+function get() {
+    return bar;
+}
+for (var i = 0; i < 1e6; ++i)
+    foo();
+for (var i = 0; i < 1e6; ++i)
+    shouldBe(get(), 4);
+
+shouldBe(bar, 4);
+$.evalScript('let bar = 3;');
+shouldBe(bar, 3);
+shouldBe(get(), 3);
+
+for (var i = 0; i < 1e6; ++i)
+    shouldBe(get(), 3);
+
+foo();
+shouldBe(bar, 4);
+shouldBe(get(), 4);
+
+for (var i = 0; i < 1e6; ++i)
+    shouldBe(get(), 4);

--- a/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-tdz-ftl.js
+++ b/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-tdz-ftl.js
@@ -1,0 +1,53 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+noInline(shouldBe);
+
+function foo() {
+    bar = 4;
+}
+function get() {
+    return bar;
+}
+for (var i = 0; i < 1e6; ++i)
+    foo();
+for (var i = 0; i < 1e6; ++i)
+    shouldBe(get(), 4);
+
+shouldBe(bar, 4);
+shouldThrow(() => {
+    $.evalScript('get(); let bar = 3;');
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    shouldBe(bar, 3);
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    shouldBe(get(), 3);
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    $.evalScript('bar;');
+}, `ReferenceError: Cannot access uninitialized variable.`);
+
+for (var i = 0; i < 1e3; ++i) {
+    shouldThrow(() => {
+        shouldBe(get(), 3);
+    }, `ReferenceError: Cannot access uninitialized variable.`);
+}
+

--- a/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-tdz.js
+++ b/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-tdz.js
@@ -1,0 +1,44 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+noInline(shouldBe);
+
+function foo() {
+    bar = 4;
+}
+function get() {
+    return bar;
+}
+foo();
+shouldBe(get(), 4);
+
+shouldBe(bar, 4);
+shouldThrow(() => {
+    $.evalScript('get(); let bar = 3;');
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    shouldBe(bar, 3);
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    shouldBe(get(), 3);
+}, `ReferenceError: Cannot access uninitialized variable.`);
+shouldThrow(() => {
+    $.evalScript('bar;');
+}, `ReferenceError: Cannot access uninitialized variable.`);

--- a/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property.js
+++ b/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property.js
@@ -1,0 +1,31 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+noInline(shouldBe);
+
+function foo() {
+    bar = 4;
+}
+foo();
+shouldBe(bar, 4);
+$.evalScript('let bar = 3;');
+shouldBe(bar, 3);
+foo();
+shouldBe(bar, 4);

--- a/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadowing-global-properties-and-eval-injection.js
+++ b/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadowing-global-properties-and-eval-injection.js
@@ -1,0 +1,36 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+noInline(shouldThrow);
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+noInline(shouldBe);
+
+bar = 0;
+function foo(code) {
+    eval(code);
+    return (function () {
+        return bar;
+    }());
+}
+shouldBe(foo(`42`), 0);
+
+$.evalScript(`let bar = 42`);
+shouldBe(foo(`42`), 42);
+
+shouldBe(foo(`var bar = 1`), 1);
+shouldBe(foo(`42`), 42);

--- a/implementation-contributed/javascriptcore/stress/object-tostring-changed-proto.js
+++ b/implementation-contributed/javascriptcore/stress/object-tostring-changed-proto.js
@@ -1,0 +1,18 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(value)
+{
+    return Object.prototype.toString.call(value);
+}
+noInline(test);
+
+var object = {};
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(test(object), `[object Object]`);
+Object.prototype[Symbol.toStringTag] = "Hello";
+shouldBe(test(object), `[object Hello]`);

--- a/implementation-contributed/javascriptcore/stress/object-tostring-changed.js
+++ b/implementation-contributed/javascriptcore/stress/object-tostring-changed.js
@@ -1,0 +1,18 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(value)
+{
+    return Object.prototype.toString.call(value);
+}
+noInline(test);
+
+var object = {};
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(test(object), `[object Object]`);
+object[Symbol.toStringTag] = "Hello";
+shouldBe(test(object), `[object Hello]`);

--- a/implementation-contributed/javascriptcore/stress/object-tostring-misc.js
+++ b/implementation-contributed/javascriptcore/stress/object-tostring-misc.js
@@ -1,0 +1,26 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(value)
+{
+    return Object.prototype.toString.call(value);
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    switch (i % 3) {
+    case 0:
+        shouldBe(test(null), `[object Null]`);
+        break;
+    case 1:
+        shouldBe(test(undefined), `[object Undefined]`);
+        break;
+    case 2:
+        shouldBe(test(true), `[object Boolean]`);
+        break;
+    }
+}

--- a/implementation-contributed/javascriptcore/stress/object-tostring-other.js
+++ b/implementation-contributed/javascriptcore/stress/object-tostring-other.js
@@ -1,0 +1,19 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(value)
+{
+    return Object.prototype.toString.call(value);
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    if (i & 0x1)
+        shouldBe(test(null), `[object Null]`);
+    else
+        shouldBe(test(undefined), `[object Undefined]`);
+}

--- a/implementation-contributed/javascriptcore/stress/object-tostring-untyped.js
+++ b/implementation-contributed/javascriptcore/stress/object-tostring-untyped.js
@@ -1,0 +1,50 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(value)
+{
+    return Object.prototype.toString.call(value);
+}
+noInline(test);
+
+var value0 = {};
+var value1 = { [Symbol.toStringTag]: "Hello" };
+var value2 = new Date();
+var value3 = "Hello";
+var value4 = 42;
+var value5 = Symbol("Cocoa");
+var value6 = 42.195;
+var value7 = false;
+
+for (var i = 0; i < 1e6; ++i) {
+    switch (i % 8) {
+    case 0:
+        shouldBe(test(value0), `[object Object]`);
+        break;
+    case 1:
+        shouldBe(test(value1), `[object Hello]`);
+        break;
+    case 2:
+        shouldBe(test(value2), `[object Date]`);
+        break;
+    case 3:
+        shouldBe(test(value3), `[object String]`);
+        break;
+    case 4:
+        shouldBe(test(value4), `[object Number]`);
+        break;
+    case 5:
+        shouldBe(test(value5), `[object Symbol]`);
+        break;
+    case 6:
+        shouldBe(test(value6), `[object Number]`);
+        break;
+    case 7:
+        shouldBe(test(value7), `[object Boolean]`);
+        break;
+    }
+}

--- a/implementation-contributed/javascriptcore/stress/put-by-id-flags.js
+++ b/implementation-contributed/javascriptcore/stress/put-by-id-flags.js
@@ -1,0 +1,23 @@
+function f(x, y) {
+    x.y = y;
+};
+
+function g(x) {
+    return x.y + 42;
+}
+noInline(f);
+noInline(g);
+
+var x = {};
+var y = {};
+f(x, 42);
+f(y, {});
+
+while (!numberOfDFGCompiles(g)) {
+    optimizeNextInvocation(g);
+    if (typeof g(x) !== 'number')
+        throw 'failed warming up';
+}
+
+if (typeof g(y) !== 'string')
+    throw 'failed after compilation';

--- a/implementation-contributed/javascriptcore/stress/regexp-compile-oom.js
+++ b/implementation-contributed/javascriptcore/stress/regexp-compile-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $hostOS != "darwin" or $architecture == "arm" or $architecture == "x86"
+//@ skip if $hostOS != "darwin" or $architecture == "arm" or $architecture == "x86" or not $jitTests
 // Test that throw an OOM exception when compiling a pathological, but valid nested RegExp.
 
 var failures = [];

--- a/implementation-contributed/javascriptcore/stress/regress-192717.js
+++ b/implementation-contributed/javascriptcore/stress/regress-192717.js
@@ -1,5 +1,5 @@
-//@ runDefault("--useLLInt=false", "--forceCodeBlockToJettisonDueToOldAge=true", "--maxPerThreadStackUsage=200000", "--exceptionStackTraceLimit=1", "--defaultErrorStackTraceLimit=1")
 //@ skip if $memoryLimited or $buildType == "debug"
+//@ runDefault("--useLLInt=false", "--forceCodeBlockToJettisonDueToOldAge=true", "--maxPerThreadStackUsage=200000", "--exceptionStackTraceLimit=1", "--defaultErrorStackTraceLimit=1")
 
 let foo = 'let a';
 for (let i = 0; i < 400000; i++)

--- a/implementation-contributed/javascriptcore/stress/string-get-by-val-lowering.js
+++ b/implementation-contributed/javascriptcore/stress/string-get-by-val-lowering.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(value)
+{
+    return value[2];
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(test("Hello"), 'l');
+    shouldBe(test("World"), 'r');
+    shouldBe(test("Nice"), 'c');
+}

--- a/implementation-contributed/javascriptcore/stress/string-overflow-createError.js
+++ b/implementation-contributed/javascriptcore/stress/string-overflow-createError.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 var exception;
 try {
     bar = '2.3023e-320'

--- a/implementation-contributed/javascriptcore/stress/to-this-omission-with-different-strict-modes.js
+++ b/implementation-contributed/javascriptcore/stress/to-this-omission-with-different-strict-modes.js
@@ -1,0 +1,10 @@
+function thisA() {
+    return this.a
+}
+function thisAStrictWrapper() {
+    'use strict';
+    thisA.apply(this);
+}
+let x = false;
+for (let j=0; j<1e4; j++)
+    thisAStrictWrapper.call(x);

--- a/implementation-contributed/javascriptcore/stress/type-check-hoisting-phase-hoist-check-structure-on-tdz-this-value.js
+++ b/implementation-contributed/javascriptcore/stress/type-check-hoisting-phase-hoist-check-structure-on-tdz-this-value.js
@@ -1,0 +1,53 @@
+//@ skip if not $jitTests
+
+function __isPropertyOfType(obj, name, type) {
+    desc = Object.getOwnPropertyDescriptor(obj, name)
+    return typeof type === 'undefined' || typeof desc.value === type;
+}
+function __getProperties(obj, type) {
+    let properties = [];
+    for (let name of Object.getOwnPropertyNames(obj)) {
+        if (__isPropertyOfType(obj, name, type)) properties.push(name);
+    }
+    let proto = Object.getPrototypeOf(obj);
+    while (proto && proto != Object.prototype) {
+        Object.getOwnPropertyNames(proto).forEach(name => {
+        });
+        proto = Object.getPrototypeOf(proto);
+    }
+    return properties;
+}
+function* __getObjects(root = this, level = 0) {
+    if (level > 4) return;
+    let obj_names = __getProperties(root, 'object');
+    for (let obj_name of obj_names) {
+        let obj = root[obj_name];
+        yield* __getObjects(obj, level + 1);
+    }
+}
+function __getRandomObject() {
+    for (let obj of __getObjects()) {
+    }
+}
+var theClass = class {
+    constructor() {
+        if (242487 != null && typeof __getRandomObject() == "object") try {
+        } catch (e) {}
+    }
+};
+var childClass = class Class extends theClass {
+    constructor() {
+        var arrow = () => {
+            try {
+                super();
+            } catch (e) {}
+            this.idValue
+        };
+        arrow()()();
+    }
+};
+for (var counter = 0; counter < 1000; counter++) {
+    try {
+        new childClass();
+    } catch (e) {}
+}

--- a/implementation-contributed/javascriptcore/stress/type-for-get-by-val-can-be-widen-after-ai.js
+++ b/implementation-contributed/javascriptcore/stress/type-for-get-by-val-can-be-widen-after-ai.js
@@ -1,0 +1,25 @@
+//@ runDefault("--jitPolicyScale=0")
+// Run with for i in {1..1000}; do echo $i && VM=/path/to/WebKit/WebKitBuild/Debug/ && DYLD_FRAMEWORK_PATH=$VM $VM/jsc --useDollarVM=1 --jitPolicyScale=0 type-for-get-by-val-can-be-widen-after-ai.js ; done
+
+function Hello(y) {
+  this.y = y;
+  this.x = foo(this.y);
+}
+function foo(z) {
+  try {
+    for (var i = 0; i < 1; i++) {
+      z[i];
+    }
+  } catch {
+  }
+}
+new Hello('a');
+new Hello('a');
+for (let i = 0; i < 100; ++i) {
+  new Hello();
+}
+
+// Busy loop to let the crash reporter have a chance to capture the crash log for the Compiler thread.
+for (let i = 0; i < 1000000; ++i) {
+    $vm.ftlTrue();
+}

--- a/implementation-contributed/javascriptcore/stress/typed-array-array-modes-profile.js
+++ b/implementation-contributed/javascriptcore/stress/typed-array-array-modes-profile.js
@@ -1,0 +1,18 @@
+function foo(o) {
+    for (var i = 0; i < 100; ++i) {
+        o.f = o.f;
+    }
+}
+
+let typedArrays = [
+    Uint8Array,
+    Uint32Array,
+    Uint8Array,
+];
+
+for (let constructor of typedArrays) {
+    let a = new constructor(0);
+    for (let i = 0; i < 10000; i++) {
+        foo(a);
+    }
+}


### PR DESCRIPTION
# Import JavaScript Test Changes from JavaScriptCore

Changes imported in this pull request include all changes made since
[344dd04163](https://github.com///github/blob/344dd04163) in JavaScriptCore and all changes made since [4146be1823](../blob/4146be1823) in
test262.



### 4 Files Updated From JavaScriptCore

These files have been modified in JavaScriptCore.

 - [implementation-contributed/javascriptcore/stress/regexp-compile-oom.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/regexp-compile-oom.js)
 - [implementation-contributed/javascriptcore/stress/regress-192717.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/regress-192717.js)
 - [implementation-contributed/javascriptcore/stress/string-overflow-createError.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/string-overflow-createError.js)
 - [implementation-contributed/javascriptcore/stress/type-check-hoisting-phase-hoist-check-structure-on-tdz-this-value.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/type-check-hoisting-phase-hoist-check-structure-on-tdz-this-value.js)









### 36 New Files Added in JavaScriptCore

These are new files added in JavaScriptCore and have been synced to the
`implementation-contributed/javascriptcore` directory.

 - [implementation-contributed/javascriptcore/stress/ai-should-perform-array-check-on-get-by-val-constant-folding.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/ai-should-perform-array-check-on-get-by-val-constant-folding.js)
 - [implementation-contributed/javascriptcore/stress/array-species-create-should-handle-masquerader.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/array-species-create-should-handle-masquerader.js)
 - [implementation-contributed/javascriptcore/stress/big-int-json-stringify-to-json.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/big-int-json-stringify-to-json.js)
 - [implementation-contributed/javascriptcore/stress/big-int-json-stringify.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/big-int-json-stringify.js)
 - [implementation-contributed/javascriptcore/stress/big-int-literal-inside-literal-object.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/big-int-literal-inside-literal-object.js)
 - [implementation-contributed/javascriptcore/stress/bit-op-with-object-returning-int32.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/bit-op-with-object-returning-int32.js)
 - [implementation-contributed/javascriptcore/stress/cant-eliminate-string-object-structure-check-when-string-object-is-proven.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/cant-eliminate-string-object-structure-check-when-string-object-is-proven.js)
 - [implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-ftl.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-ftl.js)
 - [implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-tdz-ftl.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-tdz-ftl.js)
 - [implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-tdz.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property-tdz.js)
 - [implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadow-existing-global-property.js)
 - [implementation-contributed/javascriptcore/stress/const-lexical-binding-shadowing-global-properties-and-eval-injection.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/const-lexical-binding-shadowing-global-properties-and-eval-injection.js)
 - [implementation-contributed/javascriptcore/stress/constructing-builtin-functions-with-getter-prototype-should-only-call-getter-once-per-new-1.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/constructing-builtin-functions-with-getter-prototype-should-only-call-getter-once-per-new-1.js)
 - [implementation-contributed/javascriptcore/stress/constructing-builtin-functions-with-getter-prototype-should-only-call-getter-once-per-new-2.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/constructing-builtin-functions-with-getter-prototype-should-only-call-getter-once-per-new-2.js)
 - [implementation-contributed/javascriptcore/stress/dfg-combined-liveness-consider-terminal-blocks-bytecode-liveness.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/dfg-combined-liveness-consider-terminal-blocks-bytecode-liveness.js)
 - [implementation-contributed/javascriptcore/stress/get-by-id-change-mode.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/get-by-id-change-mode.js)
 - [implementation-contributed/javascriptcore/stress/global-add-function-should-not-be-shadowed-by-lexical-bindings.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/global-add-function-should-not-be-shadowed-by-lexical-bindings.js)
 - [implementation-contributed/javascriptcore/stress/global-static-variables-should-not-be-shadowed-by-lexical-bindings.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/global-static-variables-should-not-be-shadowed-by-lexical-bindings.js)
 - [implementation-contributed/javascriptcore/stress/is-undefined-or-null-builtin.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/is-undefined-or-null-builtin.js)
 - [implementation-contributed/javascriptcore/stress/jsfunction-cannot-use-allocation-profile-with-builtin-functions-with-no-prototype.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/jsfunction-cannot-use-allocation-profile-with-builtin-functions-with-no-prototype.js)
 - [implementation-contributed/javascriptcore/stress/json-surrogate-pair.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/json-surrogate-pair.js)
 - [implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-ftl.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-ftl.js)
 - [implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-tdz-ftl.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-tdz-ftl.js)
 - [implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-tdz.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property-tdz.js)
 - [implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadow-existing-global-property.js)
 - [implementation-contributed/javascriptcore/stress/let-lexical-binding-shadowing-global-properties-and-eval-injection.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/let-lexical-binding-shadowing-global-properties-and-eval-injection.js)
 - [implementation-contributed/javascriptcore/stress/object-tostring-changed-proto.js](../blob/javascriptcore-test262-automation-export-4146be1823/implementation-contributed/javascriptcore/stress/object-tostring-changed-proto.js)
 -.......report too long for Github. Review Travis log for full output of changes files.