### PR TITLE
Add tests for setting class-name in ClassDefinitionEvaluation

### DIFF
--- a/test/language/computed-property-names/class/static/method-number.js
+++ b/test/language/computed-property-names/class/static/method-number.js
@@ -21,6 +21,6 @@ assert(
   "`compareArray(Object.keys(C), [])` returns `true`"
 );
 assert(
-  compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'prototype', 'a', 'c', 'name']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'prototype', 'a', 'c', 'name'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'prototype', 'name', 'a', 'c']),
+  "`compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'prototype', 'name', 'a', 'c'])` returns `true`"
 );

--- a/test/language/computed-property-names/class/static/method-string.js
+++ b/test/language/computed-property-names/class/static/method-string.js
@@ -21,6 +21,6 @@ assert(
   "`compareArray(Object.keys(C), [])` returns `true`"
 );
 assert(
-  compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'a', 'b', 'c', 'd', 'name']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'a', 'b', 'c', 'd', 'name'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'name', 'a', 'b', 'c', 'd']),
+  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'name', 'a', 'b', 'c', 'd'])` returns `true`"
 );

--- a/test/language/computed-property-names/class/static/method-symbol.js
+++ b/test/language/computed-property-names/class/static/method-symbol.js
@@ -24,8 +24,8 @@ assert(
   "`compareArray(Object.keys(C), [])` returns `true`"
 );
 assert(
-  compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'a', 'c', 'name']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'a', 'c', 'name'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'name', 'a', 'c']),
+  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'name', 'a', 'c'])` returns `true`"
 );
 assert(
   compareArray(Object.getOwnPropertySymbols(C), [sym1, sym2]),

--- a/test/language/expressions/class/elements/class-name-static-initializer-anonymous.js
+++ b/test/language/expressions/class/elements/class-name-static-initializer-anonymous.js
@@ -1,0 +1,26 @@
+// Copyright 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-classdefinitionevaluation
+description: >
+    The inferred class-name is present when executing static field initializers of anonymous class expressions.
+info: |
+    14.6.13 Runtime Semantics: ClassDefinitionEvaluation
+
+    [...]
+    17. Perform MakeClassConstructor(F).
+    18. If className is not undefined, then
+        a. Perform SetFunctionName(F, className).
+    [...]
+
+features: [class-static-fields-public]
+---*/
+
+var className;
+
+var C = class {
+    static f = (className = this.name);
+}
+
+assert.sameValue(className, "C");

--- a/test/language/expressions/class/elements/class-name-static-initializer-decl.js
+++ b/test/language/expressions/class/elements/class-name-static-initializer-decl.js
@@ -1,0 +1,26 @@
+// Copyright 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-classdefinitionevaluation
+description: >
+    The class-name is present when executing static field initializers of class declarations.
+info: |
+    14.6.13 Runtime Semantics: ClassDefinitionEvaluation
+
+    [...]
+    17. Perform MakeClassConstructor(F).
+    18. If className is not undefined, then
+        a. Perform SetFunctionName(F, className).
+    [...]
+
+features: [class-static-fields-public]
+---*/
+
+var className;
+
+class C {
+    static f = (className = this.name);
+}
+
+assert.sameValue(className, "C");

--- a/test/language/expressions/class/elements/class-name-static-initializer-default-export.js
+++ b/test/language/expressions/class/elements/class-name-static-initializer-default-export.js
@@ -1,0 +1,27 @@
+// Copyright 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-classdefinitionevaluation
+description: >
+    The class-name is present when executing static field initializers of default-exported classes.
+info: |
+    14.6.13 Runtime Semantics: ClassDefinitionEvaluation
+
+    [...]
+    17. Perform MakeClassConstructor(F).
+    18. If className is not undefined, then
+        a. Perform SetFunctionName(F, className).
+    [...]
+
+flags: [module]
+features: [class-static-fields-public]
+---*/
+
+var className;
+
+export default class {
+    static f = (className = this.name);
+}
+
+assert.sameValue(className, "default");

--- a/test/language/expressions/class/elements/class-name-static-initializer-expr.js
+++ b/test/language/expressions/class/elements/class-name-static-initializer-expr.js
@@ -1,0 +1,26 @@
+// Copyright 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-runtime-semantics-classdefinitionevaluation
+description: >
+    The class-name is present when executing static field initializers of named class expressions.
+info: |
+    14.6.13 Runtime Semantics: ClassDefinitionEvaluation
+
+    [...]
+    17. Perform MakeClassConstructor(F).
+    18. If className is not undefined, then
+        a. Perform SetFunctionName(F, className).
+    [...]
+
+features: [class-static-fields-public]
+---*/
+
+var className;
+
+var expr = class C {
+    static f = (className = this.name);
+}
+
+assert.sameValue(className, "C");


### PR DESCRIPTION
- Updates three existing tests now that "name" is added directly after "prototype".
- Adds new tests for the case which motivated the spec change.

Spec PR: tc39/ecma262#1372