### PR TITLE
Remove unreasonable expectation

### DIFF
--- a/test/intl402/Locale/likely-subtags-grandfathered.js
+++ b/test/intl402/Locale/likely-subtags-grandfathered.js
@@ -127,7 +127,6 @@ for (const {tag} of regularGrandfathered) {
 
     for (const extra of extras) {
         const loc = new Intl.Locale(tag + "-" + extra);
-        assert.sameValue(loc.toString(), tag + "-" + extra);
 
         assert.sameValue(loc.maximize().toString(), tagMax + "-" + extra);
         assert.sameValue(loc.maximize().maximize().toString(), tagMax + "-" + extra);


### PR DESCRIPTION
The regular grandfather tag will be canonicalized to something else so such check is not reasonable.
"art-lojban-fonipa" will be canonicalized to "jbo-fonipa"
"art-lojban-a-not-assigned" will be canonicalized to "jbo-a-not-assigned"
"art-lojban-u-attr" will be canonicalized to "jbo-u-attr"
"art-lojban-u-co" will be canonicalized to "jbo-u-co"
 "art-lojban-u-co-phonebk" will be canonicalized to "jbo-u-co-phonebk"
 "art-lojban-x-private" will be canonicalized to "jbo-x-private"

so we should remove the 
assert.sameValue(loc.toString(), tag + "-" + extra);  check.