### PR TITLE
Add more class declaration formations

### DIFF
--- a/src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+++ b/src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
@@ -1,0 +1,14 @@
+// Copyright (C) 2019 Jaideep Bhoosreddy (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-ClassElement
+name: class declaration module default export
+path: language/statements/class/elements/syntax/valid/export-default-
+flags: [module]
+features: [class]
+---*/
+
+export default class /*{ heritage }*/{
+  /*{ elements }*/
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-class-body-ctor-no-heritage.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-class-body-ctor-no-heritage.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-class-body-ctor-no-heritage.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: A constructor is valid without a super call in the constructor and heritage (class declaration module default export)
+esid: prod-ClassElement
+features: [class]
+flags: [generated, module]
+info: |
+    ClassTail : ClassHeritageopt { ClassBody }
+
+    It is a Syntax Error if ClassHeritage is not present and the following algorithm evaluates to true:
+      1. Let constructor be ConstructorMethod of ClassBody.
+      2. If constructor is empty, return false.
+      3. Return HasDirectSuper of constructor.
+
+---*/
+
+
+export default class {
+  constructor() {}
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-field-classelementname-initializer-alt.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-field-classelementname-initializer-alt.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-field-classelementname-initializer-alt.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: FieldDefinition, ClassElementName, PropertyName = Initializer Syntax (class declaration module default export)
+esid: prod-ClassElement
+features: [class-fields-public, class]
+flags: [generated, module]
+info: |
+    ClassElement :
+      ...
+      FieldDefinition ;
+      ;
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PropertyName :
+      LiteralPropertyName
+      ComputedPropertyName
+
+    LiteralPropertyName :
+      IdentifierName
+
+    Initializer :
+      = AssignmentExpression
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart ::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart ::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue ::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+export default class {
+  $ = 1;
+  _ = 2;
+  \u{6F} = 3;
+  ℘ = 4;      // DO NOT CHANGE THE NAME OF THIS FIELD
+  ZW_‌_NJ = 5; // DO NOT CHANGE THE NAME OF THIS FIELD
+  ZW_‍_J = 6;  // DO NOT CHANGE THE NAME OF THIS FIELD
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-field-classelementname-initializer.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-field-classelementname-initializer.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-field-classelementname-initializer.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: FieldDefinition, ClassElementName, PropertyName = Initializer Syntax (class declaration module default export)
+esid: prod-ClassElement
+features: [class-fields-public, class]
+flags: [generated, module]
+info: |
+    ClassElement :
+      ...
+      FieldDefinition ;
+      ;
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PropertyName :
+      LiteralPropertyName
+      ComputedPropertyName
+
+    LiteralPropertyName :
+      IdentifierName
+
+    Initializer :
+      = AssignmentExpression
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart ::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart ::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue ::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+export default class {
+  $ = 1;
+  _ = 2;
+  \u{6F} = 3;
+  \u2118 = 4;
+  ZW_\u200C_NJ = 5;
+  ZW_\u200D_J = 6;
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-field-identifier-alt.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-field-identifier-alt.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-field-identifier-alt.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Valid FieldDefinition, ClassElementName, PropertyName Syntax (class declaration module default export)
+esid: prod-ClassElement
+features: [class-fields-public, class]
+flags: [generated, module]
+info: |
+    ClassElement :
+      MethodDefinition
+      static MethodDefinition
+      FieldDefinition ;
+      ;
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PropertyName :
+      LiteralPropertyName
+      ComputedPropertyName
+
+    LiteralPropertyName :
+      IdentifierName
+      StringLiteral
+      NumericLiteral
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart ::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart ::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue ::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+export default class {
+  $;
+  _;
+  \u{6F};
+  ℘;      // DO NOT CHANGE THE NAME OF THIS FIELD
+  ZW_‌_NJ; // DO NOT CHANGE THE NAME OF THIS FIELD
+  ZW_‍_J;  // DO NOT CHANGE THE NAME OF THIS FIELD
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-field-identifier.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-field-identifier.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-field-identifier.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Valid FieldDefinition, ClassElementName, PropertyName Syntax (class declaration module default export)
+esid: prod-ClassElement
+features: [class-fields-public, class]
+flags: [generated, module]
+info: |
+    ClassElement :
+      MethodDefinition
+      static MethodDefinition
+      FieldDefinition ;
+      ;
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PropertyName :
+      LiteralPropertyName
+      ComputedPropertyName
+
+    LiteralPropertyName :
+      IdentifierName
+      StringLiteral
+      NumericLiteral
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart ::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart ::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue ::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+export default class {
+  $;
+  _;
+  \u{6F};
+  \u2118;
+  ZW_\u200C_NJ;
+  ZW_\u200D_J;
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-fields-multi-line.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-fields-multi-line.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-fields-multi-line.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Valid multi-line, multi-field (class declaration module default export)
+esid: prod-ClassElement
+features: [class-fields-public, class]
+flags: [generated, module]
+info: |
+    ClassElement :
+      MethodDefinition
+      static MethodDefinition
+      FieldDefinition ;
+      ;
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+---*/
+
+
+export default class {
+  x
+  y
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatemeth-duplicate-get-set.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatemeth-duplicate-get-set.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-get-set.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: It's valid if a class contains a private getter and a private setter with the same name (class declaration module default export)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated, module]
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+export default class {
+  get #m() {}
+  set #m(_) {}
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatemeth-duplicate-meth-nestedclassmeth.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatemeth-duplicate-meth-nestedclassmeth.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-meth-nestedclassmeth.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: It's valid if a nested class shadows a private method (class declaration module default export)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated, module]
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+export default class {
+  constructor() {
+    class B {
+      #m() {}
+    }
+  }
+
+  #m() {}
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatename-classelementname-initializer-alt.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatename-classelementname-initializer-alt.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatename-classelementname-initializer-alt.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Valid PrivateName = Initializer Syntax (class declaration module default export)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated, module]
+info: |
+    ClassElement :
+      MethodDefinition
+      static MethodDefinition
+      FieldDefinition ;
+      ;
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    Initializer :
+      = AssignmentExpression
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+export default class {
+  #$ = 1;
+  #_ = 2;
+  #\u{6F} = 3;
+  #℘ = 4;      // DO NOT CHANGE THE NAME OF THIS FIELD
+  #ZW_‌_NJ = 5; // DO NOT CHANGE THE NAME OF THIS FIELD
+  #ZW_‍_J = 6;  // DO NOT CHANGE THE NAME OF THIS FIELD
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatename-classelementname-initializer.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatename-classelementname-initializer.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatename-classelementname-initializer.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Valid PrivateName = Initializer Syntax (class declaration module default export)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated, module]
+info: |
+    ClassElement :
+      MethodDefinition
+      static MethodDefinition
+      FieldDefinition ;
+      ;
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    Initializer :
+      = AssignmentExpression
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+export default class {
+  #$ = 1;
+  #_ = 2;
+  #\u{6F} = 3;
+  #\u2118 = 4;
+  #ZW_\u200C_NJ = 5;
+  #ZW_\u200D_J = 6;
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatename-identifier.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatename-identifier.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatename-identifier.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Valid PrivateName Syntax (class declaration module default export)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated, module]
+info: |
+    ClassElement :
+      MethodDefinition
+      static MethodDefinition
+      FieldDefinition ;
+      ;
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+    IdentifierName ::
+      IdentifierStart
+      IdentifierName IdentifierPart
+
+    IdentifierStart ::
+      UnicodeIDStart
+      $
+      _
+      \ UnicodeEscapeSequence
+
+    IdentifierPart::
+      UnicodeIDContinue
+      $
+      \ UnicodeEscapeSequence
+      <ZWNJ> <ZWJ>
+
+    UnicodeIDStart::
+      any Unicode code point with the Unicode property "ID_Start"
+
+    UnicodeIDContinue::
+      any Unicode code point with the Unicode property "ID_Continue"
+
+
+    NOTE 3
+    The sets of code points with Unicode properties "ID_Start" and
+    "ID_Continue" include, respectively, the code points with Unicode
+    properties "Other_ID_Start" and "Other_ID_Continue".
+
+---*/
+
+
+export default class {
+  #$;
+  #_;
+  #\u{6F};
+  #\u2118;
+  #ZW_\u200C_NJ;
+  #ZW_\u200D_J;
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatename-no-initializer-with-method.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatename-no-initializer-with-method.js
@@ -1,0 +1,32 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatename-no-initializer-with-method.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: SyntaxError (class declaration module default export)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated, module]
+info: |
+    ClassElement :
+      MethodDefinition
+      static MethodDefinition
+      FieldDefinition ;
+      ;
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+---*/
+
+
+export default class {
+  #x
+  m() {}
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatenames-multi-line.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-privatenames-multi-line.js
@@ -1,0 +1,32 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatenames-multi-line.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: SyntaxError (class declaration module default export)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated, module]
+info: |
+    ClassElement :
+      MethodDefinition
+      static MethodDefinition
+      FieldDefinition ;
+      ;
+
+    FieldDefinition :
+      ClassElementName Initializer _opt
+
+    ClassElementName :
+      PropertyName
+      PrivateName
+
+    PrivateName ::
+      # IdentifierName
+
+---*/
+
+
+export default class {
+  #x
+  #y
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-ctor-accessor-meth-valid.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-ctor-accessor-meth-valid.js
@@ -1,0 +1,30 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-static-ctor-accessor-meth-valid.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Static Accessor Methods can be named constructor (class declaration module default export)
+esid: prod-ClassElement
+features: [class]
+flags: [generated, module]
+info: |
+    Class Definitions / Static Semantics: Early Errors
+
+    ClassElement : MethodDefinition
+        It is a Syntax Error if PropName of MethodDefinition is not "constructor" and HasDirectSuper of MethodDefinition is true.
+        It is a Syntax Error if PropName of MethodDefinition is "constructor" and SpecialMethod of MethodDefinition is true.
+    ClassElement : static MethodDefinition
+        It is a Syntax Error if HasDirectSuper of MethodDefinition is true.
+        It is a Syntax Error if PropName of MethodDefinition is "prototype".
+
+---*/
+
+
+export default class {
+  static get constructor() {}
+  static set constructor(_) {}
+  constructor() {} // stacks with a valid constructor
+}
+
+assert(C.hasOwnProperty('constructor'));
+assert(C.prototype.hasOwnProperty('constructor'));
+assert.notSameValue(C.prototype.constructor, C.constructor);

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-ctor-async-gen-meth-valid.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-ctor-async-gen-meth-valid.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-static-ctor-async-gen-meth-valid.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Static Async Generator Methods can be named constructor (class declaration module default export)
+esid: prod-ClassElement
+features: [async-iteration, class]
+flags: [generated, module]
+info: |
+    Class Definitions / Static Semantics: Early Errors
+
+    ClassElement : MethodDefinition
+        It is a Syntax Error if PropName of MethodDefinition is not "constructor" and HasDirectSuper of MethodDefinition is true.
+        It is a Syntax Error if PropName of MethodDefinition is "constructor" and SpecialMethod of MethodDefinition is true.
+    ClassElement : static MethodDefinition
+        It is a Syntax Error if HasDirectSuper of MethodDefinition is true.
+        It is a Syntax Error if PropName of MethodDefinition is "prototype".
+
+---*/
+
+
+export default class {
+  static async * constructor() {}
+  constructor() {} // stacks with a valid constructor
+}
+
+assert(C.hasOwnProperty('constructor'));
+assert(C.prototype.hasOwnProperty('constructor'));
+assert.notSameValue(C.prototype.constructor, C.constructor);

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-ctor-async-meth-valid.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-ctor-async-meth-valid.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-static-ctor-async-meth-valid.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Static Methods can be named constructor (class declaration module default export)
+esid: prod-ClassElement
+features: [async-functions, class]
+flags: [generated, module]
+info: |
+    Class Definitions / Static Semantics: Early Errors
+
+    ClassElement : MethodDefinition
+        It is a Syntax Error if PropName of MethodDefinition is not "constructor" and HasDirectSuper of MethodDefinition is true.
+        It is a Syntax Error if PropName of MethodDefinition is "constructor" and SpecialMethod of MethodDefinition is true.
+    ClassElement : static MethodDefinition
+        It is a Syntax Error if HasDirectSuper of MethodDefinition is true.
+        It is a Syntax Error if PropName of MethodDefinition is "prototype".
+
+---*/
+
+
+export default class {
+  static async constructor() {}
+  constructor() {} // stacks with a valid constructor
+}
+
+assert(C.hasOwnProperty('constructor'));
+assert(C.prototype.hasOwnProperty('constructor'));
+assert.notSameValue(C.prototype.constructor, C.constructor);

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-ctor-gen-meth-valid.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-ctor-gen-meth-valid.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-static-ctor-gen-meth-valid.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Static Generator Methods can be named constructor (class declaration module default export)
+esid: prod-ClassElement
+features: [generators, class]
+flags: [generated, module]
+info: |
+    Class Definitions / Static Semantics: Early Errors
+
+    ClassElement : MethodDefinition
+        It is a Syntax Error if PropName of MethodDefinition is not "constructor" and HasDirectSuper of MethodDefinition is true.
+        It is a Syntax Error if PropName of MethodDefinition is "constructor" and SpecialMethod of MethodDefinition is true.
+    ClassElement : static MethodDefinition
+        It is a Syntax Error if HasDirectSuper of MethodDefinition is true.
+        It is a Syntax Error if PropName of MethodDefinition is "prototype".
+
+---*/
+
+
+export default class {
+  static * constructor() {}
+  constructor() {} // stacks with a valid constructor
+}
+
+assert(C.hasOwnProperty('constructor'));
+assert(C.prototype.hasOwnProperty('constructor'));
+assert.notSameValue(C.prototype.constructor, C.constructor);

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-ctor-meth-valid.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-ctor-meth-valid.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-static-ctor-meth-valid.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Static Methods can be named constructor (class declaration module default export)
+esid: prod-ClassElement
+features: [class]
+flags: [generated, module]
+info: |
+    Class Definitions / Static Semantics: Early Errors
+
+    ClassElement : MethodDefinition
+        It is a Syntax Error if PropName of MethodDefinition is not "constructor" and HasDirectSuper of MethodDefinition is true.
+        It is a Syntax Error if PropName of MethodDefinition is "constructor" and SpecialMethod of MethodDefinition is true.
+    ClassElement : static MethodDefinition
+        It is a Syntax Error if HasDirectSuper of MethodDefinition is true.
+        It is a Syntax Error if PropName of MethodDefinition is "prototype".
+
+---*/
+
+
+export default class {
+  static constructor() {}
+  constructor() {} // stacks with a valid constructor
+}
+
+assert(C.hasOwnProperty('constructor'));
+assert(C.prototype.hasOwnProperty('constructor'));
+assert.notSameValue(C.prototype.constructor, C.constructor);

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-private-async-gen-meth-prototype.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-private-async-gen-meth-prototype.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-static-private-async-gen-meth-prototype.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Static Async Generator Private Methods can be named "#prototype" (class declaration module default export)
+esid: prod-ClassElement
+features: [async-iteration, class-static-methods-private, class]
+flags: [generated, module]
+info: |
+    Class Definitions / Static Semantics: Early Errors
+
+    ClassElement : static MethodDefinition
+        It is a Syntax Error if PropName of MethodDefinition is "prototype"
+
+---*/
+
+
+export default class {
+  static async * #prototype() {}
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-private-async-meth-prototype.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-private-async-meth-prototype.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-static-private-async-meth-prototype.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Static Async Private Methods can be named "#prototype" (class declaration module default export)
+esid: prod-ClassElement
+features: [async-functions, class-static-methods-private, class]
+flags: [generated, module]
+info: |
+    Class Definitions / Static Semantics: Early Errors
+
+    ClassElement : static MethodDefinition
+        It is a Syntax Error if PropName of MethodDefinition is "prototype"
+
+---*/
+
+
+export default class {
+  static async #prototype() {}
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-private-gen-meth-prototype.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-private-gen-meth-prototype.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-static-private-gen-meth-prototype.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Static Generator Private Methods can be named "#prototype" (class declaration module default export)
+esid: prod-ClassElement
+features: [generators, class-static-methods-private, class]
+flags: [generated, module]
+info: |
+    Class Definitions / Static Semantics: Early Errors
+
+    ClassElement : static MethodDefinition
+        It is a Syntax Error if PropName of MethodDefinition is "prototype"
+
+---*/
+
+
+export default class {
+  static * #prototype() {}
+}

--- a/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-private-meth-prototype.js
+++ b/test/language/statements/class/elements/syntax/valid/export-default-grammar-static-private-meth-prototype.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-static-private-meth-prototype.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax-export-default.template
+/*---
+description: Static Private Methods can be named "#prototype" (class declaration module default export)
+esid: prod-ClassElement
+features: [class-static-methods-private, class]
+flags: [generated, module]
+info: |
+    Class Definitions / Static Semantics: Early Errors
+
+    ClassElement : static MethodDefinition
+        It is a Syntax Error if PropName of MethodDefinition is "prototype"
+
+---*/
+
+
+export default class {
+  static #prototype() {}
+}


### PR DESCRIPTION
Related Issue: https://github.com/tc39/test262/issues/1343#issuecomment-446225159

This PR attempts to adds additional class declaration formations as per @littledan's test plan

In particular:

   - [x] Types of declarations
       - [x] export default class
       - [x] export class X
       - [x] class declaration at the top level of a script/module
       - [x] class declaration in a block
       - [x] class declaration inside a function at the top level