### PR TITLE
Use .. for git diffs in the CI routines

### DIFF
--- a/tools/scripts/ci_lint.sh
+++ b/tools/scripts/ci_lint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
-  paths=$(git diff --diff-filter ACMR --name-only origin/master -- test/)
+  paths=$(git diff --diff-filter ACMR --name-only origin/master.. -- test/)
 
   if [ "$paths" == "" ]; then
     echo No test files added or modified. Exiting.

--- a/tools/scripts/ci_test.sh
+++ b/tools/scripts/ci_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
-  paths=$(git diff --diff-filter ACMR --name-only origin/master -- test/)
+  paths=$(git diff --diff-filter ACMR --name-only origin/master.. -- test/)
 
   if [ "$paths" == "" ]; then
     echo No test files added or modified. Exiting.


### PR DESCRIPTION
 the double dot gets only commits not in the left side of the double dot.

The right side assumes HEAD.

This will allow us to fetch the correct list of new or modified files in the current branch.

Ref #2137 