### PR TITLE
Check private methods are not installed before super returns

### DIFF
--- a/src/class-elements/prod-private-getter-before-super-return-in-constructor.case
+++ b/src/class-elements/prod-private-getter-before-super-return-in-constructor.case
@@ -1,0 +1,42 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Private getters are installed "when super returns" and no earlier (call in constructor)
+info: |
+  SuperCall: super Arguments
+    1. Let newTarget be GetNewTarget().
+    2. If newTarget is undefined, throw a ReferenceError exception.
+    3. Let func be ? GetSuperConstructor().
+    4. Let argList be ArgumentListEvaluation of Arguments.
+    5. ReturnIfAbrupt(argList).
+    6. Let result be ? Construct(func, argList, newTarget).
+    7. Let thisER be GetThisEnvironment( ).
+    8. Let F be thisER.[[FunctionObject]].
+    9. Assert: F is an ECMAScript function object.
+    10. Perform ? InitializeInstanceElements(result, F).
+
+  EDITOR'S NOTE:
+    Private fields are added to the object one by one, interspersed with
+    evaluation of the initializers, following the construction of the
+    receiver. These semantics allow for a later initializer to refer to
+    a previous private field.
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+constructor() {
+    this.f();
+}
+
+//- assertions
+class D extends C {
+    f() { this.#m; }
+    get #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('f'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private getters are not installed before super returns');

--- a/src/class-elements/prod-private-getter-before-super-return-in-field-initializer.case
+++ b/src/class-elements/prod-private-getter-before-super-return-in-field-initializer.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Private getters are installed "when super returns" and no earlier (call in field initializer)
+info: |
+  SuperCall: super Arguments
+    1. Let newTarget be GetNewTarget().
+    2. If newTarget is undefined, throw a ReferenceError exception.
+    3. Let func be ? GetSuperConstructor().
+    4. Let argList be ArgumentListEvaluation of Arguments.
+    5. ReturnIfAbrupt(argList).
+    6. Let result be ? Construct(func, argList, newTarget).
+    7. Let thisER be GetThisEnvironment( ).
+    8. Let F be thisER.[[FunctionObject]].
+    9. Assert: F is an ECMAScript function object.
+    10. Perform ? InitializeInstanceElements(result, F).
+
+  EDITOR'S NOTE:
+    Private fields are added to the object one by one, interspersed with
+    evaluation of the initializers, following the construction of the
+    receiver. These semantics allow for a later initializer to refer to
+    a previous private field.
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+f = this.g();
+
+//- assertions
+class D extends C {
+    g() { this.#m; }
+    get #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('g'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private getters are not installed before super returns');

--- a/src/class-elements/prod-private-method-before-super-return-in-constructor.case
+++ b/src/class-elements/prod-private-method-before-super-return-in-constructor.case
@@ -1,0 +1,42 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Private methods are installed "when super returns" and no earlier (call in constructor)
+info: |
+  SuperCall: super Arguments
+    1. Let newTarget be GetNewTarget().
+    2. If newTarget is undefined, throw a ReferenceError exception.
+    3. Let func be ? GetSuperConstructor().
+    4. Let argList be ArgumentListEvaluation of Arguments.
+    5. ReturnIfAbrupt(argList).
+    6. Let result be ? Construct(func, argList, newTarget).
+    7. Let thisER be GetThisEnvironment( ).
+    8. Let F be thisER.[[FunctionObject]].
+    9. Assert: F is an ECMAScript function object.
+    10. Perform ? InitializeInstanceElements(result, F).
+
+  EDITOR'S NOTE:
+    Private fields are added to the object one by one, interspersed with
+    evaluation of the initializers, following the construction of the
+    receiver. These semantics allow for a later initializer to refer to
+    a previous private field.
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+constructor() {
+    this.f();
+}
+
+//- assertions
+class D extends C {
+    f() { this.#m(); }
+    #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('f'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private methods are not installed before super returns');

--- a/src/class-elements/prod-private-method-before-super-return-in-field-initializer.case
+++ b/src/class-elements/prod-private-method-before-super-return-in-field-initializer.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Private methods are installed "when super returns" and no earlier (call in field initializer)
+info: |
+  SuperCall: super Arguments
+    1. Let newTarget be GetNewTarget().
+    2. If newTarget is undefined, throw a ReferenceError exception.
+    3. Let func be ? GetSuperConstructor().
+    4. Let argList be ArgumentListEvaluation of Arguments.
+    5. ReturnIfAbrupt(argList).
+    6. Let result be ? Construct(func, argList, newTarget).
+    7. Let thisER be GetThisEnvironment( ).
+    8. Let F be thisER.[[FunctionObject]].
+    9. Assert: F is an ECMAScript function object.
+    10. Perform ? InitializeInstanceElements(result, F).
+
+  EDITOR'S NOTE:
+    Private fields are added to the object one by one, interspersed with
+    evaluation of the initializers, following the construction of the
+    receiver. These semantics allow for a later initializer to refer to
+    a previous private field.
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+f = this.g();
+
+//- assertions
+class D extends C {
+    g() { this.#m(); }
+    #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('g'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private methods are not installed before super returns');

--- a/src/class-elements/prod-private-setter-before-super-return-in-constructor.case
+++ b/src/class-elements/prod-private-setter-before-super-return-in-constructor.case
@@ -1,0 +1,42 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Private setters are installed "when super returns" and no earlier (call in constructor)
+info: |
+  SuperCall: super Arguments
+    1. Let newTarget be GetNewTarget().
+    2. If newTarget is undefined, throw a ReferenceError exception.
+    3. Let func be ? GetSuperConstructor().
+    4. Let argList be ArgumentListEvaluation of Arguments.
+    5. ReturnIfAbrupt(argList).
+    6. Let result be ? Construct(func, argList, newTarget).
+    7. Let thisER be GetThisEnvironment( ).
+    8. Let F be thisER.[[FunctionObject]].
+    9. Assert: F is an ECMAScript function object.
+    10. Perform ? InitializeInstanceElements(result, F).
+
+  EDITOR'S NOTE:
+    Private fields are added to the object one by one, interspersed with
+    evaluation of the initializers, following the construction of the
+    receiver. These semantics allow for a later initializer to refer to
+    a previous private field.
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+constructor() {
+    this.f();
+}
+
+//- assertions
+class D extends C {
+    f() { this.#m = 42; }
+    set #m(val) {}
+}
+
+assert(D.prototype.hasOwnProperty('f'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private setters are not installed before super returns');

--- a/src/class-elements/prod-private-setter-before-super-return-in-field-initializer.case
+++ b/src/class-elements/prod-private-setter-before-super-return-in-field-initializer.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Private settters are installed "when super returns" and no earlier (call in field initializer)
+info: |
+  SuperCall: super Arguments
+    1. Let newTarget be GetNewTarget().
+    2. If newTarget is undefined, throw a ReferenceError exception.
+    3. Let func be ? GetSuperConstructor().
+    4. Let argList be ArgumentListEvaluation of Arguments.
+    5. ReturnIfAbrupt(argList).
+    6. Let result be ? Construct(func, argList, newTarget).
+    7. Let thisER be GetThisEnvironment( ).
+    8. Let F be thisER.[[FunctionObject]].
+    9. Assert: F is an ECMAScript function object.
+    10. Perform ? InitializeInstanceElements(result, F).
+
+  EDITOR'S NOTE:
+    Private fields are added to the object one by one, interspersed with
+    evaluation of the initializers, following the construction of the
+    receiver. These semantics allow for a later initializer to refer to
+    a previous private field.
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+f = this.g();
+
+//- assertions
+class D extends C {
+    g() { this.#m = 42; }
+    set #m(val) {}
+}
+
+assert(D.prototype.hasOwnProperty('g'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private setters are not installed before super returns');

--- a/test/language/expressions/class/elements/prod-private-getter-before-super-return-in-constructor.js
+++ b/test/language/expressions/class/elements/prod-private-getter-before-super-return-in-constructor.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-getter-before-super-return-in-constructor.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Private getters are installed "when super returns" and no earlier (call in constructor) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+var C = class {
+  constructor() {
+      this.f();
+  }
+
+}
+
+class D extends C {
+    f() { this.#m; }
+    get #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('f'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private getters are not installed before super returns');

--- a/test/language/expressions/class/elements/prod-private-getter-before-super-return-in-field-initializer.js
+++ b/test/language/expressions/class/elements/prod-private-getter-before-super-return-in-field-initializer.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-getter-before-super-return-in-field-initializer.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Private getters are installed "when super returns" and no earlier (call in field initializer) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+var C = class {
+  f = this.g();
+
+}
+
+class D extends C {
+    g() { this.#m; }
+    get #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('g'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private getters are not installed before super returns');

--- a/test/language/expressions/class/elements/prod-private-method-before-super-return-in-constructor.js
+++ b/test/language/expressions/class/elements/prod-private-method-before-super-return-in-constructor.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-method-before-super-return-in-constructor.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Private methods are installed "when super returns" and no earlier (call in constructor) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+var C = class {
+  constructor() {
+      this.f();
+  }
+
+}
+
+class D extends C {
+    f() { this.#m(); }
+    #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('f'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private methods are not installed before super returns');

--- a/test/language/expressions/class/elements/prod-private-method-before-super-return-in-field-initializer.js
+++ b/test/language/expressions/class/elements/prod-private-method-before-super-return-in-field-initializer.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-method-before-super-return-in-field-initializer.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Private methods are installed "when super returns" and no earlier (call in field initializer) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+var C = class {
+  f = this.g();
+
+}
+
+class D extends C {
+    g() { this.#m(); }
+    #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('g'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private methods are not installed before super returns');

--- a/test/language/expressions/class/elements/prod-private-setter-before-super-return-in-constructor.js
+++ b/test/language/expressions/class/elements/prod-private-setter-before-super-return-in-constructor.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-setter-before-super-return-in-constructor.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Private setters are installed "when super returns" and no earlier (call in constructor) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+var C = class {
+  constructor() {
+      this.f();
+  }
+
+}
+
+class D extends C {
+    f() { this.#m = 42; }
+    set #m(val) {}
+}
+
+assert(D.prototype.hasOwnProperty('f'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private setters are not installed before super returns');

--- a/test/language/expressions/class/elements/prod-private-setter-before-super-return-in-field-initializer.js
+++ b/test/language/expressions/class/elements/prod-private-setter-before-super-return-in-field-initializer.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-setter-before-super-return-in-field-initializer.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Private settters are installed "when super returns" and no earlier (call in field initializer) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+var C = class {
+  f = this.g();
+
+}
+
+class D extends C {
+    g() { this.#m = 42; }
+    set #m(val) {}
+}
+
+assert(D.prototype.hasOwnProperty('g'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private setters are not installed before super returns');

--- a/test/language/statements/class/elements/prod-private-getter-before-super-return-in-constructor.js
+++ b/test/language/statements/class/elements/prod-private-getter-before-super-return-in-constructor.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-getter-before-super-return-in-constructor.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Private getters are installed "when super returns" and no earlier (call in constructor) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+class C {
+  constructor() {
+      this.f();
+  }
+
+}
+
+class D extends C {
+    f() { this.#m; }
+    get #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('f'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private getters are not installed before super returns');

--- a/test/language/statements/class/elements/prod-private-getter-before-super-return-in-field-initializer.js
+++ b/test/language/statements/class/elements/prod-private-getter-before-super-return-in-field-initializer.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-getter-before-super-return-in-field-initializer.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Private getters are installed "when super returns" and no earlier (call in field initializer) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+class C {
+  f = this.g();
+
+}
+
+class D extends C {
+    g() { this.#m; }
+    get #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('g'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private getters are not installed before super returns');

--- a/test/language/statements/class/elements/prod-private-method-before-super-return-in-constructor.js
+++ b/test/language/statements/class/elements/prod-private-method-before-super-return-in-constructor.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-method-before-super-return-in-constructor.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Private methods are installed "when super returns" and no earlier (call in constructor) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+class C {
+  constructor() {
+      this.f();
+  }
+
+}
+
+class D extends C {
+    f() { this.#m(); }
+    #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('f'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private methods are not installed before super returns');

--- a/test/language/statements/class/elements/prod-private-method-before-super-return-in-field-initializer.js
+++ b/test/language/statements/class/elements/prod-private-method-before-super-return-in-field-initializer.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-method-before-super-return-in-field-initializer.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Private methods are installed "when super returns" and no earlier (call in field initializer) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+class C {
+  f = this.g();
+
+}
+
+class D extends C {
+    g() { this.#m(); }
+    #m() { return 42; }
+}
+
+assert(D.prototype.hasOwnProperty('g'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private methods are not installed before super returns');

--- a/test/language/statements/class/elements/prod-private-setter-before-super-return-in-constructor.js
+++ b/test/language/statements/class/elements/prod-private-setter-before-super-return-in-constructor.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-setter-before-super-return-in-constructor.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Private setters are installed "when super returns" and no earlier (call in constructor) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+class C {
+  constructor() {
+      this.f();
+  }
+
+}
+
+class D extends C {
+    f() { this.#m = 42; }
+    set #m(val) {}
+}
+
+assert(D.prototype.hasOwnProperty('f'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private setters are not installed before super returns');

--- a/test/language/statements/class/elements/prod-private-setter-before-super-return-in-field-initializer.js
+++ b/test/language/statements/class/elements/prod-private-setter-before-super-return-in-field-initializer.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/prod-private-setter-before-super-return-in-field-initializer.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Private settters are installed "when super returns" and no earlier (call in field initializer) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    SuperCall: super Arguments
+      1. Let newTarget be GetNewTarget().
+      2. If newTarget is undefined, throw a ReferenceError exception.
+      3. Let func be ? GetSuperConstructor().
+      4. Let argList be ArgumentListEvaluation of Arguments.
+      5. ReturnIfAbrupt(argList).
+      6. Let result be ? Construct(func, argList, newTarget).
+      7. Let thisER be GetThisEnvironment( ).
+      8. Let F be thisER.[[FunctionObject]].
+      9. Assert: F is an ECMAScript function object.
+      10. Perform ? InitializeInstanceElements(result, F).
+
+    EDITOR'S NOTE:
+      Private fields are added to the object one by one, interspersed with
+      evaluation of the initializers, following the construction of the
+      receiver. These semantics allow for a later initializer to refer to
+      a previous private field.
+
+---*/
+
+
+class C {
+  f = this.g();
+
+}
+
+class D extends C {
+    g() { this.#m = 42; }
+    set #m(val) {}
+}
+
+assert(D.prototype.hasOwnProperty('g'));
+assert.throws(TypeError, function() {
+    var d = new D();
+}, 'private setters are not installed before super returns');


### PR DESCRIPTION
Adds tests calling private methods before super is constructed - according to the test plan posted in #1343.

>  Private methods are installed "when super returns" and no earlier. A similar test is possible with field initializers instead of code called in the constructor.

I will commit the generated tests once the PR is approved.

@leobalter @rwaldron for review.
cc: @littledan @jbhoosreddy @caiolima 