### PR TITLE
Update list pattern to sync with CLDR 35

### DIFF
--- a/test/intl402/ListFormat/prototype/format/en-us-short.js
+++ b/test/intl402/ListFormat/prototype/format/en-us-short.js
@@ -45,9 +45,9 @@ assert.sameValue(typeof lf.format, "function", "format should be supported");
 for (const f of transforms) {
   assert.sameValue(lf.format(f([])), "");
   assert.sameValue(lf.format(f(["foo"])), "foo");
-  assert.sameValue(lf.format(f(["foo", "bar"])), "foo and bar");
-  assert.sameValue(lf.format(f(["foo", "bar", "baz"])), "foo, bar, and baz");
-  assert.sameValue(lf.format(f(["foo", "bar", "baz", "quux"])), "foo, bar, baz, and quux");
+  assert.sameValue(lf.format(f(["foo", "bar"])), "foo & bar");
+  assert.sameValue(lf.format(f(["foo", "bar", "baz"])), "foo, bar, & baz");
+  assert.sameValue(lf.format(f(["foo", "bar", "baz", "quux"])), "foo, bar, baz, & quux");
 }
 
 assert.sameValue(lf.format("foo"), "f, o, and o");

--- a/test/intl402/ListFormat/prototype/formatToParts/en-us-short.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/en-us-short.js
@@ -58,14 +58,14 @@ for (const f of transforms) {
   ]);
   verifyFormatParts(lf.formatToParts(f(["foo", "bar"])), [
     { "type": "element", "value": "foo" },
-    { "type": "literal", "value": " and " },
+    { "type": "literal", "value": " & " },
     { "type": "element", "value": "bar" },
   ]);
   verifyFormatParts(lf.formatToParts(f(["foo", "bar", "baz"])), [
     { "type": "element", "value": "foo" },
     { "type": "literal", "value": ", " },
     { "type": "element", "value": "bar" },
-    { "type": "literal", "value": ", and " },
+    { "type": "literal", "value": ", & " },
     { "type": "element", "value": "baz" },
   ]);
   verifyFormatParts(lf.formatToParts(f(["foo", "bar", "baz", "quux"])), [
@@ -74,7 +74,7 @@ for (const f of transforms) {
     { "type": "element", "value": "bar" },
     { "type": "literal", "value": ", " },
     { "type": "element", "value": "baz" },
-    { "type": "literal", "value": ", and " },
+    { "type": "literal", "value": ", & " },
     { "type": "element", "value": "quux" },
   ]);
 }
@@ -83,6 +83,6 @@ verifyFormatParts(lf.formatToParts("foo"), [
   { "type": "element", "value": "f" },
   { "type": "literal", "value": ", " },
   { "type": "element", "value": "o" },
-  { "type": "literal", "value": ", and " },
+  { "type": "literal", "value": ", & " },
   { "type": "element", "value": "o" },
 ]);


### PR DESCRIPTION
update list pattern to sync with CLDR 35

CLDR 35 change "and" to "&" for the list form pattern "short"
see https://unicode.org/cldr/trac/ticket/11520
Also compare
https://www.unicode.org/repos/cldr/tags/release-34/common/main/en.xml
against
https://www.unicode.org/repos/cldr/tags/release-35-beta/common/main/en.xml

Notice the addition of
```
<listPattern type="standard-short">
<listPatternPart type="start">{0}, {1}</listPatternPart>
<listPatternPart type="middle">{0}, {1}</listPatternPart>
<listPatternPart type="end">{0}, & {1}</listPatternPart>
<listPatternPart type="2">{0} & {1}</listPatternPart>
</listPattern>
```