### PR TITLE
Improve Proxy/apply coverage

### DIFF
--- a/test/built-ins/Proxy/apply/call-parameters.js
+++ b/test/built-ins/Proxy/apply/call-parameters.js
@@ -14,7 +14,9 @@ features: [Proxy]
 ---*/
 
 var _target, _args, _handler, _context;
-var target = function() {};
+var target = function() {
+  throw new Test262Error('target should not be called');
+};
 var handler = {
   apply: function(t, c, args) {
     _handler = this;

--- a/test/built-ins/Proxy/apply/call-parameters.js
+++ b/test/built-ins/Proxy/apply/call-parameters.js
@@ -14,9 +14,7 @@ features: [Proxy]
 ---*/
 
 var _target, _args, _handler, _context;
-var target = function(a, b) {
-  return a + b;
-};
+var target = function() {};
 var handler = {
   apply: function(t, c, args) {
     _handler = this;

--- a/test/built-ins/Proxy/apply/call-parameters.js
+++ b/test/built-ins/Proxy/apply/call-parameters.js
@@ -1,6 +1,7 @@
 // Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
 es6id: 9.5.13
 description: >
     trap is called with handler object as its context, and parameters are:

--- a/test/built-ins/Proxy/apply/call-result.js
+++ b/test/built-ins/Proxy/apply/call-result.js
@@ -13,7 +13,9 @@ features: [Proxy]
 ---*/
 
 var result = {};
-var p = new Proxy(function() {}, {
+var p = new Proxy(function() {
+  throw new Test262Error('target should not be called');
+}, {
   apply: function(t, c, args) {
     return result;
   },

--- a/test/built-ins/Proxy/apply/call-result.js
+++ b/test/built-ins/Proxy/apply/call-result.js
@@ -12,15 +12,11 @@ info: |
 features: [Proxy]
 ---*/
 
-var target = function(a, b) {
-  return a + b;
-};
 var result = {};
-var handler = {
+var p = new Proxy(function() {}, {
   apply: function(t, c, args) {
     return result;
-  }
-};
-var p = new Proxy(target, handler);
+  },
+});
 
 assert.sameValue(p.call(), result);

--- a/test/built-ins/Proxy/apply/call-result.js
+++ b/test/built-ins/Proxy/apply/call-result.js
@@ -1,6 +1,7 @@
 // Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
 es6id: 9.5.13
 description: >
     Return the result from the trap method.

--- a/test/built-ins/Proxy/apply/null-handler-realm.js
+++ b/test/built-ins/Proxy/apply/null-handler-realm.js
@@ -3,6 +3,9 @@
 /*---
 esid: sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
 description: >
+    Throws a TypeError exception if handler is null (honoring the realm of the
+    current execution context). 
+info: |
     [[Call]] (thisArgument, argumentsList)
 
     1. Let handler be O.[[ProxyHandler]].

--- a/test/built-ins/Proxy/apply/null-handler-realm.js
+++ b/test/built-ins/Proxy/apply/null-handler-realm.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
+description: >
+    [[Call]] (thisArgument, argumentsList)
+
+    1. Let handler be O.[[ProxyHandler]].
+    2. If handler is null, throw a TypeError exception.
+features: [cross-realm, Proxy]
+---*/
+
+var OProxy = $262.createRealm().global.Proxy;
+var p = OProxy.revocable(function() {}, {});
+
+p.revoke();
+
+assert.throws(TypeError, function() {
+  p.proxy();
+});

--- a/test/built-ins/Proxy/apply/null-handler-realm.js
+++ b/test/built-ins/Proxy/apply/null-handler-realm.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// Copyright (C) 2019 Aleksey Shvayka. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist

--- a/test/built-ins/Proxy/apply/null-handler.js
+++ b/test/built-ins/Proxy/apply/null-handler.js
@@ -1,6 +1,7 @@
 // Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
 es6id: 9.5.13
 description: >
     [[Call]] (thisArgument, argumentsList)

--- a/test/built-ins/Proxy/apply/return-abrupt.js
+++ b/test/built-ins/Proxy/apply/return-abrupt.js
@@ -1,6 +1,7 @@
 // Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
 es6id: 9.5.13
 description: >
     Return is an abrupt completion

--- a/test/built-ins/Proxy/apply/return-abrupt.js
+++ b/test/built-ins/Proxy/apply/return-abrupt.js
@@ -8,7 +8,9 @@ description: >
 features: [Proxy]
 ---*/
 
-var p = new Proxy(function() {}, {
+var p = new Proxy(function() {
+  throw 'not the Test262Error you are looking for';
+}, {
   apply: function(t, c, args) {
     throw new Test262Error();
   }

--- a/test/built-ins/Proxy/apply/return-abrupt.js
+++ b/test/built-ins/Proxy/apply/return-abrupt.js
@@ -8,10 +8,7 @@ description: >
 features: [Proxy]
 ---*/
 
-var target = function(a, b) {
-  return a + b;
-};
-var p = new Proxy(target, {
+var p = new Proxy(function() {}, {
   apply: function(t, c, args) {
     throw new Test262Error();
   }

--- a/test/built-ins/Proxy/apply/trap-is-not-callable.js
+++ b/test/built-ins/Proxy/apply/trap-is-not-callable.js
@@ -1,6 +1,7 @@
 // Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
 es6id: 9.5.13
 description: >
     Throws if trap is not callable.

--- a/test/built-ins/Proxy/apply/trap-is-null.js
+++ b/test/built-ins/Proxy/apply/trap-is-null.js
@@ -24,17 +24,23 @@ features: [Proxy]
 ---*/
 
 var calls = 0;
+var _context;
 
-function target(a, b) {
-  assert.sameValue(this, ctx);
-  calls += 1;
-  return a + b;
-}
+var target = new Proxy(function() {}, {
+  apply: function(_target, context, args) {
+    calls++;
+    _context = context;
+    return args[0] + args[1];
+  }
+})
 
-var ctx = {};
 var p = new Proxy(target, {
   apply: null
 });
-var res = p.call(ctx, 1, 2);
-assert.sameValue(res, 3, "`apply` trap is `null`");
-assert.sameValue(calls, 1, "target is called once");
+
+var context = {};
+var res = p.call(context, 1, 2);
+
+assert.sameValue(calls, 1, "apply is null: [[Call]] is invoked once");
+assert.sameValue(_context, context, "apply is null: context is passed to [[Call]]");
+assert.sameValue(res, 3, "apply is null: result of [[Call]] is returned");

--- a/test/built-ins/Proxy/apply/trap-is-undefined-no-property.js
+++ b/test/built-ins/Proxy/apply/trap-is-undefined-no-property.js
@@ -24,15 +24,20 @@ features: [Proxy]
 ---*/
 
 var calls = 0;
+var _context;
 
-function target(a, b) {
-  assert.sameValue(this, ctx);
-  calls += 1;
-  return a + b;
-}
+var target = new Proxy(function() {}, {
+  apply: function(_target, context, args) {
+    calls++;
+    _context = context;
+    return args[0] + args[1];
+  }
+})
 
-var ctx = {};
 var p = new Proxy(target, {});
-var res = p.call(ctx, 1, 2);
-assert.sameValue(res, 3, "`apply` trap is missing");
-assert.sameValue(calls, 1, "target is called once");
+var context = {};
+var res = p.call(context, 1, 2);
+
+assert.sameValue(calls, 1, "apply is missing: [[Call]] is invoked once");
+assert.sameValue(_context, context, "apply is missing: context is passed to [[Call]]");
+assert.sameValue(res, 3, "apply is missing: result of [[Call]] is returned");

--- a/test/built-ins/Proxy/apply/trap-is-undefined.js
+++ b/test/built-ins/Proxy/apply/trap-is-undefined.js
@@ -24,17 +24,23 @@ features: [Proxy]
 ---*/
 
 var calls = 0;
+var _context;
 
-function target(a, b) {
-  assert.sameValue(this, ctx);
-  calls += 1;
-  return a + b;
-}
+var target = new Proxy(function() {}, {
+  apply: function(_target, context, args) {
+    calls++;
+    _context = context;
+    return args[0] + args[1];
+  }
+})
 
-var ctx = {};
 var p = new Proxy(target, {
   apply: undefined
 });
-var res = p.call(ctx, 1, 2);
-assert.sameValue(res, 3, "`apply` trap is `null`");
-assert.sameValue(calls, 1, "target is called once");
+
+var context = {};
+var res = p.call(context, 1, 2);
+
+assert.sameValue(calls, 1, "apply is undefined: [[Call]] is invoked once");
+assert.sameValue(_context, context, "apply is undefined: context is passed to [[Call]]");
+assert.sameValue(res, 3, "apply is undefined: result of [[Call]] is returned");


### PR DESCRIPTION
I would really love feedback on 2a65c06: I assert that [`[[Call]]`](https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist) method of proxies does `.[[Call]]` on the target, not just making ordinary [`[[Call]`](https://tc39.github.io/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist).

There are [similar tests](https://github.com/tc39/test262/blob/2682ab57cf61796b503575b81bd73dc69c10e372/implementation-contributed/javascriptcore/stress/proxy-get-set-correct-receiver.js#L94) for `[[Get]]` and `[[Set]]`, contributed by JSC team.

Follow-up of #1075.