### PR TITLE
Add test case for CJK Unified Ideograph range.

### DIFF
--- a/test/language/identifiers/vals-cjk-escaped.js
+++ b/test/language/identifiers/vals-cjk-escaped.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2019 Student Main. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+info: |
+    IdentifierName and ReservedWord are tokens that are interpreted according to the 
+    Default Identifier Syntax given in Unicode Standard Annex #31, 
+    Identifier and Pattern Syntax, with some small modifications.
+esid: sec-names-and-keywords
+description: Check CJK UNIFIED IDEOGRAPH range is correct.
+---*/
+
+// CJK UNIFIED IDEOGRAPH 4e00-9fff
+// u4e00
+var \u4e00 = 1;
+assert.sameValue(一, 1);
+
+// u6c5f, check parser included all CJK range not only first and last
+var \u6c5f = 1;
+assert.sameValue(江, 1);
+
+// u9fa5, last character in CJK UNIFIED IDEOGRAPH as for 2019
+var \u9fa5 = 1;
+assert.sameValue(龥, 1);
+
+// CJK UNIFIED IDEOGRAPH EXTENDED A 3400-4dbf
+// u3400
+var \u3400 = 1;
+assert.sameValue(㐀, 1);
+
+// u362e
+var \u362e = 1;
+assert.sameValue(㘮, 1);
+
+// u4db5, last in CJK UNIFIED IDEOGRAPH EXTENDED A
+var \u4db5 = 1;
+assert.sameValue(䶵, 1);

--- a/test/language/identifiers/vals-cjk.js
+++ b/test/language/identifiers/vals-cjk.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2019 Student Main. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+info: |
+    IdentifierName and ReservedWord are tokens that are interpreted according to the 
+    Default Identifier Syntax given in Unicode Standard Annex #31, 
+    Identifier and Pattern Syntax, with some small modifications.
+esid: sec-names-and-keywords
+description: Check CJK UNIFIED IDEOGRAPH range is correct.
+---*/
+
+// CJK UNIFIED IDEOGRAPH 4e00-9fff
+// u4e00
+var 一 = 1;
+assert.sameValue(一, 1);
+
+// u6c5f, check parser included all CJK range not only first and last character
+var 江 = 1;
+assert.sameValue(江, 1);
+
+// u9fa5, last character in CJK UNIFIED IDEOGRAPH as for 2019
+var 龥 = 1;
+assert.sameValue(龥, 1);
+
+// CJK UNIFIED IDEOGRAPH EXTENDED A 3400-4dbf
+// u3400
+var 㐀 = 1;
+assert.sameValue(㐀, 1);
+
+// u362e
+var 㘮 = 1;
+assert.sameValue(㘮, 1);
+
+// u4db5, last in CJK UNIFIED IDEOGRAPH EXTENDED A
+var 䶵 = 1;
+assert.sameValue(䶵, 1);


### PR DESCRIPTION
Add test to ensure CJK character is fully included.

Some parser only included first and last character in CJK, maybe caused by confusion in UnicodeData.txt:
```
4DFE;HEXAGRAM FOR AFTER COMPLETION;So;0;ON;;;;;N;;;;;
4DFF;HEXAGRAM FOR BEFORE COMPLETION;So;0;ON;;;;;N;;;;;
4E00;<CJK Ideograph, First>;Lo;0;L;;;;;N;;;;;
9FEF;<CJK Ideograph, Last>;Lo;0;L;;;;;N;;;;;
A000;YI SYLLABLE IT;Lo;0;L;;;;;N;;;;;
A001;YI SYLLABLE IX;Lo;0;L;;;;;N;;;;;
```