### PR TITLE
Refactor module _FIXTURE.js to have no harness dependencies

### DIFF
--- a/test/language/module-code/instn-iee-bndng-cls.js
+++ b/test/language/module-code/instn-iee-bndng-cls.js
@@ -43,5 +43,10 @@ assert.throws(ReferenceError, function() {
   typeof B;
 }, 'binding is created but not initialized');
 
-import { B } from './instn-iee-bndng-cls_FIXTURE.js';
+import { B, results } from './instn-iee-bndng-cls_FIXTURE.js';
 export class A {}
+
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');

--- a/test/language/module-code/instn-iee-bndng-cls.js
+++ b/test/language/module-code/instn-iee-bndng-cls.js
@@ -46,6 +46,7 @@ assert.throws(ReferenceError, function() {
 import { B, results } from './instn-iee-bndng-cls_FIXTURE.js';
 export class A {}
 
+assert.sameValue(results.length, 4);
 assert.sameValue(results[0], 'ReferenceError');
 assert.sameValue(results[1], 'undefined');
 assert.sameValue(results[2], 'ReferenceError');

--- a/test/language/module-code/instn-iee-bndng-cls_FIXTURE.js
+++ b/test/language/module-code/instn-iee-bndng-cls_FIXTURE.js
@@ -5,14 +5,17 @@ export { A as B } from './instn-iee-bndng-cls.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
+export const results = [];
+try {
   A;
-});
-assert.sameValue(typeof A, 'undefined');
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
+try {
   B;
-});
-assert.sameValue(typeof B, 'undefined');
+} catch (error) {
+  results.push(error.name, typeof B);
+}

--- a/test/language/module-code/instn-iee-bndng-const.js
+++ b/test/language/module-code/instn-iee-bndng-const.js
@@ -46,6 +46,7 @@ assert.throws(ReferenceError, function() {
 import { B, results } from './instn-iee-bndng-const_FIXTURE.js';
 export const A = null;
 
+assert.sameValue(results.length, 4);
 assert.sameValue(results[0], 'ReferenceError');
 assert.sameValue(results[1], 'undefined');
 assert.sameValue(results[2], 'ReferenceError');

--- a/test/language/module-code/instn-iee-bndng-const.js
+++ b/test/language/module-code/instn-iee-bndng-const.js
@@ -40,8 +40,13 @@ flags: [module]
 ---*/
 
 assert.throws(ReferenceError, function() {
-  typeof y;
+  typeof B;
 }, 'binding is created but not initialized');
 
-import { y } from './instn-iee-bndng-const_FIXTURE.js';
-export const x = null;
+import { B, results } from './instn-iee-bndng-const_FIXTURE.js';
+export const A = null;
+
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');

--- a/test/language/module-code/instn-iee-bndng-const_FIXTURE.js
+++ b/test/language/module-code/instn-iee-bndng-const_FIXTURE.js
@@ -1,18 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-export { x as y } from './instn-iee-bndng-const.js';
+export { A as B } from './instn-iee-bndng-const.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
-  x;
-});
-assert.sameValue(typeof x, 'undefined');
+export const results = [];
+try {
+  A;
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
-  y;
-});
-assert.sameValue(typeof y, 'undefined');
+try {
+  B;
+} catch (error) {
+  results.push(error.name, typeof B);
+}

--- a/test/language/module-code/instn-iee-bndng-fun.js
+++ b/test/language/module-code/instn-iee-bndng-fun.js
@@ -54,6 +54,7 @@ assert.sameValue(B(), 77, 'binding value is immutable');
 import { B, results } from './instn-iee-bndng-fun_FIXTURE.js';
 export function A() { return 77; }
 
+assert.sameValue(results.length, 4);
 assert.sameValue(results[0], 'ReferenceError');
 assert.sameValue(results[1], 'undefined');
 assert.sameValue(results[2], 'ReferenceError');

--- a/test/language/module-code/instn-iee-bndng-fun.js
+++ b/test/language/module-code/instn-iee-bndng-fun.js
@@ -40,16 +40,21 @@ flags: [module]
 ---*/
 
 assert.sameValue(
-  f2(),
+  B(),
   77,
   'binding is initialized to function value prior to module evaluation'
 );
 
 assert.throws(TypeError, function() {
-  f2 = null;
+  B = null;
 }, 'binding rejects assignment');
 
