### PR TITLE
add flat/flatMap to Array unscopables

### DIFF
--- a/test/built-ins/Array/prototype/Symbol.unscopables/value.js
+++ b/test/built-ins/Array/prototype/Symbol.unscopables/value.js
@@ -13,11 +13,13 @@ info: |
     4. Perform CreateDataProperty(unscopableList, "fill", true).
     5. Perform CreateDataProperty(unscopableList, "find", true).
     6. Perform CreateDataProperty(unscopableList, "findIndex", true).
-    7. Perform CreateDataProperty(unscopableList, "includes", true).
-    8. Perform CreateDataProperty(unscopableList, "keys", true).
-    9. Perform CreateDataProperty(unscopableList, "values", true).
-    10. Assert: Each of the above calls will return true.
-    11. Return unscopableList.
+    7. Perform CreateDataProperty(unscopableList, "flat", true).
+    8. Perform CreateDataProperty(unscopableList, "flatMap", true).
+    9. Perform CreateDataProperty(unscopableList, "includes", true).
+    10. Perform CreateDataProperty(unscopableList, "keys", true).
+    11. Perform CreateDataProperty(unscopableList, "values", true).
+    12. Assert: Each of the above calls returns true.
+    13. Return unscopableList.
 includes: [propertyHelper.js]
 features: [Symbol.unscopables]
 ---*/
@@ -50,6 +52,16 @@ assert.sameValue(unscopables.findIndex, true, '`findIndex` property value');
 verifyEnumerable(unscopables, 'findIndex');
 verifyWritable(unscopables, 'findIndex');
 verifyConfigurable(unscopables, 'findIndex');
+
+assert.sameValue(unscopables.flat, true, '`flat` property value');
+verifyEnumerable(unscopables, 'flat');
+verifyWritable(unscopables, 'flat');
+verifyConfigurable(unscopables, 'flat');
+
+assert.sameValue(unscopables.flatMap, true, '`flatMap` property value');
+verifyEnumerable(unscopables, 'flatMap');
+verifyWritable(unscopables, 'flatMap');
+verifyConfigurable(unscopables, 'flatMap');
 
 assert.sameValue(unscopables.includes, true, '`includes` property value');
 verifyEnumerable(unscopables, 'includes');


### PR DESCRIPTION
This implements the change to `Array.prototype[@@unscopables]` in the flat/flatMap proposal (stage 4). Relevant spec PR: https://github.com/tc39/ecma262/pull/1309