### PR TITLE
correct value that matches languageAlias 

### DIFF
--- a/test/intl402/Locale/constructor-non-iana-canon.js
+++ b/test/intl402/Locale/constructor-non-iana-canon.js
@@ -52,9 +52,19 @@ var testData = [
     },
     {
         tag: "aar-x-private",
-    },
+        // "aar" should be canonicalized into "aa" because "aar" matches the type attribute of
+        // a languageAlias element in 
+        // https://www.unicode.org/repos/cldr/trunk/common/supplemental/supplementalMetadata.xml
+        canonical: "aa-x-private",
+        maximized: "aa-Latn-ET-x-private",
+   },
     {
         tag: "heb-x-private",
+        // "heb" should be canonicalized into "he" because "heb" matches the type attribute of
+        // a languageAlias element in 
+        // https://www.unicode.org/repos/cldr/trunk/common/supplemental/supplementalMetadata.xml
+        canonical: "he-x-private",
+        maximized: "he-Hebr-IL-x-private",
     },
     {
         tag: "de-u-kf",
@@ -62,6 +72,11 @@ var testData = [
     },
     {
         tag: "ces",
+        // "ces" should be canonicalized into "cs" because "ces" matches the type attribute of
+        // a languageAlias element in 
+        // https://www.unicode.org/repos/cldr/trunk/common/supplemental/supplementalMetadata.xml
+        canonical: "cs",
+        maximized: "cs-Latn-CZ",
     },
     {
         tag: "hy-arevela",


### PR DESCRIPTION
Per  https://tc39.github.io/ecma402/#sec-canonicalizelanguagetag
*6.2.3 CanonicalizeLanguageTag ( locale )*
```
The CanonicalizeLanguageTag abstract operation returns the canonical and 
case-regularized form of the locale argument (which must be a String value that is a 
structurally valid Unicode BCP 47 Locale Identifier as verified by the 
IsStructurallyValidLanguageTag abstract operation). A conforming implementation 
shall take the steps specified in the “BCP 47 Language Tag to Unicode BCP 47 
Locale Identifier” algorithm, from Unicode Technical Standard #35 LDML § 3.3.1 
BCP 47 Language Tag Conversion.
```
And
http://unicode.org/reports/tr35/#BCP_47_Language_Tag_Conversion
```
2. If the BCP 47 primary language subtag matches the type attribute of a 
languageAlias element in Supplemental Data, replace the language subtag 
with the replacement value.
  * If there are additional subtags in the replacement value, add them to the result, 
    but only if there is no corresponding subtag already in the tag.
```
and
https://www.unicode.org/repos/cldr/trunk/common/supplemental/supplementalMetadata.xml
```
...
<languageAlias type="aar" replacement="aa" reason="overlong"/>
 <!--  [Afar]  -->
...
<languageAlias type="ces" replacement="cs" reason="overlong"/>
 <!--  [Czech]  -->
...
<languageAlias type="heb" replacement="he" reason="overlong"/>
 <!--  [Hebrew]  -->
```