### PR TITLE
Remove trailing spaces from YAML blocks

### DIFF
--- a/test/built-ins/Function/StrictFunction_restricted-properties.js
+++ b/test/built-ins/Function/StrictFunction_restricted-properties.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2015 Caitlin Potter. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-/*--- 
+/*---
 description: >
     ECMAScript Function objects defined using syntactic constructors
     in strict mode code do not have own properties "caller" or

--- a/test/built-ins/Function/prototype/bind/BoundFunction_restricted-properties.js
+++ b/test/built-ins/Function/prototype/bind/BoundFunction_restricted-properties.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2015 Caitlin Potter. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-/*--- 
+/*---
 description: >
     Functions created using Function.prototype.bind() do not have own
     properties "caller" or "arguments", but inherit them from

--- a/test/built-ins/Function/prototype/restricted-property-arguments.js
+++ b/test/built-ins/Function/prototype/restricted-property-arguments.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2015 Caitlin Potter. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-/*--- 
+/*---
 description: Intrinsic %FunctionPrototype% has poisoned own property "arguments"
 includes:
   - propertyHelper.js

--- a/test/built-ins/Function/prototype/restricted-property-caller.js
+++ b/test/built-ins/Function/prototype/restricted-property-caller.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2015 Caitlin Potter. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-/*--- 
+/*---
 description: Intrinsic %FunctionPrototype% has poisoned own property "caller"
 includes:
   - propertyHelper.js

--- a/test/language/expressions/arrow-function/ArrowFunction_restricted-properties.js
+++ b/test/language/expressions/arrow-function/ArrowFunction_restricted-properties.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2015 Caitlin Potter. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-/*--- 
+/*---
 description: >
     Functions created using ArrowFunction syntactic form do not have
     own properties "caller" or "arguments", but inherit them from

--- a/test/language/statements/function/13.2-30-s.js
+++ b/test/language/statements/function/13.2-30-s.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2015 Caitlin Potter. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-/*--- 
+/*---
  description: >
     Functions created using Function.prototype.bind() do not have own
     properties "caller" or "arguments", but inherit them from


### PR DESCRIPTION
This makes 7 tests pass in JSC:

```yaml
test/built-ins/Function/StrictFunction_restricted-properties.js:
  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
test/built-ins/Function/prototype/restricted-property-arguments.js:
  default: "ReferenceError: Can't find variable: verifyNotEnumerable"
  strict mode: "ReferenceError: Can't find variable: verifyNotEnumerable"
test/built-ins/Function/prototype/restricted-property-caller.js:
  default: "ReferenceError: Can't find variable: verifyNotEnumerable"
  strict mode: "ReferenceError: Can't find variable: verifyNotEnumerable"
```

JSC issue: [test262-runner misbehaves when test file YAML has a trailing space](https://bugs.webkit.org/show_bug.cgi?id=193053).
Ref #1997.
Follow-up of #2018.