### PR TITLE
Remove 'cel-gaulish' from test

### DIFF
--- a/test/intl402/Locale/extensions-grandfathered.js
+++ b/test/intl402/Locale/extensions-grandfathered.js
@@ -22,18 +22,6 @@ features: [Intl.Locale]
 ---*/
 
 const testData = [
-    // Regular grandfathered without modern replacement.
-    {
-        tag: "cel-gaulish",
-        options: {
-            language: "fr",
-            script: "Cyrl",
-            region: "FR",
-            numberingSystem: "latn",
-        },
-        canonical: "fr-Cyrl-FR-u-nu-latn",
-    },
-
     // Regular grandfathered with modern replacement.
     {
         tag: "art-lojban",

--- a/test/intl402/Locale/getters-grandfathered.js
+++ b/test/intl402/Locale/getters-grandfathered.js
@@ -26,13 +26,6 @@ features: [Intl.Locale]
 ---*/
 
 // Regular grandfathered language tag.
-var loc = new Intl.Locale("cel-gaulish");
-assert.sameValue(loc.baseName, "cel-gaulish"); // Step 5.
-assert.sameValue(loc.language, "cel-gaulish");
-assert.sameValue(loc.script, undefined);
-assert.sameValue(loc.region, undefined);
-
-// Regular grandfathered language tag.
 assert.throws(RangeError, () => new Intl.Locale("zh-min"));
 
 assert.throws(RangeError, () => new Intl.Locale("i-default"));

--- a/test/intl402/Locale/likely-subtags-grandfathered.js
+++ b/test/intl402/Locale/likely-subtags-grandfathered.js
@@ -67,10 +67,6 @@ const regularGrandfathered = [
         maximized: "jbo-Latn-001",
     },
     {
-        tag: "cel-gaulish",
-        canonical: "cel-gaulish",
-    },
-    {
         tag: "zh-guoyu",
         canonical: "cmn",
     },


### PR DESCRIPTION
'cel-gaulish', according to https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry

is 
"
Type: grandfathered
Tag: cel-gaulish
Description: Gaulish
Added: 2001-05-25
Deprecated: 2015-03-29
Comments: see xcg, xga, xtg
"
I think there are no point to test a deprecated + grandfathered tag regardless what behavior it should be. It is pointless to assure the quality of ECMA toward a deprecated grandfathered tag.