### PR TITLE
Remove errant tab character.

### DIFF
--- a/test/intl402/Locale/constructor-tag.js
+++ b/test/intl402/Locale/constructor-tag.js
@@ -42,7 +42,7 @@ for (const [langtag, canonical] of Object.entries(validLanguageTags)) {
   );
 }
 
-// unicode_language_subtag	= alpha{2,3} | alpha{5,8};
+// unicode_language_subtag = alpha{2,3} | alpha{5,8};
 const invalidLanguageTags = [
   "X-u-foo", 
   "Flob",


### PR DESCRIPTION
WebKit SVN choked on this as I was performing a test import today.