### PR TITLE
Port tests from Promise.all to Promise.allSettled

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -7,6 +7,10 @@
 #
 # https://github.com/tc39/process-document
 
+# Promise.allSettled
+# https://github.com/tc39/proposal-promise-allSettled
+Promise.allSettled
+
 # Hashbang Grammar
 # https://github.com/tc39/proposal-hashbang
 hashbang

--- a/harness/promiseHelper.js
+++ b/harness/promiseHelper.js
@@ -18,3 +18,57 @@ function checkSequence(arr, message) {
 
   return true;
 }
+
+function checkSettledPromises(settleds, expected, message) {
+  const prefix = message ? `${message}: ` : '';
+
+  assert.sameValue(Array.isArray(settleds), true, `${prefix}Settled values is an array`);
+
+  assert.sameValue(
+    settleds.length,
+    expected.length,
+    `${prefix}The settled values has a different length than expected`
+  );
+
+  settleds.forEach((settled, i) => {
+    assert.sameValue(
+      Object.prototype.hasOwnProperty.call(settled, 'status'),
+      true,
+      `${prefix}The settled value has a property status`
+    );
+
+    assert.sameValue(settled.status, expected[i].status, `${prefix}status for item ${i}`);
+
+    if (settled.status === 'fulfilled') {
+      assert.sameValue(
+        Object.prototype.hasOwnProperty.call(settled, 'value'),
+        true,
+        `${prefix}The fulfilled promise has a property named value`
+      );
+
+      assert.sameValue(
+        Object.prototype.hasOwnProperty.call(settled, 'reason'),
+        false,
+        `${prefix}The fulfilled promise has no property named reason`
+      );
+
+      assert.sameValue(settled.value, expected[i].value, `${prefix}value for item ${i}`);
+    } else {
+      assert.sameValue(settled.status, 'rejected', `${prefix}Valid statuses are only fulfilled or rejected`);
+
+      assert.sameValue(
+        Object.prototype.hasOwnProperty.call(settled, 'value'),
+        false,
+        `${prefix}The fulfilled promise has no property named value`
+      );
+
+      assert.sameValue(
+        Object.prototype.hasOwnProperty.call(settled, 'reason'),
+        true,
+        `${prefix}The fulfilled promise has a property named reason`
+      );
+
+      assert.sameValue(settled.reason, expected[i].reason, `${prefix}Reason value for item ${i}`);
+    }
+  });
+}

--- a/test/built-ins/Promise/allSettled/call-resolve-element-after-return.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element-after-return.js
@@ -37,18 +37,18 @@ var p1OnFulfilled;
 var p1 = {
   then(onFulfilled, onRejected) {
     p1OnFulfilled = onFulfilled;
-    onFulfilled("expectedValue");
+    onFulfilled('expectedValue');
   }
 };
 
-assert.sameValue(callCount, 0, "callCount before call to all()");
+assert.sameValue(callCount, 0, 'callCount before call to all()');
 
 Promise.allSettled.call(Constructor, [p1]);
 
-assert.sameValue(callCount, 1, "callCount after call to all()");
+assert.sameValue(callCount, 1, 'callCount after call to all()');
 checkSettledPromises(valuesArray, expected, 'valuesArray after call to all()');
 
-p1OnFulfilled("unexpectedValue");
+p1OnFulfilled('unexpectedValue');
 
-assert.sameValue(callCount, 1, "callCount after call to onFulfilled()");
+assert.sameValue(callCount, 1, 'callCount after call to onFulfilled()');
 checkSettledPromises(valuesArray, expected, 'valuesArray after call to onFulfilled()');

--- a/test/built-ins/Promise/allSettled/call-resolve-element-after-return.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element-after-return.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-resolve-element-functions
+description: >
+  Cannot change result value of resolved Promise.allSettled element after Promise.allSettled() returned.
+info: |
+  Promise.allSettled Resolve Element Functions
+
+  1. Let F be the active function object.
+  2. Let alreadyCalled be F.[[AlreadyCalled]].
+  3. If alreadyCalled.[[Value]] is true, return undefined.
+  4. Set alreadyCalled.[[Value]] to true.
+  ...
+---*/
+
+var callCount = 0;
+var valuesArray;
+
+function Constructor(executor) {
+  function resolve(values) {
+    callCount += 1;
+    valuesArray = values;
+    assert(Array.isArray(values), "values is array");
+    assert.sameValue(values.length, 1, "values.length");
+    assert.sameValue(values[0], "expectedValue", "values[0]");
+  }
+  executor(resolve, $ERROR);
+}
+Constructor.resolve = function(v) {
+  return v;
+};
+
+var p1OnFulfilled;
+
+var p1 = {
+  then(onFulfilled, onRejected) {
+    p1OnFulfilled = onFulfilled;
+    onFulfilled("expectedValue");
+  }
+};
+
+assert.sameValue(callCount, 0, "callCount before call to all()");
+
+Promise.allSettled.call(Constructor, [p1]);
+
+assert.sameValue(callCount, 1, "callCount after call to all()");
+assert.sameValue(valuesArray[0], "expectedValue", "valuesArray after call to all()");
+
+p1OnFulfilled("unexpectedValue");
+
+assert.sameValue(callCount, 1, "callCount after call to onFulfilled()");
+assert.sameValue(valuesArray[0], "expectedValue", "valuesArray after call to onFulfilled()");

--- a/test/built-ins/Promise/allSettled/call-resolve-element-after-return.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element-after-return.js
@@ -14,6 +14,7 @@ info: |
   4. Set alreadyCalled.[[Value]] to true.
   ...
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var callCount = 0;

--- a/test/built-ins/Promise/allSettled/call-resolve-element-after-return.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element-after-return.js
@@ -13,18 +13,18 @@ info: |
   3. If alreadyCalled.[[Value]] is true, return undefined.
   4. Set alreadyCalled.[[Value]] to true.
   ...
+includes: [promiseHelper.js]
 ---*/
 
 var callCount = 0;
 var valuesArray;
+var expected = [{ status: 'fulfilled', value: 'expectedValue' }];
 
 function Constructor(executor) {
   function resolve(values) {
     callCount += 1;
     valuesArray = values;
-    assert(Array.isArray(values), "values is array");
-    assert.sameValue(values.length, 1, "values.length");
-    assert.sameValue(values[0], "expectedValue", "values[0]");
+    checkSettledPromises(values, expected, 'values');
   }
   executor(resolve, $ERROR);
 }
@@ -46,9 +46,9 @@ assert.sameValue(callCount, 0, "callCount before call to all()");
 Promise.allSettled.call(Constructor, [p1]);
 
 assert.sameValue(callCount, 1, "callCount after call to all()");
-assert.sameValue(valuesArray[0], "expectedValue", "valuesArray after call to all()");
+checkSettledPromises(valuesArray, expected, 'valuesArray after call to all()');
 
 p1OnFulfilled("unexpectedValue");
 
 assert.sameValue(callCount, 1, "callCount after call to onFulfilled()");
-assert.sameValue(valuesArray[0], "expectedValue", "valuesArray after call to onFulfilled()");
+checkSettledPromises(valuesArray, expected, 'valuesArray after call to onFulfilled()');

--- a/test/built-ins/Promise/allSettled/call-resolve-element-items.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element-items.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-resolve-element-functions
+description: >
+  Cannot change result value of resolved Promise.allSettled elements.
+info: |
+  Promise.allSettled Resolve Element Functions
+
+  1. Let F be the active function object.
+  2. Let alreadyCalled be F.[[AlreadyCalled]].
+  3. If alreadyCalled.[[Value]] is true, return undefined.
+  4. Set alreadyCalled.[[Value]] to true.
+  ...
+---*/
+
+var callCount = 0;
+
+function Constructor(executor) {
+  function resolve(values) {
+    callCount += 1;
+    assert(Array.isArray(values), "values is array");
+    assert.sameValue(values.length, 2, "values length");
+    assert.sameValue(values[0], "expectedValue-p1", "values[0]");
+    assert.sameValue(values[1], "expectedValue-p2", "values[1]");
+  }
+  executor(resolve, $ERROR);
+}
+Constructor.resolve = function(v) {
+  return v;
+};
+
+var p1 = {
+  then(onFulfilled, onRejected) {
+    onFulfilled("expectedValue-p1");
+    onFulfilled("unexpectedValue-p1");
+  }
+};
+var p2 = {
+  then(onFulfilled, onRejected) {
+    onFulfilled("expectedValue-p2");
+    onFulfilled("unexpectedValue-p2");
+  }
+};
+
+assert.sameValue(callCount, 0, "callCount before call to all()");
+
+Promise.allSettled.call(Constructor, [p1, p2]);
+
+assert.sameValue(callCount, 1, "callCount after call to all()");

--- a/test/built-ins/Promise/allSettled/call-resolve-element-items.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element-items.js
@@ -13,6 +13,7 @@ info: |
   3. If alreadyCalled.[[Value]] is true, return undefined.
   4. Set alreadyCalled.[[Value]] to true.
   ...
+includes: [promiseHelper.js]
 ---*/
 
 var callCount = 0;
@@ -20,10 +21,16 @@ var callCount = 0;
 function Constructor(executor) {
   function resolve(values) {
     callCount += 1;
-    assert(Array.isArray(values), "values is array");
-    assert.sameValue(values.length, 2, "values length");
-    assert.sameValue(values[0], "expectedValue-p1", "values[0]");
-    assert.sameValue(values[1], "expectedValue-p2", "values[1]");
+    checkSettledPromises(values, [
+      {
+        status: 'fulfilled',
+        value: 'expectedValue-p1'
+      },
+      {
+        status: 'fulfilled',
+        value: 'expectedValue-p2'
+      }
+    ], 'values');
   }
   executor(resolve, $ERROR);
 }

--- a/test/built-ins/Promise/allSettled/call-resolve-element-items.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element-items.js
@@ -40,19 +40,19 @@ Constructor.resolve = function(v) {
 
 var p1 = {
   then(onFulfilled, onRejected) {
-    onFulfilled("expectedValue-p1");
-    onFulfilled("unexpectedValue-p1");
+    onFulfilled('expectedValue-p1');
+    onFulfilled('unexpectedValue-p1');
   }
 };
 var p2 = {
   then(onFulfilled, onRejected) {
-    onFulfilled("expectedValue-p2");
-    onFulfilled("unexpectedValue-p2");
+    onFulfilled('expectedValue-p2');
+    onFulfilled('unexpectedValue-p2');
   }
 };
 
-assert.sameValue(callCount, 0, "callCount before call to all()");
+assert.sameValue(callCount, 0, 'callCount before call to all()');
 
 Promise.allSettled.call(Constructor, [p1, p2]);
 
-assert.sameValue(callCount, 1, "callCount after call to all()");
+assert.sameValue(callCount, 1, 'callCount after call to all()');

--- a/test/built-ins/Promise/allSettled/call-resolve-element-items.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element-items.js
@@ -14,6 +14,7 @@ info: |
   4. Set alreadyCalled.[[Value]] to true.
   ...
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var callCount = 0;

--- a/test/built-ins/Promise/allSettled/call-resolve-element.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-resolve-element-functions
+description: >
+  Cannot change result value of resolved Promise.allSettled element.
+info: |
+  Promise.allSettled Resolve Element Functions
+
+  1. Let F be the active function object.
+  2. Let alreadyCalled be F.[[AlreadyCalled]].
+  3. If alreadyCalled.[[Value]] is true, return undefined.
+  4. Set alreadyCalled.[[Value]] to true.
+  ...
+---*/
+
+var callCount = 0;
+
+function Constructor(executor) {
+  function resolve(values) {
+    callCount += 1;
+    assert(Array.isArray(values), "values is array");
+    assert.sameValue(values.length, 1, "values length");
+    assert.sameValue(values[0], "expectedValue", "values[0]");
+  }
+  executor(resolve, $ERROR);
+}
+Constructor.resolve = function(v) {
+  return v;
+};
+
+var p1 = {
+  then(onFulfilled, onRejected) {
+    onFulfilled("expectedValue");
+    onFulfilled("unexpectedValue");
+  }
+};
+
+assert.sameValue(callCount, 0, "callCount before call to all()");
+
+Promise.allSettled.call(Constructor, [p1]);
+
+assert.sameValue(callCount, 1, "callCount after call to all()");

--- a/test/built-ins/Promise/allSettled/call-resolve-element.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element.js
@@ -36,13 +36,13 @@ Constructor.resolve = function(v) {
 
 var p1 = {
   then(onFulfilled, onRejected) {
-    onFulfilled("expectedValue");
-    onFulfilled("unexpectedValue");
+    onFulfilled('expectedValue');
+    onFulfilled('unexpectedValue');
   }
 };
 
-assert.sameValue(callCount, 0, "callCount before call to all()");
+assert.sameValue(callCount, 0, 'callCount before call to all()');
 
 Promise.allSettled.call(Constructor, [p1]);
 
-assert.sameValue(callCount, 1, "callCount after call to all()");
+assert.sameValue(callCount, 1, 'callCount after call to all()');

--- a/test/built-ins/Promise/allSettled/call-resolve-element.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element.js
@@ -13,6 +13,7 @@ info: |
   3. If alreadyCalled.[[Value]] is true, return undefined.
   4. Set alreadyCalled.[[Value]] to true.
   ...
+includes: [promiseHelper.js]
 ---*/
 
 var callCount = 0;
@@ -20,9 +21,12 @@ var callCount = 0;
 function Constructor(executor) {
   function resolve(values) {
     callCount += 1;
-    assert(Array.isArray(values), "values is array");
-    assert.sameValue(values.length, 1, "values length");
-    assert.sameValue(values[0], "expectedValue", "values[0]");
+    checkSettledPromises(values, [
+      {
+        status: 'fulfilled',
+        value: 'expectedValue'
+      }
+    ], 'values');
   }
   executor(resolve, $ERROR);
 }

--- a/test/built-ins/Promise/allSettled/call-resolve-element.js
+++ b/test/built-ins/Promise/allSettled/call-resolve-element.js
@@ -14,6 +14,7 @@ info: |
   4. Set alreadyCalled.[[Value]] to true.
   ...
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var callCount = 0;

--- a/test/built-ins/Promise/allSettled/capability-executor-called-twice.js
+++ b/test/built-ins/Promise/allSettled/capability-executor-called-twice.js
@@ -22,58 +22,58 @@ info: |
   ...
 ---*/
 
-var checkPoint = "";
+var checkPoint = '';
 Promise.allSettled.call(function(executor) {
-  checkPoint += "a";
+  checkPoint += 'a';
   executor();
-  checkPoint += "b";
+  checkPoint += 'b';
   executor(function() {}, function() {});
-  checkPoint += "c";
+  checkPoint += 'c';
 }, []);
-assert.sameValue(checkPoint, "abc", "executor initially called with no arguments");
+assert.sameValue(checkPoint, 'abc', 'executor initially called with no arguments');
 
-var checkPoint = "";
+var checkPoint = '';
 Promise.allSettled.call(function(executor) {
-  checkPoint += "a";
+  checkPoint += 'a';
   executor(undefined, undefined);
-  checkPoint += "b";
+  checkPoint += 'b';
   executor(function() {}, function() {});
-  checkPoint += "c";
+  checkPoint += 'c';
 }, []);
-assert.sameValue(checkPoint, "abc", "executor initially called with (undefined, undefined)");
+assert.sameValue(checkPoint, 'abc', 'executor initially called with (undefined, undefined)');
 
-var checkPoint = "";
+var checkPoint = '';
 assert.throws(TypeError, function() {
   Promise.allSettled.call(function(executor) {
-    checkPoint += "a";
+    checkPoint += 'a';
     executor(undefined, function() {});
-    checkPoint += "b";
+    checkPoint += 'b';
     executor(function() {}, function() {});
-    checkPoint += "c";
+    checkPoint += 'c';
   }, []);
-}, "executor initially called with (undefined, function)");
-assert.sameValue(checkPoint, "ab", "executor initially called with (undefined, function)");
+}, 'executor initially called with (undefined, function)');
+assert.sameValue(checkPoint, 'ab', 'executor initially called with (undefined, function)');
 
-var checkPoint = "";
+var checkPoint = '';
 assert.throws(TypeError, function() {
   Promise.allSettled.call(function(executor) {
-    checkPoint += "a";
+    checkPoint += 'a';
     executor(function() {}, undefined);
-    checkPoint += "b";
+    checkPoint += 'b';
     executor(function() {}, function() {});
-    checkPoint += "c";
+    checkPoint += 'c';
   }, []);
-}, "executor initially called with (function, undefined)");
-assert.sameValue(checkPoint, "ab", "executor initially called with (function, undefined)");
+}, 'executor initially called with (function, undefined)');
+assert.sameValue(checkPoint, 'ab', 'executor initially called with (function, undefined)');
 
-var checkPoint = "";
+var checkPoint = '';
 assert.throws(TypeError, function() {
   Promise.allSettled.call(function(executor) {
-    checkPoint += "a";
-    executor("invalid value", 123);
-    checkPoint += "b";
+    checkPoint += 'a';
+    executor('invalid value', 123);
+    checkPoint += 'b';
     executor(function() {}, function() {});
-    checkPoint += "c";
+    checkPoint += 'c';
   }, []);
-}, "executor initially called with (String, Number)");
-assert.sameValue(checkPoint, "ab", "executor initially called with (String, Number)");
+}, 'executor initially called with (String, Number)');
+assert.sameValue(checkPoint, 'ab', 'executor initially called with (String, Number)');

--- a/test/built-ins/Promise/allSettled/capability-executor-called-twice.js
+++ b/test/built-ins/Promise/allSettled/capability-executor-called-twice.js
@@ -20,6 +20,7 @@ info: |
   6. Set promiseCapability.[[Resolve]] to resolve.
   7. Set promiseCapability.[[Reject]] to reject.
   ...
+features: [Promise.allSettled]
 ---*/
 
 var checkPoint = '';

