### PR TITLE
Adding cases where private names are used on direct eval calls

### DIFF
--- a/test/language/statements/class/elements/private-field-visible-to-direct-eval-on-initializer.js
+++ b/test/language/statements/class/elements/private-field-visible-to-direct-eval-on-initializer.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private field is visible on initializer with direct eval
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+
+  ClassElementName : PrivateIdentifier
+    1. Let privateIdentifier be StringValue of PrivateIdentifier.
+    2. Let privateName be NewPrivateName(privateIdentifier).
+    3. Let scope be the running execution context's PrivateEnvironment.
+    4. Let scopeEnvRec be scope's EnvironmentRecord.
+    5. Perform ! scopeEnvRec.InitializeBinding(privateIdentifier, privateName).
+    6. Return privateName.
+
+  MakePrivateReference ( baseValue, privateIdentifier )
+    1. Let env be the running execution context's PrivateEnvironment.
+    2. Let privateNameBinding be ? ResolveBinding(privateIdentifier, env).
+    3. Let privateName be GetValue(privateNameBinding).
+    4. Assert: privateName is a Private Name.
+    5. Return a value of type Reference whose base value is baseValue, whose referenced name is privateName, whose strict reference flag is true.
+features: [class-fields-private, class-fields-public, class]
+---*/
+
+class C {
+  #m = 44;
+  v = eval("this.#m");
+}
+
+let c = new C();
+assert.sameValue(c.v, 44);

--- a/test/language/statements/class/elements/private-field-visible-to-direct-eval.js
+++ b/test/language/statements/class/elements/private-field-visible-to-direct-eval.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private field is visible to direct eval code
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+
+  ClassElementName : PrivateIdentifier
+    1. Let privateIdentifier be StringValue of PrivateIdentifier.
+    2. Let privateName be NewPrivateName(privateIdentifier).
+    3. Let scope be the running execution context's PrivateEnvironment.
+    4. Let scopeEnvRec be scope's EnvironmentRecord.
+    5. Perform ! scopeEnvRec.InitializeBinding(privateIdentifier, privateName).
+    6. Return privateName.
+
+  MakePrivateReference ( baseValue, privateIdentifier )
+    1. Let env be the running execution context's PrivateEnvironment.
+    2. Let privateNameBinding be ? ResolveBinding(privateIdentifier, env).
+    3. Let privateName be GetValue(privateNameBinding).
+    4. Assert: privateName is a Private Name.
+    5. Return a value of type Reference whose base value is baseValue, whose referenced name is privateName, whose strict reference flag is true.
+features: [class-fields-private, class]
+---*/
+
+class C {
+  #m = 44;
+
+  getWithEval() {
+    return eval("this.#m");
+  }
+}
+
+class D {
+  #m = 44;
+}
+
+let c = new C();
+assert.sameValue(c.getWithEval(), 44);
+
+let d = new D();
+assert.throws(TypeError, function() {
+  c.getWithEval.call(d);
+}, "invalid access to a private field");

--- a/test/language/statements/class/elements/private-getter-visible-to-direct-eval-on-initializer.js
+++ b/test/language/statements/class/elements/private-getter-visible-to-direct-eval-on-initializer.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private getter is visible on initializer with direct eval
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+
+  ClassElementName : PrivateIdentifier
+    1. Let privateIdentifier be StringValue of PrivateIdentifier.
+    2. Let privateName be NewPrivateName(privateIdentifier).
+    3. Let scope be the running execution context's PrivateEnvironment.
+    4. Let scopeEnvRec be scope's EnvironmentRecord.
+    5. Perform ! scopeEnvRec.InitializeBinding(privateIdentifier, privateName).
+    6. Return privateName.
+
+  MakePrivateReference ( baseValue, privateIdentifier )
+    1. Let env be the running execution context's PrivateEnvironment.
+    2. Let privateNameBinding be ? ResolveBinding(privateIdentifier, env).
+    3. Let privateName be GetValue(privateNameBinding).
+    4. Assert: privateName is a Private Name.
+    5. Return a value of type Reference whose base value is baseValue, whose referenced name is privateName, whose strict reference flag is true.
+features: [class-fields-private, class-fields-public, class]
+---*/
+
+class C {
+  get #m() { return "Test262"; };
+  v = eval("this.#m");
+}
+
+let c = new C();
+assert.sameValue(c.v, "Test262");