-assert.sameValue(f2(), 77, 'binding value is immutable');
+assert.sameValue(B(), 77, 'binding value is immutable');
 
-import { f2 } from './instn-iee-bndng-fun_FIXTURE.js';
-export function f() { return 77; }
+import { B, results } from './instn-iee-bndng-fun_FIXTURE.js';
+export function A() { return 77; }
+
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');

--- a/test/language/module-code/instn-iee-bndng-fun_FIXTURE.js
+++ b/test/language/module-code/instn-iee-bndng-fun_FIXTURE.js
@@ -1,18 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-export { f as f2 } from './instn-iee-bndng-fun.js';
+export { A as B } from './instn-iee-bndng-fun.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
-  f;
-});
-assert.sameValue(typeof f, 'undefined');
+export const results = [];
+try {
+  A;
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
-  f2;
-});
-assert.sameValue(typeof f2, 'undefined');
+try {
+  B;
+} catch (error) {
+  results.push(error.name, typeof B);
+}

--- a/test/language/module-code/instn-iee-bndng-gen.js
+++ b/test/language/module-code/instn-iee-bndng-gen.js
@@ -56,6 +56,7 @@ assert.sameValue(B().next().value, 455, 'binding value is immutable');
 import { B, results } from './instn-iee-bndng-gen_FIXTURE.js';
 export function* A () { return 455; }
 
+assert.sameValue(results.length, 4);
 assert.sameValue(results[0], 'ReferenceError');
 assert.sameValue(results[1], 'undefined');
 assert.sameValue(results[2], 'ReferenceError');

--- a/test/language/module-code/instn-iee-bndng-gen.js
+++ b/test/language/module-code/instn-iee-bndng-gen.js
@@ -42,16 +42,21 @@ features: [generators]
 ---*/
 
 assert.sameValue(
-  g2().next().value,
+  B().next().value,
   455,
   'binding is initialized to function value prior to module evaluation'
 );
 
 assert.throws(TypeError, function() {
-  g2 = null;
+  B = null;
 });
 
-assert.sameValue(g2().next().value, 455, 'binding value is immutable');
+assert.sameValue(B().next().value, 455, 'binding value is immutable');
 
-import { g2 } from './instn-iee-bndng-gen_FIXTURE.js';
-export function* g () { return 455; }
+import { B, results } from './instn-iee-bndng-gen_FIXTURE.js';
+export function* A () { return 455; }
+
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');

--- a/test/language/module-code/instn-iee-bndng-gen_FIXTURE.js
+++ b/test/language/module-code/instn-iee-bndng-gen_FIXTURE.js
@@ -1,18 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-export { g as g2 } from './instn-iee-bndng-gen.js';
+export { A as B } from './instn-iee-bndng-gen.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
-  g;
-});
-assert.sameValue(typeof g, 'undefined');
+export const results = [];
+try {
+  A;
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
-  g2;
-});
-assert.sameValue(typeof g2, 'undefined');
+try {
+  B;
+} catch (error) {
+  results.push(error.name, typeof B);
+}

--- a/test/language/module-code/instn-iee-bndng-let.js
+++ b/test/language/module-code/instn-iee-bndng-let.js
@@ -46,6 +46,7 @@ assert.throws(ReferenceError, function() {
 import { B, results } from './instn-iee-bndng-let_FIXTURE.js';
 export let A;
 
+assert.sameValue(results.length, 4);
 assert.sameValue(results[0], 'ReferenceError');
 assert.sameValue(results[1], 'undefined');
 assert.sameValue(results[2], 'ReferenceError');

--- a/test/language/module-code/instn-iee-bndng-let.js
+++ b/test/language/module-code/instn-iee-bndng-let.js
@@ -40,8 +40,13 @@ flags: [module]
 ---*/
 
 assert.throws(ReferenceError, function() {
-  typeof y;
+  typeof B;
 }, 'binding is created but not initialized');
 
-import { y } from './instn-iee-bndng-let_FIXTURE.js';
-export let x;
+import { B, results } from './instn-iee-bndng-let_FIXTURE.js';
+export let A;
+
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');

--- a/test/language/module-code/instn-iee-bndng-let_FIXTURE.js
+++ b/test/language/module-code/instn-iee-bndng-let_FIXTURE.js
@@ -1,18 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-export { x as y } from './instn-iee-bndng-let.js';
+export { A as B } from './instn-iee-bndng-let.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
-  x;
-});
-assert.sameValue(typeof x, 'undefined');
+export const results = [];
+try {
+  A;
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
-  y;
-});
-assert.sameValue(typeof y, 'undefined');
+try {
+  B;
+} catch (error) {
+  results.push(error.name, typeof B);
+}

