### PR TITLE
Add Object subclass test

### DIFF
--- a/test/built-ins/Object/subclass-object-arg.js
+++ b/test/built-ins/Object/subclass-object-arg.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Aleksey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-value
+author: Matthew Phillips <matthew@matthewphillips.info>
+description: >
+  NewTarget is active function and subclass of Object
+info: |
+  Object ( [ value ] )
+
+  1. If NewTarget is neither undefined nor the active function, then
+    a. Return ? OrdinaryCreateFromConstructor(NewTarget, "%ObjectPrototype%").
+  [...]
+  3. Return ! ToObject(value).
+features: [class, Reflect, Reflect.construct]
+---*/
+
+class O extends Object {}
+
+var o1 = new O({a: 1});
+var o2 = Reflect.construct(Object, [{b: 2}], O);
+
+assert.sameValue(o1.a, 1);
+assert.sameValue(o2.b, 2);


### PR DESCRIPTION
[Matthew's tweet](https://twitter.com/matthewcp/status/1131328938347773952).

This is definitely `Object`-specific issue.

<details>

<summary>Extending user-defined constructors that return objects works as expected across browsers.</summary>

```js
class A {
  constructor(arg) {
    return arg;
  }
}

class B extends A {}

let b = new B({a: 1});
b.a // => 1
```

</details>