### PR TITLE
Improve Object#toString coverage

### DIFF
--- a/test/built-ins/Object/prototype/toString/proxy-function-async.js
+++ b/test/built-ins/Object/prototype/toString/proxy-function-async.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object.prototype.tostring
+description: Proxy of async function is treated as a function.
+info: |
+  ProxyCreate ( target, handler )
+
+  [...]
+  7. If IsCallable(target) is true, then
+    a. Set P.[[Call]] as specified in 9.5.12.
+
+  Object.prototype.toString ( )
+
+  [...]
+  7. Else if O has a [[Call]] internal method, let builtinTag be "Function".
+features: [async-functions, Proxy, Symbol.toStringTag]
+---*/
+
+var asyncProxy = new Proxy(async function() {}, {});
+var asyncProxyProxy = new Proxy(asyncProxy, {});
+
+assert.sameValue(
+  Object.prototype.toString.call(asyncProxy),
+  '[object AsyncFunction]',
+  'async function proxy'
+);
+assert.sameValue(
+  Object.prototype.toString.call(asyncProxyProxy),
+  '[object AsyncFunction]',
+  'proxy for async function proxy'
+);

--- a/test/built-ins/Object/prototype/toString/proxy-function.js
+++ b/test/built-ins/Object/prototype/toString/proxy-function.js
@@ -52,14 +52,3 @@ assert.sameValue(
   '[object GeneratorFunction]',
   'proxy for generator function proxy'
 );
-
-delete generatorProxy.constructor.prototype[Symbol.toStringTag];
-
-assert.sameValue(
-  Object.prototype.toString.call(generatorProxy), '[object Function]', 'generator function proxy without Symbol.toStringTag'
-);
-assert.sameValue(
-  Object.prototype.toString.call(generatorProxyProxy),
-  '[object Function]',
-  'proxy for generator function proxy without Symbol.toStringTag'
-);

--- a/test/built-ins/Object/prototype/toString/proxy-function.js
+++ b/test/built-ins/Object/prototype/toString/proxy-function.js
@@ -14,7 +14,7 @@ info: |
     a. Set the [[Call]] internal method of P as specified in 9.5.12.
   [...]
 
-features: [generators, Proxy, Symbol.toStringTag]
+features: [generators, async-functions, Proxy, Symbol.toStringTag]
 ---*/
 
 var functionProxy = new Proxy(function() {}, {});
@@ -51,4 +51,16 @@ assert.sameValue(
   Object.prototype.toString.call(generatorProxyProxy),
   '[object GeneratorFunction]',
   'proxy for generator function proxy'
+);
+
+var asyncProxy = new Proxy(async function() {}, {});
+var asyncProxyProxy = new Proxy(asyncProxy, {});
+
+assert.sameValue(
+  Object.prototype.toString.call(asyncProxy), '[object AsyncFunction]', 'async function proxy'
+);
+assert.sameValue(
+  Object.prototype.toString.call(asyncProxyProxy),
+  '[object AsyncFunction]',
+  'proxy for async function proxy'
 );

