### PR TITLE
Improve "name" tests of Promise built-in functions

### DIFF
--- a/test/built-ins/Promise/all/resolve-element-function-name.js
+++ b/test/built-ins/Promise/all/resolve-element-function-name.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+esid: sec-promise.all-resolve-element-functions
 es6id: 25.4.4.1.2
 description: The `name` property of Promise.all Resolve Element functions
 info: |
@@ -29,3 +30,6 @@ NotPromise.resolve = function(v) {
 Promise.all.call(NotPromise, [thenable]);
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(resolveElementFunction, "name"), false);
+assert.sameValue(Object.getOwnPropertyNames(resolveElementFunction).join(), "length");
+assert.sameValue(delete resolveElementFunction.name, true);
+assert.sameValue(resolveElementFunction.name, "");

--- a/test/built-ins/Promise/all/resolve-element-function-name.js
+++ b/test/built-ins/Promise/all/resolve-element-function-name.js
@@ -30,6 +30,4 @@ NotPromise.resolve = function(v) {
 Promise.all.call(NotPromise, [thenable]);
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(resolveElementFunction, "name"), false);
-assert.sameValue(Object.getOwnPropertyNames(resolveElementFunction).join(), "length");
-assert.sameValue(delete resolveElementFunction.name, true);
 assert.sameValue(resolveElementFunction.name, "");