--- a/test/built-ins/Promise/allSettled/capability-executor-called-twice.js
+++ b/test/built-ins/Promise/allSettled/capability-executor-called-twice.js
@@ -1,0 +1,79 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Throws a TypeError if capabilities executor already called with non-undefined values.
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  3. Let promiseCapability be ? NewPromiseCapability(C).
+  ...
+
+  GetCapabilitiesExecutor Functions
+
+  ...
+  4. If promiseCapability.[[Resolve]] is not undefined, throw a TypeError exception.
+  5. If promiseCapability.[[Reject]] is not undefined, throw a TypeError exception.
+  6. Set promiseCapability.[[Resolve]] to resolve.
+  7. Set promiseCapability.[[Reject]] to reject.
+  ...
+---*/
+
+var checkPoint = "";
+Promise.allSettled.call(function(executor) {
+  checkPoint += "a";
+  executor();
+  checkPoint += "b";
+  executor(function() {}, function() {});
+  checkPoint += "c";
+}, []);
+assert.sameValue(checkPoint, "abc", "executor initially called with no arguments");
+
+var checkPoint = "";
+Promise.allSettled.call(function(executor) {
+  checkPoint += "a";
+  executor(undefined, undefined);
+  checkPoint += "b";
+  executor(function() {}, function() {});
+  checkPoint += "c";
+}, []);
+assert.sameValue(checkPoint, "abc", "executor initially called with (undefined, undefined)");
+
+var checkPoint = "";
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(function(executor) {
+    checkPoint += "a";
+    executor(undefined, function() {});
+    checkPoint += "b";
+    executor(function() {}, function() {});
+    checkPoint += "c";
+  }, []);
+}, "executor initially called with (undefined, function)");
+assert.sameValue(checkPoint, "ab", "executor initially called with (undefined, function)");
+
+var checkPoint = "";
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(function(executor) {
+    checkPoint += "a";
+    executor(function() {}, undefined);
+    checkPoint += "b";
+    executor(function() {}, function() {});
+    checkPoint += "c";
+  }, []);
+}, "executor initially called with (function, undefined)");
+assert.sameValue(checkPoint, "ab", "executor initially called with (function, undefined)");
+
+var checkPoint = "";
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(function(executor) {
+    checkPoint += "a";
+    executor("invalid value", 123);
+    checkPoint += "b";
+    executor(function() {}, function() {});
+    checkPoint += "c";
+  }, []);
+}, "executor initially called with (String, Number)");
+assert.sameValue(checkPoint, "ab", "executor initially called with (String, Number)");

--- a/test/built-ins/Promise/allSettled/capability-executor-not-callable.js
+++ b/test/built-ins/Promise/allSettled/capability-executor-not-callable.js
@@ -23,60 +23,60 @@ info: |
   ...
 ---*/
 
-var checkPoint = "";
+var checkPoint = '';
 assert.throws(TypeError, function() {
   Promise.allSettled.call(function(executor) {
-    checkPoint += "a";
+    checkPoint += 'a';
   }, []);
-}, "executor not called at all");
-assert.sameValue(checkPoint, "a", "executor not called at all");
+}, 'executor not called at all');
+assert.sameValue(checkPoint, 'a', 'executor not called at all');
 
-var checkPoint = "";
+var checkPoint = '';
 assert.throws(TypeError, function() {
   Promise.allSettled.call(function(executor) {
-    checkPoint += "a";
+    checkPoint += 'a';
     executor();
-    checkPoint += "b";
+    checkPoint += 'b';
   }, []);
-}, "executor called with no arguments");
-assert.sameValue(checkPoint, "ab", "executor called with no arguments");
+}, 'executor called with no arguments');
+assert.sameValue(checkPoint, 'ab', 'executor called with no arguments');
 
-var checkPoint = "";
+var checkPoint = '';
 assert.throws(TypeError, function() {
   Promise.allSettled.call(function(executor) {
-    checkPoint += "a";
+    checkPoint += 'a';
     executor(undefined, undefined);
-    checkPoint += "b";
+    checkPoint += 'b';
   }, []);
-}, "executor called with (undefined, undefined)");
-assert.sameValue(checkPoint, "ab", "executor called with (undefined, undefined)");
+}, 'executor called with (undefined, undefined)');
+assert.sameValue(checkPoint, 'ab', 'executor called with (undefined, undefined)');
 
-var checkPoint = "";
+var checkPoint = '';
 assert.throws(TypeError, function() {
   Promise.allSettled.call(function(executor) {
-    checkPoint += "a";
+    checkPoint += 'a';
     executor(undefined, function() {});
-    checkPoint += "b";
+    checkPoint += 'b';
   }, []);
-}, "executor called with (undefined, function)");
-assert.sameValue(checkPoint, "ab", "executor called with (undefined, function)");
+}, 'executor called with (undefined, function)');
+assert.sameValue(checkPoint, 'ab', 'executor called with (undefined, function)');
 
-var checkPoint = "";
+var checkPoint = '';
 assert.throws(TypeError, function() {
   Promise.allSettled.call(function(executor) {
-    checkPoint += "a";
+    checkPoint += 'a';
     executor(function() {}, undefined);
-    checkPoint += "b";
+    checkPoint += 'b';
   }, []);
-}, "executor called with (function, undefined)");
-assert.sameValue(checkPoint, "ab", "executor called with (function, undefined)");
+}, 'executor called with (function, undefined)');
+assert.sameValue(checkPoint, 'ab', 'executor called with (function, undefined)');
 
-var checkPoint = "";
+var checkPoint = '';
 assert.throws(TypeError, function() {
   Promise.allSettled.call(function(executor) {
-    checkPoint += "a";
-    executor(123, "invalid value");
-    checkPoint += "b";
+    checkPoint += 'a';
+    executor(123, 'invalid value');
+    checkPoint += 'b';
   }, []);
-}, "executor called with (Number, String)");
-assert.sameValue(checkPoint, "ab", "executor called with (Number, String)");
+}, 'executor called with (Number, String)');
+assert.sameValue(checkPoint, 'ab', 'executor called with (Number, String)');

--- a/test/built-ins/Promise/allSettled/capability-executor-not-callable.js
+++ b/test/built-ins/Promise/allSettled/capability-executor-not-callable.js
@@ -21,6 +21,7 @@ info: |
   8. If IsCallable(promiseCapability.[[Resolve]]) is false, throw a TypeError exception.
   9. If IsCallable(promiseCapability.[[Reject]]) is false, throw a TypeError exception.
   ...
+features: [Promise.allSettled]
 ---*/
 
 var checkPoint = '';

--- a/test/built-ins/Promise/allSettled/capability-executor-not-callable.js
+++ b/test/built-ins/Promise/allSettled/capability-executor-not-callable.js
@@ -1,0 +1,82 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Throws a TypeError if either resolve or reject capability is not callable.
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  3. Let promiseCapability be ? NewPromiseCapability(C).
+  ...
+
+  NewPromiseCapability ( C )
+
+  ...
+  5. Let executor be CreateBuiltinFunction(steps, « [[Capability]] »).
+  6. Set executor.[[Capability]] to promiseCapability.
+  7. Let promise be ? Construct(C, « executor »).
+  8. If IsCallable(promiseCapability.[[Resolve]]) is false, throw a TypeError exception.
+  9. If IsCallable(promiseCapability.[[Reject]]) is false, throw a TypeError exception.
+  ...
+---*/
+
+var checkPoint = "";
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(function(executor) {
+    checkPoint += "a";
+  }, []);
+}, "executor not called at all");
+assert.sameValue(checkPoint, "a", "executor not called at all");
+
+var checkPoint = "";
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(function(executor) {
+    checkPoint += "a";
+    executor();
+    checkPoint += "b";
+  }, []);
+}, "executor called with no arguments");
+assert.sameValue(checkPoint, "ab", "executor called with no arguments");
+
+var checkPoint = "";
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(function(executor) {
+    checkPoint += "a";
+    executor(undefined, undefined);
+    checkPoint += "b";
+  }, []);
+}, "executor called with (undefined, undefined)");
+assert.sameValue(checkPoint, "ab", "executor called with (undefined, undefined)");
+
+var checkPoint = "";
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(function(executor) {
+    checkPoint += "a";
+    executor(undefined, function() {});
+    checkPoint += "b";
+  }, []);
+}, "executor called with (undefined, function)");
+assert.sameValue(checkPoint, "ab", "executor called with (undefined, function)");
+
+var checkPoint = "";
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(function(executor) {
+    checkPoint += "a";
+    executor(function() {}, undefined);
+    checkPoint += "b";
+  }, []);
+}, "executor called with (function, undefined)");
+assert.sameValue(checkPoint, "ab", "executor called with (function, undefined)");
+
+var checkPoint = "";
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(function(executor) {
+    checkPoint += "a";
+    executor(123, "invalid value");
+    checkPoint += "b";
+  }, []);
+}, "executor called with (Number, String)");
+assert.sameValue(checkPoint, "ab", "executor called with (Number, String)");

--- a/test/built-ins/Promise/allSettled/capability-resolve-throws-no-close.js
+++ b/test/built-ins/Promise/allSettled/capability-resolve-throws-no-close.js
@@ -29,7 +29,7 @@ info: |
   IfAbruptRejectPromise
 
   1. IfAbruptRejectPromise(value, capability).
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 ---*/
 
 var returnCount = 0;

--- a/test/built-ins/Promise/allSettled/capability-resolve-throws-no-close.js
+++ b/test/built-ins/Promise/allSettled/capability-resolve-throws-no-close.js
@@ -1,0 +1,60 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-promise.allsettled
+description: >
+  Iterator is not closed when the "resolve" capability returns an abrupt
+  completion.
+info: |
+  ...
+  3. Let promiseCapability be ? NewPromiseCapability(C).
+  ...
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+  8. Return Completion(result).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  ...
+  6. Repeat
+    ...
+    d. If next is false, then
+      ...
+      iii. If remainingElementsCount.[[Value]] is 0, then
+        1. Let valuesArray be CreateArrayFromList(values).
+        2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+
+  IfAbruptRejectPromise
+
+  1. IfAbruptRejectPromise(value, capability).
+features: [Symbol.iterator]
+---*/
+
+var returnCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next() {
+      return {
+        done: true
+      };
+    },
+    return() {
+      returnCount += 1;
+      return {};
+    }
+  };
+};
+var P = function(executor) {
+  return new Promise(function(_, reject) {
+    executor(function() {
+      throw new Test262Error();
+    }, reject);
+  });
+};
+
+Promise.allSettled.call(P, iter);
+
+assert.sameValue(returnCount, 0);

--- a/test/built-ins/Promise/allSettled/capability-resolve-throws-reject.js
+++ b/test/built-ins/Promise/allSettled/capability-resolve-throws-reject.js
@@ -31,6 +31,7 @@ info: |
 
   1. IfAbruptRejectPromise(value, capability).
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var thrown = new Test262Error();

--- a/test/built-ins/Promise/allSettled/capability-resolve-throws-reject.js
+++ b/test/built-ins/Promise/allSettled/capability-resolve-throws-reject.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-promise.allsettled
+description: >
+  Promise is rejected when the "resolve" capability returns an abrupt
+  completion.
+info: |
+  ...
+  3. Let promiseCapability be ? NewPromiseCapability(C).
+  ...
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+  8. Return Completion(result).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  ...
+  6. Repeat
+    ...
+    d. If next is false, then
+      ...
+      iii. If remainingElementsCount.[[Value]] is 0, then
+        1. Let valuesArray be CreateArrayFromList(values).
+        2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+
+
+  IfAbruptRejectPromise
+
+  1. IfAbruptRejectPromise(value, capability).
+flags: [async]
+---*/
+
+var thrown = new Test262Error();
+var P = function(executor) {
+  return new Promise(function(_, reject) {
+    executor(function() {
+      throw thrown;
+    }, reject);
+  });
+};
+
+Promise.allSettled.call(P, [])
+  .then(function() {
+    $DONE('Promise incorrectly fulfilled.');
+  }, function(reason) {
+    if (reason !== thrown) {
+      $DONE('Promise rejected with incorrect "reason."');
+      return;
+    }
+    $DONE();
+  });

--- a/test/built-ins/Promise/allSettled/ctx-ctor-throws.js
+++ b/test/built-ins/Promise/allSettled/ctx-ctor-throws.js
@@ -12,6 +12,7 @@ info: |
 
   ...
   7. Let promise be ? Construct(C, « executor »).
+features: [Promise.allSettled]
 ---*/
 
 var CustomPromise = function() {

--- a/test/built-ins/Promise/allSettled/ctx-ctor-throws.js
+++ b/test/built-ins/Promise/allSettled/ctx-ctor-throws.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Promise.allSettled invoked on a constructor value that throws an error
+esid: sec-promise.allsettled
+info: |
+  3. Let promiseCapability be ? NewPromiseCapability(C).
+
+  NewPromiseCapability
+
+  ...
+  7. Let promise be ? Construct(C, « executor »).
+---*/
+
+var CustomPromise = function() {
+  throw new Test262Error();
+};
+
+assert.throws(Test262Error, function() {
+  Promise.allSettled.call(CustomPromise);
+});

--- a/test/built-ins/Promise/allSettled/ctx-ctor.js
+++ b/test/built-ins/Promise/allSettled/ctx-ctor.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Promise.allSettled invoked on a constructor value
+esid: sec-promise.allsettled
+info: |
+  3. Let promiseCapability be ? NewPromiseCapability(C).
+  ...
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  ...
+  8. Return Completion(result).
+features: [class]
+---*/
+
+var executor = null;
+var callCount = 0;
+
+class SubPromise extends Promise {
+  constructor(a) {
+    super(a);
+    executor = a;
+    callCount += 1;
+  }
+}
+
+var instance = Promise.allSettled.call(SubPromise, []);
+
+assert.sameValue(instance.constructor, SubPromise);
+assert.sameValue(instance instanceof SubPromise, true);
+
+assert.sameValue(callCount, 1);
+assert.sameValue(typeof executor, 'function');

--- a/test/built-ins/Promise/allSettled/ctx-ctor.js
+++ b/test/built-ins/Promise/allSettled/ctx-ctor.js
@@ -11,7 +11,7 @@ info: |
   6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
   ...
   8. Return Completion(result).
-features: [class]
+features: [Promise.allSettled, class]
 ---*/
 
 var executor = null;

--- a/test/built-ins/Promise/allSettled/ctx-non-ctor.js
+++ b/test/built-ins/Promise/allSettled/ctx-non-ctor.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Promise.allSettled invoked on a non-constructor value
+esid: sec-promise.allsettled
+info: |
+  ...
+  3. Let promiseCapability be ? NewPromiseCapability(C).
+
+  NewPromiseCapability ( C )
+
+  1. If IsConstructor(C) is false, throw a TypeError exception.
+---*/
+
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(eval);
+});

--- a/test/built-ins/Promise/allSettled/ctx-non-ctor.js
+++ b/test/built-ins/Promise/allSettled/ctx-non-ctor.js
@@ -12,6 +12,7 @@ info: |
   NewPromiseCapability ( C )
 
   1. If IsConstructor(C) is false, throw a TypeError exception.
+features: [Promise.allSettled]
 ---*/
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Promise/allSettled/ctx-non-object.js
+++ b/test/built-ins/Promise/allSettled/ctx-non-object.js
@@ -8,7 +8,7 @@ esid: sec-promise.allsettled
 info: |
   1. Let C be the this value.
   2. If Type(C) is not Object, throw a TypeError exception.
-features: [Symbol]
+features: [Promise.allSettled, Symbol]
 ---*/
 
 assert.throws(TypeError, function() {

--- a/test/built-ins/Promise/allSettled/ctx-non-object.js
+++ b/test/built-ins/Promise/allSettled/ctx-non-object.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Promise.allSettled invoked on a non-object value
+esid: sec-promise.allsettled
+info: |
+  1. Let C be the this value.
+  2. If Type(C) is not Object, throw a TypeError exception.
+features: [Symbol]
+---*/
+
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(undefined, []);
+});
+
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(null, []);
+});
+
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(86, []);
+});
+
+assert.throws(TypeError, function() {
+  Promise.allSettled.call('string', []);
+});
+
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(true, []);
+});
+
+assert.throws(TypeError, function() {
+  Promise.allSettled.call(Symbol(), []);
+});

--- a/test/built-ins/Promise/allSettled/does-not-invoke-array-setters.js
+++ b/test/built-ins/Promise/allSettled/does-not-invoke-array-setters.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-performpromiseallsettled
+description: >
+  Indexed setter properties on Array.prototype are not invoked.
+info: |
+  Promise.allSettled ( iterable )
+
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b, IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  ...
+  4. Let remainingElementsCount be a new Record { [[value]]: 1 }.
+  ...
+  6.d ...
+    ii. Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
+    iii. If remainingElementsCount.[[value]] is 0,
+      1. Let valuesArray be CreateArrayFromList(values).
+      ...
+  ...
+
+  7.3.16 CreateArrayFromList (elements)
+    ...
+    4. For each element e of elements
+      a. Let status be CreateDataProperty(array, ToString(n), e).
+      b. Assert: status is true.
+    ...
+flags: [async]
+---*/
+
+Object.defineProperty(Array.prototype, 0, {
+  set() {
+    throw new Test262Error("Setter on Array.prototype called");
+  }
+});
+
+Promise.allSettled([42]).then(function() {
+  $DONE();
+}, $DONE);

--- a/test/built-ins/Promise/allSettled/does-not-invoke-array-setters.js
+++ b/test/built-ins/Promise/allSettled/does-not-invoke-array-setters.js
@@ -36,7 +36,7 @@ flags: [async]
 
 Object.defineProperty(Array.prototype, 0, {
   set() {
-    throw new Test262Error("Setter on Array.prototype called");
+    throw new Test262Error('Setter on Array.prototype called');
   }
 });
 

