### PR TITLE
Verify that private methods and accessors aren't visible to [[GetOwnProperty]] and [[HasProperty]].

### DIFF
--- a/src/class-elements/private-getter-is-not-a-own-property.case
+++ b/src/class-elements/private-getter-is-not-a-own-property.case
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Private getter is not stored as an own property of objects
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+get #m() { return "Test262"; }
+
+checkPrivateGetter() {
+  assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
+  assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
+
+  assert.sameValue(this.hasOwnProperty("#m"), false);
+  assert.sameValue(Reflect.has(this, "#m"), false);
+
+  assert.compareArray(Object.getOwnPropertyNames(this), []);
+  assert.compareArray(Reflect.ownKeys(this), []);
+
+  assert.sameValue("#m" in this, false);
+
+  const descriptors = Object.getOwnPropertyDescriptors(this);
+  assert.sameValue("#m" in descriptors, false);
+
+  assert.sameValue(this.#m, "Test262");
+}
+//- assertions
+let c = new C();
+c.checkPrivateGetter();

--- a/src/class-elements/private-getter-is-not-a-own-property.case
+++ b/src/class-elements/private-getter-is-not-a-own-property.case
@@ -27,22 +27,15 @@ features: [class-methods-private]
 get #m() { return "Test262"; }
 
 checkPrivateGetter() {
-  assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
-  assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
-
   assert.sameValue(this.hasOwnProperty("#m"), false);
-  assert.sameValue(Reflect.has(this, "#m"), false);
-
-  assert.compareArray(Object.getOwnPropertyNames(this), []);
-  assert.compareArray(Reflect.ownKeys(this), []);
-
   assert.sameValue("#m" in this, false);
 
-  const descriptors = Object.getOwnPropertyDescriptors(this);
-  assert.sameValue("#m" in descriptors, false);
+  assert.sameValue(this.__lookupGetter__("#m"), undefined);
 
   assert.sameValue(this.#m, "Test262");
+
+  return 0;
 }
 //- assertions
 let c = new C();
-c.checkPrivateGetter();
+assert.sameValue(c.checkPrivateGetter(), 0);

--- a/src/class-elements/private-method-is-not-a-own-property.case
+++ b/src/class-elements/private-method-is-not-a-own-property.case
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Private method is not stored as an own property of objects
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+template: default
+includes: [compareArray.js]
+features: [class-methods-private]
+---*/
+
+//- elements
+#m() { return "Test262"; }
+
+checkPrivateMethod() {
+  assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
+  assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
+
+  assert.sameValue(this.hasOwnProperty("#m"), false);
+  assert.sameValue(Reflect.has(this, "#m"), false);
+
+  assert.compareArray(Object.getOwnPropertyNames(this), []);
+  assert.compareArray(Reflect.ownKeys(this), []);
+
+  assert.sameValue("#m" in this, false);
+
+  const descriptors = Object.getOwnPropertyDescriptors(this);
+  assert.sameValue("#m" in descriptors, false);
+
+  assert.sameValue(this.#m(), "Test262");
+}
+//- assertions
+let c = new C();
+c.checkPrivateMethod();

--- a/src/class-elements/private-setter-is-not-a-own-property.case
+++ b/src/class-elements/private-setter-is-not-a-own-property.case
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Private setter is not stored as an own property of objects
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+set #m(v) { this._v = v; }
+
+checkPrivateSetter() {
+  assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
+  assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
+
+  assert.sameValue(this.hasOwnProperty("#m"), false);
+  assert.sameValue(Reflect.has(this, "#m"), false);
+
+  assert.compareArray(Object.getOwnPropertyNames(this), []);
+  assert.compareArray(Reflect.ownKeys(this), []);
+
+  assert.sameValue("#m" in this, false);
+
+  const descriptors = Object.getOwnPropertyDescriptors(this);
+  assert.sameValue("#m" in descriptors, false);
+
+  this.#m = "Test262";
+  assert.sameValue(this._v, "Test262");
+}
+//- assertions
+let c = new C();
+c.checkPrivateSetter();

--- a/src/class-elements/private-setter-is-not-a-own-property.case
+++ b/src/class-elements/private-setter-is-not-a-own-property.case
@@ -27,23 +27,16 @@ features: [class-methods-private]
 set #m(v) { this._v = v; }
 
 checkPrivateSetter() {
-  assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
-  assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
-
   assert.sameValue(this.hasOwnProperty("#m"), false);
-  assert.sameValue(Reflect.has(this, "#m"), false);
-
-  assert.compareArray(Object.getOwnPropertyNames(this), []);
-  assert.compareArray(Reflect.ownKeys(this), []);
-
   assert.sameValue("#m" in this, false);
 
-  const descriptors = Object.getOwnPropertyDescriptors(this);
-  assert.sameValue("#m" in descriptors, false);
+  assert.sameValue(this.__lookupSetter__("#m"), undefined);
 
   this.#m = "Test262";
   assert.sameValue(this._v, "Test262");
+
+  return 0;
 }
 //- assertions
 let c = new C();
-c.checkPrivateSetter();
+assert.sameValue(c.checkPrivateSetter(), 0);

--- a/test/language/expressions/class/elements/private-getter-is-not-a-own-property.js
+++ b/test/language/expressions/class/elements/private-getter-is-not-a-own-property.js
@@ -30,23 +30,16 @@ var C = class {
   get #m() { return "Test262"; }
 
   checkPrivateGetter() {
-    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
-    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
-
     assert.sameValue(this.hasOwnProperty("#m"), false);
-    assert.sameValue(Reflect.has(this, "#m"), false);
-
-    assert.compareArray(Object.getOwnPropertyNames(this), []);
-    assert.compareArray(Reflect.ownKeys(this), []);
-
     assert.sameValue("#m" in this, false);
 
-    const descriptors = Object.getOwnPropertyDescriptors(this);
-    assert.sameValue("#m" in descriptors, false);
+    assert.sameValue(this.__lookupGetter__("#m"), undefined);
 
     assert.sameValue(this.#m, "Test262");
+
+    return 0;
   }
 }
 
 let c = new C();
-c.checkPrivateGetter();
+assert.sameValue(c.checkPrivateGetter(), 0);

--- a/test/language/expressions/class/elements/private-getter-is-not-a-own-property.js
+++ b/test/language/expressions/class/elements/private-getter-is-not-a-own-property.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-is-not-a-own-property.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Private getter is not stored as an own property of objects (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+        a. Let entry be PrivateFieldFind(P, O).
+        b. If entry is empty, throw a TypeError exception.
+        c. Return entry.[[PrivateFieldValue]].
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      6. Else,
+        a. Assert: P.[[Kind]] is "accessor".
+        b. If P does not have a [[Get]] field, throw a TypeError exception.
+        c. Let getter be P.[[Get]].
+        d. Return ? Call(getter, O).
+
+---*/
+
+
+var C = class {
+  get #m() { return "Test262"; }
+
+  checkPrivateGetter() {
+    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
+    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
+
+    assert.sameValue(this.hasOwnProperty("#m"), false);
+    assert.sameValue(Reflect.has(this, "#m"), false);
+
+    assert.compareArray(Object.getOwnPropertyNames(this), []);
+    assert.compareArray(Reflect.ownKeys(this), []);
+
+    assert.sameValue("#m" in this, false);
+
+    const descriptors = Object.getOwnPropertyDescriptors(this);
+    assert.sameValue("#m" in descriptors, false);
+
+    assert.sameValue(this.#m, "Test262");
+  }
+}
+
+let c = new C();
+c.checkPrivateGetter();

--- a/test/language/expressions/class/elements/private-method-is-not-a-own-property.js
+++ b/test/language/expressions/class/elements/private-method-is-not-a-own-property.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-is-not-a-own-property.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Private method is not stored as an own property of objects (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+        a. Let entry be PrivateFieldFind(P, O).
+        b. If entry is empty, throw a TypeError exception.
+        c. Return entry.[[PrivateFieldValue]].
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      6. Else,
+        a. Assert: P.[[Kind]] is "accessor".
+        b. If P does not have a [[Get]] field, throw a TypeError exception.
+        c. Let getter be P.[[Get]].
+        d. Return ? Call(getter, O).
+
+---*/
+
+
+var C = class {
+  #m() { return "Test262"; }
+
+  checkPrivateMethod() {
+    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
+    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
+
+    assert.sameValue(this.hasOwnProperty("#m"), false);
+    assert.sameValue(Reflect.has(this, "#m"), false);
+
+    assert.compareArray(Object.getOwnPropertyNames(this), []);
+    assert.compareArray(Reflect.ownKeys(this), []);
+
+    assert.sameValue("#m" in this, false);
+
+    const descriptors = Object.getOwnPropertyDescriptors(this);
+    assert.sameValue("#m" in descriptors, false);
+
+    assert.sameValue(this.#m(), "Test262");
+  }
+}
+
+let c = new C();
+c.checkPrivateMethod();

--- a/test/language/expressions/class/elements/private-method-is-not-a-own-property.js
+++ b/test/language/expressions/class/elements/private-method-is-not-a-own-property.js
@@ -6,7 +6,6 @@ description: Private method is not stored as an own property of objects (field d
 esid: prod-FieldDefinition
 features: [class-methods-private, class]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     PrivateFieldGet (P, O)
       1. Assert: P is a Private Name.
@@ -31,23 +30,14 @@ var C = class {
   #m() { return "Test262"; }
 
   checkPrivateMethod() {
-    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
-    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
-
     assert.sameValue(this.hasOwnProperty("#m"), false);
-    assert.sameValue(Reflect.has(this, "#m"), false);
-
-    assert.compareArray(Object.getOwnPropertyNames(this), []);
-    assert.compareArray(Reflect.ownKeys(this), []);
-
     assert.sameValue("#m" in this, false);
 
-    const descriptors = Object.getOwnPropertyDescriptors(this);
-    assert.sameValue("#m" in descriptors, false);
-
     assert.sameValue(this.#m(), "Test262");
+    
+    return 0;
   }
 }
 
 let c = new C();
-c.checkPrivateMethod();
+assert.sameValue(c.checkPrivateMethod(), 0);

--- a/test/language/expressions/class/elements/private-setter-is-not-a-own-property.js
+++ b/test/language/expressions/class/elements/private-setter-is-not-a-own-property.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-is-not-a-own-property.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Private setter is not stored as an own property of objects (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+        a. Let entry be PrivateFieldFind(P, O).
+        b. If entry is empty, throw a TypeError exception.
+        c. Return entry.[[PrivateFieldValue]].
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      6. Else,
+        a. Assert: P.[[Kind]] is "accessor".
+        b. If P does not have a [[Get]] field, throw a TypeError exception.
+        c. Let getter be P.[[Get]].
+        d. Return ? Call(getter, O).
+
+---*/
+
+
+var C = class {
+  set #m(v) { this._v = v; }
+
+  checkPrivateSetter() {
+    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
+    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
+
+    assert.sameValue(this.hasOwnProperty("#m"), false);
+    assert.sameValue(Reflect.has(this, "#m"), false);
+
+    assert.compareArray(Object.getOwnPropertyNames(this), []);
+    assert.compareArray(Reflect.ownKeys(this), []);
+
+    assert.sameValue("#m" in this, false);
+
+    const descriptors = Object.getOwnPropertyDescriptors(this);
+    assert.sameValue("#m" in descriptors, false);
+
+    this.#m = "Test262";
+    assert.sameValue(this._v, "Test262");
+  }
+}
+
+let c = new C();
+c.checkPrivateSetter();

--- a/test/language/expressions/class/elements/private-setter-is-not-a-own-property.js
+++ b/test/language/expressions/class/elements/private-setter-is-not-a-own-property.js
@@ -30,24 +30,17 @@ var C = class {
   set #m(v) { this._v = v; }
 
   checkPrivateSetter() {
-    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
-    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
-
     assert.sameValue(this.hasOwnProperty("#m"), false);
-    assert.sameValue(Reflect.has(this, "#m"), false);
-
-    assert.compareArray(Object.getOwnPropertyNames(this), []);
-    assert.compareArray(Reflect.ownKeys(this), []);
-
     assert.sameValue("#m" in this, false);
 
-    const descriptors = Object.getOwnPropertyDescriptors(this);
-    assert.sameValue("#m" in descriptors, false);
+    assert.sameValue(this.__lookupSetter__("#m"), undefined);
 
     this.#m = "Test262";
     assert.sameValue(this._v, "Test262");
+
+    return 0;
   }
 }
 
 let c = new C();
-c.checkPrivateSetter();
+assert.sameValue(c.checkPrivateSetter(), 0);

--- a/test/language/statements/class/elements/private-field-is-not-clobbered-by-computed-property.js
+++ b/test/language/statements/class/elements/private-field-is-not-clobbered-by-computed-property.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: Private method is not stored as an own property of objects
+description: Private field is not clobbered by computed property
+esid: sec-privatefieldget
 info: |
   PrivateFieldGet (P, O)
     1. Assert: P is a Private Name.
@@ -19,21 +20,24 @@ info: |
       b. If P does not have a [[Get]] field, throw a TypeError exception.
       c. Let getter be P.[[Get]].
       d. Return ? Call(getter, O).
-template: default
-features: [class-methods-private]
+features: [class-fields-public, class-fields-private, class]
 ---*/
 
-//- elements
-#m() { return "Test262"; }
+class C {
+  #m = 44;
+  ["#m"] = this.#m / 11;
 
-checkPrivateMethod() {
-  assert.sameValue(this.hasOwnProperty("#m"), false);
-  assert.sameValue("#m" in this, false);
-
-  assert.sameValue(this.#m(), "Test262");
+  checkPrivateField() {
+    assert.sameValue(this.hasOwnProperty("#m"), true);
+    assert.sameValue("#m" in this, true);
   
-  return 0;
+    assert.sameValue(this["#m"], 4);
+  
+    assert.sameValue(this.#m, 44);
+  
+    return 0;
+  }
 }
-//- assertions
+
 let c = new C();
-assert.sameValue(c.checkPrivateMethod(), 0);
+assert.sameValue(c.checkPrivateField(), 0);

--- a/test/language/statements/class/elements/private-getter-is-not-a-own-property.js
+++ b/test/language/statements/class/elements/private-getter-is-not-a-own-property.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-is-not-a-own-property.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Private getter is not stored as an own property of objects (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+        a. Let entry be PrivateFieldFind(P, O).
+        b. If entry is empty, throw a TypeError exception.
+        c. Return entry.[[PrivateFieldValue]].
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      6. Else,
+        a. Assert: P.[[Kind]] is "accessor".
+        b. If P does not have a [[Get]] field, throw a TypeError exception.
+        c. Let getter be P.[[Get]].
+        d. Return ? Call(getter, O).
+
+---*/
+
+
+class C {
+  get #m() { return "Test262"; }
+
+  checkPrivateGetter() {
+    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
+    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
+
+    assert.sameValue(this.hasOwnProperty("#m"), false);
+    assert.sameValue(Reflect.has(this, "#m"), false);
+
+    assert.compareArray(Object.getOwnPropertyNames(this), []);
+    assert.compareArray(Reflect.ownKeys(this), []);
+
+    assert.sameValue("#m" in this, false);
+
+    const descriptors = Object.getOwnPropertyDescriptors(this);
+    assert.sameValue("#m" in descriptors, false);
+
+    assert.sameValue(this.#m, "Test262");
+  }
+}
+
+let c = new C();
+c.checkPrivateGetter();

--- a/test/language/statements/class/elements/private-getter-is-not-a-own-property.js
+++ b/test/language/statements/class/elements/private-getter-is-not-a-own-property.js
@@ -30,23 +30,16 @@ class C {
   get #m() { return "Test262"; }
 
   checkPrivateGetter() {
-    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
-    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
-
     assert.sameValue(this.hasOwnProperty("#m"), false);
-    assert.sameValue(Reflect.has(this, "#m"), false);
-
-    assert.compareArray(Object.getOwnPropertyNames(this), []);
-    assert.compareArray(Reflect.ownKeys(this), []);
-
     assert.sameValue("#m" in this, false);
 
-    const descriptors = Object.getOwnPropertyDescriptors(this);
-    assert.sameValue("#m" in descriptors, false);
+    assert.sameValue(this.__lookupGetter__("#m"), undefined);
 
     assert.sameValue(this.#m, "Test262");
+
+    return 0;
   }
 }
 
 let c = new C();
-c.checkPrivateGetter();
+assert.sameValue(c.checkPrivateGetter(), 0);

--- a/test/language/statements/class/elements/private-getter-is-not-clobbered-by-computed-property.js
+++ b/test/language/statements/class/elements/private-getter-is-not-clobbered-by-computed-property.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: Private method is not stored as an own property of objects
+description: Private getter is not clobbered by computed property
+esid: sec-privatefieldget
 info: |
   PrivateFieldGet (P, O)
     1. Assert: P is a Private Name.
@@ -19,21 +20,24 @@ info: |
       b. If P does not have a [[Get]] field, throw a TypeError exception.
       c. Let getter be P.[[Get]].
       d. Return ? Call(getter, O).
-template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public, class]
 ---*/
 
-//- elements
-#m() { return "Test262"; }
-
-checkPrivateMethod() {
-  assert.sameValue(this.hasOwnProperty("#m"), false);
-  assert.sameValue("#m" in this, false);
-
-  assert.sameValue(this.#m(), "Test262");
+class C {
+  get #m() { return "Test262"; }
+  ["#m"] = 0;
   
-  return 0;
+  checkPrivateGetter() {
+    assert.sameValue(this.hasOwnProperty("#m"), true);
+    assert.sameValue("#m" in this, true);
+  
+    assert.sameValue(this["#m"], 0);
+  
+    assert.sameValue(this.#m, "Test262");
+  
+    return 0;
+  }
 }
-//- assertions
+
 let c = new C();
-assert.sameValue(c.checkPrivateMethod(), 0);
+assert.sameValue(c.checkPrivateGetter(), 0);

--- a/test/language/statements/class/elements/private-method-is-not-a-own-property.js
+++ b/test/language/statements/class/elements/private-method-is-not-a-own-property.js
@@ -6,7 +6,6 @@ description: Private method is not stored as an own property of objects (field d
 esid: prod-FieldDefinition
 features: [class-methods-private, class]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     PrivateFieldGet (P, O)
       1. Assert: P is a Private Name.
@@ -31,23 +30,14 @@ class C {
   #m() { return "Test262"; }
 
   checkPrivateMethod() {
-    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
-    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
-
     assert.sameValue(this.hasOwnProperty("#m"), false);
-    assert.sameValue(Reflect.has(this, "#m"), false);
-
-    assert.compareArray(Object.getOwnPropertyNames(this), []);
-    assert.compareArray(Reflect.ownKeys(this), []);
-
     assert.sameValue("#m" in this, false);
 
-    const descriptors = Object.getOwnPropertyDescriptors(this);
-    assert.sameValue("#m" in descriptors, false);
-
     assert.sameValue(this.#m(), "Test262");
+    
+    return 0;
   }
 }
 
 let c = new C();
-c.checkPrivateMethod();
+assert.sameValue(c.checkPrivateMethod(), 0);

--- a/test/language/statements/class/elements/private-method-is-not-a-own-property.js
+++ b/test/language/statements/class/elements/private-method-is-not-a-own-property.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-is-not-a-own-property.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Private method is not stored as an own property of objects (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+        a. Let entry be PrivateFieldFind(P, O).
+        b. If entry is empty, throw a TypeError exception.
+        c. Return entry.[[PrivateFieldValue]].
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      6. Else,
+        a. Assert: P.[[Kind]] is "accessor".
+        b. If P does not have a [[Get]] field, throw a TypeError exception.
+        c. Let getter be P.[[Get]].
+        d. Return ? Call(getter, O).
+
+---*/
+
+
+class C {
+  #m() { return "Test262"; }
+
+  checkPrivateMethod() {
+    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
+    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
+
+    assert.sameValue(this.hasOwnProperty("#m"), false);
+    assert.sameValue(Reflect.has(this, "#m"), false);
+
+    assert.compareArray(Object.getOwnPropertyNames(this), []);
+    assert.compareArray(Reflect.ownKeys(this), []);
+
+    assert.sameValue("#m" in this, false);
+
+    const descriptors = Object.getOwnPropertyDescriptors(this);
+    assert.sameValue("#m" in descriptors, false);
+
+    assert.sameValue(this.#m(), "Test262");
+  }
+}
+
+let c = new C();
+c.checkPrivateMethod();

--- a/test/language/statements/class/elements/private-method-is-not-clobbered-by-computed-property.js
+++ b/test/language/statements/class/elements/private-method-is-not-clobbered-by-computed-property.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: Private method is not stored as an own property of objects
+description: Private method is not clobbered by computed property
+esid: sec-privatefieldget
 info: |
   PrivateFieldGet (P, O)
     1. Assert: P is a Private Name.
@@ -19,21 +20,24 @@ info: |
       b. If P does not have a [[Get]] field, throw a TypeError exception.
       c. Let getter be P.[[Get]].
       d. Return ? Call(getter, O).
-template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public, class]
 ---*/
 
-//- elements
-#m() { return "Test262"; }
-
-checkPrivateMethod() {
-  assert.sameValue(this.hasOwnProperty("#m"), false);
-  assert.sameValue("#m" in this, false);
-
-  assert.sameValue(this.#m(), "Test262");
+class C {
+  #m() { return "Test262"; }
+  ["#m"] = 0;
   
-  return 0;
+  checkPrivateMethod() {
+    assert.sameValue(this.hasOwnProperty("#m"), true);
+    assert.sameValue("#m" in this, true);
+  
+    assert.sameValue(this["#m"], 0);
+  
+    assert.sameValue(this.#m(), "Test262");
+  
+    return 0;
+  }
 }
-//- assertions
+
 let c = new C();
 assert.sameValue(c.checkPrivateMethod(), 0);

--- a/test/language/statements/class/elements/private-setter-is-not-a-own-property.js
+++ b/test/language/statements/class/elements/private-setter-is-not-a-own-property.js
@@ -30,24 +30,17 @@ class C {
   set #m(v) { this._v = v; }
 
   checkPrivateSetter() {
-    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
-    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
-
     assert.sameValue(this.hasOwnProperty("#m"), false);
-    assert.sameValue(Reflect.has(this, "#m"), false);
-
-    assert.compareArray(Object.getOwnPropertyNames(this), []);
-    assert.compareArray(Reflect.ownKeys(this), []);
-
     assert.sameValue("#m" in this, false);
 
-    const descriptors = Object.getOwnPropertyDescriptors(this);
-    assert.sameValue("#m" in descriptors, false);
+    assert.sameValue(this.__lookupSetter__("#m"), undefined);
 
     this.#m = "Test262";
     assert.sameValue(this._v, "Test262");
+
+    return 0;
   }
 }
 
 let c = new C();
-c.checkPrivateSetter();
+assert.sameValue(c.checkPrivateSetter(), 0);

--- a/test/language/statements/class/elements/private-setter-is-not-a-own-property.js
+++ b/test/language/statements/class/elements/private-setter-is-not-a-own-property.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-is-not-a-own-property.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Private setter is not stored as an own property of objects (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+        a. Let entry be PrivateFieldFind(P, O).
+        b. If entry is empty, throw a TypeError exception.
+        c. Return entry.[[PrivateFieldValue]].
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      6. Else,
+        a. Assert: P.[[Kind]] is "accessor".
+        b. If P does not have a [[Get]] field, throw a TypeError exception.
+        c. Let getter be P.[[Get]].
+        d. Return ? Call(getter, O).
+
+---*/
+
+
+class C {
+  set #m(v) { this._v = v; }
+
+  checkPrivateSetter() {
+    assert.sameValue(Object.getOwnPropertyDescriptor(this, "#m"), undefined);
+    assert.sameValue(Reflect.getOwnPropertyDescriptor(this, "#m"), undefined);
+
+    assert.sameValue(this.hasOwnProperty("#m"), false);
+    assert.sameValue(Reflect.has(this, "#m"), false);
+
+    assert.compareArray(Object.getOwnPropertyNames(this), []);
+    assert.compareArray(Reflect.ownKeys(this), []);
+
+    assert.sameValue("#m" in this, false);
+
+    const descriptors = Object.getOwnPropertyDescriptors(this);
+    assert.sameValue("#m" in descriptors, false);
+
+    this.#m = "Test262";
+    assert.sameValue(this._v, "Test262");
+  }
+}
+
+let c = new C();
+c.checkPrivateSetter();

--- a/test/language/statements/class/elements/private-setter-is-not-clobbered-by-computed-property.js
+++ b/test/language/statements/class/elements/private-setter-is-not-clobbered-by-computed-property.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: Private method is not stored as an own property of objects
+description: Private setter is not clobbered by computed property
+esid: sec-privatefieldget
 info: |
   PrivateFieldGet (P, O)
     1. Assert: P is a Private Name.
@@ -19,21 +20,25 @@ info: |
       b. If P does not have a [[Get]] field, throw a TypeError exception.
       c. Let getter be P.[[Get]].
       d. Return ? Call(getter, O).
-template: default
-features: [class-methods-private]
+features: [class-methods-private, class-fields-public, class]
 ---*/
 
-//- elements
-#m() { return "Test262"; }
-
-checkPrivateMethod() {
-  assert.sameValue(this.hasOwnProperty("#m"), false);
-  assert.sameValue("#m" in this, false);
-
-  assert.sameValue(this.#m(), "Test262");
+class C {
+  set #m(v) { this._v = v; }
+  ["#m"] = 0;
   
-  return 0;
+  checkPrivateSetter() {
+    assert.sameValue(this.hasOwnProperty("#m"), true);
+    assert.sameValue("#m" in this, true);
+  
+    assert.sameValue(this["#m"], 0);
+  
+    this.#m = "Test262";
+    assert.sameValue(this._v, "Test262");
+  
+    return 0;
+  }
 }
-//- assertions
+
 let c = new C();
-assert.sameValue(c.checkPrivateMethod(), 0);
+assert.sameValue(c.checkPrivateSetter(), 0);


### PR DESCRIPTION
It closes #2187.

I'm not sure if I should consider `__lookupGetter__` and `__lookupSetter__` on those tests, since it is deprecated.

CC: @leobalter @jbhoosreddy @mkubilayk 