### PR TITLE
Adding test cases to cover usage of private methods and accessors on inner classes.

### DIFF
--- a/src/class-elements/private-getter-on-nested-class.case
+++ b/src/class-elements/private-getter-on-nested-class.case
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName is available on inner classes (private getter)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+get #m() { return 'test262'; }
+
+B = class {
+  method(o) {
+    return o.#m;
+  }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(c), 'test262');

--- a/src/class-elements/private-getter-on-nested-class.case
+++ b/src/class-elements/private-getter-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName is available on inner classes (private getter)
+desc: PrivateName of private getter is available on inner classes
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-getter-shadowed-by-field-on-nested-class.case
+++ b/src/class-elements/private-getter-shadowed-by-field-on-nested-class.case
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed on inner classes by a private field (private getter)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private, class-fields-private]
+---*/
+
+//- elements
+get #m() { return 'outer class'; }
+
+method() { return this.#m; }
+
+B = class {
+  method(o) {
+    return o.#m;
+  }
+
+  #m = 'test262';
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class field from an object of outer class');

--- a/src/class-elements/private-getter-shadowed-by-field-on-nested-class.case
+++ b/src/class-elements/private-getter-shadowed-by-field-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed on inner classes by a private field (private getter)
+desc: PrivateName of private getter can be shadowed on inner classes by a private field
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private, class-fields-private]
+features: [class-methods-private, class-fields-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-getter-shadowed-by-getter-on-nested-class.case
+++ b/src/class-elements/private-getter-shadowed-by-getter-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed on inner classes by a private getter (private getter)
+desc: PrivateName of private getter can be shadowed on inner classes by a private getter
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-getter-shadowed-by-getter-on-nested-class.case
+++ b/src/class-elements/private-getter-shadowed-by-getter-on-nested-class.case
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed on inner classes by a private getter (private getter)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+get #m() { return 'outer class'; }
+
+method() { return this.#m; }
+
+B = class {
+  method(o) {
+    return o.#m;
+  }
+
+  get #m() { return 'test262'; }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class getter from an object of outer class');

--- a/src/class-elements/private-getter-shadowed-by-method-on-nested-class.case
+++ b/src/class-elements/private-getter-shadowed-by-method-on-nested-class.case
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed on inner class by a private method (private getter)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+get #m() { throw new Test262Error(); }
+
+B = class {
+  method(o) {
+    return o.#m();
+  }
+
+  #m() { return 'test262'; }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class method from an object of outer class');

--- a/src/class-elements/private-getter-shadowed-by-method-on-nested-class.case
+++ b/src/class-elements/private-getter-shadowed-by-method-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed on inner class by a private method (private getter)
+desc: PrivateName of private getter can be shadowed on inner class by a private method
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-getter-shadowed-by-setter-on-nested-class.case
+++ b/src/class-elements/private-getter-shadowed-by-setter-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed on inner classes by a private setter (private getter)
+desc: PrivateName of private getter can be shadowed on inner classes by a private setter
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-getter-shadowed-by-setter-on-nested-class.case
+++ b/src/class-elements/private-getter-shadowed-by-setter-on-nested-class.case
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed on inner classes by a private setter (private getter)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+get #m() { return 'outer class'; }
+
+method() { return this.#m; }
+
+B = class {
+  method(o) {
+    return o.#m;
+  }
+
+  set #m(v) { this._v = v; }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB);
+}, '[[Get]] operation of an accessor without getter');
+
+assert.sameValue(c.method(), 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'access of inner class accessor from an object of outer class');

--- a/src/class-elements/private-method-on-nested-class.case
+++ b/src/class-elements/private-method-on-nested-class.case
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName is available on inner classes (private method)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+#m() { return 'test262'; }
+
+B = class {
+  method(o) {
+    return o.#m();
+  }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(c), 'test262');

--- a/src/class-elements/private-method-on-nested-class.case
+++ b/src/class-elements/private-method-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName is available on inner classes (private method)
+desc: PrivateName of private method is available on inner classes
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-method-shadowed-by-field-on-nested-class.case
+++ b/src/class-elements/private-method-shadowed-by-field-on-nested-class.case
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed on inner classes by a private field (private method)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private, class-fields-private]
+---*/
+
+//- elements
+#m() { return 'outer class'; }
+
+method() { return this.#m(); }
+
+B = class {
+  method(o) {
+    return o.#m;
+  }
+
+  #m = 'test262';
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class field from an object of outer class');

--- a/src/class-elements/private-method-shadowed-by-field-on-nested-class.case
+++ b/src/class-elements/private-method-shadowed-by-field-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed on inner classes by a private field (private method)
+desc: PrivateName of private method can be shadowed on inner classes by a private field
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private, class-fields-private]
+features: [class-methods-private, class-fields-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-method-shadowed-by-getter-on-nested-class.case
+++ b/src/class-elements/private-method-shadowed-by-getter-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed on inner classes by a private getter (private method)
+desc: PrivateName of private method can be shadowed on inner classes by a private getter
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-method-shadowed-by-getter-on-nested-class.case
+++ b/src/class-elements/private-method-shadowed-by-getter-on-nested-class.case
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed on inner classes by a private getter (private method)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+#m() { return 'outer class'; }
+
+method() { return this.#m(); }
+
+B = class {
+  method(o) {
+    return o.#m;
+  }
+
+  get #m() { return 'test262'; }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class getter from an object of outer class');

--- a/src/class-elements/private-method-shadowed-by-setter-on-nested-class.case
+++ b/src/class-elements/private-method-shadowed-by-setter-on-nested-class.case
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed on inner classes by a private setter (private method)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+#m() { return 'outer class'; }
+
+method() { return this.#m(); }
+
+B = class {
+  method(o) {
+    return o.#m;
+  }
+
+  set #m(v) { this._v = v; }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB);
+}, '[[Get]] operation of an accessor without getter');
+
+assert.sameValue(c.method(), 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'access of inner class accessor from an object of outer class');

--- a/src/class-elements/private-method-shadowed-by-setter-on-nested-class.case
+++ b/src/class-elements/private-method-shadowed-by-setter-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed on inner classes by a private setter (private method)
+desc: PrivateName of private method can be shadowed on inner classes by a private setter
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-method-shadowed-on-nested-class.case
+++ b/src/class-elements/private-method-shadowed-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed by inner class private method (private method)
+desc: PrivateName of private method can be shadowed by inner class private method
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-method-shadowed-on-nested-class.case
+++ b/src/class-elements/private-method-shadowed-on-nested-class.case
@@ -1,0 +1,35 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed by inner class private method (private method)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+#m() { throw new Test262Error(); }
+
+B = class {
+  method() {
+    return this.#m();
+  }
+
+  #m() { return 'test262'; }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(), 'test262');

--- a/src/class-elements/private-setter-on-nested-class.case
+++ b/src/class-elements/private-setter-on-nested-class.case
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName is available on inner classes (private setter)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+set #m(v) { this._v = v; }
+
+B = class {
+  method(o, v) {
+    o.#m = v;
+  }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+innerB.method(c, 'test262');
+assert.sameValue(c._v, 'test262');

--- a/src/class-elements/private-setter-on-nested-class.case
+++ b/src/class-elements/private-setter-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName is available on inner classes (private setter)
+desc: PrivateName of private setter is available on inner classes
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-setter-shadowed-by-field-on-nested-class.case
+++ b/src/class-elements/private-setter-shadowed-by-field-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed on inner classes by a private field (private setter)
+desc: PrivateName of private setter can be shadowed on inner classes by a private field
 info: |
   Updated Productions
 
@@ -16,11 +16,11 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private, class-fields-private]
+features: [class-methods-private, class-fields-private, class-fields-public]
 ---*/
 
 //- elements
-set #m(v) { this._v = v }
+set #m(v) { this._v = v; }
 
 method(v) { this.#m = v; }
 

--- a/src/class-elements/private-setter-shadowed-by-field-on-nested-class.case
+++ b/src/class-elements/private-setter-shadowed-by-field-on-nested-class.case
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed on inner classes by a private field (private setter)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private, class-fields-private]
+---*/
+
+//- elements
+set #m(v) { this._v = v }
+
+method(v) { this.#m = v; }
+
+B = class {
+  method(o, v) {
+    o.#m = v;
+  }
+
+  get m() { return this.#m; }
+
+  #m;
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+
+innerB.method(innerB, 'test262');
+assert.sameValue(innerB.m, 'test262');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c, 'foo');
+}, 'accessed inner class field from an object of outer class');

--- a/src/class-elements/private-setter-shadowed-by-getter-on-nested-class.case
+++ b/src/class-elements/private-setter-shadowed-by-getter-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed on inner classes by a private getter (private setter)
+desc: PrivateName of private setter can be shadowed on inner classes by a private getter
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements

--- a/src/class-elements/private-setter-shadowed-by-getter-on-nested-class.case
+++ b/src/class-elements/private-setter-shadowed-by-getter-on-nested-class.case
@@ -1,0 +1,47 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed on inner classes by a private getter (private setter)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+set #m(v) { this._v = v; }
+
+method(v) { this.#m = v; }
+
+B = class {
+  method(o, v) {
+    o.#m = v;
+  }
+
+  get #m() { return 'test262'; }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB);
+}, 'invalid [[Set]] of an acessor without setter');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'invalid access of inner class getter from an object of outer class');

--- a/src/class-elements/private-setter-shadowed-by-method-on-nested-class.case
+++ b/src/class-elements/private-setter-shadowed-by-method-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed on inner class by a private method (private setter)
+desc: PrivateName of private setter can be shadowed on inner class by a private method
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements
@@ -44,4 +44,4 @@ assert.sameValue(c._v, 'outer class');
 
 assert.throws(TypeError, function() {
   innerB.method(c);
-}, 'ivalid access of inner class method from an object of outer class');
+}, 'invalid access of inner class method from an object of outer class');

--- a/src/class-elements/private-setter-shadowed-by-method-on-nested-class.case
+++ b/src/class-elements/private-setter-shadowed-by-method-on-nested-class.case
@@ -1,0 +1,47 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed on inner class by a private method (private setter)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+set #m(v) { this._v = v; }
+
+method(v) { this.#m = v; }
+
+B = class {
+  method(o, v) {
+    o.#m = v;
+  }
+
+  #m() { return 'test262'; }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB, 'foo');
+}, 'invalid [[Set]] operation in a private method');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'ivalid access of inner class method from an object of outer class');

--- a/src/class-elements/private-setter-shadowed-by-setter-on-nested-class.case
+++ b/src/class-elements/private-setter-shadowed-by-setter-on-nested-class.case
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName can be shadowed on inner classes by a private setter (private setter)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+set #m(v) { this._v = v; }
+
+method(v) { this.#m = v; }
+
+B = class {
+  method(o, v) {
+    o.#m = v;
+  }
+
+  set #m(v) { this._v = v; }
+}
+//- assertions
+let c = new C();
+let innerB = new c.B();
+
+innerB.method(innerB, 'test262');
+assert.sameValue(innerB._v, 'test262');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c, 'foo');
+}, 'access of inner class accessor from an object of outer class');

--- a/src/class-elements/private-setter-shadowed-by-setter-on-nested-class.case
+++ b/src/class-elements/private-setter-shadowed-by-setter-on-nested-class.case
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: PrivateName can be shadowed on inner classes by a private setter (private setter)
+desc: PrivateName of private setter can be shadowed on inner classes by a private setter
 info: |
   Updated Productions
 
@@ -16,7 +16,7 @@ info: |
     CallExpression[?Yield, ?Await].PrivateName
 
 template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public]
 ---*/
 
 //- elements

--- a/test/language/expressions/class/elements/private-getter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-getter-on-nested-class.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName is available on inner classes (private getter) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  get #m() { return 'test262'; }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(c), 'test262');

--- a/test/language/expressions/class/elements/private-getter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-getter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-getter-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName is available on inner classes (private getter) (field definitions in a class expression)
+description: PrivateName of private getter is available on inner classes (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-getter-shadowed-by-field-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-getter-shadowed-by-field-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-getter-shadowed-by-field-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private field (private getter) (field definitions in a class expression)
+description: PrivateName of private getter can be shadowed on inner classes by a private field (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class-fields-private, class]
+features: [class-methods-private, class-fields-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-getter-shadowed-by-field-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-getter-shadowed-by-field-on-nested-class.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-shadowed-by-field-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private field (private getter) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  get #m() { return 'outer class'; }
+
+  method() { return this.#m; }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    #m = 'test262';
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class field from an object of outer class');

--- a/test/language/expressions/class/elements/private-getter-shadowed-by-getter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-getter-shadowed-by-getter-on-nested-class.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-shadowed-by-getter-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private getter (private getter) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  get #m() { return 'outer class'; }
+
+  method() { return this.#m; }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    get #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class getter from an object of outer class');

--- a/test/language/expressions/class/elements/private-getter-shadowed-by-getter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-getter-shadowed-by-getter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-getter-shadowed-by-getter-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private getter (private getter) (field definitions in a class expression)
+description: PrivateName of private getter can be shadowed on inner classes by a private getter (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-getter-shadowed-by-method-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-getter-shadowed-by-method-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-getter-shadowed-by-method-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed on inner class by a private method (private getter) (field definitions in a class expression)
+description: PrivateName of private getter can be shadowed on inner class by a private method (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-getter-shadowed-by-method-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-getter-shadowed-by-method-on-nested-class.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-shadowed-by-method-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed on inner class by a private method (private getter) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  get #m() { throw new Test262Error(); }
+
+  B = class {
+    method(o) {
+      return o.#m();
+    }
+
+    #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class method from an object of outer class');

--- a/test/language/expressions/class/elements/private-getter-shadowed-by-setter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-getter-shadowed-by-setter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-getter-shadowed-by-setter-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private setter (private getter) (field definitions in a class expression)
+description: PrivateName of private getter can be shadowed on inner classes by a private setter (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-getter-shadowed-by-setter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-getter-shadowed-by-setter-on-nested-class.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-shadowed-by-setter-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private setter (private getter) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  get #m() { return 'outer class'; }
+
+  method() { return this.#m; }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    set #m(v) { this._v = v; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB);
+}, '[[Get]] operation of an accessor without getter');
+
+assert.sameValue(c.method(), 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'access of inner class accessor from an object of outer class');

--- a/test/language/expressions/class/elements/private-method-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-method-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-method-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName is available on inner classes (private method) (field definitions in a class expression)
+description: PrivateName of private method is available on inner classes (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-method-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-method-on-nested-class.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName is available on inner classes (private method) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  #m() { return 'test262'; }
+
+  B = class {
+    method(o) {
+      return o.#m();
+    }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(c), 'test262');

--- a/test/language/expressions/class/elements/private-method-shadowed-by-field-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-method-shadowed-by-field-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-method-shadowed-by-field-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private field (private method) (field definitions in a class expression)
+description: PrivateName of private method can be shadowed on inner classes by a private field (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class-fields-private, class]
+features: [class-methods-private, class-fields-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-method-shadowed-by-field-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-method-shadowed-by-field-on-nested-class.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-shadowed-by-field-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private field (private method) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  #m() { return 'outer class'; }
+
+  method() { return this.#m(); }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    #m = 'test262';
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class field from an object of outer class');

--- a/test/language/expressions/class/elements/private-method-shadowed-by-getter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-method-shadowed-by-getter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-method-shadowed-by-getter-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private getter (private method) (field definitions in a class expression)
+description: PrivateName of private method can be shadowed on inner classes by a private getter (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-method-shadowed-by-getter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-method-shadowed-by-getter-on-nested-class.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-shadowed-by-getter-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private getter (private method) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  #m() { return 'outer class'; }
+
+  method() { return this.#m(); }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    get #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class getter from an object of outer class');

--- a/test/language/expressions/class/elements/private-method-shadowed-by-setter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-method-shadowed-by-setter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-method-shadowed-by-setter-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private setter (private method) (field definitions in a class expression)
+description: PrivateName of private method can be shadowed on inner classes by a private setter (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-method-shadowed-by-setter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-method-shadowed-by-setter-on-nested-class.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-shadowed-by-setter-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private setter (private method) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  #m() { return 'outer class'; }
+
+  method() { return this.#m(); }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    set #m(v) { this._v = v; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB);
+}, '[[Get]] operation of an accessor without getter');
+
+assert.sameValue(c.method(), 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'access of inner class accessor from an object of outer class');

--- a/test/language/expressions/class/elements/private-method-shadowed-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-method-shadowed-on-nested-class.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-shadowed-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed by inner class private method (private method) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  #m() { throw new Test262Error(); }
+
+  B = class {
+    method() {
+      return this.#m();
+    }
+
+    #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(), 'test262');

--- a/test/language/expressions/class/elements/private-method-shadowed-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-method-shadowed-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-method-shadowed-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed by inner class private method (private method) (field definitions in a class expression)
+description: PrivateName of private method can be shadowed by inner class private method (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-setter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-setter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-setter-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName is available on inner classes (private setter) (field definitions in a class expression)
+description: PrivateName of private setter is available on inner classes (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-setter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-setter-on-nested-class.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName is available on inner classes (private setter) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  set #m(v) { this._v = v; }
+
+  B = class {
+    method(o, v) {
+      o.#m = v;
+    }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+innerB.method(c, 'test262');
+assert.sameValue(c._v, 'test262');

--- a/test/language/expressions/class/elements/private-setter-shadowed-by-field-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-setter-shadowed-by-field-on-nested-class.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-shadowed-by-field-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private field (private setter) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  set #m(v) { this._v = v }
+
+  method(v) { this.#m = v; }
+
+  B = class {
+    method(o, v) {
+      o.#m = v;
+    }
+
+    get m() { return this.#m; }
+
+    #m;
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+innerB.method(innerB, 'test262');
+assert.sameValue(innerB.m, 'test262');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c, 'foo');
+}, 'accessed inner class field from an object of outer class');

--- a/test/language/expressions/class/elements/private-setter-shadowed-by-field-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-setter-shadowed-by-field-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-setter-shadowed-by-field-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private field (private setter) (field definitions in a class expression)
+description: PrivateName of private setter can be shadowed on inner classes by a private field (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class-fields-private, class]
+features: [class-methods-private, class-fields-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions
@@ -22,7 +22,7 @@ info: |
 
 
 var C = class {
-  set #m(v) { this._v = v }
+  set #m(v) { this._v = v; }
 
   method(v) { this.#m = v; }
 

--- a/test/language/expressions/class/elements/private-setter-shadowed-by-getter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-setter-shadowed-by-getter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-setter-shadowed-by-getter-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private getter (private setter) (field definitions in a class expression)
+description: PrivateName of private setter can be shadowed on inner classes by a private getter (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-setter-shadowed-by-getter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-setter-shadowed-by-getter-on-nested-class.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-shadowed-by-getter-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private getter (private setter) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  set #m(v) { this._v = v; }
+
+  method(v) { this.#m = v; }
+
+  B = class {
+    method(o, v) {
+      o.#m = v;
+    }
+
+    get #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB);
+}, 'invalid [[Set]] of an acessor without setter');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'invalid access of inner class getter from an object of outer class');

--- a/test/language/expressions/class/elements/private-setter-shadowed-by-method-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-setter-shadowed-by-method-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-setter-shadowed-by-method-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed on inner class by a private method (private setter) (field definitions in a class expression)
+description: PrivateName of private setter can be shadowed on inner class by a private method (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions
@@ -47,4 +47,4 @@ assert.sameValue(c._v, 'outer class');
 
 assert.throws(TypeError, function() {
   innerB.method(c);
-}, 'ivalid access of inner class method from an object of outer class');
+}, 'invalid access of inner class method from an object of outer class');

--- a/test/language/expressions/class/elements/private-setter-shadowed-by-method-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-setter-shadowed-by-method-on-nested-class.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-shadowed-by-method-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed on inner class by a private method (private setter) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  set #m(v) { this._v = v; }
+
+  method(v) { this.#m = v; }
+
+  B = class {
+    method(o, v) {
+      o.#m = v;
+    }
+
+    #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB, 'foo');
+}, 'invalid [[Set]] operation in a private method');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'ivalid access of inner class method from an object of outer class');

--- a/test/language/expressions/class/elements/private-setter-shadowed-by-setter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-setter-shadowed-by-setter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-setter-shadowed-by-setter-on-nested-class.case
 // - src/class-elements/default/cls-expr.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private setter (private setter) (field definitions in a class expression)
+description: PrivateName of private setter can be shadowed on inner classes by a private setter (field definitions in a class expression)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/expressions/class/elements/private-setter-shadowed-by-setter-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-setter-shadowed-by-setter-on-nested-class.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-shadowed-by-setter-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private setter (private setter) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  set #m(v) { this._v = v; }
+
+  method(v) { this.#m = v; }
+
+  B = class {
+    method(o, v) {
+      o.#m = v;
+    }
+
+    set #m(v) { this._v = v; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+innerB.method(innerB, 'test262');
+assert.sameValue(innerB._v, 'test262');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c, 'foo');
+}, 'access of inner class accessor from an object of outer class');

--- a/test/language/statements/class/elements/private-getter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-getter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-getter-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName is available on inner classes (private getter) (field definitions in a class declaration)
+description: PrivateName of private getter is available on inner classes (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-getter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-getter-on-nested-class.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName is available on inner classes (private getter) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  get #m() { return 'test262'; }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(c), 'test262');

--- a/test/language/statements/class/elements/private-getter-shadowed-by-field-on-nested-class.js
+++ b/test/language/statements/class/elements/private-getter-shadowed-by-field-on-nested-class.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-shadowed-by-field-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private field (private getter) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  get #m() { return 'outer class'; }
+
+  method() { return this.#m; }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    #m = 'test262';
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class field from an object of outer class');

--- a/test/language/statements/class/elements/private-getter-shadowed-by-field-on-nested-class.js
+++ b/test/language/statements/class/elements/private-getter-shadowed-by-field-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-getter-shadowed-by-field-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private field (private getter) (field definitions in a class declaration)
+description: PrivateName of private getter can be shadowed on inner classes by a private field (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class-fields-private, class]
+features: [class-methods-private, class-fields-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-getter-shadowed-by-getter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-getter-shadowed-by-getter-on-nested-class.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-shadowed-by-getter-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private getter (private getter) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  get #m() { return 'outer class'; }
+
+  method() { return this.#m; }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    get #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class getter from an object of outer class');

--- a/test/language/statements/class/elements/private-getter-shadowed-by-getter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-getter-shadowed-by-getter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-getter-shadowed-by-getter-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private getter (private getter) (field definitions in a class declaration)
+description: PrivateName of private getter can be shadowed on inner classes by a private getter (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-getter-shadowed-by-method-on-nested-class.js
+++ b/test/language/statements/class/elements/private-getter-shadowed-by-method-on-nested-class.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-shadowed-by-method-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed on inner class by a private method (private getter) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  get #m() { throw new Test262Error(); }
+
+  B = class {
+    method(o) {
+      return o.#m();
+    }
+
+    #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class method from an object of outer class');

--- a/test/language/statements/class/elements/private-getter-shadowed-by-method-on-nested-class.js
+++ b/test/language/statements/class/elements/private-getter-shadowed-by-method-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-getter-shadowed-by-method-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed on inner class by a private method (private getter) (field definitions in a class declaration)
+description: PrivateName of private getter can be shadowed on inner class by a private method (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-getter-shadowed-by-setter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-getter-shadowed-by-setter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-getter-shadowed-by-setter-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private setter (private getter) (field definitions in a class declaration)
+description: PrivateName of private getter can be shadowed on inner classes by a private setter (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-getter-shadowed-by-setter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-getter-shadowed-by-setter-on-nested-class.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-shadowed-by-setter-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private setter (private getter) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  get #m() { return 'outer class'; }
+
+  method() { return this.#m; }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    set #m(v) { this._v = v; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB);
+}, '[[Get]] operation of an accessor without getter');
+
+assert.sameValue(c.method(), 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'access of inner class accessor from an object of outer class');

--- a/test/language/statements/class/elements/private-method-on-nested-class.js
+++ b/test/language/statements/class/elements/private-method-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-method-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName is available on inner classes (private method) (field definitions in a class declaration)
+description: PrivateName of private method is available on inner classes (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-method-on-nested-class.js
+++ b/test/language/statements/class/elements/private-method-on-nested-class.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName is available on inner classes (private method) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  #m() { return 'test262'; }
+
+  B = class {
+    method(o) {
+      return o.#m();
+    }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(c), 'test262');

--- a/test/language/statements/class/elements/private-method-shadowed-by-field-on-nested-class.js
+++ b/test/language/statements/class/elements/private-method-shadowed-by-field-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-method-shadowed-by-field-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private field (private method) (field definitions in a class declaration)
+description: PrivateName of private method can be shadowed on inner classes by a private field (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class-fields-private, class]
+features: [class-methods-private, class-fields-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-method-shadowed-by-field-on-nested-class.js
+++ b/test/language/statements/class/elements/private-method-shadowed-by-field-on-nested-class.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-shadowed-by-field-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private field (private method) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  #m() { return 'outer class'; }
+
+  method() { return this.#m(); }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    #m = 'test262';
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class field from an object of outer class');

--- a/test/language/statements/class/elements/private-method-shadowed-by-getter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-method-shadowed-by-getter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-method-shadowed-by-getter-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private getter (private method) (field definitions in a class declaration)
+description: PrivateName of private method can be shadowed on inner classes by a private getter (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-method-shadowed-by-getter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-method-shadowed-by-getter-on-nested-class.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-shadowed-by-getter-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private getter (private method) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  #m() { return 'outer class'; }
+
+  method() { return this.#m(); }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    get #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(innerB), 'test262');
+assert.sameValue(c.method(), 'outer class');
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'accessed inner class getter from an object of outer class');

--- a/test/language/statements/class/elements/private-method-shadowed-by-setter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-method-shadowed-by-setter-on-nested-class.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-shadowed-by-setter-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private setter (private method) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  #m() { return 'outer class'; }
+
+  method() { return this.#m(); }
+
+  B = class {
+    method(o) {
+      return o.#m;
+    }
+
+    set #m(v) { this._v = v; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB);
+}, '[[Get]] operation of an accessor without getter');
+
+assert.sameValue(c.method(), 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'access of inner class accessor from an object of outer class');

--- a/test/language/statements/class/elements/private-method-shadowed-by-setter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-method-shadowed-by-setter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-method-shadowed-by-setter-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private setter (private method) (field definitions in a class declaration)
+description: PrivateName of private method can be shadowed on inner classes by a private setter (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-method-shadowed-on-nested-class.js
+++ b/test/language/statements/class/elements/private-method-shadowed-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-method-shadowed-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed by inner class private method (private method) (field definitions in a class declaration)
+description: PrivateName of private method can be shadowed by inner class private method (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-method-shadowed-on-nested-class.js
+++ b/test/language/statements/class/elements/private-method-shadowed-on-nested-class.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-shadowed-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed by inner class private method (private method) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  #m() { throw new Test262Error(); }
+
+  B = class {
+    method() {
+      return this.#m();
+    }
+
+    #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+assert.sameValue(innerB.method(), 'test262');

--- a/test/language/statements/class/elements/private-setter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-setter-on-nested-class.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName is available on inner classes (private setter) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  set #m(v) { this._v = v; }
+
+  B = class {
+    method(o, v) {
+      o.#m = v;
+    }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+innerB.method(c, 'test262');
+assert.sameValue(c._v, 'test262');

--- a/test/language/statements/class/elements/private-setter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-setter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-setter-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName is available on inner classes (private setter) (field definitions in a class declaration)
+description: PrivateName of private setter is available on inner classes (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-setter-shadowed-by-field-on-nested-class.js
+++ b/test/language/statements/class/elements/private-setter-shadowed-by-field-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-setter-shadowed-by-field-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private field (private setter) (field definitions in a class declaration)
+description: PrivateName of private setter can be shadowed on inner classes by a private field (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class-fields-private, class]
+features: [class-methods-private, class-fields-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions
@@ -22,7 +22,7 @@ info: |
 
 
 class C {
-  set #m(v) { this._v = v }
+  set #m(v) { this._v = v; }
 
   method(v) { this.#m = v; }
 

--- a/test/language/statements/class/elements/private-setter-shadowed-by-field-on-nested-class.js
+++ b/test/language/statements/class/elements/private-setter-shadowed-by-field-on-nested-class.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-shadowed-by-field-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private field (private setter) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class-fields-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  set #m(v) { this._v = v }
+
+  method(v) { this.#m = v; }
+
+  B = class {
+    method(o, v) {
+      o.#m = v;
+    }
+
+    get m() { return this.#m; }
+
+    #m;
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+innerB.method(innerB, 'test262');
+assert.sameValue(innerB.m, 'test262');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c, 'foo');
+}, 'accessed inner class field from an object of outer class');

--- a/test/language/statements/class/elements/private-setter-shadowed-by-getter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-setter-shadowed-by-getter-on-nested-class.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-shadowed-by-getter-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private getter (private setter) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  set #m(v) { this._v = v; }
+
+  method(v) { this.#m = v; }
+
+  B = class {
+    method(o, v) {
+      o.#m = v;
+    }
+
+    get #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB);
+}, 'invalid [[Set]] of an acessor without setter');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'invalid access of inner class getter from an object of outer class');

--- a/test/language/statements/class/elements/private-setter-shadowed-by-getter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-setter-shadowed-by-getter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-setter-shadowed-by-getter-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private getter (private setter) (field definitions in a class declaration)
+description: PrivateName of private setter can be shadowed on inner classes by a private getter (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions

--- a/test/language/statements/class/elements/private-setter-shadowed-by-method-on-nested-class.js
+++ b/test/language/statements/class/elements/private-setter-shadowed-by-method-on-nested-class.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-shadowed-by-method-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed on inner class by a private method (private setter) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  set #m(v) { this._v = v; }
+
+  method(v) { this.#m = v; }
+
+  B = class {
+    method(o, v) {
+      o.#m = v;
+    }
+
+    #m() { return 'test262'; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+assert.throws(TypeError, function() {
+  innerB.method(innerB, 'foo');
+}, 'invalid [[Set]] operation in a private method');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c);
+}, 'ivalid access of inner class method from an object of outer class');

--- a/test/language/statements/class/elements/private-setter-shadowed-by-method-on-nested-class.js
+++ b/test/language/statements/class/elements/private-setter-shadowed-by-method-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-setter-shadowed-by-method-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed on inner class by a private method (private setter) (field definitions in a class declaration)
+description: PrivateName of private setter can be shadowed on inner class by a private method (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions
@@ -47,4 +47,4 @@ assert.sameValue(c._v, 'outer class');
 
 assert.throws(TypeError, function() {
   innerB.method(c);
-}, 'ivalid access of inner class method from an object of outer class');
+}, 'invalid access of inner class method from an object of outer class');

--- a/test/language/statements/class/elements/private-setter-shadowed-by-setter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-setter-shadowed-by-setter-on-nested-class.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-shadowed-by-setter-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName can be shadowed on inner classes by a private setter (private setter) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  set #m(v) { this._v = v; }
+
+  method(v) { this.#m = v; }
+
+  B = class {
+    method(o, v) {
+      o.#m = v;
+    }
+
+    set #m(v) { this._v = v; }
+  }
+}
+
+let c = new C();
+let innerB = new c.B();
+
+innerB.method(innerB, 'test262');
+assert.sameValue(innerB._v, 'test262');
+
+c.method('outer class');
+assert.sameValue(c._v, 'outer class');
+
+assert.throws(TypeError, function() {
+  innerB.method(c, 'foo');
+}, 'access of inner class accessor from an object of outer class');

--- a/test/language/statements/class/elements/private-setter-shadowed-by-setter-on-nested-class.js
+++ b/test/language/statements/class/elements/private-setter-shadowed-by-setter-on-nested-class.js
@@ -2,9 +2,9 @@
 // - src/class-elements/private-setter-shadowed-by-setter-on-nested-class.case
 // - src/class-elements/default/cls-decl.template
 /*---
-description: PrivateName can be shadowed on inner classes by a private setter (private setter) (field definitions in a class declaration)
+description: PrivateName of private setter can be shadowed on inner classes by a private setter (field definitions in a class declaration)
 esid: prod-FieldDefinition
-features: [class-methods-private, class]
+features: [class-methods-private, class-fields-public, class]
 flags: [generated]
 info: |
     Updated Productions


### PR DESCRIPTION
It closes #2149.

These tests are validating if the scope of private methods and accessors are properly handled, mainly on cases when they are shadowed on inner classes.