--- a/test/built-ins/Promise/allSettled/does-not-invoke-array-setters.js
+++ b/test/built-ins/Promise/allSettled/does-not-invoke-array-setters.js
@@ -32,6 +32,7 @@ info: |
       b. Assert: status is true.
     ...
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 Object.defineProperty(Array.prototype, 0, {

--- a/test/built-ins/Promise/allSettled/invoke-resolve-error-close.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-error-close.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Explicit iterator closing in response to error
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat
+    ...
+    i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
+features: [Symbol.iterator]
+---*/
+
+var iterDoneSpy = {};
+var callCount = 0;
+iterDoneSpy[Symbol.iterator] = function() {
+  return {
+    next() {
+      return {
+        value: null,
+        done: false
+      };
+    },
+    return() {
+      callCount += 1;
+    }
+  };
+};
+
+Promise.resolve = function() {
+  throw new Error();
+};
+
+Promise.allSettled(iterDoneSpy);
+
+assert.sameValue(callCount, 1);

--- a/test/built-ins/Promise/allSettled/invoke-resolve-error-close.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-error-close.js
@@ -16,7 +16,7 @@ info: |
   6. Repeat
     ...
     i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 ---*/
 
 var iterDoneSpy = {};

--- a/test/built-ins/Promise/allSettled/invoke-resolve-error-reject.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-error-reject.js
@@ -16,6 +16,7 @@ info: |
     ...
     i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var thrown = new Test262Error();

--- a/test/built-ins/Promise/allSettled/invoke-resolve-error-reject.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-error-reject.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Promise rejection in response to error
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat
+    ...
+    i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
+flags: [async]
+---*/
+
+var thrown = new Test262Error();
+Promise.resolve = function() {
+  throw thrown;
+};
+
+Promise.allSettled([1])
+  .then(function() {
+    $ERROR('The promise should not be fulfilled.');
+  }, function(reason) {
+    if (reason !== thrown) {
+      $ERROR('The promise should be rejected with the thrown error object');
+    }
+  }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/invoke-resolve-get-error-close.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-get-error-close.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Error retrieving the constructor's `resolve` method (closing iterator)
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat
+    ...
+    i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
+features: [Symbol.iterator]
+---*/
+
+var iter = {};
+var returnCount = 0;
+iter[Symbol.iterator] = function() {
+  return {
+    next() {
+      return {
+        done: false
+      };
+    },
+    return() {
+      returnCount += 1;
+      return {};
+    }
+  };
+};
+Object.defineProperty(Promise, 'resolve', {
+  get() {
+    throw new Test262Error();
+  }
+});
+
+Promise.allSettled(iter);
+
+assert.sameValue(returnCount, 1);

--- a/test/built-ins/Promise/allSettled/invoke-resolve-get-error-close.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-get-error-close.js
@@ -16,7 +16,7 @@ info: |
   6. Repeat
     ...
     i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 ---*/
 
 var iter = {};

--- a/test/built-ins/Promise/allSettled/invoke-resolve-get-error-reject.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-get-error-reject.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Error retrieving the constructor's `resolve` method (rejecting promise)
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat
+    ...
+    i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
+flags: [async]
+---*/
+
+var error = new Test262Error();
+Object.defineProperty(Promise, 'resolve', {
+  get() {
+    throw error;
+  }
+});
+
+Promise.allSettled([new Promise(function() {})]).then(function() {
+  $ERROR('The promise should be rejected');
+}, function(reason) {
+  assert.sameValue(reason, error);
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/invoke-resolve-get-error-reject.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-get-error-reject.js
@@ -17,6 +17,7 @@ info: |
     ...
     i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var error = new Test262Error();

--- a/test/built-ins/Promise/allSettled/invoke-resolve-get-once-multiple-calls.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-get-once-multiple-calls.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Gets constructor's `resolve` method once from zero to many invocations.
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Let promiseResolve be ? Get(constructor, `"resolve"`).
+  7. 1. If IsCallable(promiseResolve) is false, throw a TypeError exception.
+  8. Repeat
+    ...
+    i. Let nextPromise be ? Call(promiseResolve, constructor, « nextValue »).
+---*/
+
+var p1 = Promise.resolve(1);
+var p2 = Promise.resolve(1);
+var p3 = Promise.reject(1);
+var p4 = Promise.resolve(1);
+var resolve = Promise.resolve;
+var getCount = 0;
+var callCount = 0;
+
+Object.defineProperty(Promise, 'resolve', {
+  configurable: true,
+  get() {
+    getCount += 1;
+    return function() {
+      callCount += 1;
+      return resolve.apply(Promise, arguments);
+    };
+  }
+});
+
+Promise.allSettled([p1, p2, p3, p4]);
+
+assert.sameValue(
+  getCount, 1, 'Got `resolve` only once for each iterated value'
+);
+assert.sameValue(
+  callCount, 4, '`resolve` invoked once for each iterated value'
+);

--- a/test/built-ins/Promise/allSettled/invoke-resolve-get-once-multiple-calls.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-get-once-multiple-calls.js
@@ -15,6 +15,7 @@ info: |
   8. Repeat
     ...
     i. Let nextPromise be ? Call(promiseResolve, constructor, « nextValue »).
+features: [Promise.allSettled]
 ---*/
 
 var p1 = Promise.resolve(1);

--- a/test/built-ins/Promise/allSettled/invoke-resolve-get-once-no-calls.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-get-once-no-calls.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Gets constructor's `resolve` method once from zero to many invocations.
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Let promiseResolve be ? Get(constructor, `"resolve"`).
+  7. 1. If IsCallable(promiseResolve) is false, throw a TypeError exception.
+  8. Repeat
+    ...
+    i. Let nextPromise be ? Call(promiseResolve, constructor, « nextValue »).
+---*/
+
+var resolve = Promise.resolve;
+var getCount = 0;
+var callCount = 0;
+
+Object.defineProperty(Promise, 'resolve', {
+  configurable: true,
+  get() {
+    getCount += 1;
+    return function() {
+      callCount += 1;
+      return resolve.apply(Promise, arguments);
+    };
+  }
+});
+
+Promise.allSettled([]);
+
+assert.sameValue(
+  getCount, 1, 'Got `resolve` only once for each iterated value'
+);
+assert.sameValue(
+  callCount, 0, '`resolve` not called for empty iterator'
+);

--- a/test/built-ins/Promise/allSettled/invoke-resolve-get-once-no-calls.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-get-once-no-calls.js
@@ -15,6 +15,7 @@ info: |
   8. Repeat
     ...
     i. Let nextPromise be ? Call(promiseResolve, constructor, « nextValue »).
+features: [Promise.allSettled]
 ---*/
 
 var resolve = Promise.resolve;

--- a/test/built-ins/Promise/allSettled/invoke-resolve-return.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-return.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Use of the value returned by the constructor's `resolve` method.
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat
+    ...
+    i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
+    ...
+    z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+---*/
+
+var originalCallCount = 0;
+var newCallCount = 0;
+var P = function(executor) {
+  executor(function() {}, function() {});
+};
+P.resolve = function() {
+  return newThenable;
+};
+
+var originalThenable = {
+  then() {
+    originalCallCount += 1;
+  }
+};
+var newThenable = {
+  then() {
+    newCallCount += 1;
+  }
+};
+
+Promise.allSettled.call(P, [originalThenable]);
+
+assert.sameValue(originalCallCount, 0, 'original `then` method not invoked');
+assert.sameValue(newCallCount, 1, 'new `then` method invoked exactly once');

--- a/test/built-ins/Promise/allSettled/invoke-resolve-return.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve-return.js
@@ -13,6 +13,7 @@ info: |
     i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
     ...
     z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+features: [Promise.allSettled]
 ---*/
 
 var originalCallCount = 0;

--- a/test/built-ins/Promise/allSettled/invoke-resolve.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Invocation of the constructor's `resolve` method
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat
+    ...
+    i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
+    ...
+    z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+---*/
+
+var p1 = new Promise(function() {});
+var p2 = new Promise(function() {});
+var p3 = new Promise(function() {});
+var resolve = Promise.resolve;
+var callCount = 0;
+var current = p1;
+var next = p2;
+var afterNext = p3;
+
+Promise.resolve = function(nextValue) {
+  assert.sameValue(
+    nextValue, current, '`resolve` invoked with next iterated value'
+  );
+  assert.sameValue(
+    arguments.length, 1, '`resolve` invoked with a single argument'
+  );
+  assert.sameValue(this, Promise, '`this` value is the constructor');
+
+  current = next;
+  next = afterNext;
+  afterNext = null;
+
+  callCount += 1;
+
+  return resolve.apply(Promise, arguments);
+};
+
+Promise.allSettled([p1, p2, p3]);
+
+assert.sameValue(
+  callCount, 3, '`resolve` invoked once for each iterated value'
+);

--- a/test/built-ins/Promise/allSettled/invoke-resolve.js
+++ b/test/built-ins/Promise/allSettled/invoke-resolve.js
@@ -15,6 +15,7 @@ info: |
     i. Let nextPromise be ? Invoke(constructor, "resolve", « nextValue »).
     ...
     z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+features: [Promise.allSettled]
 ---*/
 
 var p1 = new Promise(function() {});

--- a/test/built-ins/Promise/allSettled/invoke-then-error-close.js
+++ b/test/built-ins/Promise/allSettled/invoke-then-error-close.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Error thrown when invoking the instance's `then` method (closing iterator)
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+features: [Symbol.iterator]
+---*/
+
+var promise = new Promise(function() {});
+var returnCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next() {
+      return {
+        done: false,
+        value: promise
+      };
+    },
+    return() {
+      returnCount += 1;
+      return {};
+    }
+  };
+};
+
+promise.then = function() {
+  throw new Test262Error();
+};
+
+Promise.allSettled(iter);
+
+assert.sameValue(returnCount, 1);

--- a/test/built-ins/Promise/allSettled/invoke-then-error-close.js
+++ b/test/built-ins/Promise/allSettled/invoke-then-error-close.js
@@ -13,7 +13,7 @@ info: |
   Runtime Semantics: PerformPromiseAllSettled
 
   z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 ---*/
 
 var promise = new Promise(function() {});

--- a/test/built-ins/Promise/allSettled/invoke-then-error-reject.js
+++ b/test/built-ins/Promise/allSettled/invoke-then-error-reject.js
@@ -15,6 +15,7 @@ info: |
 
   z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var promise = new Promise(function() {});

--- a/test/built-ins/Promise/allSettled/invoke-then-error-reject.js
+++ b/test/built-ins/Promise/allSettled/invoke-then-error-reject.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Error thrown when invoking the instance's `then` method (rejecting Promise)
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+flags: [async]
+---*/
+
+var promise = new Promise(function() {});
+var error = new Test262Error();
+
+promise.then = function() {
+  throw error;
+};
+
+Promise.allSettled([promise]).then(function() {
+  throw new Test262Error('The promise should be rejected');
+}, function(reason) {
+  assert.sameValue(reason, error);
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/invoke-then-get-error-close.js
+++ b/test/built-ins/Promise/allSettled/invoke-then-get-error-close.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Error thrown when accesing the instance's `then` method (closing iterator)
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+features: [Symbol.iterator]
+---*/
+
+var promise = new Promise(function() {});
+var returnCount = 0;
+var iter = {};
+iter[Symbol.iterator] = function() {
+  return {
+    next() {
+      return {
+        done: false,
+        value: promise
+      };
+    },
+    return() {
+      returnCount += 1;
+      return {};
+    }
+  };
+};
+
+Object.defineProperty(promise, 'then', {
+  get() {
+    throw new Test262Error();
+  }
+});
+
+Promise.allSettled(iter);
+
+assert.sameValue(returnCount, 1);

--- a/test/built-ins/Promise/allSettled/invoke-then-get-error-close.js
+++ b/test/built-ins/Promise/allSettled/invoke-then-get-error-close.js
@@ -13,7 +13,7 @@ info: |
   Runtime Semantics: PerformPromiseAllSettled
 
   z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 ---*/
 
 var promise = new Promise(function() {});

--- a/test/built-ins/Promise/allSettled/invoke-then-get-error-reject.js
+++ b/test/built-ins/Promise/allSettled/invoke-then-get-error-reject.js
@@ -14,6 +14,7 @@ info: |
 
   z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var promise = new Promise(function() {});

--- a/test/built-ins/Promise/allSettled/invoke-then-get-error-reject.js
+++ b/test/built-ins/Promise/allSettled/invoke-then-get-error-reject.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+  Error thrown when accessing the instance's `then` method (rejecting Promise)
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+flags: [async]
+---*/
+
+var promise = new Promise(function() {});
+var error = new Test262Error();
+
+Object.defineProperty(promise, 'then', {
+  get() {
+    throw error;
+  }
+});
+
+Promise.allSettled([promise]).then(function() {
+  $ERROR('The promise should be rejected');
+}, function(reason) {
+  assert.sameValue(reason, error);
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/invoke-then.js
+++ b/test/built-ins/Promise/allSettled/invoke-then.js
@@ -14,6 +14,7 @@ info: |
   Runtime Semantics: PerformPromiseAllSettled
 
   z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+features: [Promise.allSettled]
 ---*/
 
 var p1 = new Promise(function() {});

--- a/test/built-ins/Promise/allSettled/invoke-then.js
+++ b/test/built-ins/Promise/allSettled/invoke-then.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Invocation of the instance's `then` method
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+---*/
+
+var p1 = new Promise(function() {});
+var p2 = new Promise(function() {});
+var p3 = new Promise(function() {});
+var callCount = 0;
+var currentThis = p1;
+var nextThis = p2;
+var afterNextThis = p3;
+
+p1.then = p2.then = p3.then = function(a, b) {
+  assert.sameValue(typeof a, 'function', 'type of first argument');
+  assert.sameValue(
+    a.length,
+    1,
+    'The length property of a promise resolve function is 1.'
+  );
+  assert.sameValue(typeof b, 'function', 'type of second argument');
+  assert.sameValue(
+    b.length,
+    1,
+    'The length property of a promise reject function is 1.'
+  );
+  assert.sameValue(arguments.length, 2, '`then` invoked with two arguments');
+  assert.sameValue(this, currentThis, '`this` value');
+
+  currentThis = nextThis;
+  nextThis = afterNextThis;
+  afterNextThis = null;
+
+  callCount += 1;
+};
+
+Promise.allSettled([p1, p2, p3]);
+
+assert.sameValue(callCount, 3, '`then` invoked once for every iterated value');

--- a/test/built-ins/Promise/allSettled/is-function.js
+++ b/test/built-ins/Promise/allSettled/is-function.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-promise.allsettled
 description: Promise.allSettled is callable
+features: [Promise.allSettled]
 ---*/
 
 assert.sameValue(typeof Promise.allSettled, 'function');

--- a/test/built-ins/Promise/allSettled/is-function.js
+++ b/test/built-ins/Promise/allSettled/is-function.js
@@ -1,0 +1,9 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: Promise.allSettled is callable
+---*/
+
+assert.sameValue(typeof Promise.allSettled, 'function');

--- a/test/built-ins/Promise/allSettled/iter-arg-is-false-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-false-reject.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument is `false`
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  #sec-getiterator
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  Let iterator be ? Call(method, obj).
+  If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled(false).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-arg-is-false-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-false-reject.js
@@ -20,7 +20,7 @@ info: |
   Let iterator be ? Call(method, obj).
   If Type(iterator) is not Object, throw a TypeError exception.
   ...
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-arg-is-null-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-null-reject.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument is `null`
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  #sec-getiterator
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  Let iterator be ? Call(method, obj).
+  If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled(null).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-arg-is-null-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-null-reject.js
@@ -20,7 +20,7 @@ info: |
   Let iterator be ? Call(method, obj).
   If Type(iterator) is not Object, throw a TypeError exception.
   ...
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-arg-is-number-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-number-reject.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument is a number
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  #sec-getiterator
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  Let iterator be ? Call(method, obj).
+  If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled(1).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-arg-is-number-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-number-reject.js
@@ -20,7 +20,7 @@ info: |
   Let iterator be ? Call(method, obj).
   If Type(iterator) is not Object, throw a TypeError exception.
   ...
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-arg-is-poisoned.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-poisoned.js
@@ -19,7 +19,7 @@ info: |
   ...
   Let iterator be ? Call(method, obj).
   ...
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-arg-is-poisoned.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-poisoned.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject with abrupt completion from GetIterator
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  #sec-getiterator
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  Let iterator be ? Call(method, obj).
+  ...
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+var poison = [];
+Object.defineProperty(poison, Symbol.iterator, {
+  get() {
+    throw new Test262Error();
+  }
+});
+
+try {
+  Promise.allSettled(false).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), Test262Error.prototype);
+    assert(error instanceof Test262Error);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-arg-is-poisoned.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-poisoned.js
@@ -24,18 +24,18 @@ flags: [async]
 ---*/
 
 var poison = [];
+var error = new Test262Error();
 Object.defineProperty(poison, Symbol.iterator, {
   get() {
-    throw new Test262Error();
+    throw error;
   }
 });
 
 try {
-  Promise.allSettled(false).then(function() {
+  Promise.allSettled(poison).then(function() {
     $DONE('The promise should be rejected, but was resolved');
-  }, function(error) {
-    assert.sameValue(Object.getPrototypeOf(error), Test262Error.prototype);
-    assert(error instanceof Test262Error);
+  }, function(err) {
+    assert.sameValue(err, error);
   }).then($DONE, $DONE);
 } catch (error) {
   $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);

--- a/test/built-ins/Promise/allSettled/iter-arg-is-string-resolve.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-string-resolve.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Resolve when argument is a string
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  #sec-getiterator
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  Let iterator be ? Call(method, obj).
+  If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled("").then(function(v) {
+    assert.sameValue(v.length, 0);
+  }, function() {
+    $DONE('The promise should be resolved, but was rejected');
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be resolved, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-arg-is-string-resolve.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-string-resolve.js
@@ -25,7 +25,7 @@ flags: [async]
 ---*/
 
 try {
-  Promise.allSettled("").then(function(v) {
+  Promise.allSettled('').then(function(v) {
     assert.sameValue(v.length, 0);
   }, function() {
     $DONE('The promise should be resolved, but was rejected');

--- a/test/built-ins/Promise/allSettled/iter-arg-is-string-resolve.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-string-resolve.js
@@ -20,7 +20,7 @@ info: |
   Let iterator be ? Call(method, obj).
   If Type(iterator) is not Object, throw a TypeError exception.
   ...
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-arg-is-symbol-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-symbol-reject.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument is a symbol
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled(Symbol()).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-arg-is-symbol-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-symbol-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-arg-is-true-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-true-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-arg-is-true-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-true-reject.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument is `true`
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled(true).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-arg-is-undefined-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-undefined-reject.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument is `undefined`
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled(undefined).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-arg-is-undefined-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-arg-is-undefined-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-assigned-false-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-false-reject.js
@@ -35,7 +35,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-assigned-false-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-false-reject.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator property has the value false
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      i. Set method to ? GetMethod(obj, @@asyncIterator).
+      ii. If method is undefined, then
+        1. Let syncMethod be ? GetMethod(obj, @@iterator).
+        2. Let syncIteratorRecord be ? GetIterator(obj, sync, syncMethod).
+        ...
+  4. Let iterator be ? Call(method, obj).
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]: false
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-assigned-null-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-null-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-assigned-null-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-null-reject.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator property has the value null
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]: null
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-assigned-number-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-number-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-assigned-number-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-number-reject.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator property has the value 1
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]: 1
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-assigned-string-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-string-reject.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator property has the value ""
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]: ""
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-assigned-string-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-string-reject.js
@@ -39,7 +39,7 @@ flags: [async]
 
 try {
   Promise.allSettled({
-    [Symbol.iterator]: ""
+    [Symbol.iterator]: ''
   }).then(function() {
     $DONE('The promise should be rejected, but was resolved');
   }, function(error) {

--- a/test/built-ins/Promise/allSettled/iter-assigned-string-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-string-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-assigned-symbol-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-symbol-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-assigned-symbol-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-symbol-reject.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator property has the value Symbol()
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]: Symbol()
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-assigned-true-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-true-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-assigned-true-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-true-reject.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator property has the value true
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]: true
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-assigned-undefined-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-undefined-reject.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator property has the value undefined
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]: undefined
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-assigned-undefined-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-assigned-undefined-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-next-err-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-next-err-reject.js
@@ -33,7 +33,7 @@ info: |
   2. Else,
     a. Let result be ? Call(iteratorRecord.[[NextMethod]], iteratorRecord.[[Iterator]], « value »).
   ...
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-next-err-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-next-err-reject.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Error when call an iterator next step (rejecting promise)
+info: |
+  Promise.allSettled ( iterable )
+
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  ...
+  6. Repeat
+    a. Let next be IteratorStep(iteratorRecord).
+    b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+    c. ReturnIfAbrupt(next).
+    ...
+
+  IteratorStep ( iteratorRecord )
+
+  1. Let result be ? IteratorNext(iteratorRecord).
+
+  IteratorNext ( iteratorRecord [ , value ] )
+
+  1. If value is not present, then
+    a. Let result be ? Call(iteratorRecord.[[NextMethod]], iteratorRecord.[[Iterator]], « »).
+  2. Else,
+    a. Let result be ? Call(iteratorRecord.[[NextMethod]], iteratorRecord.[[Iterator]], « value »).
+  ...
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+var iterNextValThrows = {};
+var error = new Test262Error();
+iterNextValThrows[Symbol.iterator] = function() {
+  return {
+    next() {
+      throw error;
+    }
+  };
+};
+
+Promise.allSettled(iterNextValThrows).then(function() {
+  $DONE('The promise should be rejected.');
+}, function(reason) {
+  assert.sameValue(reason, error);
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/iter-next-val-err-no-close.js
+++ b/test/built-ins/Promise/allSettled/iter-next-val-err-no-close.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Error when accessing an iterator result's `value` property (not closing
+  iterator)
+info: |
+  Promise.allSettled ( iterable )
+
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  ...
+  6. Repeat
+    ...
+    e. Let nextValue be IteratorValue(next).
+    f. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
+    g. ReturnIfAbrupt(nextValue).
+features: [Symbol.iterator]
+---*/
+
+var iterNextValThrows = {};
+var returnCount = 0;
+var nextCount = 0;
+var poisonedVal = {
+  done: false
+};
+var error = new Test262Error();
+Object.defineProperty(poisonedVal, 'value', {
+  get() {
+    throw error;
+  }
+});
+iterNextValThrows[Symbol.iterator] = function() {
+  return {
+    next() {
+      nextCount += 1;
+      return poisonedVal;
+    },
+    return() {
+      returnCount += 1;
+      return {};
+    }
+  };
+};
+
+Promise.allSettled(iterNextValThrows);
+
+assert.sameValue(returnCount, 0);
+assert.sameValue(nextCount, 1);

--- a/test/built-ins/Promise/allSettled/iter-next-val-err-no-close.js
+++ b/test/built-ins/Promise/allSettled/iter-next-val-err-no-close.js
@@ -22,7 +22,7 @@ info: |
     e. Let nextValue be IteratorValue(next).
     f. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
     g. ReturnIfAbrupt(nextValue).
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 ---*/
 
 var iterNextValThrows = {};

--- a/test/built-ins/Promise/allSettled/iter-next-val-err-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-next-val-err-reject.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Error when accessing an iterator result's `value` property (rejecting promise)
+info: |
+  Promise.allSettled ( iterable )
+
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  ...
+  6. Repeat
+    ...
+    e. Let nextValue be IteratorValue(next).
+    f. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
+    g. ReturnIfAbrupt(nextValue).
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+var iterNextValThrows = {};
+var poisonedVal = {
+  done: false
+};
+var error = new Test262Error();
+Object.defineProperty(poisonedVal, 'value', {
+  get() {
+    throw error;
+  }
+});
+iterNextValThrows[Symbol.iterator] = function() {
+  return {
+    next() {
+      return poisonedVal;
+    }
+  };
+};
+
+Promise.allSettled(iterNextValThrows).then(function() {
+  $DONE('The promise should be rejected.');
+}, function(reason) {
+  assert.sameValue(reason, error);
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/iter-next-val-err-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-next-val-err-reject.js
@@ -21,7 +21,7 @@ info: |
     e. Let nextValue be IteratorValue(next).
     f. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
     g. ReturnIfAbrupt(nextValue).
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-returns-false-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-false-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-returns-false-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-false-reject.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator returns false
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]() {
+      return false;
+    }
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-returns-null-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-null-reject.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator returns null
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]() {
+      return null;
+    }
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-returns-null-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-null-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-returns-number-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-number-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-returns-number-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-number-reject.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator returns a number
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]() {
+      return 1;
+    }
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-returns-string-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-string-reject.js
@@ -40,7 +40,7 @@ flags: [async]
 try {
   Promise.allSettled({
     [Symbol.iterator]() {
-      return "";
+      return '';
     }
   }).then(function() {
     $DONE('The promise should be rejected, but was resolved');

--- a/test/built-ins/Promise/allSettled/iter-returns-string-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-string-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-returns-string-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-string-reject.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator returns a string
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]() {
+      return "";
+    }
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-returns-symbol-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-symbol-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-returns-symbol-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-symbol-reject.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator returns a symbol
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]() {
+      return Symbol();
+    }
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-returns-true-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-true-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-returns-true-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-true-reject.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator returns true
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]() {
+      return true;
+    }
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-returns-undefined-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-undefined-reject.js
@@ -33,7 +33,7 @@ info: |
   Call ( F, V [ , argumentsList ] )
 
   2. If IsCallable(F) is false, throw a TypeError exception.
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/iter-returns-undefined-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-returns-undefined-reject.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Reject when argument's Symbol.iterator returns undefined
+info: |
+  Promise.allSettled ( iterable )
+
+  ...
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  ...
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  ...
+
+  GetMethod
+
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+  4. If IsCallable(func) is false, throw a TypeError exception.
+
+  Call ( F, V [ , argumentsList ] )
+
+  2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+try {
+  Promise.allSettled({
+    [Symbol.iterator]() {
+      return undefined;
+    }
+  }).then(function() {
+    $DONE('The promise should be rejected, but was resolved');
+  }, function(error) {
+    assert.sameValue(Object.getPrototypeOf(error), TypeError.prototype);
+    assert(error instanceof TypeError);
+  }).then($DONE, $DONE);
+} catch (error) {
+  $DONE(`The promise should be rejected, but threw an exception: ${error.message}`);
+}

--- a/test/built-ins/Promise/allSettled/iter-step-err-no-close.js
+++ b/test/built-ins/Promise/allSettled/iter-step-err-no-close.js
@@ -19,7 +19,7 @@ info: |
     a. Let next be IteratorStep(iteratorRecord).
     b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
     c. ReturnIfAbrupt(next).
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 ---*/
 
 var iterStepThrows = {};

--- a/test/built-ins/Promise/allSettled/iter-step-err-no-close.js
+++ b/test/built-ins/Promise/allSettled/iter-step-err-no-close.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Error when advancing the provided iterable (not closing iterator)
+info: |
+  Promise.allSettled ( iterable )
+
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat
+    a. Let next be IteratorStep(iteratorRecord).
+    b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+    c. ReturnIfAbrupt(next).
+features: [Symbol.iterator]
+---*/
+
+var iterStepThrows = {};
+var poisonedDone = {};
+var returnCount = 0;
+var error = new Test262Error();
+Object.defineProperty(poisonedDone, 'done', {
+  get() {
+    throw error;
+  }
+});
+Object.defineProperty(poisonedDone, 'value', {
+  get() {}
+});
+
+iterStepThrows[Symbol.iterator] = function() {
+  return {
+    next() {
+      return poisonedDone;
+    },
+    return() {
+      returnCount += 1;
+      return {};
+    }
+  };
+};
+
+Promise.allSettled(iterStepThrows);
+
+assert.sameValue(returnCount, 0);

--- a/test/built-ins/Promise/allSettled/iter-step-err-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-step-err-reject.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Error when advancing the provided iterable (rejecting promise)
+info: |
+  Promise.allSettled ( iterable )
+
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat
+    a. Let next be IteratorStep(iteratorRecord).
+    b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
+    c. ReturnIfAbrupt(next).
+features: [Symbol.iterator]
+flags: [async]
+---*/
+
+var iterStepThrows = {};
+var poisonedDone = {};
+var error = new Test262Error();
+Object.defineProperty(poisonedDone, 'done', {
+  get() {
+    throw error;
+  }
+});
+Object.defineProperty(poisonedDone, 'value', {
+  get() {
+    $DONE('The `value` property should not be accessed.');
+  }
+});
+
+iterStepThrows[Symbol.iterator] = function() {
+  return {
+    next() {
+      return poisonedDone;
+    }
+  };
+};
+
+Promise.allSettled(iterStepThrows).then(function() {
+  $DONE('The promise should be rejected.');
+}, function(reason) {
+  assert.sameValue(reason, error);
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/iter-step-err-reject.js
+++ b/test/built-ins/Promise/allSettled/iter-step-err-reject.js
@@ -19,7 +19,7 @@ info: |
     a. Let next be IteratorStep(iteratorRecord).
     b. If next is an abrupt completion, set iteratorRecord.[[done]] to true.
     c. ReturnIfAbrupt(next).
-features: [Symbol.iterator]
+features: [Promise.allSettled, Symbol.iterator]
 flags: [async]
 ---*/
 

--- a/test/built-ins/Promise/allSettled/length.js
+++ b/test/built-ins/Promise/allSettled/length.js
@@ -17,6 +17,7 @@ info: |
   object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
   [[Configurable]]: true }.
 includes: [propertyHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 verifyProperty(Promise.allSettled, 'length', {

--- a/test/built-ins/Promise/allSettled/length.js
+++ b/test/built-ins/Promise/allSettled/length.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: Promise.allSettled `length` property
+info: |
+  ES Section 17:
+  Every built-in Function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this value
+  is equal to the largest number of named arguments shown in the subclause
+  headings for the function description, including optional parameters.
+
+  [...]
+
+  Unless otherwise specified, the length property of a built-in Function
+  object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(Promise.allSettled, 'length', {
+  configurable: true,
+  writable: false,
+  enumerable: false,
+  value: 1,
+});

--- a/test/built-ins/Promise/allSettled/name.js
+++ b/test/built-ins/Promise/allSettled/name.js
@@ -18,6 +18,7 @@ info: |
   object, if it exists, has the attributes { [[Writable]]: false,
   [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 verifyProperty(Promise.allSettled, 'name', {

--- a/test/built-ins/Promise/allSettled/name.js
+++ b/test/built-ins/Promise/allSettled/name.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: Promise.allSettled `name` property
+info: |
+  ES Section 17:
+
+  Every built-in Function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value is a
+  String. Unless otherwise specified, this value is the name that is given to
+  the function in this specification.
+
+  [...]
+
+  Unless otherwise specified, the name property of a built-in Function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(Promise.allSettled, 'name', {
+  configurable: true,
+  writable: false,
+  enumerable: false,
+  value: 'allSettled',
+});

--- a/test/built-ins/Promise/allSettled/new-reject-function.js
+++ b/test/built-ins/Promise/allSettled/new-reject-function.js
@@ -11,6 +11,7 @@ info: |
   ...
   z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
   ...
+features: [Promise.allSettled]
 ---*/
 
 function rejectFunction() {}

--- a/test/built-ins/Promise/allSettled/new-reject-function.js
+++ b/test/built-ins/Promise/allSettled/new-reject-function.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-performpromiseallsettled
 description: >
-  Each Promise.allSettled element is called with the same reject function.
+  Each Promise.allSettled element is called with a new Promise.allSettled Reject Element function.
 info: |
   Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
 
@@ -16,25 +16,28 @@ info: |
 function rejectFunction() {}
 
 function Constructor(executor) {
-  executor($ERROR, rejectFunction);
+  executor(rejectFunction, $ERROR);
 }
 Constructor.resolve = function(v) {
   return v;
 };
 
-var callCount1 = 0;
-var callCount2 = 0;
+var callCount1 = 0,
+  callCount2 = 0;
+var p1OnRejected;
 
 var p1 = {
   then(_, onRejected) {
     callCount1 += 1;
-    assert.sameValue(onRejected, rejectFunction, "p1.then");
+    p1OnRejected = onRejected;
+    assert.notSameValue(onRejected, rejectFunction, "p1.then");
   }
 };
 var p2 = {
   then(_, onRejected) {
     callCount2 += 1;
-    assert.sameValue(onRejected, rejectFunction, "p2.then");
+    assert.notSameValue(onRejected, rejectFunction, "p2.then");
+    assert.notSameValue(onRejected, p1OnRejected, "p1.onRejected != p2.onRejected");
   }
 };
 

--- a/test/built-ins/Promise/allSettled/new-reject-function.js
+++ b/test/built-ins/Promise/allSettled/new-reject-function.js
@@ -30,18 +30,18 @@ var p1 = {
   then(_, onRejected) {
     callCount1 += 1;
     p1OnRejected = onRejected;
-    assert.notSameValue(onRejected, rejectFunction, "p1.then");
+    assert.notSameValue(onRejected, rejectFunction, 'p1.then');
   }
 };
 var p2 = {
   then(_, onRejected) {
     callCount2 += 1;
-    assert.notSameValue(onRejected, rejectFunction, "p2.then");
-    assert.notSameValue(onRejected, p1OnRejected, "p1.onRejected != p2.onRejected");
+    assert.notSameValue(onRejected, rejectFunction, 'p2.then');
+    assert.notSameValue(onRejected, p1OnRejected, 'p1.onRejected != p2.onRejected');
   }
 };
 
 Promise.allSettled.call(Constructor, [p1, p2]);
 
-assert.sameValue(callCount1, 1, "p1.then call count");
-assert.sameValue(callCount2, 1, "p2.then call count");
+assert.sameValue(callCount1, 1, 'p1.then call count');
+assert.sameValue(callCount2, 1, 'p2.then call count');

--- a/test/built-ins/Promise/allSettled/new-resolve-function.js
+++ b/test/built-ins/Promise/allSettled/new-resolve-function.js
@@ -13,6 +13,7 @@ info: |
   ...
   z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
   ...
+features: [Promise.allSettled]
 ---*/
 
 function resolveFunction() {}

--- a/test/built-ins/Promise/allSettled/new-resolve-function.js
+++ b/test/built-ins/Promise/allSettled/new-resolve-function.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-performpromiseallsettled
+description: >
+  Each Promise.allSettled element is called with a new Promise.allSettled Resolve Element function.
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  ...
+  k Let resolveElement be ! CreateBuiltinFunction(steps, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
+  ...
+  z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+  ...
+---*/
+
+function resolveFunction() {}
+
+function Constructor(executor) {
+  executor(resolveFunction, $ERROR);
+}
+Constructor.resolve = function(v) {
+  return v;
+};
+
+var callCount1 = 0,
+  callCount2 = 0;
+var p1OnFulfilled;
+
+var p1 = {
+  then(onFulfilled, onRejected) {
+    callCount1 += 1;
+    p1OnFulfilled = onFulfilled;
+    assert.notSameValue(onFulfilled, resolveFunction, "p1.then");
+  }
+};
+var p2 = {
+  then(onFulfilled, onRejected) {
+    callCount2 += 1;
+    assert.notSameValue(onFulfilled, resolveFunction, "p2.then");
+    assert.notSameValue(onFulfilled, p1OnFulfilled, "p1.onFulfilled != p2.onFulfilled");
+  }
+};
+
+Promise.allSettled.call(Constructor, [p1, p2]);
+
+assert.sameValue(callCount1, 1, "p1.then call count");
+assert.sameValue(callCount2, 1, "p2.then call count");

--- a/test/built-ins/Promise/allSettled/new-resolve-function.js
+++ b/test/built-ins/Promise/allSettled/new-resolve-function.js
@@ -32,18 +32,18 @@ var p1 = {
   then(onFulfilled, onRejected) {
     callCount1 += 1;
     p1OnFulfilled = onFulfilled;
-    assert.notSameValue(onFulfilled, resolveFunction, "p1.then");
+    assert.notSameValue(onFulfilled, resolveFunction, 'p1.then');
   }
 };
 var p2 = {
   then(onFulfilled, onRejected) {
     callCount2 += 1;
-    assert.notSameValue(onFulfilled, resolveFunction, "p2.then");
-    assert.notSameValue(onFulfilled, p1OnFulfilled, "p1.onFulfilled != p2.onFulfilled");
+    assert.notSameValue(onFulfilled, resolveFunction, 'p2.then');
+    assert.notSameValue(onFulfilled, p1OnFulfilled, 'p1.onFulfilled != p2.onFulfilled');
   }
 };
 
 Promise.allSettled.call(Constructor, [p1, p2]);
 
-assert.sameValue(callCount1, 1, "p1.then call count");
-assert.sameValue(callCount2, 1, "p2.then call count");
+assert.sameValue(callCount1, 1, 'p1.then call count');
+assert.sameValue(callCount2, 1, 'p2.then call count');

--- a/test/built-ins/Promise/allSettled/prop-desc.js
+++ b/test/built-ins/Promise/allSettled/prop-desc.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: Promise.allSettled property descriptor
+info: |
+  ES Section 17
+
+  Every other data property described in clauses 18 through 26 and in Annex
+  B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(Promise, 'allSettled', {
+  configurable: true,
+  writable: true,
+  enumerable: false,
+});

--- a/test/built-ins/Promise/allSettled/prop-desc.js
+++ b/test/built-ins/Promise/allSettled/prop-desc.js
@@ -11,6 +11,7 @@ info: |
   B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
   [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 verifyProperty(Promise, 'allSettled', {

--- a/test/built-ins/Promise/allSettled/reject-deferred.js
+++ b/test/built-ins/Promise/allSettled/reject-deferred.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Rejecting through deferred invocation of the provided resolving function
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+  
+  6. Repeat
+    ...
+    z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+
+  Promise.allSettled Reject Element Functions
+
+  9. Let obj be ! ObjectCreate(%ObjectPrototype%).
+  10. Perform ! CreateDataProperty(obj, "status", "rejected").
+  11. Perform ! CreateDataProperty(obj, "reason", x).
+  12. Set values[index] to be obj.
+  13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
+  14. If remainingElementsCount.[[Value]] is 0, then
+    a. Let valuesArray be CreateArrayFromList(values).
+    b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
+flags: [async]
+---*/
+
+var simulation = {};
+var thenable = {
+  then(_, reject) {
+    new Promise(function(resolve) {
+        resolve();
+      })
+      .then(function() {
+        reject(simulation);
+      });
+  }
+};
+
+Promise.allSettled([thenable])
+  .then((settleds) => {
+    assert.sameValue(settleds.length, 1);
+    assert.sameValue(settleds[0].status, 'rejected');
+    assert.sameValue(settleds[0].reason, simulation);
+    $DONE();
+  }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/reject-deferred.js
+++ b/test/built-ins/Promise/allSettled/reject-deferred.js
@@ -23,6 +23,7 @@ info: |
     a. Let valuesArray be CreateArrayFromList(values).
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var simulation = {};

--- a/test/built-ins/Promise/allSettled/reject-element-function-extensible.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-extensible.js
@@ -8,6 +8,7 @@ info: |
   17 ECMAScript Standard Built-in Objects:
     Unless specified otherwise, the [[Extensible]] internal slot
     of a built-in object initially has the value true.
+features: [Promise.allSettled]
 ---*/
 
 var rejectElementFunction;

--- a/test/built-ins/Promise/allSettled/reject-element-function-extensible.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-extensible.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-reject-element-functions
+description: The [[Extensible]] slot of Promise.allSettled Reject Element functions
+info: |
+  17 ECMAScript Standard Built-in Objects:
+    Unless specified otherwise, the [[Extensible]] internal slot
+    of a built-in object initially has the value true.
+---*/
+
+var rejectElementFunction;
+var thenable = {
+  then(_, reject) {
+    rejectElementFunction = reject;
+  }
+};
+
+function NotPromise(executor) {
+  executor(function() {}, function() {});
+}
+NotPromise.resolve = function(v) {
+  return v;
+};
+Promise.allSettled.call(NotPromise, [thenable]);
+
+assert(Object.isExtensible(rejectElementFunction));

--- a/test/built-ins/Promise/allSettled/reject-element-function-length.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-length.js
@@ -12,6 +12,7 @@ info: |
     object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
     [[Configurable]]: true }.
 includes: [propertyHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var rejectElementFunction;

--- a/test/built-ins/Promise/allSettled/reject-element-function-length.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-length.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-reject-element-functions
+description: The `length` property of Promise.allSettled Reject Element functions
+info: |
+  The length property of a Promise.allSettled Reject Element function is 1.
+
+  17 ECMAScript Standard Built-in Objects:
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+var rejectElementFunction;
+var thenable = {
+  then(_, reject) {
+    rejectElementFunction = reject;
+  }
+};
+
+function NotPromise(executor) {
+  executor(function() {}, function() {});
+}
+NotPromise.resolve = function(v) {
+  return v;
+};
+Promise.allSettled.call(NotPromise, [thenable]);
+
+assert.sameValue(rejectElementFunction.length, 1);
+
+verifyProperty(rejectElementFunction, 'length', {
+  value: 1,
+  enumerable: false,
+  writable: false,
+  configurable: true,
+});

--- a/test/built-ins/Promise/allSettled/reject-element-function-name.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-reject-element-functions
+description: The `name` property of Promise.allSettled Reject Element functions
+info: |
+  A promise resolve function is an anonymous built-in function.
+
+  17 ECMAScript Standard Built-in Objects:
+    Every built-in Function object, including constructors, that is not
+    identified as an anonymous function has a name property whose value
+    is a String.
+---*/
+
+var rejectElementFunction;
+var thenable = {
+  then(_, reject) {
+    rejectElementFunction = reject;
+  }
+};
+
+function NotPromise(executor) {
+  executor(function() {}, function() {});
+}
+NotPromise.resolve = function(v) {
+  return v;
+};
+Promise.allSettled.call(NotPromise, [thenable]);
+
+assert.sameValue(Object.prototype.hasOwnProperty.call(rejectElementFunction, "name"), false);

--- a/test/built-ins/Promise/allSettled/reject-element-function-name.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-name.js
@@ -28,4 +28,4 @@ NotPromise.resolve = function(v) {
 };
 Promise.allSettled.call(NotPromise, [thenable]);
 
-assert.sameValue(Object.prototype.hasOwnProperty.call(rejectElementFunction, "name"), false);
+assert.sameValue(Object.prototype.hasOwnProperty.call(rejectElementFunction, 'name'), false);

--- a/test/built-ins/Promise/allSettled/reject-element-function-name.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-name.js
@@ -11,6 +11,7 @@ info: |
     Every built-in Function object, including constructors, that is not
     identified as an anonymous function has a name property whose value
     is a String.
+features: [Promise.allSettled]
 ---*/
 
 var rejectElementFunction;

--- a/test/built-ins/Promise/allSettled/reject-element-function-nonconstructor.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-nonconstructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-reject-element-functions
+description: Promise.allSettled Reject Element functions are not constructors
+info: |
+  17 ECMAScript Standard Built-in Objects:
+    Built-in function objects that are not identified as constructors do not
+    implement the [[Construct]] internal method unless otherwise specified
+    in the description of a particular function.
+---*/
+
+var rejectElementFunction;
+var thenable = {
+  then(_, reject) {
+    rejectElementFunction = reject;
+  }
+};
+
+function NotPromise(executor) {
+  executor(function() {}, function() {});
+}
+NotPromise.resolve = function(v) {
+  return v;
+};
+Promise.allSettled.call(NotPromise, [thenable]);
+
+assert.sameValue(Object.prototype.hasOwnProperty.call(rejectElementFunction, "prototype"), false);
+assert.throws(TypeError, function() {
+  new rejectElementFunction();
+});

--- a/test/built-ins/Promise/allSettled/reject-element-function-nonconstructor.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-nonconstructor.js
@@ -9,6 +9,7 @@ info: |
     Built-in function objects that are not identified as constructors do not
     implement the [[Construct]] internal method unless otherwise specified
     in the description of a particular function.
+features: [Promise.allSettled]
 ---*/
 
 var rejectElementFunction;

--- a/test/built-ins/Promise/allSettled/reject-element-function-nonconstructor.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-nonconstructor.js
@@ -26,7 +26,7 @@ NotPromise.resolve = function(v) {
 };
 Promise.allSettled.call(NotPromise, [thenable]);
 
-assert.sameValue(Object.prototype.hasOwnProperty.call(rejectElementFunction, "prototype"), false);
+assert.sameValue(Object.prototype.hasOwnProperty.call(rejectElementFunction, 'prototype'), false);
 assert.throws(TypeError, function() {
   new rejectElementFunction();
 });

--- a/test/built-ins/Promise/allSettled/reject-element-function-prototype.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-prototype.js
@@ -10,6 +10,7 @@ info: |
     constructor has the Function prototype object, which is the initial
     value of the expression Function.prototype (19.2.3), as the value of
     its [[Prototype]] internal slot.
+features: [Promise.allSettled]
 ---*/
 
 var rejectElementFunction;

--- a/test/built-ins/Promise/allSettled/reject-element-function-prototype.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-prototype.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-reject-element-functions
+description: The [[Prototype]] of Promise.allSettled Reject Element functions
+info: |
+  17 ECMAScript Standard Built-in Objects:
+    Unless otherwise specified every built-in function and every built-in
+    constructor has the Function prototype object, which is the initial
+    value of the expression Function.prototype (19.2.3), as the value of
+    its [[Prototype]] internal slot.
+---*/
+
+var rejectElementFunction;
+var thenable = {
+  then(_, reject) {
+    rejectElementFunction = reject;
+  }
+};
+
+function NotPromise(executor) {
+  executor(function() {}, function() {});
+}
+NotPromise.resolve = function(v) {
+  return v;
+};
+Promise.allSettled.call(NotPromise, [thenable]);
+
+assert.sameValue(Object.getPrototypeOf(rejectElementFunction), Function.prototype);

--- a/test/built-ins/Promise/allSettled/reject-ignored-deferred.js
+++ b/test/built-ins/Promise/allSettled/reject-ignored-deferred.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Resolved promises ignore rejections through deferred invocation of the
+    provided resolving function
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+  
+  6. Repeat
+    ...
+    z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+flags: [async]
+---*/
+
+var simulation = {};
+
+var fulfiller = {
+  then(resolve) {
+    new Promise(function(resolve) {
+        resolve();
+      })
+      .then(function() {
+        resolve(42);
+      });
+  }
+};
+var rejector = {
+  then(resolve, reject) {
+    new Promise(function(resolve) {
+        resolve();
+      })
+      .then(function() {
+        resolve(simulation);
+        reject();
+      });
+  }
+};
+
+Promise.allSettled([fulfiller, rejector])
+  .then((settleds) => {
+    assert.sameValue(settleds.length, 2);
+    assert.sameValue(settleds[0].status, 'fulfilled');
+    assert.sameValue(settleds[0].value, 42);
+    assert.sameValue(settleds[1].status, 'fulfilled');
+    assert.sameValue(settleds[1].value, simulation);
+    $DONE();
+  }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/reject-ignored-deferred.js
+++ b/test/built-ins/Promise/allSettled/reject-ignored-deferred.js
@@ -15,6 +15,7 @@ info: |
     ...
     z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var simulation = {};

--- a/test/built-ins/Promise/allSettled/reject-ignored-immed.js
+++ b/test/built-ins/Promise/allSettled/reject-ignored-immed.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Resolved promises ignore rejections through immediate invocation of the
+    provided resolving function
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+  
+  6. Repeat
+    ...
+    z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+flags: [async]
+---*/
+
+var simulation = {};
+
+var fulfiller = {
+  then(resolve) {
+    resolve(42);
+  }
+};
+
+var lateRejector = {
+  then(resolve, reject) {
+    resolve(simulation);
+    reject();
+  }
+};
+
+Promise.allSettled([fulfiller, lateRejector])
+  .then((settleds) => {
+    assert.sameValue(settleds.length, 2);
+    assert.sameValue(settleds[0].status, 'fulfilled');
+    assert.sameValue(settleds[0].value, 42);
+    assert.sameValue(settleds[1].status, 'fulfilled');
+    assert.sameValue(settleds[1].value, simulation);
+    $DONE();
+  }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/reject-ignored-immed.js
+++ b/test/built-ins/Promise/allSettled/reject-ignored-immed.js
@@ -15,6 +15,7 @@ info: |
     ...
     z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var simulation = {};

--- a/test/built-ins/Promise/allSettled/reject-immed.js
+++ b/test/built-ins/Promise/allSettled/reject-immed.js
@@ -13,19 +13,18 @@ info: |
     ...
     z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
 flags: [async]
+includes: [promiseHelper.js]
 ---*/
 
 var simulation = {};
 var thenable = {
   then(_, reject) {
-    reject({});
+    reject(simulation);
   }
 };
 
 Promise.allSettled([thenable])
   .then((settleds) => {
-    assert.sameValue(settleds.length, 1);
-    assert.sameValue(settleds[0].status, 'rejected');
-    assert.sameValue(settleds[0].reason, simulation);
+    checkSettledPromises(settleds, [{ status: 'rejected', reason: simulation }]);
     $DONE();
   }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/reject-immed.js
+++ b/test/built-ins/Promise/allSettled/reject-immed.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Rejecting through immediate invocation of the provided resolving function
+esid: sec-promise.allsettled
+info: |
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+
+  Runtime Semantics: PerformPromiseAllSettled
+  
+  6. Repeat
+    ...
+    z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+flags: [async]
+---*/
+
+var simulation = {};
+var thenable = {
+  then(_, reject) {
+    reject({});
+  }
+};
+
+Promise.allSettled([thenable])
+  .then((settleds) => {
+    assert.sameValue(settleds.length, 1);
+    assert.sameValue(settleds[0].status, 'rejected');
+    assert.sameValue(settleds[0].reason, simulation);
+    $DONE();
+  }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/reject-immed.js
+++ b/test/built-ins/Promise/allSettled/reject-immed.js
@@ -14,6 +14,7 @@ info: |
     z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
 flags: [async]
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var simulation = {};

--- a/test/built-ins/Promise/allSettled/resolve-before-loop-exit-from-same.js
+++ b/test/built-ins/Promise/allSettled/resolve-before-loop-exit-from-same.js
@@ -24,6 +24,7 @@ info: |
   4. Set alreadyCalled.[[Value]] to true.
   ...
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var callCount = 0;

--- a/test/built-ins/Promise/allSettled/resolve-before-loop-exit-from-same.js
+++ b/test/built-ins/Promise/allSettled/resolve-before-loop-exit-from-same.js
@@ -1,0 +1,72 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-performpromiseallsettled
+description: >
+  Cannot tamper remainingElementsCount when Promise.allSettled resolve element function is called twice in a row.
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  4. Let remainingElementsCount be a new Record { [[Value]]: 1 }.
+  ...
+  6.d ...
+    ii. Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
+    iii. If remainingElementsCount.[[value]] is 0, then
+      1. Let valuesArray be CreateArrayFromList(values).
+      2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+  ...
+
+  Promise.allSettled Resolve Element Functions
+
+  2. Let alreadyCalled be F.[[AlreadyCalled]].
+  3. If alreadyCalled.[[Value]] is true, return undefined.
+  4. Set alreadyCalled.[[Value]] to true.
+  ...
+---*/
+
+var callCount = 0;
+
+function Constructor(executor) {
+  function resolve(values) {
+    callCount += 1;
+    assert(Array.isArray(values), "values is array");
+    assert.sameValue(values.length, 3, "values length");
+    assert.sameValue(values[0], "p1-fulfill", "values[0]");
+    assert.sameValue(values[1], "p2-fulfill", "values[1]");
+    assert.sameValue(values[2], "p3-fulfill", "values[2]");
+  }
+  executor(resolve, $ERROR);
+}
+Constructor.resolve = function(v) {
+  return v;
+};
+
+var p1OnFulfilled;
+
+var p1 = {
+  then(onFulfilled, onRejected) {
+    p1OnFulfilled = onFulfilled;
+  }
+};
+var p2 = {
+  then(onFulfilled, onRejected) {
+    onFulfilled("p2-fulfill");
+    onFulfilled("p2-fulfill-unexpected");
+  }
+};
+var p3 = {
+  then(onFulfilled, onRejected) {
+    onFulfilled("p3-fulfill");
+  }
+};
+
+assert.sameValue(callCount, 0, "callCount before call to all()");
+
+Promise.allSettled.call(Constructor, [p1, p2, p3]);
+
+assert.sameValue(callCount, 0, "callCount after call to all()");
+
+p1OnFulfilled("p1-fulfill");
+
+assert.sameValue(callCount, 1, "callCount after resolving p1");

--- a/test/built-ins/Promise/allSettled/resolve-before-loop-exit-from-same.js
+++ b/test/built-ins/Promise/allSettled/resolve-before-loop-exit-from-same.js
@@ -61,22 +61,22 @@ var p1 = {
 };
 var p2 = {
   then(onFulfilled, onRejected) {
-    onFulfilled("p2-fulfill");
-    onFulfilled("p2-fulfill-unexpected");
+    onFulfilled('p2-fulfill');
+    onFulfilled('p2-fulfill-unexpected');
   }
 };
 var p3 = {
   then(onFulfilled, onRejected) {
-    onFulfilled("p3-fulfill");
+    onFulfilled('p3-fulfill');
   }
 };
 
-assert.sameValue(callCount, 0, "callCount before call to all()");
+assert.sameValue(callCount, 0, 'callCount before call to all()');
 
 Promise.allSettled.call(Constructor, [p1, p2, p3]);
 
-assert.sameValue(callCount, 0, "callCount after call to all()");
+assert.sameValue(callCount, 0, 'callCount after call to all()');
 
-p1OnFulfilled("p1-fulfill");
+p1OnFulfilled('p1-fulfill');
 
-assert.sameValue(callCount, 1, "callCount after resolving p1");
+assert.sameValue(callCount, 1, 'callCount after resolving p1');

--- a/test/built-ins/Promise/allSettled/resolve-before-loop-exit-from-same.js
+++ b/test/built-ins/Promise/allSettled/resolve-before-loop-exit-from-same.js
@@ -23,6 +23,7 @@ info: |
   3. If alreadyCalled.[[Value]] is true, return undefined.
   4. Set alreadyCalled.[[Value]] to true.
   ...
+includes: [promiseHelper.js]
 ---*/
 
 var callCount = 0;
@@ -30,11 +31,20 @@ var callCount = 0;
 function Constructor(executor) {
   function resolve(values) {
     callCount += 1;
-    assert(Array.isArray(values), "values is array");
-    assert.sameValue(values.length, 3, "values length");
-    assert.sameValue(values[0], "p1-fulfill", "values[0]");
-    assert.sameValue(values[1], "p2-fulfill", "values[1]");
-    assert.sameValue(values[2], "p3-fulfill", "values[2]");
+    checkSettledPromises(values, [
+      {
+        status: 'fulfilled',
+        value: 'p1-fulfill'
+      },
+      {
+        status: 'fulfilled',
+        value: 'p2-fulfill'
+      },
+      {
+        status: 'fulfilled',
+        value: 'p3-fulfill'
+      }
+    ], 'values');
   }
   executor(resolve, $ERROR);
 }

--- a/test/built-ins/Promise/allSettled/resolve-before-loop-exit.js
+++ b/test/built-ins/Promise/allSettled/resolve-before-loop-exit.js
@@ -24,6 +24,7 @@ info: |
   4. Set alreadyCalled.[[Value]] to true.
   ...
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var callCount = 0;

--- a/test/built-ins/Promise/allSettled/resolve-before-loop-exit.js
+++ b/test/built-ins/Promise/allSettled/resolve-before-loop-exit.js
@@ -61,18 +61,18 @@ var p1 = {
 };
 var p2 = {
   then(onFulfilled, onRejected) {
-    p1OnFulfilled("p1-fulfill");
-    onFulfilled("p2-fulfill");
+    p1OnFulfilled('p1-fulfill');
+    onFulfilled('p2-fulfill');
   }
 };
 var p3 = {
   then(onFulfilled, onRejected) {
-    onFulfilled("p3-fulfill");
+    onFulfilled('p3-fulfill');
   }
 };
 
-assert.sameValue(callCount, 0, "callCount before call to all()");
+assert.sameValue(callCount, 0, 'callCount before call to all()');
 
 Promise.allSettled.call(Constructor, [p1, p2, p3]);
 
-assert.sameValue(callCount, 1, "callCount after call to all()");
+assert.sameValue(callCount, 1, 'callCount after call to all()');

--- a/test/built-ins/Promise/allSettled/resolve-before-loop-exit.js
+++ b/test/built-ins/Promise/allSettled/resolve-before-loop-exit.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-performpromiseallsettled
+description: >
+  Cannot tamper remainingElementsCount when two Promise.allSettled resolve element functions are called in succession.
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  4. Let remainingElementsCount be a new Record { [[Value]]: 1 }.
+  ...
+  6.d ...
+    ii. Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
+    iii. If remainingElementsCount.[[value]] is 0, then
+      1. Let valuesArray be CreateArrayFromList(values).
+      2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+  ...
+
+  Promise.allSettled Resolve Element Functions
+
+  2. Let alreadyCalled be F.[[AlreadyCalled]].
+  3. If alreadyCalled.[[Value]] is true, return undefined.
+  4. Set alreadyCalled.[[Value]] to true.
+  ...
+---*/
+
+var callCount = 0;
+
+function Constructor(executor) {
+  function resolve(values) {
+    callCount += 1;
+    assert(Array.isArray(values), "values is array");
+    assert.sameValue(values.length, 3, "values length");
+    assert.sameValue(values[0], "p1-fulfill", "values[0]");
+    assert.sameValue(values[1], "p2-fulfill", "values[1]");
+    assert.sameValue(values[2], "p3-fulfill", "values[2]");
+  }
+  executor(resolve, $ERROR);
+}
+Constructor.resolve = function(v) {
+  return v;
+};
+
+var p1OnFulfilled;
+
+var p1 = {
+  then(onFulfilled, onRejected) {
+    p1OnFulfilled = onFulfilled;
+  }
+};
+var p2 = {
+  then(onFulfilled, onRejected) {
+    p1OnFulfilled("p1-fulfill");
+    onFulfilled("p2-fulfill");
+  }
+};
+var p3 = {
+  then(onFulfilled, onRejected) {
+    onFulfilled("p3-fulfill");
+  }
+};
+
+assert.sameValue(callCount, 0, "callCount before call to all()");
+
+Promise.allSettled.call(Constructor, [p1, p2, p3]);
+
+assert.sameValue(callCount, 1, "callCount after call to all()");

--- a/test/built-ins/Promise/allSettled/resolve-before-loop-exit.js
+++ b/test/built-ins/Promise/allSettled/resolve-before-loop-exit.js
@@ -23,6 +23,7 @@ info: |
   3. If alreadyCalled.[[Value]] is true, return undefined.
   4. Set alreadyCalled.[[Value]] to true.
   ...
+includes: [promiseHelper.js]
 ---*/
 
 var callCount = 0;
@@ -30,11 +31,20 @@ var callCount = 0;
 function Constructor(executor) {
   function resolve(values) {
     callCount += 1;
-    assert(Array.isArray(values), "values is array");
-    assert.sameValue(values.length, 3, "values length");
-    assert.sameValue(values[0], "p1-fulfill", "values[0]");
-    assert.sameValue(values[1], "p2-fulfill", "values[1]");
-    assert.sameValue(values[2], "p3-fulfill", "values[2]");
+    checkSettledPromises(values, [
+      {
+        status: 'fulfilled',
+        value: 'p1-fulfill'
+      },
+      {
+        status: 'fulfilled',
+        value: 'p2-fulfill'
+      },
+      {
+        status: 'fulfilled',
+        value: 'p3-fulfill'
+      }
+    ], 'values');
   }
   executor(resolve, $ERROR);
 }

--- a/test/built-ins/Promise/allSettled/resolve-element-function-extensible.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-extensible.js
@@ -8,6 +8,7 @@ info: |
   17 ECMAScript Standard Built-in Objects:
     Unless specified otherwise, the [[Extensible]] internal slot
     of a built-in object initially has the value true.
+features: [Promise.allSettled]
 ---*/
 
 var resolveElementFunction;

--- a/test/built-ins/Promise/allSettled/resolve-element-function-extensible.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-extensible.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-resolve-element-functions
+description: The [[Extensible]] slot of Promise.allSettled Resolve Element functions
+info: |
+  17 ECMAScript Standard Built-in Objects:
+    Unless specified otherwise, the [[Extensible]] internal slot
+    of a built-in object initially has the value true.
+---*/
+
+var resolveElementFunction;
+var thenable = {
+  then(fulfill) {
+    resolveElementFunction = fulfill;
+  }
+};
+
+function NotPromise(executor) {
+  executor(function() {}, function() {});
+}
+NotPromise.resolve = function(v) {
+  return v;
+};
+Promise.allSettled.call(NotPromise, [thenable]);
+
+assert(Object.isExtensible(resolveElementFunction));

--- a/test/built-ins/Promise/allSettled/resolve-element-function-length.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-length.js
@@ -12,6 +12,7 @@ info: |
     object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
     [[Configurable]]: true }.
 includes: [propertyHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var resolveElementFunction;

--- a/test/built-ins/Promise/allSettled/resolve-element-function-length.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-length.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-resolve-element-functions
+description: The `length` property of Promise.allSettled Resolve Element functions
+info: |
+  The length property of a Promise.allSettled resolve element function is 1.
+
+  17 ECMAScript Standard Built-in Objects:
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+var resolveElementFunction;
+var thenable = {
+  then(fulfill) {
+    resolveElementFunction = fulfill;
+  }
+};
+
+function NotPromise(executor) {
+  executor(function() {}, function() {});
+}
+NotPromise.resolve = function(v) {
+  return v;
+};
+Promise.allSettled.call(NotPromise, [thenable]);
+
+verifyProperty(resolveElementFunction, 'length', {
+  value: 1,
+  enumerable: false,
+  writable: false,
+  configurable: true,
+});

--- a/test/built-ins/Promise/allSettled/resolve-element-function-name.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-name.js
@@ -29,6 +29,6 @@ NotPromise.resolve = function(v) {
 Promise.allSettled.call(NotPromise, [thenable]);
 
 assert.sameValue(
-  Object.prototype.hasOwnProperty.call(resolveElementFunction, "name"),
+  Object.prototype.hasOwnProperty.call(resolveElementFunction, 'name'),
   false
 );

--- a/test/built-ins/Promise/allSettled/resolve-element-function-name.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-resolve-element-functions
+description: The `name` property of Promise.allSettled Resolve Element functions
+info: |
+  A promise resolve function is an anonymous built-in function.
+
+  17 ECMAScript Standard Built-in Objects:
+    Every built-in Function object, including constructors, that is not
+    identified as an anonymous function has a name property whose value
+    is a String.
+---*/
+
+var resolveElementFunction;
+var thenable = {
+  then(fulfill) {
+    resolveElementFunction = fulfill;
+  }
+};
+
+function NotPromise(executor) {
+  executor(function() {}, function() {});
+}
+NotPromise.resolve = function(v) {
+  return v;
+};
+Promise.allSettled.call(NotPromise, [thenable]);
+
+assert.sameValue(Object.prototype.hasOwnProperty.call(resolveElementFunction, "name"), false);

--- a/test/built-ins/Promise/allSettled/resolve-element-function-name.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-name.js
@@ -11,6 +11,7 @@ info: |
     Every built-in Function object, including constructors, that is not
     identified as an anonymous function has a name property whose value
     is a String.
+features: [Promise.allSettled]
 ---*/
 
 var resolveElementFunction;

--- a/test/built-ins/Promise/allSettled/resolve-element-function-name.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-name.js
@@ -28,4 +28,7 @@ NotPromise.resolve = function(v) {
 };
 Promise.allSettled.call(NotPromise, [thenable]);
 
-assert.sameValue(Object.prototype.hasOwnProperty.call(resolveElementFunction, "name"), false);
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(resolveElementFunction, "name"),
+  false
+);

--- a/test/built-ins/Promise/allSettled/resolve-element-function-nonconstructor.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-nonconstructor.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-resolve-element-functions
+description: Promise.allSettled Resolve Element functions are not constructors
+info: |
+  17 ECMAScript Standard Built-in Objects:
+    Built-in function objects that are not identified as constructors do not
+    implement the [[Construct]] internal method unless otherwise specified
+    in the description of a particular function.
+---*/
+
+var resolveElementFunction;
+var thenable = {
+  then(fulfill) {
+    resolveElementFunction = fulfill;
+  }
+};
+
+function NotPromise(executor) {
+  executor(function() {}, function() {});
+}
+NotPromise.resolve = function(v) {
+  return v;
+};
+Promise.allSettled.call(NotPromise, [thenable]);
+
+assert.sameValue(Object.prototype.hasOwnProperty.call(resolveElementFunction, "prototype"), false);
+assert.throws(TypeError, function() {
+  new resolveElementFunction();
+});

--- a/test/built-ins/Promise/allSettled/resolve-element-function-nonconstructor.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-nonconstructor.js
@@ -9,6 +9,7 @@ info: |
     Built-in function objects that are not identified as constructors do not
     implement the [[Construct]] internal method unless otherwise specified
     in the description of a particular function.
+features: [Promise.allSettled]
 ---*/
 
 var resolveElementFunction;

--- a/test/built-ins/Promise/allSettled/resolve-element-function-nonconstructor.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-nonconstructor.js
@@ -26,7 +26,7 @@ NotPromise.resolve = function(v) {
 };
 Promise.allSettled.call(NotPromise, [thenable]);
 
-assert.sameValue(Object.prototype.hasOwnProperty.call(resolveElementFunction, "prototype"), false);
+assert.sameValue(Object.prototype.hasOwnProperty.call(resolveElementFunction, 'prototype'), false);
 assert.throws(TypeError, function() {
   new resolveElementFunction();
 });

--- a/test/built-ins/Promise/allSettled/resolve-element-function-prototype.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-prototype.js
@@ -10,6 +10,7 @@ info: |
     constructor has the Function prototype object, which is the initial
     value of the expression Function.prototype (19.2.3), as the value of
     its [[Prototype]] internal slot.
+features: [Promise.allSettled]
 ---*/
 
 var resolveElementFunction;

--- a/test/built-ins/Promise/allSettled/resolve-element-function-prototype.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-prototype.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled-resolve-element-functions
+description: The [[Prototype]] of Promise.allSettled Resolve Element functions
+info: |
+  17 ECMAScript Standard Built-in Objects:
+    Unless otherwise specified every built-in function and every built-in
+    constructor has the Function prototype object, which is the initial
+    value of the expression Function.prototype (19.2.3), as the value of
+    its [[Prototype]] internal slot.
+---*/
+
+var resolveElementFunction;
+var thenable = {
+  then(fulfill) {
+    resolveElementFunction = fulfill;
+  }
+};
+
+function NotPromise(executor) {
+  executor(function() {}, function() {});
+}
+NotPromise.resolve = function(v) {
+  return v;
+};
+Promise.allSettled.call(NotPromise, [thenable]);
+
+assert.sameValue(Object.getPrototypeOf(resolveElementFunction), Function.prototype);

--- a/test/built-ins/Promise/allSettled/resolve-from-same-thenable.js
+++ b/test/built-ins/Promise/allSettled/resolve-from-same-thenable.js
@@ -24,6 +24,7 @@ info: |
   4. Set alreadyCalled.[[Value]] to true.
   ...
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var callCount = 0;

--- a/test/built-ins/Promise/allSettled/resolve-from-same-thenable.js
+++ b/test/built-ins/Promise/allSettled/resolve-from-same-thenable.js
@@ -23,6 +23,7 @@ info: |
   3. If alreadyCalled.[[Value]] is true, return undefined.
   4. Set alreadyCalled.[[Value]] to true.
   ...
+includes: [promiseHelper.js]
 ---*/
 
 var callCount = 0;
@@ -30,11 +31,20 @@ var callCount = 0;
 function Constructor(executor) {
   function resolve(values) {
     callCount += 1;
-    assert(Array.isArray(values, "values is array"));
-    assert.sameValue(values.length, 3, "values length");
-    assert.sameValue(values[0], "p1-fulfill", "values[0]");
-    assert.sameValue(values[1], "p2-fulfill", "values[1]");
-    assert.sameValue(values[2], "p3-fulfill", "values[2]");
+    checkSettledPromises(values, [
+      {
+        status: 'fulfilled',
+        value: 'p1-fulfill'
+      },
+      {
+        status: 'fulfilled',
+        value: 'p2-fulfill'
+      },
+      {
+        status: 'fulfilled',
+        value: 'p3-fulfill'
+      }
+    ], 'values');
   }
   executor(resolve, $ERROR);
 }

--- a/test/built-ins/Promise/allSettled/resolve-from-same-thenable.js
+++ b/test/built-ins/Promise/allSettled/resolve-from-same-thenable.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-performpromiseallsettled
+description: >
+  Cannot tamper remainingElementsCount when Promise.allSettled resolve element function is called multiple times.
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  4. Let remainingElementsCount be a new Record { [[Value]]: 1 }.
+  ...
+  6.d ...
+    ii. Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
+    iii. If remainingElementsCount.[[value]] is 0, then
+      1. Let valuesArray be CreateArrayFromList(values).
+      2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+  ...
+
+  Promise.allSettled Resolve Element Functions
+
+  2. Let alreadyCalled be F.[[AlreadyCalled]].
+  3. If alreadyCalled.[[Value]] is true, return undefined.
+  4. Set alreadyCalled.[[Value]] to true.
+  ...
+---*/
+
+var callCount = 0;
+
+function Constructor(executor) {
+  function resolve(values) {
+    callCount += 1;
+    assert(Array.isArray(values, "values is array"));
+    assert.sameValue(values.length, 3, "values length");
+    assert.sameValue(values[0], "p1-fulfill", "values[0]");
+    assert.sameValue(values[1], "p2-fulfill", "values[1]");
+    assert.sameValue(values[2], "p3-fulfill", "values[2]");
+  }
+  executor(resolve, $ERROR);
+}
+Constructor.resolve = function(v) {
+  return v;
+};
+
+var p1OnFulfilled, p2OnFulfilled, p3OnFulfilled;
+
+var p1 = {
+  then(onFulfilled, onRejected) {
+    p1OnFulfilled = onFulfilled;
+  }
+};
+var p2 = {
+  then(onFulfilled, onRejected) {
+    p2OnFulfilled = onFulfilled;
+  }
+};
+var p3 = {
+  then(onFulfilled, onRejected) {
+    p3OnFulfilled = onFulfilled;
+  }
+};
+
+assert.sameValue(callCount, 0, "callCount before call to all()");
+
+Promise.allSettled.call(Constructor, [p1, p2, p3]);
+
+assert.sameValue(callCount, 0, "callCount after call to all()");
+
+p1OnFulfilled("p1-fulfill");
+p1OnFulfilled("p1-fulfill-unexpected-1");
+p1OnFulfilled("p1-fulfill-unexpected-2");
+
+assert.sameValue(callCount, 0, "callCount after resolving p1");
+
+p2OnFulfilled("p2-fulfill");
+p3OnFulfilled("p3-fulfill");
+
+assert.sameValue(callCount, 1, "callCount after resolving all elements");

--- a/test/built-ins/Promise/allSettled/resolve-from-same-thenable.js
+++ b/test/built-ins/Promise/allSettled/resolve-from-same-thenable.js
@@ -70,19 +70,19 @@ var p3 = {
   }
 };
 
-assert.sameValue(callCount, 0, "callCount before call to all()");
+assert.sameValue(callCount, 0, 'callCount before call to all()');
 
 Promise.allSettled.call(Constructor, [p1, p2, p3]);
 
-assert.sameValue(callCount, 0, "callCount after call to all()");
+assert.sameValue(callCount, 0, 'callCount after call to all()');
 
-p1OnFulfilled("p1-fulfill");
-p1OnFulfilled("p1-fulfill-unexpected-1");
-p1OnFulfilled("p1-fulfill-unexpected-2");
+p1OnFulfilled('p1-fulfill');
+p1OnFulfilled('p1-fulfill-unexpected-1');
+p1OnFulfilled('p1-fulfill-unexpected-2');
 
-assert.sameValue(callCount, 0, "callCount after resolving p1");
+assert.sameValue(callCount, 0, 'callCount after resolving p1');
 
-p2OnFulfilled("p2-fulfill");
-p3OnFulfilled("p3-fulfill");
+p2OnFulfilled('p2-fulfill');
+p3OnFulfilled('p3-fulfill');
 
-assert.sameValue(callCount, 1, "callCount after resolving all elements");
+assert.sameValue(callCount, 1, 'callCount after resolving all elements');

--- a/test/built-ins/Promise/allSettled/resolve-non-thenable.js
+++ b/test/built-ins/Promise/allSettled/resolve-non-thenable.js
@@ -10,7 +10,7 @@ info: |
     a. Let valuesArray be ! CreateArrayFromList(values).
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
-includes: [compareArray.js]
+includes: [compareArray.js, promiseHelper.js]
 ---*/
 
 var v1 = {};
@@ -19,15 +19,20 @@ var v3 = {};
 
 Promise.allSettled([v1, v2, v3])
   .then(function(values) {
-    assert.sameValue(Array.isArray(values), true, 'Resolved with an Array instance.');
-    assert.sameValue(values.length, 3, 'value.length');
-    assert.compareArray(Object.keys(values[0]), ['status', 'value']);
-    assert.sameValue(values[0].status, 'fulfilled', 'values[0].status');
-    assert.sameValue(values[0].value, v1, 'values[0].value');
-    assert.sameValue(values[1].status, 'fulfilled', 'values[1].status');
-    assert.sameValue(values[1].value, v2, 'values[1].value');
-    assert.sameValue(values[2].status, 'fulfilled', 'values[2].status');
-    assert.sameValue(values[2].value, v3, 'values[2].value');
+    checkSettledPromises(values, [
+      {
+        status: 'fulfilled',
+        value: v1
+      },
+      {
+        status: 'fulfilled',
+        value: v2
+      },
+      {
+        status: 'fulfilled',
+        value: v3
+      }
+    ], 'values');
   }, function() {
     $DONE('The promise should not be rejected.');
   }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolve-non-thenable.js
+++ b/test/built-ins/Promise/allSettled/resolve-non-thenable.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Resolving with a non-thenable object value
+esid: sec-promise.allsettled
+info: |
+  Promise.allSettled Resolve Element Functions
+
+  14. If remainingElementsCount.[[Value]] is 0, then
+    a. Let valuesArray be ! CreateArrayFromList(values).
+    b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
+flags: [async]
+includes: [compareArray.js]
+---*/
+
+var v1 = {};
+var v2 = {};
+var v3 = {};
+
+Promise.allSettled([v1, v2, v3])
+  .then(function(values) {
+    assert.sameValue(Array.isArray(values), true, 'Resolved with an Array instance.');
+    assert.sameValue(values.length, 3, 'value.length');
+    assert.compareArray(Object.keys(values[0]), ['status', 'value']);
+    assert.sameValue(values[0].status, 'fulfilled', 'values[0].status');
+    assert.sameValue(values[0].value, v1, 'values[0].value');
+    assert.sameValue(values[1].status, 'fulfilled', 'values[1].status');
+    assert.sameValue(values[1].value, v2, 'values[1].value');
+    assert.sameValue(values[2].status, 'fulfilled', 'values[2].status');
+    assert.sameValue(values[2].value, v3, 'values[2].value');
+  }, function() {
+    $DONE('The promise should not be rejected.');
+  }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolve-non-thenable.js
+++ b/test/built-ins/Promise/allSettled/resolve-non-thenable.js
@@ -11,6 +11,7 @@ info: |
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
 includes: [compareArray.js, promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var v1 = {};

--- a/test/built-ins/Promise/allSettled/resolve-poisoned-then.js
+++ b/test/built-ins/Promise/allSettled/resolve-poisoned-then.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Resolving with an object with a "poisoned" `then` property
+esid: sec-promise.allsettled
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  4. Let remainingElementsCount be a new Record { [[Value]]: 1 }.
+  ...
+  6.d ...
+    ii. Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
+    iii. If remainingElementsCount.[[value]] is 0, then
+      1. Let valuesArray be CreateArrayFromList(values).
+      2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+  ...
+flags: [async]
+---*/
+
+var value = {};
+var promise;
+
+try {
+  Object.defineProperty(Array.prototype, 'then', {
+    get() {
+      throw value;
+    },
+    configurable: true
+  });
+
+  promise = Promise.allSettled([]);
+} finally {
+  delete Array.prototype.then;
+}
+
+promise.then(function() {
+  $DONE('The promise should not be fulfilled.');
+}, function(val) {
+  if (val !== value) {
+    $DONE('The promise should be rejected with the expected value.');
+    return;
+  }
+
+  $DONE();
+});

--- a/test/built-ins/Promise/allSettled/resolve-poisoned-then.js
+++ b/test/built-ins/Promise/allSettled/resolve-poisoned-then.js
@@ -15,6 +15,7 @@ info: |
       2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
   ...
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/allSettled/resolve-thenable.js
+++ b/test/built-ins/Promise/allSettled/resolve-thenable.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Resolving with a thenable object value
+esid: sec-promise.allsettled
+info: |
+  Let promiseCapability be NewPromiseCapability(C).
+flags: [async]
+---*/
+
+var value = {};
+var promise;
+
+try {
+  Array.prototype.then = function(resolve) {
+    resolve(value);
+  };
+
+  promise = Promise.allSettled([]);
+} finally {
+  delete Array.prototype.then;
+}
+
+promise.then(function(val) {
+  assert.sameValue(val, value);
+}, function() {
+  $DONE('The promise should not be rejected.');
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolve-thenable.js
+++ b/test/built-ins/Promise/allSettled/resolve-thenable.js
@@ -6,6 +6,7 @@ esid: sec-promise.allsettled
 info: |
   Let promiseCapability be NewPromiseCapability(C).
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var value = {};

--- a/test/built-ins/Promise/allSettled/resolved-all-fulfilled.js
+++ b/test/built-ins/Promise/allSettled/resolved-all-fulfilled.js
@@ -41,6 +41,7 @@ info: |
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Promise/allSettled/resolved-all-fulfilled.js
+++ b/test/built-ins/Promise/allSettled/resolved-all-fulfilled.js
@@ -40,6 +40,7 @@ info: |
     a. Let valuesArray be CreateArrayFromList(values).
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
+includes: [promiseHelper.js]
 ---*/
 
 var obj = {};
@@ -54,11 +55,9 @@ var p3 = new Promise(function(resolve) {
 });
 
 Promise.allSettled([p1, p2, p3]).then(function(settled) {
-  assert.sameValue(settled.length, 3);
-  assert.sameValue(settled[0].value, 1);
-  assert.sameValue(settled[0].status, 'fulfilled');
-  assert.sameValue(settled[1].value, 'test262');
-  assert.sameValue(settled[1].status, 'fulfilled');
-  assert.sameValue(settled[2].value, obj);
-  assert.sameValue(settled[2].status, 'fulfilled');
+  checkSettledPromises(settled, [
+    { status: 'fulfilled', value: 1 },
+    { status: 'fulfilled', value: 'test262' },
+    { status: 'fulfilled', value: obj }
+  ], 'settled');
 }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolved-all-fulfilled.js
+++ b/test/built-ins/Promise/allSettled/resolved-all-fulfilled.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Resolution is a collection of all the settled values (all fulfilled)
+info: |
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat,
+    ...
+    j. Let steps be the algorithm steps defined in Promise.allSettled Resolve Element Functions.
+    k. Let resolveElement be ! CreateBuiltinFunction(steps, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
+    ...
+    r. Let rejectSteps be the algorithm steps defined in Promise.allSettled Reject Element Functions.
+    s. Let rejectElement be ! CreateBuiltinFunction(rejectSteps, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
+    ...
+    z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+
+  Promise.allSettled Resolve Element Functions
+
+  9. Let obj be ! ObjectCreate(%ObjectPrototype%).
+  10. Perform ! CreateDataProperty(obj, "status", "fulfilled").
+  11. Perform ! CreateDataProperty(obj, "value", x).
+  12. Set values[index] to be obj.
+  13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
+  14. If remainingElementsCount.[[Value]] is 0, then
+    a. Let valuesArray be ! CreateArrayFromList(values).
+    b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
+
+  Promise.allSettled Reject Element Functions
+
+  9. Let obj be ! ObjectCreate(%ObjectPrototype%).
+  10. Perform ! CreateDataProperty(obj, "status", "rejected").
+  11. Perform ! CreateDataProperty(obj, "reason", x).
+  12. Set values[index] to be obj.
+  13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
+  14. If remainingElementsCount.[[Value]] is 0, then
+    a. Let valuesArray be CreateArrayFromList(values).
+    b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
+flags: [async]
+---*/
+
+var obj = {};
+var p1 = new Promise(function(resolve) {
+  resolve(1);
+});
+var p2 = new Promise(function(resolve) {
+  resolve('test262');
+});
+var p3 = new Promise(function(resolve) {
+  resolve(obj);
+});
+
+Promise.allSettled([p1, p2, p3]).then(function(settled) {
+  assert.sameValue(settled.length, 3);
+  assert.sameValue(settled[0].value, 1);
+  assert.sameValue(settled[0].status, 'fulfilled');
+  assert.sameValue(settled[1].value, 'test262');
+  assert.sameValue(settled[1].status, 'fulfilled');
+  assert.sameValue(settled[2].value, obj);
+  assert.sameValue(settled[2].status, 'fulfilled');
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolved-all-mixed.js
+++ b/test/built-ins/Promise/allSettled/resolved-all-mixed.js
@@ -40,6 +40,7 @@ info: |
     a. Let valuesArray be CreateArrayFromList(values).
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
+includes: [promiseHelper.js]
 ---*/
 
 var obj1 = {};
@@ -64,23 +65,12 @@ var f3 = new Promise(function(resolve) {
 });
 
 Promise.allSettled([r1, f1, f2, r2, r3, f3]).then(function(settled) {
-  assert.sameValue(settled.length, 6);
-  // r1
-  assert.sameValue(settled[0].reason, 1);
-  assert.sameValue(settled[0].status, 'rejected');
-  // f1
-  assert.sameValue(settled[1].value, 2);
-  assert.sameValue(settled[1].status, 'fulfilled');
-  // f2
-  assert.sameValue(settled[2].value, 'tc39');
-  assert.sameValue(settled[2].status, 'fulfilled');
-  // r2
-  assert.sameValue(settled[3].reason, 'test262');
-  assert.sameValue(settled[3].status, 'rejected');
-  // r3
-  assert.sameValue(settled[4].reason, obj1);
-  assert.sameValue(settled[4].status, 'rejected');
-  // r4
-  assert.sameValue(settled[5].value, obj2);
-  assert.sameValue(settled[5].status, 'fulfilled');
+  checkSettledPromises(settled, [
+    { status: 'rejected', reason: 1 },
+    { status: 'fulfilled', value: 2 },
+    { status: 'fulfilled', value: 'tc39' },
+    { status: 'rejected', reason: 'test262' },
+    { status: 'rejected', reason: obj1 },
+    { status: 'fulfilled', value: obj2 }
+  ], 'settled');
 }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolved-all-mixed.js
+++ b/test/built-ins/Promise/allSettled/resolved-all-mixed.js
@@ -1,0 +1,86 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Resolution is a collection of all the settled values (fulfilled and rejected)
+info: |
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat,
+    ...
+    j. Let steps be the algorithm steps defined in Promise.allSettled Resolve Element Functions.
+    k. Let resolveElement be ! CreateBuiltinFunction(steps, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
+    ...
+    r. Let rejectSteps be the algorithm steps defined in Promise.allSettled Reject Element Functions.
+    s. Let rejectElement be ! CreateBuiltinFunction(rejectSteps, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
+    ...
+    z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+
+  Promise.allSettled Resolve Element Functions
+
+  9. Let obj be ! ObjectCreate(%ObjectPrototype%).
+  10. Perform ! CreateDataProperty(obj, "status", "fulfilled").
+  11. Perform ! CreateDataProperty(obj, "value", x).
+  12. Set values[index] to be obj.
+  13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
+  14. If remainingElementsCount.[[Value]] is 0, then
+    a. Let valuesArray be ! CreateArrayFromList(values).
+    b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
+
+  Promise.allSettled Reject Element Functions
+
+  9. Let obj be ! ObjectCreate(%ObjectPrototype%).
+  10. Perform ! CreateDataProperty(obj, "status", "rejected").
+  11. Perform ! CreateDataProperty(obj, "reason", x).
+  12. Set values[index] to be obj.
+  13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
+  14. If remainingElementsCount.[[Value]] is 0, then
+    a. Let valuesArray be CreateArrayFromList(values).
+    b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
+flags: [async]
+---*/
+
+var obj1 = {};
+var obj2 = {};
+var r1 = new Promise(function(_, reject) {
+  reject(1);
+});
+var f1 = new Promise(function(resolve) {
+  resolve(2);
+});
+var f2 = new Promise(function(resolve) {
+  resolve('tc39');
+});
+var r2 = new Promise(function(_, reject) {
+  reject('test262');
+});
+var r3 = new Promise(function(_, reject) {
+  reject(obj1);
+});
+var f3 = new Promise(function(resolve) {
+  resolve(obj2);
+});
+
+Promise.allSettled([r1, f1, f2, r2, r3, f3]).then(function(settled) {
+  assert.sameValue(settled.length, 6);
+  // r1
+  assert.sameValue(settled[0].reason, 1);
+  assert.sameValue(settled[0].status, 'rejected');
+  // f1
+  assert.sameValue(settled[1].value, 2);
+  assert.sameValue(settled[1].status, 'fulfilled');
+  // f2
+  assert.sameValue(settled[2].value, 'tc39');
+  assert.sameValue(settled[2].status, 'fulfilled');
+  // r2
+  assert.sameValue(settled[3].reason, 'test262');
+  assert.sameValue(settled[3].status, 'rejected');
+  // r3
+  assert.sameValue(settled[4].reason, obj1);
+  assert.sameValue(settled[4].status, 'rejected');
+  // r4
+  assert.sameValue(settled[5].value, obj2);
+  assert.sameValue(settled[5].status, 'fulfilled');
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolved-all-mixed.js
+++ b/test/built-ins/Promise/allSettled/resolved-all-mixed.js
@@ -41,6 +41,7 @@ info: |
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var obj1 = {};

--- a/test/built-ins/Promise/allSettled/resolved-all-rejected.js
+++ b/test/built-ins/Promise/allSettled/resolved-all-rejected.js
@@ -41,6 +41,7 @@ info: |
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Promise/allSettled/resolved-all-rejected.js
+++ b/test/built-ins/Promise/allSettled/resolved-all-rejected.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Resolution is a collection of all the settled values (fulfiled and rejected promises)
+info: |
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat,
+    ...
+    j. Let steps be the algorithm steps defined in Promise.allSettled Resolve Element Functions.
+    k. Let resolveElement be ! CreateBuiltinFunction(steps, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
+    ...
+    r. Let rejectSteps be the algorithm steps defined in Promise.allSettled Reject Element Functions.
+    s. Let rejectElement be ! CreateBuiltinFunction(rejectSteps, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
+    ...
+    z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+
+  Promise.allSettled Resolve Element Functions
+
+  9. Let obj be ! ObjectCreate(%ObjectPrototype%).
+  10. Perform ! CreateDataProperty(obj, "status", "fulfilled").
+  11. Perform ! CreateDataProperty(obj, "value", x).
+  12. Set values[index] to be obj.
+  13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
+  14. If remainingElementsCount.[[Value]] is 0, then
+    a. Let valuesArray be ! CreateArrayFromList(values).
+    b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
+
+  Promise.allSettled Reject Element Functions
+
+  9. Let obj be ! ObjectCreate(%ObjectPrototype%).
+  10. Perform ! CreateDataProperty(obj, "status", "rejected").
+  11. Perform ! CreateDataProperty(obj, "reason", x).
+  12. Set values[index] to be obj.
+  13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
+  14. If remainingElementsCount.[[Value]] is 0, then
+    a. Let valuesArray be CreateArrayFromList(values).
+    b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
+flags: [async]
+---*/
+
+var obj = {};
+var p1 = new Promise(function(_, reject) {
+  reject(1);
+});
+var p2 = new Promise(function(_, reject) {
+  reject('test262');
+});
+var p3 = new Promise(function(_, reject) {
+  reject(obj);
+});
+
+Promise.allSettled([p1, p2, p3]).then(function(settled) {
+  assert.sameValue(settled.length, 3);
+  assert.sameValue(settled[0].reason, 1);
+  assert.sameValue(settled[0].status, 'rejected');
+  assert.sameValue(settled[1].reason, 'test262');
+  assert.sameValue(settled[1].status, 'rejected');
+  assert.sameValue(settled[2].reason, obj);
+  assert.sameValue(settled[2].status, 'rejected');
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolved-all-rejected.js
+++ b/test/built-ins/Promise/allSettled/resolved-all-rejected.js
@@ -40,6 +40,7 @@ info: |
     a. Let valuesArray be CreateArrayFromList(values).
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
+includes: [promiseHelper.js]
 ---*/
 
 var obj = {};
@@ -54,11 +55,9 @@ var p3 = new Promise(function(_, reject) {
 });
 
 Promise.allSettled([p1, p2, p3]).then(function(settled) {
-  assert.sameValue(settled.length, 3);
-  assert.sameValue(settled[0].reason, 1);
-  assert.sameValue(settled[0].status, 'rejected');
-  assert.sameValue(settled[1].reason, 'test262');
-  assert.sameValue(settled[1].status, 'rejected');
-  assert.sameValue(settled[2].reason, obj);
-  assert.sameValue(settled[2].status, 'rejected');
+  checkSettledPromises(settled, [
+    { status: 'rejected', reason: 1 },
+    { status: 'rejected', reason: 'test262' },
+    { status: 'rejected', reason: obj }
+  ], 'settled');
 }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolved-immed.js
+++ b/test/built-ins/Promise/allSettled/resolved-immed.js
@@ -6,6 +6,7 @@ esid: sec-promise.allsettled
 description: Promise.allSettled([]) returns immediately
 includes: [promiseHelper.js]
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/allSettled/resolved-immed.js
+++ b/test/built-ins/Promise/allSettled/resolved-immed.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: Promise.allSettled([]) returns immediately
+includes: [promiseHelper.js]
+flags: [async]
+---*/
+
+var sequence = [];
+
+Promise.allSettled([]).then(function() {
+  sequence.push(2);
+}).catch($DONE);
+
+Promise.resolve().then(function() {
+  sequence.push(3);
+}).then(function() {
+  sequence.push(4);
+  checkSequence(sequence, "Promises resolved in unexpected sequence");
+}).then($DONE, $DONE);
+
+sequence.push(1);

--- a/test/built-ins/Promise/allSettled/resolved-immed.js
+++ b/test/built-ins/Promise/allSettled/resolved-immed.js
@@ -18,7 +18,7 @@ Promise.resolve().then(function() {
   sequence.push(3);
 }).then(function() {
   sequence.push(4);
-  checkSequence(sequence, "Promises resolved in unexpected sequence");
+  checkSequence(sequence, 'Promises resolved in unexpected sequence');
 }).then($DONE, $DONE);
 
 sequence.push(1);

--- a/test/built-ins/Promise/allSettled/resolved-sequence-extra-ticks.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence-extra-ticks.js
@@ -29,15 +29,15 @@ sequence.push(1);
 
 Promise.allSettled([p1]).then(function(resolved) {
   sequence.push(4);
-  checkSequence(sequence, "Expected Promise.allSettled().then to queue second");
+  checkSequence(sequence, 'Expected Promise.allSettled().then to queue second');
 }).catch($DONE);
 
 p1.then(function() {
   sequence.push(3);
-  checkSequence(sequence, "Expected p1.then to queue first");
+  checkSequence(sequence, 'Expected p1.then to queue first');
 }).then(function() {
   sequence.push(5);
-  checkSequence(sequence, "Expected final then to queue last");
+  checkSequence(sequence, 'Expected final then to queue last');
 }).then($DONE, $DONE);
 
 sequence.push(2);

--- a/test/built-ins/Promise/allSettled/resolved-sequence-extra-ticks.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence-extra-ticks.js
@@ -17,6 +17,7 @@ info: |
   ...
 flags: [async]
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/allSettled/resolved-sequence-extra-ticks.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence-extra-ticks.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: Resolution ticks are set in a predictable sequence with extra then calls
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  4. Let remainingElementsCount be a new Record { [[Value]]: 1 }.
+  ...
+  6.d ...
+    ii. Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
+    iii. If remainingElementsCount.[[value]] is 0, then
+      1. Let valuesArray be CreateArrayFromList(values).
+      2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+  ...
+flags: [async]
+includes: [promiseHelper.js]
+---*/
+
+var sequence = [];
+
+var p1 = new Promise(function(resolve) {
+  resolve({});
+});
+
+sequence.push(1);
+
+Promise.allSettled([p1]).then(function(resolved) {
+  sequence.push(4);
+  checkSequence(sequence, "Expected Promise.allSettled().then to queue second");
+}).catch($DONE);
+
+p1.then(function() {
+  sequence.push(3);
+  checkSequence(sequence, "Expected p1.then to queue first");
+}).then(function() {
+  sequence.push(5);
+  checkSequence(sequence, "Expected final then to queue last");
+}).then($DONE, $DONE);
+
+sequence.push(2);

--- a/test/built-ins/Promise/allSettled/resolved-sequence-mixed.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence-mixed.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Resolution ticks are set in a predictable sequence of mixed fulfilled and rejected promises
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  4. Let remainingElementsCount be a new Record { [[Value]]: 1 }.
+  ...
+  6.d ...
+    ii. Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
+    iii. If remainingElementsCount.[[value]] is 0, then
+      1. Let valuesArray be CreateArrayFromList(values).
+      2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+  ...
+flags: [async]
+includes: [promiseHelper.js]
+---*/
+
+var sequence = [];
+
+var p1 = new Promise(function(_, reject) {
+  reject('');
+});
+var p2 = new Promise(function(resolve) {
+  resolve('');
+});
+var p3 = new Promise(function(_, reject) {
+  reject('');
+});
+
+sequence.push(1);
+
+p1.catch(function() {
+  sequence.push(3);
+  checkSequence(sequence, "Expected to be called first.");
+}).catch($DONE);
+
+Promise.allSettled([p1, p2, p3]).then(function() {
+  sequence.push(6);
+  checkSequence(sequence, "Expected to be called fourth.");
+}).then($DONE, $DONE);
+
+p2.then(function() {
+  sequence.push(4);
+  checkSequence(sequence, "Expected to be called second.");
+}).catch($DONE);
+
+sequence.push(2);
+
+p3.catch(function() {
+  sequence.push(5);
+  checkSequence(sequence, "Expected to be called third.");
+}).catch($DONE);

--- a/test/built-ins/Promise/allSettled/resolved-sequence-mixed.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence-mixed.js
@@ -18,6 +18,7 @@ info: |
   ...
 flags: [async]
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/allSettled/resolved-sequence-mixed.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence-mixed.js
@@ -36,22 +36,22 @@ sequence.push(1);
 
 p1.catch(function() {
   sequence.push(3);
-  checkSequence(sequence, "Expected to be called first.");
+  checkSequence(sequence, 'Expected to be called first.');
 }).catch($DONE);
 
 Promise.allSettled([p1, p2, p3]).then(function() {
   sequence.push(6);
-  checkSequence(sequence, "Expected to be called fourth.");
+  checkSequence(sequence, 'Expected to be called fourth.');
 }).then($DONE, $DONE);
 
 p2.then(function() {
   sequence.push(4);
-  checkSequence(sequence, "Expected to be called second.");
+  checkSequence(sequence, 'Expected to be called second.');
 }).catch($DONE);
 
 sequence.push(2);
 
 p3.catch(function() {
   sequence.push(5);
-  checkSequence(sequence, "Expected to be called third.");
+  checkSequence(sequence, 'Expected to be called third.');
 }).catch($DONE);

--- a/test/built-ins/Promise/allSettled/resolved-sequence-with-rejections.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence-with-rejections.js
@@ -17,6 +17,7 @@ info: |
   ...
 flags: [async]
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/allSettled/resolved-sequence-with-rejections.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence-with-rejections.js
@@ -32,17 +32,17 @@ sequence.push(1);
 
 p1.catch(function() {
   sequence.push(3);
-  checkSequence(sequence, "Expected to be called first.");
+  checkSequence(sequence, 'Expected to be called first.');
 }).catch($DONE);
 
 Promise.allSettled([p1, p2]).then(function() {
   sequence.push(5);
-  checkSequence(sequence, "Expected to be called third.");
+  checkSequence(sequence, 'Expected to be called third.');
 }).then($DONE, $DONE);
 
 p2.catch(function() {
   sequence.push(4);
-  checkSequence(sequence, "Expected to be called second.");
+  checkSequence(sequence, 'Expected to be called second.');
 }).catch($DONE);
 
 sequence.push(2);

--- a/test/built-ins/Promise/allSettled/resolved-sequence-with-rejections.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence-with-rejections.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: Resolution ticks are set in a predictable sequence
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  4. Let remainingElementsCount be a new Record { [[Value]]: 1 }.
+  ...
+  6.d ...
+    ii. Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
+    iii. If remainingElementsCount.[[value]] is 0, then
+      1. Let valuesArray be CreateArrayFromList(values).
+      2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+  ...
+flags: [async]
+includes: [promiseHelper.js]
+---*/
+
+var sequence = [];
+
+var p1 = new Promise(function(_, reject) {
+  reject('foo');
+});
+var p2 = new Promise(function(_, reject) {
+  reject('bar');
+});
+
+sequence.push(1);
+
+p1.catch(function() {
+  sequence.push(3);
+  checkSequence(sequence, "Expected to be called first.");
+}).catch($DONE);
+
+Promise.allSettled([p1, p2]).then(function() {
+  sequence.push(5);
+  checkSequence(sequence, "Expected to be called third.");
+}).then($DONE, $DONE);
+
+p2.catch(function() {
+  sequence.push(4);
+  checkSequence(sequence, "Expected to be called second.");
+}).catch($DONE);
+
+sequence.push(2);

--- a/test/built-ins/Promise/allSettled/resolved-sequence.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence.js
@@ -17,6 +17,7 @@ info: |
   ...
 flags: [async]
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var sequence = [];

--- a/test/built-ins/Promise/allSettled/resolved-sequence.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: Resolution ticks are set in a predictable sequence
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  4. Let remainingElementsCount be a new Record { [[Value]]: 1 }.
+  ...
+  6.d ...
+    ii. Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
+    iii. If remainingElementsCount.[[value]] is 0, then
+      1. Let valuesArray be CreateArrayFromList(values).
+      2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+  ...
+flags: [async]
+includes: [promiseHelper.js]
+---*/
+
+var sequence = [];
+
+var p1 = new Promise(function(resolve) {
+  resolve(1);
+});
+var p2 = new Promise(function(resolve) {
+  resolve(2);
+});
+
+sequence.push(1);
+
+p1.then(function() {
+  sequence.push(3);
+  checkSequence(sequence, "Expected to be called first.");
+}).catch($DONE);
+
+Promise.allSettled([p1, p2]).then(function() {
+  sequence.push(5);
+  checkSequence(sequence, "Expected to be called third.");
+}).then($DONE, $DONE);
+
+p2.then(function() {
+  sequence.push(4);
+  checkSequence(sequence, "Expected to be called second.");
+}).catch($DONE);
+
+sequence.push(2);

--- a/test/built-ins/Promise/allSettled/resolved-sequence.js
+++ b/test/built-ins/Promise/allSettled/resolved-sequence.js
@@ -32,17 +32,17 @@ sequence.push(1);
 
 p1.then(function() {
   sequence.push(3);
-  checkSequence(sequence, "Expected to be called first.");
+  checkSequence(sequence, 'Expected to be called first.');
 }).catch($DONE);
 
 Promise.allSettled([p1, p2]).then(function() {
   sequence.push(5);
-  checkSequence(sequence, "Expected to be called third.");
+  checkSequence(sequence, 'Expected to be called third.');
 }).then($DONE, $DONE);
 
 p2.then(function() {
   sequence.push(4);
-  checkSequence(sequence, "Expected to be called second.");
+  checkSequence(sequence, 'Expected to be called second.');
 }).catch($DONE);
 
 sequence.push(2);

--- a/test/built-ins/Promise/allSettled/resolved-then-catch-finally.js
+++ b/test/built-ins/Promise/allSettled/resolved-then-catch-finally.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: >
+  Resolution is a collection of all the settled values (all fulfilled)
+info: |
+  Runtime Semantics: PerformPromiseAllSettled
+
+  6. Repeat,
+    ...
+    j. Let steps be the algorithm steps defined in Promise.allSettled Resolve Element Functions.
+    k. Let resolveElement be ! CreateBuiltinFunction(steps, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
+    ...
+    r. Let rejectSteps be the algorithm steps defined in Promise.allSettled Reject Element Functions.
+    s. Let rejectElement be ! CreateBuiltinFunction(rejectSteps, « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
+    ...
+    z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+
+  Promise.allSettled Resolve Element Functions
+
+  9. Let obj be ! ObjectCreate(%ObjectPrototype%).
+  10. Perform ! CreateDataProperty(obj, "status", "fulfilled").
+  11. Perform ! CreateDataProperty(obj, "value", x).
+  12. Set values[index] to be obj.
+  13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
+  14. If remainingElementsCount.[[Value]] is 0, then
+    a. Let valuesArray be ! CreateArrayFromList(values).
+    b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
+
+  Promise.allSettled Reject Element Functions
+
+  9. Let obj be ! ObjectCreate(%ObjectPrototype%).
+  10. Perform ! CreateDataProperty(obj, "status", "rejected").
+  11. Perform ! CreateDataProperty(obj, "reason", x).
+  12. Set values[index] to be obj.
+  13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
+  14. If remainingElementsCount.[[Value]] is 0, then
+    a. Let valuesArray be CreateArrayFromList(values).
+    b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
+flags: [async]
+---*/
+
+var p0 = Promise.resolve(2).then(v => v + 1);
+var p1 = Promise.reject(21).catch(v => v * 2);
+var p2 = Promise.resolve('nope').then(() => { throw 'foo' });
+var p3 = Promise.reject('yes').then(() => { throw 'nope'; });
+var p4 = Promise.resolve('here').finally(() => 'nope');
+var p5 = Promise.reject('here too').finally(() => 'nope');
+var p6 = Promise.resolve('nope').finally(() => { throw 'finally'; });
+var p7 = Promise.reject('nope').finally(() => { throw 'finally after rejected'; });
+var p8 = Promise.reject(1).then(() => 'nope', () => 0);
+
+Promise.allSettled([p0, p1, p2, p3, p4, p5, p6, p7, p8]).then(function(settled) {
+  assert.sameValue(settled.length, 9);
+
+  assert.sameValue(settled[0].value, 3);
+  assert.sameValue(settled[0].status, 'fulfilled');
+
+  assert.sameValue(settled[1].value, 42);
+  assert.sameValue(settled[1].status, 'fulfilled');
+
+  assert.sameValue(settled[2].reason, 'foo');
+  assert.sameValue(settled[2].status, 'rejected');
+
+  assert.sameValue(settled[3].reason, 'yes');
+  assert.sameValue(settled[3].status, 'rejected');
+
+  assert.sameValue(settled[4].value, 'here');
+  assert.sameValue(settled[4].status, 'fulfilled');
+
+  assert.sameValue(settled[5].reason, 'here too');
+  assert.sameValue(settled[5].status, 'rejected');
+
+  assert.sameValue(settled[6].reason, 'finally');
+  assert.sameValue(settled[6].status, 'rejected');
+
+  assert.sameValue(settled[7].reason, 'finally after rejected');
+  assert.sameValue(settled[7].status, 'rejected');
+
+  assert.sameValue(settled[8].value, 0);
+  assert.sameValue(settled[8].status, 'fulfilled');
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolved-then-catch-finally.js
+++ b/test/built-ins/Promise/allSettled/resolved-then-catch-finally.js
@@ -40,6 +40,7 @@ info: |
     a. Let valuesArray be CreateArrayFromList(values).
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
+includes: [promiseHelper.js]
 ---*/
 
 var p0 = Promise.resolve(2).then(v => v + 1);
@@ -53,32 +54,15 @@ var p7 = Promise.reject('nope').finally(() => { throw 'finally after rejected'; 
 var p8 = Promise.reject(1).then(() => 'nope', () => 0);
 
 Promise.allSettled([p0, p1, p2, p3, p4, p5, p6, p7, p8]).then(function(settled) {
-  assert.sameValue(settled.length, 9);
-
-  assert.sameValue(settled[0].value, 3);
-  assert.sameValue(settled[0].status, 'fulfilled');
-
-  assert.sameValue(settled[1].value, 42);
-  assert.sameValue(settled[1].status, 'fulfilled');
-
-  assert.sameValue(settled[2].reason, 'foo');
-  assert.sameValue(settled[2].status, 'rejected');
-
-  assert.sameValue(settled[3].reason, 'yes');
-  assert.sameValue(settled[3].status, 'rejected');
-
-  assert.sameValue(settled[4].value, 'here');
-  assert.sameValue(settled[4].status, 'fulfilled');
-
-  assert.sameValue(settled[5].reason, 'here too');
-  assert.sameValue(settled[5].status, 'rejected');
-
-  assert.sameValue(settled[6].reason, 'finally');
-  assert.sameValue(settled[6].status, 'rejected');
-
-  assert.sameValue(settled[7].reason, 'finally after rejected');
-  assert.sameValue(settled[7].status, 'rejected');
-
-  assert.sameValue(settled[8].value, 0);
-  assert.sameValue(settled[8].status, 'fulfilled');
+  checkSettledPromises(settled, [
+    { status: 'fulfilled', value: 3 },
+    { status: 'fulfilled', value: 42 },
+    { status: 'rejected', reason: 'foo' },
+    { status: 'rejected', reason: 'yes' },
+    { status: 'fulfilled', value: 'here' },
+    { status: 'rejected', reason: 'here too' },
+    { status: 'rejected', reason: 'finally' },
+    { status: 'rejected', reason: 'finally after rejected' },
+    { status: 'fulfilled', value: 0 },
+  ], 'settled');
 }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolved-then-catch-finally.js
+++ b/test/built-ins/Promise/allSettled/resolved-then-catch-finally.js
@@ -41,6 +41,7 @@ info: |
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var p0 = Promise.resolve(2).then(v => v + 1);

--- a/test/built-ins/Promise/allSettled/resolves-empty-array.js
+++ b/test/built-ins/Promise/allSettled/resolves-empty-array.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: Promise.allSettled([]) returns a Promise for an empty array
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  4. Let remainingElementsCount be a new Record { [[Value]]: 1 }.
+  ...
+  6.d ...
+    ii. Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
+    iii. If remainingElementsCount.[[value]] is 0, then
+      1. Let valuesArray be CreateArrayFromList(values).
+      2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+  ...
+flags: [async]
+---*/
+
+var arg = [];
+
+Promise.allSettled(arg).then(function(result) {
+  assert.sameValue(result.length, 0);
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolves-empty-array.js
+++ b/test/built-ins/Promise/allSettled/resolves-empty-array.js
@@ -16,10 +16,11 @@ info: |
       2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
   ...
 flags: [async]
+includes: [promiseHelper.js]
 ---*/
 
 var arg = [];
 
 Promise.allSettled(arg).then(function(result) {
-  assert.sameValue(result.length, 0);
+  checkSettledPromises(result, []);
 }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolves-empty-array.js
+++ b/test/built-ins/Promise/allSettled/resolves-empty-array.js
@@ -17,6 +17,7 @@ info: |
   ...
 flags: [async]
 includes: [promiseHelper.js]
+features: [Promise.allSettled]
 ---*/
 
 var arg = [];

--- a/test/built-ins/Promise/allSettled/resolves-to-array.js
+++ b/test/built-ins/Promise/allSettled/resolves-to-array.js
@@ -23,5 +23,5 @@ var arg = [];
 Promise.allSettled([]).then(function(result) {
   assert(Array.isArray(result));
   assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
-  assert.notSameValue(result, arg, 'the resolved array is a new one');
+  assert.notSameValue(result, arg, 'the resolved array is a new array');
 }).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolves-to-array.js
+++ b/test/built-ins/Promise/allSettled/resolves-to-array.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: Promise.allSettled returned a promise resolves into an array
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  4. Let remainingElementsCount be a new Record { [[Value]]: 1 }.
+  ...
+  6.d ...
+    ii. Set remainingElementsCount.[[value]] to remainingElementsCount.[[value]] − 1.
+    iii. If remainingElementsCount.[[value]] is 0, then
+      1. Let valuesArray be CreateArrayFromList(values).
+      2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+  ...
+flags: [async]
+---*/
+
+var arg = [];
+
+Promise.allSettled([]).then(function(result) {
+  assert(Array.isArray(result));
+  assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+  assert.notSameValue(result, arg, 'the resolved array is a new one');
+}).then($DONE, $DONE);

--- a/test/built-ins/Promise/allSettled/resolves-to-array.js
+++ b/test/built-ins/Promise/allSettled/resolves-to-array.js
@@ -16,6 +16,7 @@ info: |
       2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
   ...
 flags: [async]
+features: [Promise.allSettled]
 ---*/
 
 var arg = [];

--- a/test/built-ins/Promise/allSettled/returns-promise.js
+++ b/test/built-ins/Promise/allSettled/returns-promise.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-promise.allsettled
+description: Promise.allSettled returns a Promise
+info: |
+  Promise.allSettled ( iterable )
+
+  3. Let promiseCapability be ? NewPromiseCapability(C).
+  4. Let iteratorRecord be GetIterator(iterable).
+  5. IfAbruptRejectPromise(iteratorRecord, promiseCapability).
+  6. Let result be PerformPromiseAllSettled(iteratorRecord, C, promiseCapability).
+  7. If result is an abrupt completion, then
+    a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
+    b. IfAbruptRejectPromise(result, promiseCapability).
+  8. Return Completion(result).
+---*/
+
+var p = Promise.allSettled([]);
+
+assert(p instanceof Promise);
+assert.sameValue(Object.getPrototypeOf(p), Promise.prototype);

--- a/test/built-ins/Promise/allSettled/returns-promise.js
+++ b/test/built-ins/Promise/allSettled/returns-promise.js
@@ -15,6 +15,7 @@ info: |
     a. If iteratorRecord.[[Done]] is false, set result to IteratorClose(iteratorRecord, result).
     b. IfAbruptRejectPromise(result, promiseCapability).
   8. Return Completion(result).
+features: [Promise.allSettled]
 ---*/
 
 var p = Promise.allSettled([]);

--- a/test/built-ins/Promise/allSettled/same-reject-function.js
+++ b/test/built-ins/Promise/allSettled/same-reject-function.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-performpromiseallsettled
+description: >
+  Each Promise.allSettled element is called with the same reject function.
+info: |
+  Runtime Semantics: PerformPromiseAllSettled ( iteratorRecord, constructor, resultCapability )
+
+  ...
+  z. Perform ? Invoke(nextPromise, "then", « resolveElement, rejectElement »).
+  ...
+---*/
+
+function rejectFunction() {}
+
+function Constructor(executor) {
+  executor($ERROR, rejectFunction);
+}
+Constructor.resolve = function(v) {
+  return v;
+};
+
+var callCount1 = 0;
+var callCount2 = 0;
+
+var p1 = {
+  then(_, onRejected) {
+    callCount1 += 1;
+    assert.sameValue(onRejected, rejectFunction, "p1.then");
+  }
+};
+var p2 = {
+  then(_, onRejected) {
+    callCount2 += 1;
+    assert.sameValue(onRejected, rejectFunction, "p2.then");
+  }
+};
+
+Promise.allSettled.call(Constructor, [p1, p2]);
+
+assert.sameValue(callCount1, 1, "p1.then call count");
+assert.sameValue(callCount2, 1, "p2.then call count");

--- a/test/built-ins/Promise/allSettled/species-get-error.js
+++ b/test/built-ins/Promise/allSettled/species-get-error.js
@@ -18,7 +18,7 @@ function C(executor) {
 }
 Object.defineProperty(C, Symbol.species, {
   get() {
-    throw new Test262Error("Getter for Symbol.species called");
+    throw new Test262Error('Getter for Symbol.species called');
   }
 });
 

--- a/test/built-ins/Promise/allSettled/species-get-error.js
+++ b/test/built-ins/Promise/allSettled/species-get-error.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Promise.allSettled() does not retrieve `Symbol.species` property of the `this` value
+esid: sec-promise.allsettled
+info: |
+  1. Let C be the this value.
+  2. If Type(C) is not Object, throw a TypeError exception.
+  3. Let promiseCapability be ? NewPromiseCapability(C).
+  ...
+features: [Symbol.species]
+---*/
+
+function C(executor) {
+  executor(function() {}, function() {});
+}
+Object.defineProperty(C, Symbol.species, {
+  get() {
+    throw new Test262Error("Getter for Symbol.species called");
+  }
+});
+
+Promise.allSettled.call(C, []);

--- a/test/built-ins/Promise/allSettled/species-get-error.js
+++ b/test/built-ins/Promise/allSettled/species-get-error.js
@@ -10,7 +10,7 @@ info: |
   2. If Type(C) is not Object, throw a TypeError exception.
   3. Let promiseCapability be ? NewPromiseCapability(C).
   ...
-features: [Symbol.species]
+features: [Promise.allSettled, Symbol.species]
 ---*/
 
 function C(executor) {


### PR DESCRIPTION
Most of the spec tests are pretty similar, so I've been porting the tests over. This still requires modding things here and there.