--- a/test/language/statements/class/elements/private-getter-visible-to-direct-eval.js
+++ b/test/language/statements/class/elements/private-getter-visible-to-direct-eval.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private getter is visible to direct eval code
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+
+  ClassElementName : PrivateIdentifier
+    1. Let privateIdentifier be StringValue of PrivateIdentifier.
+    2. Let privateName be NewPrivateName(privateIdentifier).
+    3. Let scope be the running execution context's PrivateEnvironment.
+    4. Let scopeEnvRec be scope's EnvironmentRecord.
+    5. Perform ! scopeEnvRec.InitializeBinding(privateIdentifier, privateName).
+    6. Return privateName.
+
+  MakePrivateReference ( baseValue, privateIdentifier )
+    1. Let env be the running execution context's PrivateEnvironment.
+    2. Let privateNameBinding be ? ResolveBinding(privateIdentifier, env).
+    3. Let privateName be GetValue(privateNameBinding).
+    4. Assert: privateName is a Private Name.
+    5. Return a value of type Reference whose base value is baseValue, whose referenced name is privateName, whose strict reference flag is true.
+features: [class-methods-private, class]
+---*/
+
+class C {
+  get #m() { return "Test262"; };
+
+  getWithEval() {
+    return eval("this.#m");
+  }
+}
+
+class D {
+  get #m() { throw new Test262Error(); };
+}
+
+let c = new C();
+assert.sameValue(c.getWithEval(), "Test262");
+
+let d = new D();
+assert.throws(TypeError, function() {
+  c.getWithEval.call(d);
+}, "invalid access to a private getter");

--- a/test/language/statements/class/elements/private-method-visible-to-direct-eval-on-initializer.js
+++ b/test/language/statements/class/elements/private-method-visible-to-direct-eval-on-initializer.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private method is visible on initializer with direct eval
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+
+  ClassElementName : PrivateIdentifier
+    1. Let privateIdentifier be StringValue of PrivateIdentifier.
+    2. Let privateName be NewPrivateName(privateIdentifier).
+    3. Let scope be the running execution context's PrivateEnvironment.
+    4. Let scopeEnvRec be scope's EnvironmentRecord.
+    5. Perform ! scopeEnvRec.InitializeBinding(privateIdentifier, privateName).
+    6. Return privateName.
+
+  MakePrivateReference ( baseValue, privateIdentifier )
+    1. Let env be the running execution context's PrivateEnvironment.
+    2. Let privateNameBinding be ? ResolveBinding(privateIdentifier, env).
+    3. Let privateName be GetValue(privateNameBinding).
+    4. Assert: privateName is a Private Name.
+    5. Return a value of type Reference whose base value is baseValue, whose referenced name is privateName, whose strict reference flag is true.
+features: [class-fields-private, class-fields-public, class]
+---*/
+
+class C {
+  #m() { return "Test262"; };
+  v = eval("this.#m()");
+}
+
+let c = new C();
+assert.sameValue(c.v, "Test262");

--- a/test/language/statements/class/elements/private-method-visible-to-direct-eval.js
+++ b/test/language/statements/class/elements/private-method-visible-to-direct-eval.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private method is visible to direct eval code
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+
+  ClassElementName : PrivateIdentifier
+    1. Let privateIdentifier be StringValue of PrivateIdentifier.
+    2. Let privateName be NewPrivateName(privateIdentifier).
+    3. Let scope be the running execution context's PrivateEnvironment.
+    4. Let scopeEnvRec be scope's EnvironmentRecord.
+    5. Perform ! scopeEnvRec.InitializeBinding(privateIdentifier, privateName).
+    6. Return privateName.
+
+  MakePrivateReference ( baseValue, privateIdentifier )
+    1. Let env be the running execution context's PrivateEnvironment.
+    2. Let privateNameBinding be ? ResolveBinding(privateIdentifier, env).
+    3. Let privateName be GetValue(privateNameBinding).
+    4. Assert: privateName is a Private Name.
+    5. Return a value of type Reference whose base value is baseValue, whose referenced name is privateName, whose strict reference flag is true.
+features: [class-methods-private, class]
+---*/
+
+class C {
+  #m() { return "Test262"; };
+
+  getWithEval() {
+    return eval("this.#m()");
+  }
+}
+
+class D {
+  #m() { throw new Test262Error(); };
+}
+
+let c = new C();
+assert.sameValue(c.getWithEval(), "Test262");
+
+let d = new D();
+assert.throws(TypeError, function() {
+  c.getWithEval.call(d);
+}, "invalid access to a private method");

