### PR TITLE
change irregular grandfather tag to it's canonical

### DIFF
--- a/test/intl402/Intl/getCanonicalLocales/Locale-object.js
+++ b/test/intl402/Intl/getCanonicalLocales/Locale-object.js
@@ -14,7 +14,7 @@ features: [Intl.Locale]
 
 assert.compareArray(Intl.getCanonicalLocales([
   "fr-CA",
-  new Intl.Locale("en-gb-oed"),
+  new Intl.Locale("en-gb-oxendict"),
   "de",
   new Intl.Locale("jp", { "calendar": "gregory" }),
   "zh",


### PR DESCRIPTION
To sync with the latest spec which referring to UTS35