### PR TITLE
Add test for ({* identifier})

### DIFF
--- a/test/language/expressions/object/prop-def-invalid-star-prefix.js
+++ b/test/language/expressions/object/prop-def-invalid-star-prefix.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2019 Tiancheng "Timothy" Gu. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  * is not a valid prefix of an identifier reference
+esid: sec-object-initializer
+info: |
+    PropertyDefinition:
+      IdentifierReference
+      CoverInitializedName
+      PropertyName : AssignmentExpression
+      MethodDefinition
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+({* foo});


### PR DESCRIPTION
Counterpart to language/expressions/object/prop-def-invalid-async-prefix.js.