### PR TITLE
UpdateExpressions: No early error for arguments and eval in non-strict mode

### DIFF
--- a/test/language/expressions/postfix-decrement/arguments-nostrict.js
+++ b/test/language/expressions/postfix-decrement/arguments-nostrict.js
@@ -7,24 +7,19 @@ description: >
   It is an early Reference Error if AssignmentTargetType of LeftHandSideExpression is invalid. (arguments)
 info: |
 
-  sec-update-expressions-static-semantics-assignmenttargettype
+  sec-identifiers-static-semantics-assignmenttargettype
 
-    UpdateExpression : LeftHandSideExpression --
-
-    Return invalid.
+    1. If this IdentifierReference is contained in strict mode code and StringValue of Identifier is "eval" or  "arguments", return strict.
+    2. Return simple.
 
   sec-update-expressions-static-semantics-early-errors
 
     UpdateExpression : LeftHandSideExpression --
 
     It is an early Reference Error if AssignmentTargetType of LeftHandSideExpression is invalid.
+    It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is strict.
 
 flags: [noStrict]
-negative:
-  phase: parse
-  type: ReferenceError
 ---*/
-
-$DONOTEVALUATE();
 
 arguments--;

--- a/test/language/expressions/postfix-decrement/eval-nostrict.js
+++ b/test/language/expressions/postfix-decrement/eval-nostrict.js
@@ -7,24 +7,19 @@ description: >
   It is an early Reference Error if AssignmentTargetType of LeftHandSideExpression is invalid. (eval)
 info: |
 
-  sec-update-expressions-static-semantics-assignmenttargettype
+  sec-identifiers-static-semantics-assignmenttargettype
 
-    UpdateExpression : LeftHandSideExpression --
-
-    Return invalid.
+    1. If this IdentifierReference is contained in strict mode code and StringValue of Identifier is "eval" or  "arguments", return strict.
+    2. Return simple.
 
   sec-update-expressions-static-semantics-early-errors
 
     UpdateExpression : LeftHandSideExpression --
 
     It is an early Reference Error if AssignmentTargetType of LeftHandSideExpression is invalid.
+    It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is strict.
 
 flags: [noStrict]
-negative:
-  phase: parse
-  type: ReferenceError
 ---*/
-
-$DONOTEVALUATE();
 
 eval--;

--- a/test/language/expressions/postfix-increment/arguments-nostrict.js
+++ b/test/language/expressions/postfix-increment/arguments-nostrict.js
@@ -7,24 +7,19 @@ description: >
   It is an early Reference Error if AssignmentTargetType of LeftHandSideExpression is invalid. (arguments)
 info: |
 
-  sec-update-expressions-static-semantics-assignmenttargettype
+  sec-identifiers-static-semantics-assignmenttargettype
 
-    UpdateExpression : LeftHandSideExpression ++
-
-    Return invalid.
+    1. If this IdentifierReference is contained in strict mode code and StringValue of Identifier is "eval" or  "arguments", return strict.
+    2. Return simple.
 
   sec-update-expressions-static-semantics-early-errors
 
     UpdateExpression : LeftHandSideExpression ++
 
     It is an early Reference Error if AssignmentTargetType of LeftHandSideExpression is invalid.
+    It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is strict.
 
 flags: [noStrict]
-negative:
-  phase: parse
-  type: ReferenceError
 ---*/
-
-$DONOTEVALUATE();
 
 arguments++;

--- a/test/language/expressions/postfix-increment/eval-nostrict.js
+++ b/test/language/expressions/postfix-increment/eval-nostrict.js
@@ -7,24 +7,19 @@ description: >
   It is an early Reference Error if AssignmentTargetType of LeftHandSideExpression is invalid. (eval)
 info: |
 
-  sec-update-expressions-static-semantics-assignmenttargettype
+  sec-identifiers-static-semantics-assignmenttargettype
 
-    UpdateExpression : LeftHandSideExpression ++
-
-    Return invalid.
+    1. If this IdentifierReference is contained in strict mode code and StringValue of Identifier is "eval" or  "arguments", return strict.
+    2. Return simple.
 
   sec-update-expressions-static-semantics-early-errors
 
     UpdateExpression : LeftHandSideExpression ++
 
     It is an early Reference Error if AssignmentTargetType of LeftHandSideExpression is invalid.
+    It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is strict.
 
 flags: [noStrict]
-negative:
-  phase: parse
-  type: ReferenceError
 ---*/
-
-$DONOTEVALUATE();
 
 eval++;

--- a/test/language/expressions/prefix-decrement/arguments-nostrict.js
+++ b/test/language/expressions/prefix-decrement/arguments-nostrict.js
@@ -7,24 +7,19 @@ description: >
   It is an early Reference Error if AssignmentTargetType of UnaryExpression is invalid. (arguments)
 info: |
 