--- a/test/language/module-code/instn-iee-bndng-var.js
+++ b/test/language/module-code/instn-iee-bndng-var.js
@@ -54,6 +54,7 @@ assert.sameValue(B, undefined, 'binding value is immutable');
 import { B, results } from './instn-iee-bndng-var_FIXTURE.js';
 export var A = 99;
 
+assert.sameValue(results.length, 4);
 assert.sameValue(results[0], 'ReferenceError');
 assert.sameValue(results[1], 'undefined');
 assert.sameValue(results[2], 'ReferenceError');

--- a/test/language/module-code/instn-iee-bndng-var.js
+++ b/test/language/module-code/instn-iee-bndng-var.js
@@ -40,16 +40,22 @@ flags: [module]
 ---*/
 
 assert.sameValue(
-  y,
+  B,
   undefined,
   'binding is initialized to `undefined` prior to module evaulation'
 );
 
 assert.throws(TypeError, function() {
-  y = null;
+  B = null;
 }, 'binding rejects assignment');
 
-assert.sameValue(y, undefined, 'binding value is immutable');
+assert.sameValue(B, undefined, 'binding value is immutable');
 
-import { y } from './instn-iee-bndng-var_FIXTURE.js';
-export var x = 99;
+import { B, results } from './instn-iee-bndng-var_FIXTURE.js';
+export var A = 99;
+
+assert.sameValue(results[0], 'ReferenceError');
+assert.sameValue(results[1], 'undefined');
+assert.sameValue(results[2], 'ReferenceError');
+assert.sameValue(results[3], 'undefined');
+

--- a/test/language/module-code/instn-iee-bndng-var_FIXTURE.js
+++ b/test/language/module-code/instn-iee-bndng-var_FIXTURE.js
@@ -1,18 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-export { x as y } from './instn-iee-bndng-var.js';
+export { A as B } from './instn-iee-bndng-var.js';
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ImportName:
-assert.throws(ReferenceError, function() {
-  x;
-});
-assert.sameValue(typeof x, 'undefined');
+export const results = [];
+try {
+  A;
+} catch (error) {
+  results.push(error.name, typeof A);
+}
 
 // Taken together, the following two assertions demonstrate that there is no
 // entry in the environment record for ExportName:
-assert.throws(ReferenceError, function() {
-  y;
-});
-assert.sameValue(typeof y, 'undefined');
+try {
+  B;
+} catch (error) {
+  results.push(error.name, typeof B);
+}


### PR DESCRIPTION
```
rwaldron in ~/clonez/test262 on master
$ test262_runner test/language/module-code/instn-iee-bndng-{cls,const,fun,gen,let,var}.js
-----------------------------------------------------------------------------------------
V8 (jsvu)

test262-harness --hostArgs='' --hostType=d8 --hostPath=/Users/rwaldron/.jsvu/v8 test/language/module-code/instn-iee-bndng-cls.js test/language/module-code/instn-iee-bndng-const.js test/language/module-code/instn-iee-bndng-fun.js test/language/module-code/instn-iee-bndng-gen.js test/language/module-code/instn-iee-bndng-let.js test/language/module-code/instn-iee-bndng-var.js

Ran 12 tests
12 passed
0 failed

-----------------------------------------------------------------------------------------
ChakraCore (jsvu)

test262-harness --hostArgs='' --hostType=ch --hostPath=/Users/rwaldron/.jsvu/chakra test/language/module-code/instn-iee-bndng-cls.js test/language/module-code/instn-iee-bndng-const.js test/language/module-code/instn-iee-bndng-fun.js test/language/module-code/instn-iee-bndng-gen.js test/language/module-code/instn-iee-bndng-let.js test/language/module-code/instn-iee-bndng-var.js

Ran 12 tests
12 passed
0 failed

-----------------------------------------------------------------------------------------
JavaScriptCore (jsvu)

test262-harness --hostArgs='' --hostType=jsc --hostPath=/Users/rwaldron/.jsvu/javascriptcore test/language/module-code/instn-iee-bndng-cls.js test/language/module-code/instn-iee-bndng-const.js test/language/module-code/instn-iee-bndng-fun.js test/language/module-code/instn-iee-bndng-gen.js test/language/module-code/instn-iee-bndng-let.js test/language/module-code/instn-iee-bndng-var.js

Ran 12 tests
12 passed
0 failed

-----------------------------------------------------------------------------------------
SpiderMonkey (jsvu)

test262-harness --hostArgs='' --hostType=jsshell --hostPath=/Users/rwaldron/.jsvu/sm test/language/module-code/instn-iee-bndng-cls.js test/language/module-code/instn-iee-bndng-const.js test/language/module-code/instn-iee-bndng-fun.js test/language/module-code/instn-iee-bndng-gen.js test/language/module-code/instn-iee-bndng-let.js test/language/module-code/instn-iee-bndng-var.js

Ran 12 tests
12 passed
0 failed

-----------------------------------------------------------------------------------------
Moddable (jsvu)

test262-harness --hostArgs='' --hostType=xs --hostPath=/Users/rwaldron/.jsvu/xs test/language/module-code/instn-iee-bndng-cls.js test/language/module-code/instn-iee-bndng-const.js test/language/module-code/instn-iee-bndng-fun.js test/language/module-code/instn-iee-bndng-gen.js test/language/module-code/instn-iee-bndng-let.js test/language/module-code/instn-iee-bndng-var.js

Ran 12 tests
12 passed
0 failed
```

