### PR TITLE
Adding case to verify if PrivateEnvironment is properly set when evaluating 'ClassHeritage'

### DIFF
--- a/src/class-elements/grammar-private-environment-on-class-heritage-array-literal.case
+++ b/src/class-elements/grammar-private-environment-on-class-heritage-array-literal.case
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Caio Lima (Igalia S.L). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if an array literal evaluated on ClassHeritage uses a private name.
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+template: syntax/invalid
+features: [class-fields-private, class-fields-public]
+---*/
+
+//- heritage
+
+extends (o) => [o.#foo]
+
+//- elements
+
+#foo;

--- a/src/class-elements/grammar-private-environment-on-class-heritage-chained-usage.case
+++ b/src/class-elements/grammar-private-environment-on-class-heritage-chained-usage.case
@@ -27,7 +27,7 @@ features: [class-fields-private, class-fields-public]
 
 //- heritage
 
-extends class extends class extends class { x = this.#foo; } { #foo; x = this.#ba;r } { #bar; x = this.#fuz; }
+extends class extends class extends class { x = this.#foo; } { #foo; x = this.#bar; } { #bar; x = this.#fuz; }
 
 //- elements
 

--- a/src/class-elements/grammar-private-environment-on-class-heritage-chained-usage.case
+++ b/src/class-elements/grammar-private-environment-on-class-heritage-chained-usage.case
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Caio Lima (Igalia S.L). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class expression evaluated on ClassHeritage uses an private name declared on subclass.
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+template: syntax/invalid
+features: [class-fields-private, class-fields-public]
+---*/
+
+//- heritage
+
+extends class extends class extends class { x = this.#foo; } { #foo; x = this.#ba;r } { #bar; x = this.#fuz; }
+
+//- elements
+
+#fuz;

--- a/src/class-elements/grammar-private-environment-on-class-heritage-function-expression.case
+++ b/src/class-elements/grammar-private-environment-on-class-heritage-function-expression.case
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Caio Lima (Igalia S.L). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a function expression evaluated on ClassHeritage uses a private name.
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+template: syntax/invalid
+features: [class-fields-private, class-fields-public]
+---*/
+
+//- heritage
+
+extends function() { x = this.#foo; }
+
+//- elements
+
+#foo;

--- a/src/class-elements/grammar-private-environment-on-class-heritage-obj-literal.case
+++ b/src/class-elements/grammar-private-environment-on-class-heritage-obj-literal.case
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Caio Lima (Igalia S.L). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a object literal evaluated on ClassHeritage uses a private name.
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+template: syntax/invalid
+features: [class-fields-private, class-fields-public]
+---*/
+
+//- heritage
+
+extends (o) => {x: o.#foo}
+
+//- elements
+
+#foo;

--- a/src/class-elements/grammar-private-environment-on-class-heritage-recursive.case
+++ b/src/class-elements/grammar-private-environment-on-class-heritage-recursive.case
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Caio Lima (Igalia S.L). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class expression evaluated on ClassHeritage of a ClassHeritage uses an undeclared private name.
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+template: syntax/invalid
+features: [class-fields-private, class-fields-public]
+---*/
+
+//- heritage
+
+extends class extends class { x = this.#foo; } {}
+
+//- elements
+
+#foo;

--- a/src/class-elements/grammar-private-environment-on-class-heritage.case
+++ b/src/class-elements/grammar-private-environment-on-class-heritage.case
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Caio Lima (Igalia S.L). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class expression evaluated on ClassHeritage uses an undeclared private name.
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+template: syntax/invalid
+features: [class-fields-private, class-fields-public]
+---*/
+
+//- heritage
+
+extends class { x = this.#foo; }
+
+//- elements
+
+#foo;

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-array-literal.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-array-literal.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage-array-literal.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if an array literal evaluated on ClassHeritage uses a private name. (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class extends (o) => [o.#foo]
+{
+  #foo;
+};

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-chained-usage.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-chained-usage.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage-chained-usage.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class expression evaluated on ClassHeritage uses an private name declared on subclass. (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class extends class extends class extends class { x = this.#foo; } { #foo; x = this.#ba;r } { #bar; x = this.#fuz; }
+{
+  #fuz;
+};

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-chained-usage.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-chained-usage.js
@@ -33,7 +33,7 @@ info: |
 
 $DONOTEVALUATE();
 
-var C = class extends class extends class extends class { x = this.#foo; } { #foo; x = this.#ba;r } { #bar; x = this.#fuz; }
+var C = class extends class extends class extends class { x = this.#foo; } { #foo; x = this.#bar; } { #bar; x = this.#fuz; }
 {
   #fuz;
 };

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-function-expression.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-function-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage-function-expression.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a function expression evaluated on ClassHeritage uses a private name. (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class extends function() { x = this.#foo; }
+{
+  #foo;
+};

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-obj-literal.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-obj-literal.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage-obj-literal.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a object literal evaluated on ClassHeritage uses a private name. (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class extends (o) => {x: o.#foo}
+{
+  #foo;
+};

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-recursive.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-recursive.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage-recursive.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class expression evaluated on ClassHeritage of a ClassHeritage uses an undeclared private name. (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class extends class extends class { x = this.#foo; } {}
+{
+  #foo;
+};

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class expression evaluated on ClassHeritage uses an undeclared private name. (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class extends class { x = this.#foo; }
+{
+  #foo;
+};

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-array-literal.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-array-literal.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage-array-literal.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if an array literal evaluated on ClassHeritage uses a private name. (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C extends (o) => [o.#foo]
+{
+  #foo;
+}

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-chained-usage.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-chained-usage.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage-chained-usage.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class expression evaluated on ClassHeritage uses an private name declared on subclass. (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C extends class extends class extends class { x = this.#foo; } { #foo; x = this.#ba;r } { #bar; x = this.#fuz; }
+{
+  #fuz;
+}

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-chained-usage.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-chained-usage.js
@@ -33,7 +33,7 @@ info: |
 
 $DONOTEVALUATE();
 
-class C extends class extends class extends class { x = this.#foo; } { #foo; x = this.#ba;r } { #bar; x = this.#fuz; }
+class C extends class extends class extends class { x = this.#foo; } { #foo; x = this.#bar; } { #bar; x = this.#fuz; }
 {
   #fuz;
 }

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-function-expression.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-function-expression.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage-function-expression.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a function expression evaluated on ClassHeritage uses a private name. (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C extends function() { x = this.#foo; }
+{
+  #foo;
+}

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-obj-literal.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-obj-literal.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage-obj-literal.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a object literal evaluated on ClassHeritage uses a private name. (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C extends (o) => {x: o.#foo}
+{
+  #foo;
+}

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-recursive.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage-recursive.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage-recursive.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class expression evaluated on ClassHeritage of a ClassHeritage uses an undeclared private name. (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C extends class extends class { x = this.#foo; } {}
+{
+  #foo;
+}

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-private-environment-on-class-heritage.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-environment-on-class-heritage.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class expression evaluated on ClassHeritage uses an undeclared private name. (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage { ClassBody }
+        ...
+        5. Let outerPrivateEnvironment be the PrivateEnvironment of the running execution context.
+        6. Let classPrivateEnvironment be NewDeclarativeEnvironment(outerPrivateEnvironment).
+        7. Let classPrivateEnvRec be classPrivateEnvironment's EnvironmentRecord.
+        8. If ClassBodyopt is present, then
+            a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+              i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+        9. If ClassHeritageopt is not present, then
+            a. Let protoParent be the intrinsic object %ObjectPrototype%.
+            b. Let constructorParent be the intrinsic object %FunctionPrototype%.
+        10. Else,
+            a. Set the running execution context's LexicalEnvironment to classScope.
+            b. NOTE: The running execution context's PrivateEnvironment is outerPrivateEnvironment when evaluating ClassHeritage.
+        ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C extends class { x = this.#foo; }
+{
+  #foo;
+}


### PR DESCRIPTION
It closes #2141.

This case is relevant because implementors can misunderstand how to properly set `PrivateEnvironment` when evaluating classes, since it differs from `LexicalEnvironment`.