--- a/test/built-ins/Promise/all/resolve-element-function-name.js
+++ b/test/built-ins/Promise/all/resolve-element-function-name.js
@@ -3,7 +3,6 @@
 
 /*---
 esid: sec-promise.all-resolve-element-functions
-es6id: 25.4.4.1.2
 description: The `name` property of Promise.all Resolve Element functions
 info: |
   A promise resolve function is an anonymous built-in function.

--- a/test/built-ins/Promise/allSettled/reject-element-function-name.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-name.js
@@ -30,3 +30,6 @@ NotPromise.resolve = function(v) {
 Promise.allSettled.call(NotPromise, [thenable]);
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(rejectElementFunction, 'name'), false);
+assert.sameValue(Object.getOwnPropertyNames(rejectElementFunction).join(), 'length');
+assert.sameValue(delete rejectElementFunction.name, true);
+assert.sameValue(rejectElementFunction.name, '');

--- a/test/built-ins/Promise/allSettled/reject-element-function-name.js
+++ b/test/built-ins/Promise/allSettled/reject-element-function-name.js
@@ -30,6 +30,4 @@ NotPromise.resolve = function(v) {
 Promise.allSettled.call(NotPromise, [thenable]);
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(rejectElementFunction, 'name'), false);
-assert.sameValue(Object.getOwnPropertyNames(rejectElementFunction).join(), 'length');
-assert.sameValue(delete rejectElementFunction.name, true);
 assert.sameValue(rejectElementFunction.name, '');

--- a/test/built-ins/Promise/allSettled/resolve-element-function-name.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-name.js
@@ -33,3 +33,9 @@ assert.sameValue(
   Object.prototype.hasOwnProperty.call(resolveElementFunction, 'name'),
   false
 );
+assert.sameValue(
+  Object.getOwnPropertyNames(resolveElementFunction).join(),
+  'length'
+);
+assert.sameValue(delete resolveElementFunction.name, true);
+assert.sameValue(resolveElementFunction.name, '');

--- a/test/built-ins/Promise/allSettled/resolve-element-function-name.js
+++ b/test/built-ins/Promise/allSettled/resolve-element-function-name.js
@@ -33,9 +33,4 @@ assert.sameValue(
   Object.prototype.hasOwnProperty.call(resolveElementFunction, 'name'),
   false
 );
-assert.sameValue(
-  Object.getOwnPropertyNames(resolveElementFunction).join(),
-  'length'
-);
-assert.sameValue(delete resolveElementFunction.name, true);
 assert.sameValue(resolveElementFunction.name, '');

--- a/test/built-ins/Promise/executor-function-name.js
+++ b/test/built-ins/Promise/executor-function-name.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+esid: sec-getcapabilitiesexecutor-functions
 es6id: 25.4.1.5.1
 description: The `name` property of GetCapabilitiesExecutor functions
 info: |
@@ -22,3 +23,6 @@ function NotPromise(executor) {
 Promise.resolve.call(NotPromise);
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(executorFunction, "name"), false);
+assert.sameValue(Object.getOwnPropertyNames(executorFunction).join(), "length");
+assert.sameValue(delete executorFunction.name, true);
+assert.sameValue(executorFunction.name, "");

--- a/test/built-ins/Promise/executor-function-name.js
+++ b/test/built-ins/Promise/executor-function-name.js
@@ -3,7 +3,6 @@
 
 /*---
 esid: sec-getcapabilitiesexecutor-functions
-es6id: 25.4.1.5.1
 description: The `name` property of GetCapabilitiesExecutor functions
 info: |
   A GetCapabilitiesExecutor function is an anonymous built-in function.

--- a/test/built-ins/Promise/executor-function-name.js
+++ b/test/built-ins/Promise/executor-function-name.js
@@ -23,6 +23,4 @@ function NotPromise(executor) {
 Promise.resolve.call(NotPromise);
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(executorFunction, "name"), false);
-assert.sameValue(Object.getOwnPropertyNames(executorFunction).join(), "length");
-assert.sameValue(delete executorFunction.name, true);
 assert.sameValue(executorFunction.name, "");

--- a/test/built-ins/Promise/reject-function-name.js
+++ b/test/built-ins/Promise/reject-function-name.js
@@ -20,6 +20,4 @@ new Promise(function(resolve, reject) {
 });
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(rejectFunction, "name"), false);
-assert.sameValue(Object.getOwnPropertyNames(rejectFunction).join(), "length");
-assert.sameValue(delete rejectFunction.name, true);
 assert.sameValue(rejectFunction.name, "");

--- a/test/built-ins/Promise/reject-function-name.js
+++ b/test/built-ins/Promise/reject-function-name.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+esid: sec-promise-reject-functions
 es6id: 25.4.1.3.1
 description: The `name` property of Promise Reject functions
 info: |
@@ -19,3 +20,6 @@ new Promise(function(resolve, reject) {
 });
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(rejectFunction, "name"), false);
+assert.sameValue(Object.getOwnPropertyNames(rejectFunction).join(), "length");
+assert.sameValue(delete rejectFunction.name, true);
+assert.sameValue(rejectFunction.name, "");

--- a/test/built-ins/Promise/reject-function-name.js
+++ b/test/built-ins/Promise/reject-function-name.js
@@ -3,7 +3,6 @@
 
 /*---
 esid: sec-promise-reject-functions
-es6id: 25.4.1.3.1
 description: The `name` property of Promise Reject functions
 info: |
   A promise reject function is an anonymous built-in function.

--- a/test/built-ins/Promise/resolve-function-name.js
+++ b/test/built-ins/Promise/resolve-function-name.js
@@ -20,6 +20,4 @@ new Promise(function(resolve, reject) {
 });
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(resolveFunction, "name"), false);
-assert.sameValue(Object.getOwnPropertyNames(resolveFunction).join(), "length");
-assert.sameValue(delete resolveFunction.name, true);
 assert.sameValue(resolveFunction.name, "");

--- a/test/built-ins/Promise/resolve-function-name.js
+++ b/test/built-ins/Promise/resolve-function-name.js
@@ -3,7 +3,6 @@
 
 /*---
 esid: sec-promise-resolve-functions
-es6id: 25.4.1.3.2
 description: The `name` property of Promise Resolve functions
 info: |
   A promise resolve function is an anonymous built-in function.

--- a/test/built-ins/Promise/resolve-function-name.js
+++ b/test/built-ins/Promise/resolve-function-name.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+esid: sec-promise-resolve-functions
 es6id: 25.4.1.3.2
 description: The `name` property of Promise Resolve functions
 info: |
@@ -19,3 +20,6 @@ new Promise(function(resolve, reject) {
 });
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(resolveFunction, "name"), false);
+assert.sameValue(Object.getOwnPropertyNames(resolveFunction).join(), "length");
+assert.sameValue(delete resolveFunction.name, true);
+assert.sameValue(resolveFunction.name, "");


### PR DESCRIPTION
| Engine              | `name`  | `Promise.allSettled` | CI |
| -------------- | --------- | -------------------- | -- |
| ChakraCore     | 👌          | ❌                               | ❌|
| JSC                  | 👌          | ❌                               | ❌|
| SpiderMonkey | ❌          | ❌                              | ❌|
| V8                    | ❌          | 👌                               | ❌|

Closes #1752.