```
rwaldron in ~/clonez/test262 on refactor-fixtures-to-eliminate-harness-file-dependencies
$ test262_runner test/language/module-code/instn-iee-bndng-{cls,const,fun,gen,let,var}.js
-----------------------------------------------------------------------------------------
V8 (jsvu)

test262-harness --hostArgs='' --hostType=d8 --hostPath=/Users/rwaldron/.jsvu/v8 test/language/module-code/instn-iee-bndng-cls.js test/language/module-code/instn-iee-bndng-const.js test/language/module-code/instn-iee-bndng-fun.js test/language/module-code/instn-iee-bndng-gen.js test/language/module-code/instn-iee-bndng-let.js test/language/module-code/instn-iee-bndng-var.js

Ran 12 tests
12 passed
0 failed

-----------------------------------------------------------------------------------------
ChakraCore (jsvu)

test262-harness --hostArgs='' --hostType=ch --hostPath=/Users/rwaldron/.jsvu/chakra test/language/module-code/instn-iee-bndng-cls.js test/language/module-code/instn-iee-bndng-const.js test/language/module-code/instn-iee-bndng-fun.js test/language/module-code/instn-iee-bndng-gen.js test/language/module-code/instn-iee-bndng-let.js test/language/module-code/instn-iee-bndng-var.js

Ran 12 tests
12 passed
0 failed

-----------------------------------------------------------------------------------------
JavaScriptCore (jsvu)

test262-harness --hostArgs='' --hostType=jsc --hostPath=/Users/rwaldron/.jsvu/javascriptcore test/language/module-code/instn-iee-bndng-cls.js test/language/module-code/instn-iee-bndng-const.js test/language/module-code/instn-iee-bndng-fun.js test/language/module-code/instn-iee-bndng-gen.js test/language/module-code/instn-iee-bndng-let.js test/language/module-code/instn-iee-bndng-var.js

Ran 12 tests
12 passed
0 failed

-----------------------------------------------------------------------------------------
SpiderMonkey (jsvu)

test262-harness --hostArgs='' --hostType=jsshell --hostPath=/Users/rwaldron/.jsvu/sm test/language/module-code/instn-iee-bndng-cls.js test/language/module-code/instn-iee-bndng-const.js test/language/module-code/instn-iee-bndng-fun.js test/language/module-code/instn-iee-bndng-gen.js test/language/module-code/instn-iee-bndng-let.js test/language/module-code/instn-iee-bndng-var.js

Ran 12 tests
12 passed
0 failed

-----------------------------------------------------------------------------------------
Moddable (jsvu)

test262-harness --hostArgs='' --hostType=xs --hostPath=/Users/rwaldron/.jsvu/xs test/language/module-code/instn-iee-bndng-cls.js test/language/module-code/instn-iee-bndng-const.js test/language/module-code/instn-iee-bndng-fun.js test/language/module-code/instn-iee-bndng-gen.js test/language/module-code/instn-iee-bndng-let.js test/language/module-code/instn-iee-bndng-var.js

Ran 12 tests
12 passed
0 failed
```