### PR TITLE
Fixes {format,formatToParts}/en-us-numeric-auto.js

### DIFF
--- a/test/intl402/RelativeTimeFormat/prototype/format/en-us-numeric-auto.js
+++ b/test/intl402/RelativeTimeFormat/prototype/format/en-us-numeric-auto.js
@@ -51,10 +51,14 @@ const exceptions = {
     "1": "tomorrow",
   },
   "hour": {
-    '0': 'this hour'
+    "-1": "1 minute ago",
+    '0': 'this hour',
+    "1": "in 1 hour",
   },
   "minute": {
-    '0': 'this minute'
+    "-1": "1 minute ago",
+    '0': 'this minute',
+    "1": "in 1 minute",
   },
   "second": {
     "-1": "1 second ago",

--- a/test/intl402/RelativeTimeFormat/prototype/format/en-us-numeric-auto.js
+++ b/test/intl402/RelativeTimeFormat/prototype/format/en-us-numeric-auto.js
@@ -51,7 +51,7 @@ const exceptions = {
     "1": "tomorrow",
   },
   "hour": {
-    "-1": "1 minute ago",
+    "-1": "1 hour ago",
     '0': 'this hour',
     "1": "in 1 hour",
   },

--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-numeric-auto.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/en-us-numeric-auto.js
@@ -46,6 +46,12 @@ function expected(key, unit, default_) {
       "0": "today",
       "1": "tomorrow",
     },
+    "hour": {
+      "0": "this hour",
+    },
+    "minute": {
+      "0": "this minute",
+    },
     "second": {
       "0": "now",
     },


### PR DESCRIPTION
The following lines expect each unit has property "-1" and "1" 
```
  const expected = unit in exceptions
    ? [exceptions[unit]["1"], exceptions[unit]["0"], exceptions[unit]["0"], exceptions[unit]["-1"]]
    : [`in 1 ${unit}`, `in 0 ${unit}s`, `0 ${unit}s ago`, `1 ${unit} ago`];
```

@Ms2ger @leobalter 