### PR TITLE
Improve coverage for UniqueFormalParameters

### DIFF
--- a/test/language/expressions/arrow-function/params-duplicate.js
+++ b/test/language/expressions/arrow-function/params-duplicate.js
@@ -2,13 +2,20 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-method-definitions
+esid: sec-arrow-function-definitions
 description: Formal parameters may not contain duplicates
 info: |
-  # 14.3 Method Definitions
+  # 14.2 Arrow Function Definitions
 
-  MethodDefinition[Yield, Await]:
-    PropertyName[?Yield, ?Await](UniqueFormalParameters[~Yield, ~Await]){FunctionBody[~Yield, ~Await]}
+  When the production
+
+    ArrowParameters:CoverParenthesizedExpressionAndArrowParameterList
+
+  is recognized the following grammar is used to refine the interpretation
+  of CoverParenthesizedExpressionAndArrowParameterList:
+
+    ArrowFormalParameters[Yield, Await]:
+      (UniqueFormalParameters[?Yield, ?Await])
 
   # 14.1.2 Static Semantics: Early Errors
 
@@ -23,6 +30,4 @@ negative:
 
 $DONOTEVALUATE();
 
-class Foo {
-  foo(a, a) { }
-}
+0, (a, a) => { };

--- a/test/language/expressions/async-arrow-function/early-errors-arrow-duplicate-parameters.js
+++ b/test/language/expressions/async-arrow-function/early-errors-arrow-duplicate-parameters.js
@@ -3,13 +3,30 @@
 
 /*---
 author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
-description: >
-  If strict mode, early error rules for StrictFormalParameters are applied
+esid: sec-async-arrow-function-definitions
+description: Formal parameters may not contain duplicates
+info: |
+  # 14.2 Arrow Function Definitions
+
+  When the production
+
+    ArrowParameters:CoverParenthesizedExpressionAndArrowParameterList
+
+  is recognized the following grammar is used to refine the interpretation
+  of CoverParenthesizedExpressionAndArrowParameterList:
+
+    ArrowFormalParameters[Yield, Await]:
+      (UniqueFormalParameters[?Yield, ?Await])
+
+  # 14.1.2 Static Semantics: Early Errors
+
+  UniqueFormalParameters:FormalParameters
+
+  - It is a Syntax Error if BoundNames of FormalParameters contains any
+    duplicate elements.
 negative:
   phase: parse
   type: SyntaxError
-flags: [onlyStrict]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/expressions/object/method-definition/early-errors-object-async-method-duplicate-parameters.js
+++ b/test/language/expressions/object/method-definition/early-errors-object-async-method-duplicate-parameters.js
@@ -1,14 +1,15 @@
-// Copyright 2019 Mike Pennisi. All rights reserved.
+// Copyright 2016 Microsoft, Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-method-definitions
+author: Brian Terlson <brian.terlson@microsoft.com>
+esid: sec-async-function-definitions
 description: Formal parameters may not contain duplicates
 info: |
-  # 14.3 Method Definitions
+  # 14.7 Async Function Definitions
 
-  MethodDefinition[Yield, Await]:
-    PropertyName[?Yield, ?Await](UniqueFormalParameters[~Yield, ~Await]){FunctionBody[~Yield, ~Await]}
+   AsyncMethod[Yield, Await]:
+     async[no LineTerminator here]PropertyName[?Yield, ?Await](UniqueFormalParameters[~Yield, +Await]){AsyncFunctionBody}
 
   # 14.1.2 Static Semantics: Early Errors
 
@@ -22,7 +23,6 @@ negative:
 ---*/
 
 $DONOTEVALUATE();
-
-class Foo {
-  foo(a, a) { }
-}
+({
+  async foo(a, a) { }
+})

--- a/test/language/expressions/object/method-definition/early-errors-object-method-duplicate-parameters.js
+++ b/test/language/expressions/object/method-definition/early-errors-object-method-duplicate-parameters.js
@@ -1,11 +1,21 @@
-// Copyright 2016 Microsoft, Inc. All rights reserved.
+// Copyright 2019 Mike Pennisi. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-author: Brian Terlson <brian.terlson@microsoft.com>
-esid: pending
-description: >
-  Early error rules for StrictFormalParameters are applied
+esid: sec-method-definitions
+description: Formal parameters may not contain duplicates
+info: |
+  # 14.3 Method Definitions
+
+  MethodDefinition[Yield, Await]:
+    PropertyName[?Yield, ?Await](UniqueFormalParameters[~Yield, ~Await]){FunctionBody[~Yield, ~Await]}
+
+  # 14.1.2 Static Semantics: Early Errors
+
+  UniqueFormalParameters:FormalParameters
+
+  - It is a Syntax Error if BoundNames of FormalParameters contains any
+    duplicate elements.
 negative:
   phase: parse
   type: SyntaxError
@@ -13,5 +23,5 @@ negative:
 
 $DONOTEVALUATE();
 ({
-  async foo(a, a) { }
+  foo(a, a) { }
 })

--- a/test/language/statements/class/definition/early-errors-class-async-method-duplicate-parameters.js
+++ b/test/language/statements/class/definition/early-errors-class-async-method-duplicate-parameters.js
@@ -1,14 +1,15 @@
-// Copyright 2019 Mike Pennisi. All rights reserved.
+// Copyright 2016 Microsoft, Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-method-definitions
+author: Brian Terlson <brian.terlson@microsoft.com>
+esid: sec-async-function-definitions
 description: Formal parameters may not contain duplicates
 info: |
-  # 14.3 Method Definitions
+  # 14.7 Arrow Function Definitions
 
-  MethodDefinition[Yield, Await]:
-    PropertyName[?Yield, ?Await](UniqueFormalParameters[~Yield, ~Await]){FunctionBody[~Yield, ~Await]}
+  AsyncMethod[Yield, Await]:
+    async[no LineTerminator here]PropertyName[?Yield, ?Await](UniqueFormalParameters[~Yield, +Await]){AsyncFunctionBody}
 
   # 14.1.2 Static Semantics: Early Errors
 
@@ -24,5 +25,5 @@ negative:
 $DONOTEVALUATE();
 
 class Foo {
-  foo(a, a) { }
+  async foo(a, a) { }
 }


### PR DESCRIPTION
Previously, the early error prohibiting duplicate entries in
UniqueFormalParameters was only tested in terms of async functions. In
one case, this was misattributed to UniqeFormalParameters and only
enforced for strict mode code.

Extend coverage to the other function-creating productions which include
UniqueFormalParameters (i.e. method definitions and non-async arrow
functions), and update the existing tests to more accurately describe
the source of the error.

---

Found some missing coverage while implementing some of this for JSHint. @bterlson might want to take a look.