### PR TITLE
Fix existing linting errors, update error phase, and add a new flags linter

### DIFF
--- a/test/language/comments/hashbang/use-strict.js
+++ b/test/language/comments/hashbang/use-strict.js
@@ -10,7 +10,7 @@ description: >
 info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
-flags: [raw, noStrict]
+flags: [raw]
 features: [hashbang]
 ---*/
 

--- a/test/language/directive-prologue/10.1.1-2gs.js
+++ b/test/language/directive-prologue/10.1.1-2gs.js
@@ -13,5 +13,5 @@ flags: [raw]
 ---*/
 
 "use strict"
-throw new Error("This code should not execute");
+throw "Test262: This statement should not be evaluated.";
 var public = 1;

--- a/test/language/directive-prologue/10.1.1-5gs.js
+++ b/test/language/directive-prologue/10.1.1-5gs.js
@@ -13,5 +13,5 @@ flags: [raw]
 ---*/
 
 "use strict";
-throw new Error("This code should not execute");
+throw "Test262: This statement should not be evaluated.";
 var public = 1;

--- a/test/language/directive-prologue/10.1.1-8gs.js
+++ b/test/language/directive-prologue/10.1.1-8gs.js
@@ -14,5 +14,5 @@ flags: [raw]
 
 "use strict";
 "use strict";
-throw new Error("This code should not execute");
+throw "Test262: This statement should not be evaluated.";
 var public = 1;

--- a/test/language/directive-prologue/14.1-4gs.js
+++ b/test/language/directive-prologue/14.1-4gs.js
@@ -13,5 +13,5 @@ flags: [raw]
 ---*/
 
 "use strict";
-throw new Error("This code should not execute");
+throw "Test262: This statement should not be evaluated.";
 eval = 42;

--- a/test/language/directive-prologue/14.1-5gs.js
+++ b/test/language/directive-prologue/14.1-5gs.js
@@ -15,5 +15,5 @@ flags: [raw]
 "a";
 "use strict";
 "c";
-throw new Error("This code should not execute");
+throw "Test262: This statement should not be evaluated.";
 eval = 42;

--- a/test/language/directive-prologue/func-decl-inside-func-decl-parse.js
+++ b/test/language/directive-prologue/func-decl-inside-func-decl-parse.js
@@ -9,10 +9,12 @@ description: >
     is strict function code if FunctionDeclaration is contained in use
     strict
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 flags: [noStrict]
 ---*/