--- a/test/language/statements/class/elements/private-setter-visible-to-direct-eval-on-initializer.js
+++ b/test/language/statements/class/elements/private-setter-visible-to-direct-eval-on-initializer.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private setter is visible on initializer with direct eval
+esid: sec-privatefieldset
+info: |
+  PrivateFieldSet (P, O, value )
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Set entry.[[PrivateFieldValue]] to value.
+      d. Return.
+    4. If P.[[Kind]] is "method", throw a TypeError exception.
+    5. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If O.[[PrivateFieldBrands]] does not contain P.[[Brand]], throw a TypeError exception.
+      c. If P does not have a [[Set]] field, throw a TypeError exception.
+      d. Let setter be P.[[Set]].
+      e. Perform ? Call(setter, O, value).
+      f. Return.
+
+  ClassElementName : PrivateIdentifier
+    1. Let privateIdentifier be StringValue of PrivateIdentifier.
+    2. Let privateName be NewPrivateName(privateIdentifier).
+    3. Let scope be the running execution context's PrivateEnvironment.
+    4. Let scopeEnvRec be scope's EnvironmentRecord.
+    5. Perform ! scopeEnvRec.InitializeBinding(privateIdentifier, privateName).
+    6. Return privateName.
+
+  MakePrivateReference ( baseValue, privateIdentifier )
+    1. Let env be the running execution context's PrivateEnvironment.
+    2. Let privateNameBinding be ? ResolveBinding(privateIdentifier, env).
+    3. Let privateName be GetValue(privateNameBinding).
+    4. Assert: privateName is a Private Name.
+    5. Return a value of type Reference whose base value is baseValue, whose referenced name is privateName, whose strict reference flag is true.
+features: [class-fields-public, class-methods-private, class]
+---*/
+
+class C {
+  set #m(v) { this._v = v; };
+  v = (eval("this.#m = 53"), this._v);
+}
+
+let c = new C();
+assert.sameValue(c.v, 53);

--- a/test/language/statements/class/elements/private-setter-visible-to-direct-eval.js
+++ b/test/language/statements/class/elements/private-setter-visible-to-direct-eval.js
@@ -43,7 +43,7 @@ class C {
   set #m(v) { this._v = v; };
 
   setWithEval(v) {
-    return eval("this.#m = v");
+    eval("this.#m = v");
   }
 }
 

--- a/test/language/statements/class/elements/private-setter-visible-to-direct-eval.js
+++ b/test/language/statements/class/elements/private-setter-visible-to-direct-eval.js
@@ -1,0 +1,61 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private setter is visible to direct eval code
+esid: sec-privatefieldset
+info: |
+  PrivateFieldSet (P, O, value )
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Set entry.[[PrivateFieldValue]] to value.
+      d. Return.
+    4. If P.[[Kind]] is "method", throw a TypeError exception.
+    5. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If O.[[PrivateFieldBrands]] does not contain P.[[Brand]], throw a TypeError exception.
+      c. If P does not have a [[Set]] field, throw a TypeError exception.
+      d. Let setter be P.[[Set]].
+      e. Perform ? Call(setter, O, value).
+      f. Return.
+
+  ClassElementName : PrivateIdentifier
+    1. Let privateIdentifier be StringValue of PrivateIdentifier.
+    2. Let privateName be NewPrivateName(privateIdentifier).
+    3. Let scope be the running execution context's PrivateEnvironment.
+    4. Let scopeEnvRec be scope's EnvironmentRecord.
+    5. Perform ! scopeEnvRec.InitializeBinding(privateIdentifier, privateName).
+    6. Return privateName.
+
+  MakePrivateReference ( baseValue, privateIdentifier )
+    1. Let env be the running execution context's PrivateEnvironment.
+    2. Let privateNameBinding be ? ResolveBinding(privateIdentifier, env).
+    3. Let privateName be GetValue(privateNameBinding).
+    4. Assert: privateName is a Private Name.
+    5. Return a value of type Reference whose base value is baseValue, whose referenced name is privateName, whose strict reference flag is true.
+features: [class-methods-private, class]
+---*/
+
+class C {
+  set #m(v) { this._v = v; };
+
+  setWithEval(v) {
+    return eval("this.#m = v");
+  }
+}
+
+class D {
+  set #m(v) { throw new Test262Error(); };
+}
+
+let c = new C();
+c.setWithEval("Test262");
+assert.sameValue(c._v, "Test262");
+
+let d = new D();
+assert.throws(TypeError, function() {
+  c.setWithEval.call(d);
+}, "invalid access to a private setter");


### PR DESCRIPTION
As direct eval's scope is the same as caller's scope, private names are available on those calls as well. It also includes direct eval used on class field initialization.

It is covering some cases of #1343.

Cc.: @jbhoosreddy, @mkubilayk and @leobalter.