### PR TITLE
Add unary operators with NewTarget test

### DIFF
--- a/test/language/expressions/new.target/unary-expr.js
+++ b/test/language/expressions/new.target/unary-expr.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: prod-UnaryExpression
+description: >
+  While increments and decrements are restricted to use with NewTarget,
+  other unary operators should not throw SyntaxError.
+info: |
+  UnaryExpression[Yield, Await]:
+    UpdateExpression[?Yield, ?Await]:
+      LeftHandSideExpression[?Yield, ?Await]:
+        NewExpression[?Yield, ?Await]:
+          MemberExpression[Yield, Await]:
+            MetaProperty:
+              NewTarget
+features: [new.target, async-functions]
+---*/
+
+function a() {
+  delete new.target;
+  typeof new.target;
+  -new.target;
+  !new.target;
+}
+
+function b() {
+  void (new.target);
+  +(new.target);
+  ~(new.target);
+}
+
+function c() {
+  delete void typeof +-~! (new.target);
+}
+
+async function d() {
+  await new.target;
+}

--- a/test/language/expressions/new.target/unary-expr.js
+++ b/test/language/expressions/new.target/unary-expr.js
@@ -14,25 +14,18 @@ info: |
             MetaProperty:
               NewTarget
 features: [new.target, async-functions]
+flags: [async]
 ---*/
 
-function a() {
-  delete new.target;
-  typeof new.target;
-  -new.target;
-  !new.target;
-}
+(function() { assert.sameValue(delete (new.target), true); })();
+(function() { assert.sameValue(void new.target, undefined); })();
+new function() { assert.sameValue(typeof new.target, 'function'); };
+new function() { assert.sameValue(+(new.target), NaN); };
+(function() { assert.sameValue(-(new.target), NaN); })();
+new function() { assert.sameValue(~new.target, -1); };
+(function() { assert.sameValue(!new.target, true); })();
+new function() { assert.sameValue(delete void typeof +-~!(new.target), true); };
 
-function b() {
-  void (new.target);
-  +(new.target);
-  ~(new.target);
-}
-
-function c() {
-  delete void typeof +-~! (new.target);
-}
-
-async function d() {
-  await new.target;
-}
+(async function() {
+  assert.sameValue(await new.target, undefined);
+})().then($DONE, $DONE);


### PR DESCRIPTION
JSC bug: [Early error on ANY operator before new.target](https://bugs.webkit.org/show_bug.cgi?id=157970).