### PR TITLE
Added case to verify invalid syntax when using private field on object destructuring

### DIFF
--- a/src/class-elements/grammar-private-field-on-object-destructuring.case
+++ b/src/class-elements/grammar-private-field-on-object-destructuring.case
@@ -12,7 +12,7 @@ info: |
      {AssignmentPropertyList[?Yield, ?Await]}
      {AssignmentPropertyList[?Yield, ?Await],AssignmentRestProperty[?Yield, ?Await]opt}
 template: syntax/invalid
-features: [class-fields-private]
+features: [class-fields-private, destructuring-binding]
 ---*/
 
 //- elements
@@ -20,5 +20,4 @@ features: [class-fields-private]
 
 destructureX() {
   const { #x: x } = this;
-  return x;
 }

--- a/src/class-elements/grammar-private-field-on-object-destructuring.case
+++ b/src/class-elements/grammar-private-field-on-object-destructuring.case
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Acessing private field from object destructuring pattern is not a valid syntax
+info: |
+  Updated Productions
+
+  ObjectAssignmentPattern[Yield, Await]:
+     {}
+     {AssignmentRestProperty[?Yield, ?Await]}
+     {AssignmentPropertyList[?Yield, ?Await]}
+     {AssignmentPropertyList[?Yield, ?Await],AssignmentRestProperty[?Yield, ?Await]opt}
+template: syntax/invalid
+features: [class-fields-private]
+---*/
+
+//- elements
+#x = 1;
+
+destructureX() {
+  const { #x: x } = this;
+  return x;
+}

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-private-field-on-object-destructuring.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-private-field-on-object-destructuring.js
@@ -1,0 +1,33 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-field-on-object-destructuring.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: Acessing private field from object destructuring pattern is not a valid syntax (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Updated Productions
+
+    ObjectAssignmentPattern[Yield, Await]:
+       {}
+       {AssignmentRestProperty[?Yield, ?Await]}
+       {AssignmentPropertyList[?Yield, ?Await]}
+       {AssignmentPropertyList[?Yield, ?Await],AssignmentRestProperty[?Yield, ?Await]opt}
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  #x = 1;
+
+  destructureX() {
+    const { #x: x } = this;
+    return x;
+  }
+};

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-private-field-on-object-destructuring.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-private-field-on-object-destructuring.js
@@ -4,7 +4,7 @@
 /*---
 description: Acessing private field from object destructuring pattern is not a valid syntax (class expression)
 esid: prod-ClassElement
-features: [class-fields-private, class]
+features: [class-fields-private, destructuring-binding, class]
 flags: [generated]
 negative:
   phase: parse
@@ -28,6 +28,5 @@ var C = class {
 
   destructureX() {
     const { #x: x } = this;
-    return x;
   }
 };

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-private-field-on-object-destructuring.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-private-field-on-object-destructuring.js
@@ -1,0 +1,33 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-field-on-object-destructuring.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: Acessing private field from object destructuring pattern is not a valid syntax (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Updated Productions
+
+    ObjectAssignmentPattern[Yield, Await]:
+       {}
+       {AssignmentRestProperty[?Yield, ?Await]}
+       {AssignmentPropertyList[?Yield, ?Await]}
+       {AssignmentPropertyList[?Yield, ?Await],AssignmentRestProperty[?Yield, ?Await]opt}
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  #x = 1;
+
+  destructureX() {
+    const { #x: x } = this;
+    return x;
+  }
+}

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-private-field-on-object-destructuring.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-private-field-on-object-destructuring.js
@@ -4,7 +4,7 @@
 /*---
 description: Acessing private field from object destructuring pattern is not a valid syntax (class declaration)
 esid: prod-ClassElement
-features: [class-fields-private, class]
+features: [class-fields-private, destructuring-binding, class]
 flags: [generated]
 negative:
   phase: parse
@@ -28,6 +28,5 @@ class C {
 
   destructureX() {
     const { #x: x } = this;
-    return x;
   }
 }


### PR DESCRIPTION
This closes #2072.