### PR TITLE
Adding private brand check cases for private methods, getters and setters.

### DIFF
--- a/test/language/statements/class/elements/private-getter-brand-check-multiple-evaluations-of-class.js
+++ b/test/language/statements/class/elements/private-getter-brand-check-multiple-evaluations-of-class.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Every new evaluation of a class creates a different brand (private getter)
+esid: sec-privatefieldget
+info: |
+  ClassTail : ClassHeritage { ClassBody }
+    ...
+    11. Let proto be ObjectCreate(protoParent).
+    ...
+    31. If PrivateBoundIdentifiers of ClassBody contains a Private Name P such that the P's [[Kind]] field is either "method" or "accessor",
+      a. Set F.[[PrivateBrand]] to proto.
+    ...
+
+  PrivateBrandCheck(O, P)
+    1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+      a. Throw a TypeError exception.
+features: [class, class-methods-private]
+---*/
+
+let createAndInstantiateClass = function () {
+  class C {
+    get #m() { return 'test262'; }
+    
+    access(o) {
+      return o.#m;
+    }
+  }
+  
+  let c = new C();
+  return c;
+};
+
+let c1 = createAndInstantiateClass();
+let c2 = createAndInstantiateClass();
+
+assert.sameValue(c1.access(c1), 'test262');
+assert.sameValue(c2.access(c2), 'test262');
+
+assert.throws(TypeError, function() {
+  c1.access(c2);
+}, 'invalid access of c1 private method');
+
+assert.throws(TypeError, function() {
+  c2.access(c1);
+}, 'invalid access of c2 private method');

