### PR TITLE
Ensure Atomics functions validate the TypedArray type before coercing the other arguments

### DIFF
--- a/test/built-ins/Atomics/add/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/add/validate-arraytype-before-index-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.add
+description: >
+  TypedArray type is validated before `index` argument is coerced.
+info: |
+  24.4.2 Atomics.add ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, add).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var index = {
+  valueOf() {
+    throw new Test262Error("index coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.add(typedArray, index, 0);
+  });
+}

--- a/test/built-ins/Atomics/add/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/add/validate-arraytype-before-value-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.add
+description: >
+  TypedArray type is validated before `value` argument is coerced.
+info: |
+  24.4.2 Atomics.add ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, add).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var value = {
+  valueOf() {
+    throw new Test262Error("value coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.add(typedArray, 0, value);
+  });
+}

--- a/test/built-ins/Atomics/and/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/and/validate-arraytype-before-index-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.add
+description: >
+  TypedArray type is validated before `index` argument is coerced.
+info: |
+  24.4.3 Atomics.and ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, and).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var index = {
+  valueOf() {
+    throw new Test262Error("index coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.and(typedArray, index, 0);
+  });
+}

--- a/test/built-ins/Atomics/and/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/and/validate-arraytype-before-value-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.add
+description: >
+  TypedArray type is validated before `value` argument is coerced.
+info: |
+  24.4.3 Atomics.and ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, and).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var value = {
+  valueOf() {
+    throw new Test262Error("value coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.and(typedArray, 0, value);
+  });
+}

--- a/test/built-ins/Atomics/compareExchange/validate-arraytype-before-expectedValue-coercion.js
+++ b/test/built-ins/Atomics/compareExchange/validate-arraytype-before-expectedValue-coercion.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.compareExchange
+description: >
+  TypedArray type is validated before `expectedValue` argument is coerced.
+info: |
+  24.4.4 Atomics.compareExchange ( typedArray, index, expectedValue, replacementValue )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var expectedValue = {
+  valueOf() {
+    throw new Test262Error("expectedValue coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.compareExchange(typedArray, 0, expectedValue, 0);
+  });
+}

--- a/test/built-ins/Atomics/compareExchange/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/compareExchange/validate-arraytype-before-index-coercion.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.compareExchange
+description: >
+  TypedArray type is validated before `index` argument is coerced.
+info: |
+  24.4.4 Atomics.compareExchange ( typedArray, index, expectedValue, replacementValue )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var index = {
+  valueOf() {
+    throw new Test262Error("index coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.compareExchange(typedArray, index, 0, 0);
+  });
+}

--- a/test/built-ins/Atomics/compareExchange/validate-arraytype-before-replacementValue-coercion.js
+++ b/test/built-ins/Atomics/compareExchange/validate-arraytype-before-replacementValue-coercion.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.compareExchange
+description: >
+  TypedArray type is validated before `replacementValue` argument is coerced.
+info: |
+  24.4.4 Atomics.compareExchange ( typedArray, index, expectedValue, replacementValue )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var replacementValue = {
+  valueOf() {
+    throw new Test262Error("replacementValue coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.compareExchange(typedArray, 0, 0, replacementValue);
+  });
+}

--- a/test/built-ins/Atomics/exchange/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/exchange/validate-arraytype-before-index-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.exchange
+description: >
+  TypedArray type is validated before `index` argument is coerced.
+info: |
+  24.4.5 Atomics.exchange ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, second).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var index = {
+  valueOf() {
+    throw new Test262Error("index coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.exchange(typedArray, index, 0);
+  });
+}

--- a/test/built-ins/Atomics/exchange/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/exchange/validate-arraytype-before-value-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.exchange
+description: >
+  TypedArray type is validated before `value` argument is coerced.
+info: |
+  24.4.5 Atomics.exchange ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, second).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var value = {
+  valueOf() {
+    throw new Test262Error("value coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.exchange(typedArray, 0, value);
+  });
+}

--- a/test/built-ins/Atomics/load/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/load/validate-arraytype-before-index-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.store
+description: >
+  TypedArray type is validated before `index` argument is coerced.
+info: |
+  24.4.7 Atomics.load ( typedArray, index )
+    1. Return ? AtomicLoad(typedArray, index).
+
+  24.4.1.12 AtomicLoad ( typedArray, index )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var index = {
+  valueOf() {
+    throw new Test262Error("index coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.load(typedArray, index);
+  });
+}

--- a/test/built-ins/Atomics/notify/validate-arraytype-before-count-coercion.js
+++ b/test/built-ins/Atomics/notify/validate-arraytype-before-count-coercion.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.notify
+description: >
+  TypedArray type is validated before `count` argument is coerced.
+info: |
+  24.4.12 Atomics.notify ( typedArray, index, count )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray, true).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var count = {
+  valueOf() {
+    throw new Test262Error("count coerced");
+  }
+};
+
+var badArrayTypes = [
+  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.notify(typedArray, 0, count);
+  });
+}

--- a/test/built-ins/Atomics/notify/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/notify/validate-arraytype-before-index-coercion.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.notify
+description: >
+  TypedArray type is validated before `index` argument is coerced.
+info: |
+  24.4.12 Atomics.notify ( typedArray, index, count )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray, true).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var index = {
+  valueOf() {
+    throw new Test262Error("index coerced");
+  }
+};
+
+var badArrayTypes = [
+  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.notify(typedArray, index, 0);
+  });
+}

--- a/test/built-ins/Atomics/or/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/or/validate-arraytype-before-index-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.or
+description: >
+  TypedArray type is validated before `index` argument is coerced.
+info: |
+  24.4.8 Atomics.or ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, or).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var index = {
+  valueOf() {
+    throw new Test262Error("index coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.or(typedArray, index, 0);
+  });
+}

