### PR TITLE
Adding new test cases to validate public class fields initialization.

### DIFF
--- a/test/language/statements/class/elements/class-field-is-observable-by-proxy.js
+++ b/test/language/statements/class/elements/class-field-is-observable-by-proxy.js
@@ -18,28 +18,29 @@ features: [class, class-fields-public, Proxy]
 ---*/
 
 let arr = [];
-
-class ProxyBase {
-  constructor() {
-    return new Proxy(this, {
-      defineProperty: function (target, key, descriptor) {
-        arr.push(key);
-        assert(descriptor.enumerable);
-        assert(descriptor.configurable);
-        assert(descriptor.writable);
-        return Reflect.defineProperty(target, key, descriptor);
-      }
-    });
-  }
+let expectedTarget = null;
+function ProxyBase() {
+  expectedTarget = this;
+  return new Proxy(this, {
+    defineProperty: function (target, key, descriptor) {
+      arr.push(key);
+      arr.push(descriptor.value);
+      arr.push(target);
+      assert.sameValue(descriptor.enumerable, true);
+      assert.sameValue(descriptor.configurable, true);
+      assert.sameValue(descriptor.writable, true);
+      return Reflect.defineProperty(target, key, descriptor);
+    }
+  });
 }
 
 class Test extends ProxyBase {
   f = 3;
-  g = "test";
+  g = "Test262";
 }
 
 let t = new Test();
 assert.sameValue(t.f, 3);
-assert.sameValue(t.g, "test");
+assert.sameValue(t.g, "Test262");
 
-assert.compareArray(arr, ["f", "g"]);
+assert.compareArray(arr, ["f", expectedTarget, 3, "g", expectedTarget, "Test262"]);

--- a/test/language/statements/class/elements/class-field-is-observable-by-proxy.js
+++ b/test/language/statements/class/elements/class-field-is-observable-by-proxy.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2019 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Public class fields initialization calls [[DefineOwnProperty]]
+esid: sec-define-field
+info: |
+  DefineField(receiver, fieldRecord)
+    ...
+    8. If fieldName is a Private Name,
+      a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+    9. Else,
+      a. Assert: IsPropertyKey(fieldName) is true.
+      b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+    10. Return.
+includes: [compareArray.js]
+features: [class, class-fields-public, Proxy]
+---*/
+
+let arr = [];
+
+class ProxyBase {
+  constructor() {
+    return new Proxy(this, {
+      defineProperty: function (target, key, descriptor) {
+        arr.push(key);
+        assert(descriptor.enumerable);
+        assert(descriptor.configurable);
+        assert(descriptor.writable);
+        return Reflect.defineProperty(target, key, descriptor);
+      }
+    });
+  }
+}
+
+class Test extends ProxyBase {
+  f = 3;
+  g = "test";
+}
+
+let t = new Test();
+assert.sameValue(t.f, 3);
+assert.sameValue(t.g, "test");
+
+assert.compareArray(arr, ["f", "g"]);

--- a/test/language/statements/class/elements/class-field-is-observable-by-proxy.js
+++ b/test/language/statements/class/elements/class-field-is-observable-by-proxy.js
@@ -43,4 +43,4 @@ let t = new Test();
 assert.sameValue(t.f, 3);
 assert.sameValue(t.g, "Test262");
 
-assert.compareArray(arr, ["f", expectedTarget, 3, "g", expectedTarget, "Test262"]);
+assert.compareArray(arr, ["f", 3, expectedTarget, "g", "Test262", expectedTarget]);

--- a/test/language/statements/class/elements/class-field-on-frozen-objects.js
+++ b/test/language/statements/class/elements/class-field-on-frozen-objects.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Public class field initialization fails on frozen object
+esid: sec-define-field
+info: |
+  DefineField(receiver, fieldRecord)
+    ...
+    8. If fieldName is a Private Name,
+      a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+    9. Else,
+      a. Assert: IsPropertyKey(fieldName) is true.
+      b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+    10. Return.
+includes: [compareArray.js]
+features: [class, class-fields-public]
+flags: [onlyStrict]
+---*/
+
+class Test {
+  f = Object.freeze(this);
+  g = "Test262";
+}
+
+assert.throws(TypeError, function() {
+  new Test();
+}, "Frozen objects can't be changed");

--- a/test/language/statements/class/elements/private-class-field-on-frozen-objects.js
+++ b/test/language/statements/class/elements/private-class-field-on-frozen-objects.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: It is possible to add private fields on frozen objects
+esid: sec-define-field
+info: |
+  DefineField(receiver, fieldRecord)
+    ...
+    8. If fieldName is a Private Name,
+      a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+    9. Else,
+      a. Assert: IsPropertyKey(fieldName) is true.
+      b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+    10. Return.
+includes: [compareArray.js]
+features: [class, class-fields-private]
+flags: [onlyStrict]
+---*/
+
+class Test {
+  f = Object.freeze(this);
+  #g = "Test262";
+
+  get g() {
+    return this.#g;
+  }
+}
+
+let t = new Test();
+assert.sameValue(t.g, "Test262");

--- a/test/language/statements/class/elements/private-class-field-on-frozen-objects.js
+++ b/test/language/statements/class/elements/private-class-field-on-frozen-objects.js
@@ -19,8 +19,8 @@ flags: [onlyStrict]
 ---*/
 
 class Test {
-  f = Object.freeze(this);
-  #g = "Test262";
+  f = this;
+  #g = (Object.freeze(this), "Test262");
 
   get g() {
     return this.#g;

--- a/test/language/statements/class/elements/public-class-field-initialization-is-visible-to-proxy.js
+++ b/test/language/statements/class/elements/public-class-field-initialization-is-visible-to-proxy.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: It is possible to add private fields on frozen objects
+description: Public class field initialization calls [[DefineOwnProperty]] and can be observed by Proxies
 esid: sec-define-field
 info: |
   DefineField(receiver, fieldRecord)
@@ -13,20 +13,20 @@ info: |
       a. Assert: IsPropertyKey(fieldName) is true.
       b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
     10. Return.
-includes: [compareArray.js]
-features: [class, class-fields-private]
-flags: [onlyStrict]
+includes: [propertyHelper.js]
+features: [class, class-fields-public]
 ---*/
 
-class Test {
-  f = Object.freeze(this);
-  #g = "Test262";
-
-  get g() {
-    return this.#g;
-  }
+function ProxyBase() {
+  return new Proxy(this, {
+    defineProperty: function (target, key, descriptor) {
+      throw new Test262Error();
+    }
+  });
 }
 
-let t = new Test();
-assert.sameValue(t.f, t);
-assert.sameValue(t.g, "Test262");
+class Base extends Super {
+  f = "Test262";
+}
+
+assert.throws(Test262Error, () => { new Base(); });

--- a/test/language/statements/class/elements/public-class-field-initialization-is-visible-to-proxy.js
+++ b/test/language/statements/class/elements/public-class-field-initialization-is-visible-to-proxy.js
@@ -25,7 +25,7 @@ function ProxyBase() {
   });
 }
 
-class Base extends Super {
+class Base extends ProxyBase {
   f = "Test262";
 }
 

--- a/test/language/statements/class/elements/public-class-field-initialization-on-super-class-with-setter.js
+++ b/test/language/statements/class/elements/public-class-field-initialization-on-super-class-with-setter.js
@@ -28,7 +28,10 @@ class Base extends Super {
 }
 
 let o = new Base();
-assert.sameValue(o.f, "Test262");
-verifyEnumerable(o, "f");
-verifyWritable(o, "f");
-verifyConfigurable(o, "f");
+
+verifyProperty(o, "f", {
+  value: "Test262",
+  enumerable: true,
+  writable: true,
+  configurable: true,
+});

--- a/test/language/statements/class/elements/public-class-field-initialization-on-super-class-with-setter.js
+++ b/test/language/statements/class/elements/public-class-field-initialization-on-super-class-with-setter.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Caio Lima. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Public class field initialization calls [[DefineOwnProperty]] and don't execute super's getter
+esid: sec-define-field
+info: |
+  DefineField(receiver, fieldRecord)
+    ...
+    8. If fieldName is a Private Name,
+      a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+    9. Else,
+      a. Assert: IsPropertyKey(fieldName) is true.
+      b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+    10. Return.
+includes: [propertyHelper.js]
+features: [class, class-fields-public]
+---*/
+
+class Super {
+  set f(v) {
+    throw new Test262Error();
+  }
+}
+
+class Base extends Super {
+  f = "Test262";
+}
+
+let o = new Base();
+assert.sameValue(o.f, "Test262");
+verifyEnumerable(o, "f");
+verifyWritable(o, "f");
+verifyConfigurable(o, "f");


### PR DESCRIPTION
This PR is adding following missing cases:

1. Following the Spec, `DefineField(receiver, fieldRecord)` calls `CreateDataPropertyOrThrow(receiver, fieldName, initValue)` and this operation can be user observable.
2. Frozen objects can't be changed.
3. `[[DefineOwnProperty]]` is used to define a public field, and it doesn't call setter of `Super`.

CC: @leobalter @caitp @xanlpz 