--- a/test/built-ins/Object/prototype/toString/symbol-tag-non-str-builtin.js
+++ b/test/built-ins/Object/prototype/toString/symbol-tag-non-str-builtin.js
@@ -1,0 +1,76 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object.prototype.tostring
+description: >
+  Non-string values of `Symbol.toStringTag` property are ignored.
+info: |
+  Object.prototype.toString ( )
+
+  [...]
+  15. Let tag be ? Get(O, @@toStringTag).
+  16. If Type(tag) is not String, set tag to builtinTag.
+  17. Return the string-concatenation of "[object ", tag, and "]".
+features: [Symbol.toStringTag, Symbol.iterator, generators]
+---*/
+
+var toString = Object.prototype.toString;
+var defaultTag = '[object Object]';
+
+delete Symbol.prototype[Symbol.toStringTag];
+assert.sameValue(toString.call(Symbol('desc')), defaultTag);
+
+Object.defineProperty(Math, Symbol.toStringTag, {value: Symbol()});
+assert.sameValue(toString.call(Math), defaultTag);
+
+var strIter = ''[Symbol.iterator]();
+var strIterProto = Object.getPrototypeOf(strIter);
+delete strIterProto[Symbol.toStringTag];
+assert.sameValue(toString.call(strIter), defaultTag);
+
+var arrIter = [][Symbol.iterator]();
+var arrIterProto = Object.getPrototypeOf(arrIter)
+Object.defineProperty(arrIterProto, Symbol.toStringTag, {value: null});
+assert.sameValue(toString.call(arrIter), defaultTag);
+
+var map = new Map();
+delete Map.prototype[Symbol.toStringTag];
+assert.sameValue(toString.call(map), defaultTag);
+
+var mapIter = map[Symbol.iterator]();
+var mapIterProto = Object.getPrototypeOf(mapIter);
+Object.defineProperty(mapIterProto, Symbol.toStringTag, {
+  get: function() { return new String('ShouldNotBeUnwrapped'); },
+});
+assert.sameValue(toString.call(mapIter), defaultTag);
+
+var set = new Set();
+delete Set.prototype[Symbol.toStringTag];
+assert.sameValue(toString.call(set), defaultTag);
+
+var setIter = set[Symbol.iterator]();
+var setIterProto = Object.getPrototypeOf(setIter);
+Object.defineProperty(setIterProto, Symbol.toStringTag, {value: false});
+assert.sameValue(toString.call(setIter), defaultTag);
+
+var wm = new WeakMap();
+delete WeakMap.prototype[Symbol.toStringTag];
+assert.sameValue(toString.call(wm), defaultTag);
+
+var ws = new WeakSet();
+Object.defineProperty(WeakSet.prototype, Symbol.toStringTag, {value: 0});
+assert.sameValue(toString.call(ws), defaultTag);
+
+delete JSON[Symbol.toStringTag];
+assert.sameValue(toString.call(JSON), defaultTag);
+
+var gen = (function* () {})();
+var genProto = Object.getPrototypeOf(gen);
+Object.defineProperty(genProto, Symbol.toStringTag, {
+  get: function() { return {}; },
+});
+assert.sameValue(toString.call(gen), defaultTag);
+
+var promise = new Promise(function() {});
+delete Promise.prototype[Symbol.toStringTag];
+assert.sameValue(toString.call(promise), defaultTag);

--- a/test/built-ins/Object/prototype/toString/symbol-tag-non-str-proxy-function.js
+++ b/test/built-ins/Object/prototype/toString/symbol-tag-non-str-proxy-function.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2016 the Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object.prototype.tostring
+description: >
+  Non-string values of `Symbol.toStringTag` property are ignored.
+info: |
+  ProxyCreate ( target, handler )
+
+  [...]
+  7. If IsCallable(target) is true, then
+    a. Set P.[[Call]] as specified in 9.5.12.
+
+  Object.prototype.toString ( )
+
+  [...]
+  7. Else if O has a [[Call]] internal method, let builtinTag be "Function".
+  [...]
+  15. Let tag be ? Get(O, @@toStringTag).
+  16. If Type(tag) is not String, set tag to builtinTag.
+  17. Return the string-concatenation of "[object ", tag, and "]".
+features: [generators, async-functions, Proxy, Symbol.toStringTag]
+---*/
+
+var generatorProxy = new Proxy(function* () {}, {});
+var generatorProxyProxy = new Proxy(generatorProxy, {});
+delete generatorProxy.constructor.prototype[Symbol.toStringTag];
+
+assert.sameValue(
+  Object.prototype.toString.call(generatorProxy),
+  '[object Function]',
+  'generator function proxy without Symbol.toStringTag'
+);
+assert.sameValue(
+  Object.prototype.toString.call(generatorProxyProxy),
+  '[object Function]',
+  'proxy for generator function proxy without Symbol.toStringTag'
+);
+
+var asyncProxy = new Proxy(async function() {}, {});
+var asyncProxyProxy = new Proxy(asyncProxy, {});
+Object.defineProperty(asyncProxy.constructor.prototype, Symbol.toStringTag, {
+  value: undefined,
+});
+
+assert.sameValue(
+  Object.prototype.toString.call(asyncProxy),
+  '[object Function]',
+  'async function proxy without Symbol.toStringTag'
+);
+assert.sameValue(
+  Object.prototype.toString.call(asyncProxyProxy),
+  '[object Function]',
+  'proxy for async function proxy without Symbol.toStringTag'
+);


### PR DESCRIPTION
JSC issues:
* [toString called on proxies returns incorrect tag](https://bugs.webkit.org/show_bug.cgi?id=161111)
* [Object.prototype.toString is not spec-perfect](https://bugs.webkit.org/show_bug.cgi?id=199138)

Follow-up of #755.