--- a/test/built-ins/Atomics/or/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/or/validate-arraytype-before-value-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.or
+description: >
+  TypedArray type is validated before `value` argument is coerced.
+info: |
+  24.4.8 Atomics.or ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, or).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var value = {
+  valueOf() {
+    throw new Test262Error("value coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.or(typedArray, 0, value);
+  });
+}

--- a/test/built-ins/Atomics/store/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/store/validate-arraytype-before-index-coercion.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.store
+description: >
+  TypedArray type is validated before `index` argument is coerced.
+info: |
+  24.4.9 Atomics.store ( typedArray, index, value )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var index = {
+  valueOf() {
+    throw new Test262Error("index coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.store(typedArray, index, 0);
+  });
+}

--- a/test/built-ins/Atomics/store/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/store/validate-arraytype-before-value-coercion.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.store
+description: >
+  TypedArray type is validated before `value` argument is coerced.
+info: |
+  24.4.9 Atomics.store ( typedArray, index, value )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var value = {
+  valueOf() {
+    throw new Test262Error("value coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.store(typedArray, 0, value);
+  });
+}

--- a/test/built-ins/Atomics/sub/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/sub/validate-arraytype-before-index-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.sub
+description: >
+  TypedArray type is validated before `index` argument is coerced.
+info: |
+  24.4.10 Atomics.sub ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, sub).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var index = {
+  valueOf() {
+    throw new Test262Error("index coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.sub(typedArray, index, 0);
+  });
+}

--- a/test/built-ins/Atomics/sub/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/sub/validate-arraytype-before-value-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.sub
+description: >
+  TypedArray type is validated before `value` argument is coerced.
+info: |
+  24.4.10 Atomics.sub ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, sub).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var value = {
+  valueOf() {
+    throw new Test262Error("value coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.sub(typedArray, 0, value);
+  });
+}

--- a/test/built-ins/Atomics/wait/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/wait/validate-arraytype-before-index-coercion.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.notify
+description: >
+  TypedArray type is validated before `index` argument is coerced.
+info: |
+  24.4.11 Atomics.wait ( typedArray, index, value, timeout )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray, true).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var index = {
+  valueOf() {
+    throw new Test262Error("index coerced");
+  }
+};
+
+var badArrayTypes = [
+  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.wait(typedArray, index, 0, 0);
+  });
+}

--- a/test/built-ins/Atomics/wait/validate-arraytype-before-timeout-coercion.js
+++ b/test/built-ins/Atomics/wait/validate-arraytype-before-timeout-coercion.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.notify
+description: >
+  TypedArray type is validated before `timeout` argument is coerced.
+info: |
+  24.4.11 Atomics.wait ( typedArray, index, value, timeout )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray, true).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var timeout = {
+  valueOf() {
+    throw new Test262Error("timeout coerced");
+  }
+};
+
+var badArrayTypes = [
+  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.wait(typedArray, 0, 0, timeout);
+  });
+}

--- a/test/built-ins/Atomics/wait/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/wait/validate-arraytype-before-value-coercion.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.notify
+description: >
+  TypedArray type is validated before `value` argument is coerced.
+info: |
+  24.4.11 Atomics.wait ( typedArray, index, value, timeout )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray, true).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var value = {
+  valueOf() {
+    throw new Test262Error("value coerced");
+  }
+};
+
+var badArrayTypes = [
+  Int8Array, Uint8Array, Int16Array, Uint16Array, Uint32Array,
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.wait(typedArray, 0, value, 0);
+  });
+}

--- a/test/built-ins/Atomics/xor/validate-arraytype-before-index-coercion.js
+++ b/test/built-ins/Atomics/xor/validate-arraytype-before-index-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.xor
+description: >
+  TypedArray type is validated before `index` argument is coerced.
+info: |
+  24.4.13 Atomics.xor ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, xor).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var index = {
+  valueOf() {
+    throw new Test262Error("index coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.xor(typedArray, index, 0);
+  });
+}

--- a/test/built-ins/Atomics/xor/validate-arraytype-before-value-coercion.js
+++ b/test/built-ins/Atomics/xor/validate-arraytype-before-value-coercion.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.xor
+description: >
+  TypedArray type is validated before `value` argument is coerced.
+info: |
+  24.4.13 Atomics.xor ( typedArray, index, value )
+    1. Return ? AtomicReadModifyWrite(typedArray, index, value, xor).
+
+  24.4.1.11 AtomicReadModifyWrite ( typedArray, index, value, op )
+    1. Let buffer be ? ValidateSharedIntegerTypedArray(typedArray).
+    ...
+
+  24.4.1.1 ValidateSharedIntegerTypedArray ( typedArray [ , onlyInt32 ] )
+    ...
+    4. Let typeName be typedArray.[[TypedArrayName]].
+    5. If onlyInt32 is true, then
+      a. If typeName is not "Int32Array", throw a TypeError exception.
+    6. Else,
+      a. If typeName is not "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array",
+         or "Uint32Array", throw a TypeError exception.
+    ...
+features: [Atomics]
+---*/
+
+var value = {
+  valueOf() {
+    throw new Test262Error("value coerced");
+  }
+};
+
+var badArrayTypes = [
+  Uint8ClampedArray, Float32Array, Float64Array
+];
+
+for (var badArrayType of badArrayTypes) {
+  var typedArray = new badArrayType(new SharedArrayBuffer(8));
+  assert.throws(TypeError, function() {
+    Atomics.xor(typedArray, 0, value);
+  });
+}


### PR DESCRIPTION
Note: SpiderMonkey currently fails these tests (except for `Atomics.wait` and `Atomics.notify`).