### PR TITLE
change the removed unit 'generic' to 'gigabit'

### DIFF
--- a/test/intl402/NumberFormat/style-unit.js
+++ b/test/intl402/NumberFormat/style-unit.js
@@ -20,7 +20,7 @@ const validOptions = [
 ];
 
 for (const [validOption, expected] of validOptions) {
-  const nf = new Intl.NumberFormat([], {"style": validOption, "unit": "generic"});
+  const nf = new Intl.NumberFormat([], {"style": validOption, "unit": "gigabit"});
   const resolvedOptions = nf.resolvedOptions();
   assert.sameValue(resolvedOptions.style, expected);
 }


### PR DESCRIPTION
https://github.com/tc39/proposal-unified-intl-numberformat/pull/42 removed 'generic'. So we need to change the value to a still valid unit.
@sffc @littledan @leobalter 