### PR TITLE
INTERPRETING.md: explicitly disallow use of Test262-Defined Bindings and Host-Defined Functions in _FIXTURE.js files

### DIFF
--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -137,9 +137,9 @@ This must precede any additional text modifications described by test metadata.
 Test262 includes tests for ECMAScript 2015 module code, denoted by the "module"
 metadata flag. Files bearing a name ending in `_FIXTURE.js`:
 
-- **MUST** not be interpreted as standalone tests; they are intended to be referenced by test files.
-- **MUST** not refer to, or make use of any [Test262-Defined Bindings](#test262-defined-bindings) in any way. 
-- **MUST** not refer to, or make use of any [Host-Defined Functions](#host-defined-functions) in any way. 
+- **MUST NOT** be interpreted as standalone tests; they are intended to be referenced by test files.
+- **MUST NOT** refer to, or make use of any [Test262-Defined Bindings](#test262-defined-bindings) in any way. 
+- **MUST NOT** refer to, or make use of any [Host-Defined Functions](#host-defined-functions) in any way. 
 
 All module specifiers used by Test262 begin with the character sequence `./`.
 The remaining characters should be interpreted as the name of a file within the

--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -135,9 +135,11 @@ This must precede any additional text modifications described by test metadata.
 ### Modules
 
 Test262 includes tests for ECMAScript 2015 module code, denoted by the "module"
-metadata flag. Files bearing a name ending in `_FIXTURE.js` should not be
-interpreted as standalone tests; they are intended to be referenced by test
-files.
+metadata flag. Files bearing a name ending in `_FIXTURE.js`:
+
+- **MUST** not be interpreted as standalone tests; they are intended to be referenced by test files.
+- **MUST** not refer to, or make use of any [Test262-Defined Bindings](#test262-defined-bindings) in any way. 
+- **MUST** not refer to, or make use of any [Host-Defined Functions](#host-defined-functions) in any way. 
 
 All module specifiers used by Test262 begin with the character sequence `./`.
 The remaining characters should be interpreted as the name of a file within the


### PR DESCRIPTION
@jugglinmike @leobalter This change simply codifies the predominant pattern in Test262. There were 6 total _FIXTURE.js files that used assertions, but those have been updated in #2129. 