### PR TITLE
add exceptions for hour & minute in Intl.RelativeTimeFormat numeric auto

### DIFF
--- a/test/intl402/RelativeTimeFormat/prototype/format/en-us-numeric-auto.js
+++ b/test/intl402/RelativeTimeFormat/prototype/format/en-us-numeric-auto.js
@@ -50,6 +50,12 @@ const exceptions = {
     "0": "today",
     "1": "tomorrow",
   },
+  "hour": {
+    '0': 'this hour'
+  },
+  "minute": {
+    '0': 'this minute'
+  },
   "second": {
     "-1": "1 second ago",
     "0": "now",


### PR DESCRIPTION
As of CLDR v34 this seems to be the case.