--- a/test/language/statements/class/elements/private-getter-brand-check-super-class.js
+++ b/test/language/statements/class/elements/private-getter-brand-check-super-class.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Subclass can access private methods of a superclass (private getter)
+esid: sec-privatefieldget
+info: |
+  SuperCall : super Arguments
+    ...
+    10. Perform ? InitializeInstanceElements(result, F).
+    ...
+
+  InitializeInstanceFieldsElements ( O, constructor )
+    1. Assert: Type ( O ) is Object.
+    2. Assert: Assert constructor is an ECMAScript function object.
+    3. If constructor.[[PrivateBrand]] is not undefined,
+      a. Perform ? PrivateBrandAdd(O, constructor.[[PrivateBrand]]).
+    4. Let fieldRecords be the value of constructor's [[Fields]] internal slot.
+    5. For each item fieldRecord in order from fieldRecords,
+      a. Perform ? DefineField(O, fieldRecord).
+    6. Return.
+features: [class, class-methods-private]
+---*/
+
+class S {
+  get #m() { return 'super class'; }
+  
+  superAccess() { return this.#m; }
+}
+
+class C extends S {
+  get #m() { return 'test262'; }
+  
+  access() {
+    return this.#m;
+  }
+}
+  
+let c = new C();
+
+assert.sameValue(c.access(), 'test262');
+assert.sameValue(c.superAccess(), 'super class');
+
+let s = new S();
+assert.sameValue(s.superAccess(), 'super class');
+assert.throws(TypeError, function() {
+  c.access.call(s);
+}, 'invalid access of C private method');

--- a/test/language/statements/class/elements/private-getter-brand-check.js
+++ b/test/language/statements/class/elements/private-getter-brand-check.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: PrivateBrandCheck fails when the object O doesn't have P.[[Brand]] (private getter)
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+
+  PrivateBrandCheck(O, P)
+    1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+      a. Throw a TypeError exception.
+features: [class, class-methods-private]
+---*/
+
+class C {
+  get #m() { return 'test262'; }
+  
+  access(o) {
+    return o.#m;
+  }
+}
+
+let c = new C();
+assert.sameValue(c.access(c), 'test262');
+
+let o = {};
+assert.throws(TypeError, function() {
+  c.access(o);
+}, 'invalid access a private method');
+

--- a/test/language/statements/class/elements/private-method-brand-check-multiple-evaluations-of-class.js
+++ b/test/language/statements/class/elements/private-method-brand-check-multiple-evaluations-of-class.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Every new evaluation of a class creates a different brand (private method)
+esid: sec-privatefieldget
+info: |
+  ClassTail : ClassHeritage { ClassBody }
+    ...
+    11. Let proto be ObjectCreate(protoParent).
+    ...
+    31. If PrivateBoundIdentifiers of ClassBody contains a Private Name P such that the P's [[Kind]] field is either "method" or "accessor",
+      a. Set F.[[PrivateBrand]] to proto.
+    ...
+
+  PrivateBrandCheck(O, P)
+    1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+      a. Throw a TypeError exception.
+features: [class, class-methods-private]
+---*/
+
+let createAndInstantiateClass = function () {
+  class C {
+    #m() { return 'test262'; }
+    
+    access(o) {
+      return o.#m();
+    }
+  }
+  
+  let c = new C();
+  return c;
+};
+
+let c1 = createAndInstantiateClass();
+let c2 = createAndInstantiateClass();
+
+assert.sameValue(c1.access(c1), 'test262');
+assert.sameValue(c2.access(c2), 'test262');
+
+assert.throws(TypeError, function() {
+  c1.access(c2);
+}, 'invalid access of c1 private method');
+
+assert.throws(TypeError, function() {
+  c2.access(c1);
+}, 'invalid access of c2 private method');

--- a/test/language/statements/class/elements/private-method-brand-check-super-class.js
+++ b/test/language/statements/class/elements/private-method-brand-check-super-class.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Subclass can access private methods of a superclass (private method)
+esid: sec-privatefieldget
+info: |
+  SuperCall : super Arguments
+    ...
+    10. Perform ? InitializeInstanceElements(result, F).
+    ...
+
+  InitializeInstanceFieldsElements ( O, constructor )
+    1. Assert: Type ( O ) is Object.
+    2. Assert: Assert constructor is an ECMAScript function object.
+    3. If constructor.[[PrivateBrand]] is not undefined,
+      a. Perform ? PrivateBrandAdd(O, constructor.[[PrivateBrand]]).
+    4. Let fieldRecords be the value of constructor's [[Fields]] internal slot.
+    5. For each item fieldRecord in order from fieldRecords,
+      a. Perform ? DefineField(O, fieldRecord).
+    6. Return.
+features: [class, class-methods-private]
+---*/
+
+class S {
+  #method() { return 'super class'; }
+  
+  superAccess() { return this.#method(); }
+}
+
+class C extends S {
+  #method() { return 'test262'; }
+  
+  access() {
+    return this.#method();
+  }
+}
+  
+let c = new C();
+
+assert.sameValue(c.access(), 'test262');
+assert.sameValue(c.superAccess(), 'super class');
+
+let s = new S();
+assert.sameValue(s.superAccess(), 'super class');
+assert.throws(TypeError, function() {
+  c.access.call(s);
+}, 'invalid access of C private method');

--- a/test/language/statements/class/elements/private-method-brand-check.js
+++ b/test/language/statements/class/elements/private-method-brand-check.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: PrivateBrandCheck fails when the object O doesn't have P.[[Brand]] (private method)
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+
+  PrivateBrandCheck(O, P)
+    1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+      a. Throw a TypeError exception.
+features: [class, class-methods-private]
+---*/
+
+class C {
+  #m() { return 'test262'; }
+  
+  access(o) {
+    return o.#m();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.access(c), 'test262');
+
+let o = {};
+assert.throws(TypeError, function() {
+  c.access(o);
+}, 'invalid access a private method');
+

--- a/test/language/statements/class/elements/private-setter-brand-check-multiple-evaluations-of-class.js
+++ b/test/language/statements/class/elements/private-setter-brand-check-multiple-evaluations-of-class.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Every new evaluation of a class creates a different brand (private setter)
+esid: sec-privatefieldget
+info: |
+  ClassTail : ClassHeritage { ClassBody }
+    ...
+    11. Let proto be ObjectCreate(protoParent).
+    ...
+    31. If PrivateBoundIdentifiers of ClassBody contains a Private Name P such that the P's [[Kind]] field is either "method" or "accessor",
+      a. Set F.[[PrivateBrand]] to proto.
+    ...
+
+  PrivateBrandCheck(O, P)
+    1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+      a. Throw a TypeError exception.
+features: [class, class-methods-private]
+---*/
+
+let createAndInstantiateClass = function () {
+  class C {
+    set #m(v) { this._v = v; }
+    
+    access(o, v) {
+      o.#m = v;
+    }
+  }
+  
+  let c = new C();
+  return c;
+};
+
+let c1 = createAndInstantiateClass();
+let c2 = createAndInstantiateClass();
+
+c1.access(c1, 'test262');
+assert.sameValue(c1._v, 'test262');
+c2.access(c2, 'test262');
+assert.sameValue(c2._v, 'test262');
+
+assert.throws(TypeError, function() {
+  c1.access(c2, 'foo');
+}, 'invalid access of c1 private method');
+
+assert.throws(TypeError, function() {
+  c2.access(c1, 'foo');
+}, 'invalid access of c2 private method');

--- a/test/language/statements/class/elements/private-setter-brand-check-super-class.js
+++ b/test/language/statements/class/elements/private-setter-brand-check-super-class.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Subclass can access private methods of a superclass (private setter)
+esid: sec-privatefieldget
+info: |
+  SuperCall : super Arguments
+    ...
+    10. Perform ? InitializeInstanceElements(result, F).
+    ...
+
+  InitializeInstanceFieldsElements ( O, constructor )
+    1. Assert: Type ( O ) is Object.
+    2. Assert: Assert constructor is an ECMAScript function object.
+    3. If constructor.[[PrivateBrand]] is not undefined,
+      a. Perform ? PrivateBrandAdd(O, constructor.[[PrivateBrand]]).
+    4. Let fieldRecords be the value of constructor's [[Fields]] internal slot.
+    5. For each item fieldRecord in order from fieldRecords,
+      a. Perform ? DefineField(O, fieldRecord).
+    6. Return.
+features: [class, class-methods-private]
+---*/
+
+class S {
+  set #m(v) { this._v = v }
+  
+  superAccess(v) { this.#m = v; }
+}
+
+class C extends S {
+  set #m(v) { this._u = v; }
+  
+  access(v) {
+    return this.#m = v;
+  }
+}
+  
+let c = new C();
+
+c.access('test262');
+assert.sameValue(c._u, 'test262');
+
+c.superAccess('super class');
+assert.sameValue(c._v, 'super class');
+
+let s = new S();
+s.superAccess('super class')
+assert.sameValue(s._v, 'super class');
+
+assert.throws(TypeError, function() {
+  c.access.call(s, 'foo');
+}, 'invalid access of C private method');

--- a/test/language/statements/class/elements/private-setter-brand-check.js
+++ b/test/language/statements/class/elements/private-setter-brand-check.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: PrivateBrandCheck fails when the object O doesn't have P.[[Brand]] (private setter)
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+
+  PrivateBrandCheck(O, P)
+    1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+      a. Throw a TypeError exception.
+features: [class, class-methods-private]
+---*/
+
+class C {
+  set #m(v) { this._v = v; }
+  
+  access(o, v) {
+    return o.#m = v;
+  }
+}
+
+let c = new C();
+c.access(c, 'test262');
+assert.sameValue(c._v, 'test262');
+
+let o = {};
+assert.throws(TypeError, function() {
+  c.access(o, 'foo');
+}, 'invalid access a private setter');
+


### PR DESCRIPTION
It closes #2151.

Cases we are adding:

1. Try to access a private method with an object that is not instance of the class where method/accessor is defined.
2. Multiple evaluations of a `class` generates different PrivateNames.
3. Super class private methods are accessible by subclass's object.