### PR TITLE
Split Intl.getCanonicalLocales from Locale

### DIFF
--- a/test/intl402/Intl/getCanonicalLocales/grandfathered.js
+++ b/test/intl402/Intl/getCanonicalLocales/grandfathered.js
@@ -1,0 +1,33 @@
+// Copyright 2018 André Bargull; Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Split from intl402/Locale/likely-subtags-grandfathered.js
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+    Verifies canonicalization of specific tags.
+---*/
+
+
+const regularGrandfathered = [
+    {
+        tag: "art-lojban",
+        canonical: "jbo",
+    },
+    {
+        tag: "zh-guoyu",
+        canonical: "cmn",
+    },
+    {
+        tag: "zh-hakka",
+        canonical: "hak",
+    },
+    {
+        tag: "zh-xiang",
+        canonical: "hsn",
+    },
+];
+
+for (const {tag, canonical} of regularGrandfathered) {
+    assert.sameValue(Intl.getCanonicalLocales(tag)[0], canonical);
+}

--- a/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
+++ b/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
@@ -38,15 +38,27 @@ var testData = [
     },
     {
         tag: "aar-x-private",
+        // "aar" should be canonicalized into "aa" because "aar" matches the type attribute of
+        // a languageAlias element in 
+        // https://www.unicode.org/repos/cldr/trunk/common/supplemental/supplementalMetadata.xml
+        canonical: "aa-x-private", 
     },
     {
         tag: "heb-x-private",
+        // "heb" should be canonicalized into "he" because "heb" matches the type attribute of
+        // a languageAlias element in 
+        // https://www.unicode.org/repos/cldr/trunk/common/supplemental/supplementalMetadata.xml
+        canonical: "he-x-private",
     },
     {
         tag: "de-u-kf",
     },
     {
         tag: "ces",
+        // "ces" should be canonicalized into "cs" because "ces" matches the type attribute of
+        // a languageAlias element in 
+        // https://www.unicode.org/repos/cldr/trunk/common/supplemental/supplementalMetadata.xml
+        canonical: "cs",
     },
     {
         tag: "hy-arevela",

--- a/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
+++ b/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
@@ -1,0 +1,37 @@
+// Copyright 2018 André Bargull; Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+// Slip from intl402/Locale/constructor-non-iana-canon.js
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+    Verifies canonicalization, of specific tags.
+info: |
+    ApplyOptionsToTag( tag, options )
+    10. Return CanonicalizeLanguageTag(tag).
+---*/
+
+// Test some language tags where we know that either CLDR or ICU produce
+// different results compared to the canonicalization specified in RFC 5646.
+var testData = [
+    {
+        tag: "mo",
+        canonical: "ro",
+    },
+    {
+        tag: "hy-arevela",
+        canonical: "hy",
+    },
+    {
+        tag: "hy-arevmda",
+        canonical: "hyw",
+    },
+];
+
+for (const {tag, canonical = tag} of testData) {
+    assert.sameValue(
+      Intl.getCanonicalLocales(tag)[0],
+      canonical,
+      'The value of Intl.getCanonicalLocales(tag)[0] equals the value of `canonical`'
+    );
+}

--- a/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
+++ b/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
@@ -19,6 +19,36 @@ var testData = [
         canonical: "ro",
     },
     {
+        tag: "es-ES-preeuro",
+    },
+    {
+        tag: "uz-UZ-cyrillic",
+    },
+    {
+        tag: "posix",
+    },
+    {
+        tag: "hi-direct",
+    },
+    {
+        tag: "zh-pinyin",
+    },
+    {
+        tag: "zh-stroke",
+    },
+    {
+        tag: "aar-x-private",
+    },
+    {
+        tag: "heb-x-private",
+    },
+    {
+        tag: "de-u-kf",
+    },
+    {
+        tag: "ces",
+    },
+    {
         tag: "hy-arevela",
         canonical: "hy",
     },

--- a/test/intl402/Locale/constructor-non-iana-canon.js
+++ b/test/intl402/Locale/constructor-non-iana-canon.js
@@ -75,12 +75,6 @@ var testData = [
 ];
 
 for (const {tag, canonical = tag, maximized = canonical, minimized = canonical} of testData) {
-    assert.sameValue(
-      Intl.getCanonicalLocales(tag)[0],
-      canonical,
-      'The value of Intl.getCanonicalLocales(tag)[0] equals the value of `canonical`'
-    );
-
     const loc = new Intl.Locale(tag);
     assert.sameValue(
       new Intl.Locale(tag).toString(),

--- a/test/intl402/Locale/likely-subtags-grandfathered.js
+++ b/test/intl402/Locale/likely-subtags-grandfathered.js
@@ -83,8 +83,6 @@ const regularGrandfathered = [
 ];
 
 for (const {tag, canonical, maximized = canonical, minimized = canonical} of regularGrandfathered) {
-    assert.sameValue(Intl.getCanonicalLocales(tag)[0], canonical);
-
     const loc = new Intl.Locale(tag);
     assert.sameValue(loc.toString(), canonical);
 


### PR DESCRIPTION
I found some of our tests for Locale failed on the result of Intl.getCanonicalLocales which should not be part of the verification for Locale but instead for getCanonicalLocales so I MOVE these test from Locale under Intl/getCanonicalLocales to make us have better picture which PART is failing.