### PR TITLE
Add tests for calling BigInt functions with fewer arguments than required

### DIFF
--- a/test/built-ins/BigInt/asIntN/bigint-tobigint-errors.js
+++ b/test/built-ins/BigInt/asIntN/bigint-tobigint-errors.js
@@ -11,6 +11,14 @@ features: [BigInt, computed-property-names, Symbol, Symbol.toPrimitive]
 ---*/
 assert.sameValue(typeof BigInt, 'function');
 assert.sameValue(typeof BigInt.asIntN, 'function');
+
+assert.throws(TypeError, function () {
+  BigInt.asIntN();
+}, "ToBigInt: no argument => undefined => TypeError");
+assert.throws(TypeError, function () {
+  BigInt.asIntN(0);
+}, "ToBigInt: no argument => undefined => TypeError");
+
 assert.throws(TypeError, function() {
   BigInt.asIntN(0, undefined);
 }, "ToBigInt: undefined => TypeError");

--- a/test/built-ins/BigInt/asUintN/bigint-tobigint-errors.js
+++ b/test/built-ins/BigInt/asUintN/bigint-tobigint-errors.js
@@ -12,6 +12,13 @@ features: [BigInt, computed-property-names, Symbol, Symbol.toPrimitive]
 assert.sameValue(typeof BigInt, 'function');
 assert.sameValue(typeof BigInt.asUintN, 'function');
 
+assert.throws(TypeError, function () {
+  BigInt.asUintN();
+}, "ToBigInt: no argument => undefined => TypeError");
+assert.throws(TypeError, function () {
+  BigInt.asUintN(0);
+}, "ToBigInt: no argument => undefined => TypeError");
+
 assert.throws(TypeError, function() {
   BigInt.asUintN(0, undefined);
 }, "ToBigInt: undefined => TypeError");


### PR DESCRIPTION
BigInt.asIntN and BigInt.asUintN should throw TypeErrors when the required bigint argument is not present

See https://bugzilla.mozilla.org/show_bug.cgi?id=1526279