### PR TITLE
Fix parseTestRecord.py for optional top license header

### DIFF
--- a/tools/packaging/test/fixtures/test262-yaml-headers-no-cr.js
+++ b/tools/packaging/test/fixtures/test262-yaml-headers-no-cr.js
@@ -1,0 +1,15 @@
+/*---
+info: >
+    The production Block { } in strict code can't contain function
+    declaration;
+description: Trying to declare function at the Block statement
+negative: SyntaxError
+bestPractice: "http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls"
+flags: [onlyStrict]
+---*/
+
+"use strict";
+{
+    function __func(){}
+}
+

--- a/tools/packaging/test/test_common.py
+++ b/tools/packaging/test/test_common.py
@@ -37,7 +37,7 @@ declaration;""", record['commentary'])
                          record['description'])
         self.assertEqual("", record['onlyStrict'])
         self.assertEqual("SyntaxError", record['negative'])
-        self.assertEqual("http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls",
+        self.assertEqual('http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls',
                          record['bestPractice'])
 
 
@@ -55,9 +55,23 @@ class TestYAMLParsing(unittest.TestCase):
         self.assertEqual(['onlyStrict'], record['flags'])
         self.assertEqual("", record['onlyStrict'])
         self.assertEqual("SyntaxError", record['negative'])
-        self.assertEqual("http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls",
+        self.assertEqual('"http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls"',
                          record['bestPractice'])
 
+    def test_no_header(self):
+        name = 'fixtures/test262-yaml-headers-no-cr.js'
+        contents = slurpFile(name)
+        record = convertDocString(contents)
+
+        self.assertEqual("The production Block { } in strict code can't contain function declaration;\n", record['commentary'])
+
+        self.assertEqual("Trying to declare function at the Block statement",
+                         record['description'])
+        self.assertEqual(['onlyStrict'], record['flags'])
+        self.assertEqual("", record['onlyStrict'])
+        self.assertEqual("SyntaxError", record['negative'])
+        self.assertEqual('"http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls"',
+                         record['bestPractice'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/packaging/test/test_parseTestRecord.py
+++ b/tools/packaging/test/test_parseTestRecord.py
@@ -161,7 +161,35 @@ flags: [onlyStrict]"""
         self.assertEqual(['onlyStrict'], record['flags'])
         self.assertEqual("", record['onlyStrict'])
         self.assertEqual("SyntaxError", record['negative'])
-        self.assertEqual("http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls",
+        self.assertEqual('"http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls"',
+                         record['bestPractice'])
+
+        self.assertEqual(""""use strict";
+{
+    function __func(){}
+}
+
+""", record['test'])
+
+class TestYAML2Parsing(unittest.TestCase):
+    def test_test(self):
+        self.assertTrue(True)
+
+    def test_overview(self):
+        name = 'fixtures/test262-yaml-headers-no-cr.js'
+        contents = slurpFile(name)
+        record = parseTestRecord(contents, name)
+
+        self.assertEqual('',
+                         record['header'])
+        self.assertEqual("The production Block { } in strict code can't contain function declaration;\n", record['commentary'])
+
+        self.assertEqual("Trying to declare function at the Block statement",
+                         record['description'])
+        self.assertEqual(['onlyStrict'], record['flags'])
+        self.assertEqual("", record['onlyStrict'])
+        self.assertEqual("SyntaxError", record['negative'])
+        self.assertEqual('"http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls"',
                          record['bestPractice'])
 
         self.assertEqual(""""use strict";

--- a/tools/packaging/test/test_parseTestRecord.py
+++ b/tools/packaging/test/test_parseTestRecord.py
@@ -19,7 +19,6 @@ def slurpFile(name):
         contents = f.read()
     return contents
 
-
 class TestOldParsing(unittest.TestCase):
 
     def test_test(self):
@@ -198,7 +197,6 @@ class TestYAML2Parsing(unittest.TestCase):
 }
 
 """, record['test'])
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This should work for the hashbang tests.

Note that this is legacy code and I'm first trying to implement a fix and we can later improve this script. The change is conservative to preserve legacy functionality as I'm avoiding breaking other things.

Fixes #2080 

cc @caitp @gsathya I appreciate if you could take a look on this one, thanks.