+
+$DONOTEVALUATE();
 
 function testcase() {
   "use strict";

--- a/test/language/directive-prologue/func-decl-no-semi-parse.js
+++ b/test/language/directive-prologue/func-decl-no-semi-parse.js
@@ -8,10 +8,12 @@ description: >
     Strict Mode - Use Strict Directive Prologue is ''use strict''
     which lost the last character ';'
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 flags: [noStrict]
 ---*/
+
+$DONOTEVALUATE();
 
 function fun() {
   "use strict"

--- a/test/language/directive-prologue/func-decl-parse.js
+++ b/test/language/directive-prologue/func-decl-parse.js
@@ -8,10 +8,12 @@ description: >
     Strict Mode - Function code of a FunctionDeclaration contains Use
     Strict Directive which appears at the start of the block
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 flags: [noStrict]
 ---*/
+
+$DONOTEVALUATE();
 
 function fun() {
   "use strict";

--- a/test/language/directive-prologue/func-expr-inside-func-decl-parse.js
+++ b/test/language/directive-prologue/func-expr-inside-func-decl-parse.js
@@ -9,10 +9,12 @@ description: >
     is strict function code if FunctionExpression is contained in use
     strict
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 flags: [noStrict]
 ---*/
+
+$DONOTEVALUATE();
 
 function testcase() {
   "use strict";

--- a/test/language/directive-prologue/func-expr-no-semi-parse.js
+++ b/test/language/directive-prologue/func-expr-no-semi-parse.js
@@ -8,10 +8,12 @@ description: >
     Strict Mode - Use Strict Directive Prologue is ''use strict''
     which lost the last character ';'
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 flags: [noStrict]
 ---*/
+
+$DONOTEVALUATE();
 
 (function() {
   "use strict"

--- a/test/language/directive-prologue/func-expr-parse.js
+++ b/test/language/directive-prologue/func-expr-parse.js
@@ -8,10 +8,12 @@ description: >
     Strict Mode - Function code of a FunctionExpression contains Use
     Strict Directive which appears at the start of the block
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 flags: [noStrict]
 ---*/
+
+$DONOTEVALUATE();
 
 (function() {
   "use strict";

--- a/test/language/expressions/import.meta/syntax/goal-script.js
+++ b/test/language/expressions/import.meta/syntax/goal-script.js
@@ -8,7 +8,7 @@ description: >
 info: |
   It is an early Syntax Error if Module is not the syntactic goal symbol.
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 features: [import.meta]
 ---*/

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-array-destructuring-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-array-destructuring-expr.js
@@ -21,7 +21,7 @@ info: |
     and AssignmentTargetType(LeftHandSideExpression) is not simple.
 flags: [module]
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 features: [import.meta, destructuring-assignment]
 ---*/

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-array-rest-destructuring-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-array-rest-destructuring-expr.js
@@ -21,7 +21,7 @@ info: |
     and AssignmentTargetType(LeftHandSideExpression) is not simple.
 flags: [module]
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 features: [import.meta, destructuring-assignment]
 ---*/

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-assignment-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-assignment-expr.js
@@ -21,7 +21,7 @@ info: |
     ArrayLiteral and AssignmentTargetType of LeftHandSideExpression is invalid.
 flags: [module]
 negative:
-  phase: early
+  phase: parse
   type: ReferenceError
 features: [import.meta]
 ---*/

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-await-of-loop.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-await-of-loop.js
@@ -20,7 +20,7 @@ info: |
     It is a Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
 flags: [module]
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 features: [import.meta, async-iteration]
 ---*/

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-in-loop.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-in-loop.js
@@ -20,7 +20,7 @@ info: |
     It is a Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
 flags: [module]
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 features: [import.meta]
 ---*/

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-of-loop.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-for-of-loop.js
@@ -20,7 +20,7 @@ info: |
     It is a Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
 flags: [module]
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 features: [import.meta]
 ---*/

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-object-destructuring-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-object-destructuring-expr.js
@@ -21,7 +21,7 @@ info: |
     and AssignmentTargetType(LeftHandSideExpression) is not simple.
 flags: [module]
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 features: [import.meta, destructuring-assignment]
 ---*/

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-object-rest-destructuring-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-object-rest-destructuring-expr.js
@@ -21,7 +21,7 @@ info: |
     and AssignmentTargetType(LeftHandSideExpression) is not simple.
 flags: [module]
 negative:
-  phase: early
+  phase: parse
   type: SyntaxError
 features: [import.meta, destructuring-assignment, object-rest]
 ---*/

--- a/test/language/expressions/import.meta/syntax/invalid-assignment-target-update-expr.js
+++ b/test/language/expressions/import.meta/syntax/invalid-assignment-target-update-expr.js
@@ -22,7 +22,7 @@ info: |
     It is an early Reference Error if AssignmentTargetType of LeftHandSideExpression is invalid.
 flags: [module]
 negative:
-  phase: early
+  phase: parse
   type: ReferenceError
 features: [import.meta]
 ---*/

--- a/tools/lint/lib/checks/flags.py
+++ b/tools/lint/lib/checks/flags.py
@@ -1,0 +1,36 @@
+from ..check import Check
+
+class CheckFlags(Check):
+    '''Ensure tests don't contain any contradicting or redundant flag combinations.'''
+    ID = 'FLAGS'
+
+    def run(self, name, meta, source):
+        if meta is None or meta.get('flags') is None:
+            return
+
+        flags = meta['flags']
+
+        onlyStrict = 'onlyStrict' in flags
+        noStrict = 'noStrict' in flags
+        module = 'module' in flags
+        raw = 'raw' in flags
+        canBlockIsFalse = 'CanBlockIsFalse' in flags
+        canBlockIsTrue = 'CanBlockIsTrue' in flags
+
+        if onlyStrict and noStrict:
+            return '"onlyStrict" and "noStrict" flags are mutually exclusive'
+
+        if canBlockIsFalse and canBlockIsTrue:
+            return '"CanBlockIsFalse" and "CanBlockIsTrue" flags are mutually exclusive'
+
+        if raw and onlyStrict:
+            return 'Raw tests cannot prepend a "use strict" directive'
+
+        if raw and noStrict:
+            return '"raw" flag implies no "use strict" directive should be prepended'
+
+        if module and onlyStrict:
+            return 'Module tests cannot be run in non-strict mode'
+
+        if module and noStrict:
+            return '"module" flag implies the test is run in strict mode'

--- a/tools/lint/lib/checks/negative.py
+++ b/tools/lint/lib/checks/negative.py
@@ -27,6 +27,9 @@ class CheckNegative(Check):
         if not 'phase' in negative:
             return '"negative" must specify a "phase" field'
 
+        if negative["phase"] not in ["parse", "resolution", "runtime"]:
+            return '"phase" must be one of ["parse", "resolution", "runtime"]'
+
         if negative["phase"] in ["parse", "resolution"]:
             if meta.get('flags') and 'raw' in meta['flags']:
                 if not _THROW_STMT_LEGACY.search(source):

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -38,6 +38,7 @@ from lib.checks.license import CheckLicense
 from lib.checks.negative import CheckNegative
 from lib.checks.filename import CheckFileName
 from lib.checks.nopadding import CheckNoPadding
+from lib.checks.flags import CheckFlags
 from lib.eprint import eprint
 import lib.frontmatter
 import lib.exceptions
@@ -59,7 +60,8 @@ checks = [
     CheckHarness(),
     CheckLicense(),
     CheckNegative(),
-    CheckNoPadding()
+    CheckNoPadding(),
+    CheckFlags(),
 ]
 
 def lint(file_names):

--- a/tools/lint/test/fixtures/flags_canblock_true_and_false.js
+++ b/tools/lint/test/fixtures/flags_canblock_true_and_false.js
@@ -1,0 +1,9 @@
+FLAGS
+^ expected errors | v input
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-assignment-operators-static-semantics-early-errors
+description: Minimal test
+flags: [CanBlockIsFalse, CanBlockIsTrue]
+---*/

--- a/tools/lint/test/fixtures/flags_module_and_noStrict.js
+++ b/tools/lint/test/fixtures/flags_module_and_noStrict.js
@@ -1,0 +1,9 @@
+FLAGS
+^ expected errors | v input
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-assignment-operators-static-semantics-early-errors
+description: Minimal test
+flags: [module, noStrict]
+---*/

--- a/tools/lint/test/fixtures/flags_module_and_onlyStrict.js
+++ b/tools/lint/test/fixtures/flags_module_and_onlyStrict.js
@@ -1,0 +1,9 @@
+FLAGS
+^ expected errors | v input
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-assignment-operators-static-semantics-early-errors
+description: Minimal test
+flags: [module, onlyStrict]
+---*/

--- a/tools/lint/test/fixtures/flags_onlyStrict_and_noStrict.js
+++ b/tools/lint/test/fixtures/flags_onlyStrict_and_noStrict.js
@@ -1,0 +1,9 @@
+FLAGS
+^ expected errors | v input
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-assignment-operators-static-semantics-early-errors
+description: Minimal test
+flags: [onlyStrict, noStrict]
+---*/

--- a/tools/lint/test/fixtures/flags_raw_and_noStrict.js
+++ b/tools/lint/test/fixtures/flags_raw_and_noStrict.js
@@ -1,0 +1,9 @@
+FLAGS
+^ expected errors | v input
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-assignment-operators-static-semantics-early-errors
+description: Minimal test
+flags: [raw, noStrict]
+---*/

--- a/tools/lint/test/fixtures/flags_raw_and_onlyStrict.js
+++ b/tools/lint/test/fixtures/flags_raw_and_onlyStrict.js
@@ -1,0 +1,9 @@
+FLAGS
+^ expected errors | v input
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-assignment-operators-static-semantics-early-errors
+description: Minimal test
+flags: [raw, onlyStrict]
+---*/

--- a/tools/lint/test/fixtures/negative_invalid_phase.js
+++ b/tools/lint/test/fixtures/negative_invalid_phase.js
@@ -1,0 +1,16 @@
+NEGATIVE
+^ expected errors | v input
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-assignment-operators-static-semantics-early-errors
+description: Minimal test
+negative:
+  type: SyntaxError
+  phase: early
+flags: [raw]
+---*/
+
+$DONOTEVALUATE();
+
+!!!


### PR DESCRIPTION
- While working on the other PR, I saw that there are some existing linting errors in "test/language/directive-prologue".
- And the SpiderMonkey test262 was choking on "test/language/comments/hashbang/use-strict.js", because the flags combination "raw" and "noStrict" confused it.
- And finally there were also some tests using the old "early" phase instead of "parse".
