### PR TITLE
Skip hidden files in generator.py

### DIFF
--- a/tools/generation/generator.py
+++ b/tools/generation/generator.py
@@ -30,7 +30,13 @@ def find_cases(location):
         return None, [location]
     else:
         return None, map(
-            lambda x: os.path.join(args.cases, x), os.listdir(args.cases))
+            lambda x: os.path.join(args.cases, x),
+            filter(
+                # skip hidden files on Unix, such as ".DS_Store" on Mac
+                lambda x: not x.startswith('.'),
+                os.listdir(args.cases)
+            )
+        )
 
 def clean(args):
     for (subdir, _, fileNames) in os.walk(args.directory):


### PR DESCRIPTION
PEP-8 formatted.

<details>
<summary>macOS stack trace (running make.py)</summary>

```
Running target: build
> /usr/bin/python tools/generation/generator.py create --out test src
Traceback (most recent call last):
  File "tools/generation/generator.py", line 95, in <module>
    args.func(args)
  File "tools/generation/generator.py", line 49, in create
    for test in exp.expand('utf-8', caseFile):
  File "/Users/admin/test262/tools/generation/lib/expander.py", line 49, in expand
    for case_file in case_files:
  File "/Users/admin/test262/tools/generation/lib/expander.py", line 38, in list_cases
    for name in os.listdir(self.case_dir):
OSError: [Errno 20] Not a directory: 'src/.DS_Store'
Traceback (most recent call last):
  File "./make.py", line 78, in <module>
    targets['build']()
  File "./make.py", line 34, in wrapped
    return orig()
  File "./make.py", line 45, in build
    SRC_DIR)
  File "./make.py", line 24, in shell
    raise Exception('Command failed: ' + cmd_str)
Exception: Command failed: /usr/bin/python tools/generation/generator.py create --out test src
```

</details>