### PR TITLE
Set npm scripts to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ execution_steps: &execution_steps
     - *save_cache
     - run: ./node_modules/.bin/jsvu --os=linux64 --engines=$hostName
     - run: cp -r  ~/.jsvu r
-    - run: npm test
+    - run: npm run ci
 
 jobs:
   "Project lint, generation tests and build":

--- a/package.json
+++ b/package.json
@@ -18,14 +18,13 @@
   },
   "scripts": {
     "ci": "./tools/scripts/ci_test.sh",
-    "jsvu": "jsvu",
     "test": "test262-harness",
     "diff": "git diff --diff-filter ACMR --name-only master -- test/",
     "test:diff": "npm run test:diff:v8 && npm run test:diff:spidermonkey && npm run test:diff:chakra && npm run test:diff:javascriptcore",
     "test:diff:v8": "test262-harness -t 8 --hostType=d8 --hostPath=v8 $(npm run diff)",
     "test:diff:spidermonkey": "test262-harness -t 8 --hostType=jsshell --hostPath=spidermonkey $(npm run diff)",
-    "test:diff:chakra": "test262-harness -t 8 --hostType=d8 --hostPath=chakra $(npm run diff)",
-    "test:diff:javascriptcore": "test262-harness -t 8 --hostType=d8 --hostPath=javascriptcore $(npm run diff)",
-    "test:diff:xs": "test262-harness -t 8 --hostType=d8 --hostPath=xs $(npm run diff)"
+    "test:diff:chakra": "test262-harness -t 8 --hostType=ch --hostPath=chakra $(npm run diff)",
+    "test:diff:javascriptcore": "test262-harness -t 8 --hostType=jsc --hostPath=javascriptcore $(npm run diff)",
+    "test:diff:xs": "test262-harness -t 8 --hostType=xs --hostPath=xs $(npm run diff)"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "ci": "./tools/scripts/ci_test.sh",
     "test": "test262-harness",
-    "diff": "git diff --diff-filter ACMR --name-only master -- test/",
+    "diff": "git diff --diff-filter ACMR --name-only master.. -- test/",
     "test:diff": "npm run test:diff:v8 && npm run test:diff:spidermonkey && npm run test:diff:chakra && npm run test:diff:javascriptcore",
     "test:diff:v8": "test262-harness -t 8 --hostType=d8 --hostPath=v8 $(npm run diff)",
     "test:diff:spidermonkey": "test262-harness -t 8 --hostType=jsshell --hostPath=spidermonkey $(npm run diff)",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,15 @@
     "test262-harness": "^6.2.0"
   },
   "scripts": {
-    "test": "./tools/scripts/ci_test.sh"
+    "ci": "./tools/scripts/ci_test.sh",
+    "jsvu": "jsvu",
+    "test": "test262-harness",
+    "diff": "git diff --diff-filter ACMR --name-only master -- test/",
+    "test:diff": "npm run test:diff:v8 && npm run test:diff:spidermonkey && npm run test:diff:chakra && npm run test:diff:javascriptcore",
+    "test:diff:v8": "test262-harness -t 8 --hostType=d8 --hostPath=v8 $(npm run diff)",
+    "test:diff:spidermonkey": "test262-harness -t 8 --hostType=jsshell --hostPath=spidermonkey $(npm run diff)",
+    "test:diff:chakra": "test262-harness -t 8 --hostType=d8 --hostPath=chakra $(npm run diff)",
+    "test:diff:javascriptcore": "test262-harness -t 8 --hostType=d8 --hostPath=javascriptcore $(npm run diff)",
+    "test:diff:xs": "test262-harness -t 8 --hostType=d8 --hostPath=xs $(npm run diff)"
   }
 }


### PR DESCRIPTION
This is just helper scripts with parts I use everyday.

@mathiasbynens Ideally I'd love to set jsvu to use a custom folder inside my project's path. This would be very helpful for the CI tools as well as CircleCI's docker get's bonkers with the current path outside, regardless I add anything to the PATH for jsvu.

the `npm test` is literally just a shortcut for the local test262-harness.