### PR TITLE
remove (min|max)imumFractionDigits w/ significant

### DIFF
--- a/test/intl402/NumberFormat/prototype/resolvedOptions/order.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/order.js
@@ -22,8 +22,6 @@ const expected = [
   "currency",
   "currencyDisplay",
   "minimumIntegerDigits",
-  "minimumFractionDigits",
-  "maximumFractionDigits",
   "minimumSignificantDigits",
   "maximumSignificantDigits",
   "useGrouping",


### PR DESCRIPTION
Per change in https://tc39.github.io/proposal-unified-intl-numberformat/section11/numberformat_diff_out.html
we should not output minimumFractionDigits and maximumFractionDigits if minimumSignificantDigits or maximumSignificantDigits are set.