### PR TITLE
Add test that a Proxy instance with getPrototypeOf trap use instanceof operator on a function

### DIFF
--- a/test/built-ins/Proxy/getPrototypeOf/instanceof-return-true.js
+++ b/test/built-ins/Proxy/getPrototypeOf/instanceof-return-true.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2019 ta7sudan. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
+description: >
+    instanceof operator will return true if trap result is the prototype of
+    the function.
+features: [Proxy]
+---*/
+
+function CustomClass() {}
+
+var p = new Proxy({}, {
+  getPrototypeOf: function() {
+    return CustomClass.prototype;
+  }
+});
+
+assert(p instanceof CustomClass, 'Expected p to be the instance of CustomClass, but was not.');

--- a/test/built-ins/Proxy/getPrototypeOf/instanceof-return-true.js
+++ b/test/built-ins/Proxy/getPrototypeOf/instanceof-return-true.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 ta7sudan. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-es6id: sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
+esid: sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
 description: >
     instanceof operator will return true if trap result is the prototype of
     the function.


### PR DESCRIPTION
Note: V8 currently fails the test.
See https://bugs.chromium.org/p/v8/issues/detail?id=9036