-  sec-update-expressions-static-semantics-assignmenttargettype
+  sec-identifiers-static-semantics-assignmenttargettype
 
-    UpdateExpression : -- UnaryExpression
-
-    Return invalid.
+    1. If this IdentifierReference is contained in strict mode code and StringValue of Identifier is "eval" or  "arguments", return strict.
+    2. Return simple.
 
   sec-update-expressions-static-semantics-early-errors
 
     UpdateExpression -- UnaryExpression
 
     It is an early Reference Error if AssignmentTargetType of UnaryExpression is invalid.
+    It is an early Syntax Error if AssignmentTargetType of UnaryExpression is strict.
 
 flags: [noStrict]
-negative:
-  phase: parse
-  type: ReferenceError
 ---*/
-
-$DONOTEVALUATE();
 
 --arguments;

--- a/test/language/expressions/prefix-decrement/eval-nostrict.js
+++ b/test/language/expressions/prefix-decrement/eval-nostrict.js
@@ -7,24 +7,19 @@ description: >
   It is an early Reference Error if AssignmentTargetType of UnaryExpression is invalid. (eval)
 info: |
 
-  sec-update-expressions-static-semantics-assignmenttargettype
+  sec-identifiers-static-semantics-assignmenttargettype
 
-    UpdateExpression : -- UnaryExpression
-
-    Return invalid.
+    1. If this IdentifierReference is contained in strict mode code and StringValue of Identifier is "eval" or  "arguments", return strict.
+    2. Return simple.
 
   sec-update-expressions-static-semantics-early-errors
 
     UpdateExpression -- UnaryExpression
 
     It is an early Reference Error if AssignmentTargetType of UnaryExpression is invalid.
+    It is an early Syntax Error if AssignmentTargetType of UnaryExpression is strict.
 
 flags: [noStrict]
-negative:
-  phase: parse
-  type: ReferenceError
 ---*/
-
-$DONOTEVALUATE();
 
 --eval;

--- a/test/language/expressions/prefix-increment/arguments-nostrict.js
+++ b/test/language/expressions/prefix-increment/arguments-nostrict.js
@@ -7,24 +7,19 @@ description: >
   It is an early Reference Error if AssignmentTargetType of UnaryExpression is invalid. (arguments)
 info: |
 
-  sec-update-expressions-static-semantics-assignmenttargettype
+  sec-identifiers-static-semantics-assignmenttargettype
 
-    UpdateExpression : ++ UnaryExpression
-
-    Return invalid.
+    1. If this IdentifierReference is contained in strict mode code and StringValue of Identifier is "eval" or  "arguments", return strict.
+    2. Return simple.
 
   sec-update-expressions-static-semantics-early-errors
 
     UpdateExpression ++ UnaryExpression
 
     It is an early Reference Error if AssignmentTargetType of UnaryExpression is invalid.
+    It is an early Syntax Error if AssignmentTargetType of UnaryExpression is strict.
 
 flags: [noStrict]
-negative:
-  phase: parse
-  type: ReferenceError
 ---*/
-
-$DONOTEVALUATE();
 
 ++arguments;

--- a/test/language/expressions/prefix-increment/eval-nostrict.js
+++ b/test/language/expressions/prefix-increment/eval-nostrict.js
@@ -7,24 +7,19 @@ description: >
   It is an early Reference Error if AssignmentTargetType of UnaryExpression is invalid. (eval)
 info: |
 
-  sec-update-expressions-static-semantics-assignmenttargettype
+  sec-identifiers-static-semantics-assignmenttargettype
 
-    UpdateExpression : ++ UnaryExpression
-
-    Return invalid.
+    1. If this IdentifierReference is contained in strict mode code and StringValue of Identifier is "eval" or  "arguments", return strict.
+    2. Return simple.
 
   sec-update-expressions-static-semantics-early-errors
 
     UpdateExpression ++ UnaryExpression
 
     It is an early Reference Error if AssignmentTargetType of UnaryExpression is invalid.
+    It is an early Syntax Error if AssignmentTargetType of UnaryExpression is strict.
 
 flags: [noStrict]
-negative:
-  phase: parse
-  type: ReferenceError
 ---*/
-
-$DONOTEVALUATE();
 
 ++eval;


### PR DESCRIPTION
According to sec-identifiers-static-semantics-assignmenttargettype,
`AssignmentTargetType` of `arguments` and `eval` in non-strict mode code is
`simple`.
sec-update-expressions-static-semantics-early-errors mandates early errors for
`UpdateExpression` if `AssignmentTargetType` is `invalid` or `strict`.

These were introduced in #2005.