### PR TITLE
Added tests to cover access of private members on inner functions

### DIFF
--- a/src/class-elements/private-field-access-on-inner-arrow-function.case
+++ b/src/class-elements/private-field-access-on-inner-arrow-function.case
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName of private field is visible on inner arrow function of class scope
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-fields-private]
+---*/
+
+//- elements
+#f = 'Test262';
+
+method() {
+  let arrowFunction = () => {
+    return this.#f;
+  }
+
+  return arrowFunction();
+}
+//- assertions
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private field from an ordinary object');

--- a/src/class-elements/private-field-access-on-inner-function.case
+++ b/src/class-elements/private-field-access-on-inner-function.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName of private field is visible on inner function of class scope
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-fields-private]
+---*/
+
+//- elements
+#f = 'Test262';
+
+method() {
+  let self = this;
+  function innerFunction() {
+    return self.#f;
+  }
+
+  return innerFunction();
+}
+//- assertions
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private field from an ordinary object');

--- a/src/class-elements/private-getter-access-on-inner-arrow-function.case
+++ b/src/class-elements/private-getter-access-on-inner-arrow-function.case
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName of private getter is visible on inner arrow function of class scope
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+get #m() { return 'Test262'; }
+
+method() {
+  let arrowFunction = () => {
+    return this.#m;
+  }
+
+  return arrowFunction();
+}
+//- assertions
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private accessor from an ordinary object');

--- a/src/class-elements/private-getter-access-on-inner-function.case
+++ b/src/class-elements/private-getter-access-on-inner-function.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName of private getter is visible on inner function of class scope
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+get #m() { return 'Test262'; }
+
+method() {
+  let self = this;
+  function innerFunction() {
+    return self.#m;
+  }
+
+  return innerFunction();
+}
+//- assertions
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private accessor from an ordinary object');

--- a/src/class-elements/private-method-access-on-inner-arrow-function.case
+++ b/src/class-elements/private-method-access-on-inner-arrow-function.case
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName of private method is visible on inner arrow function of class scope
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+#m() { return 'Test262'; }
+
+method() {
+  let arrowFunction = () => {
+    return this.#m();
+  }
+
+  return arrowFunction();
+}
+//- assertions
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private method from an ordinary object');

--- a/src/class-elements/private-method-access-on-inner-function.case
+++ b/src/class-elements/private-method-access-on-inner-function.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName of private method is visible on inner function of class scope
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+#m() { return 'Test262'; }
+
+method() {
+  let self = this;
+  function innerFunction() {
+    return self.#m();
+  }
+
+  return innerFunction();
+}
+//- assertions
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private method from an ordinary object');

--- a/src/class-elements/private-setter-access-on-inner-arrow-function.case
+++ b/src/class-elements/private-setter-access-on-inner-arrow-function.case
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName of private setter is visible on inner arrow function of class scope
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+set #m(v) { this._v = v; }
+
+method() {
+  let arrowFunction = () => {
+    this.#m = 'Test262';
+  }
+
+  arrowFunction();
+}
+//- assertions
+let c = new C();
+c.method();
+assert.sameValue(c._v, 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private setter from an ordinary object');

--- a/src/class-elements/private-setter-access-on-inner-function.case
+++ b/src/class-elements/private-setter-access-on-inner-function.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName of private setter is visible on inner function of class scope
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-methods-private]
+---*/
+
+//- elements
+set #m(v) { this._v = v; }
+
+method() {
+  let self = this;
+  function innerFunction() {
+    self.#m = 'Test262';
+  }
+
+  innerFunction();
+}
+//- assertions
+let c = new C();
+c.method();
+assert.sameValue(c._v, 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private setter from an ordinary object');

--- a/test/language/expressions/class/elements/private-field-access-on-inner-arrow-function.js
+++ b/test/language/expressions/class/elements/private-field-access-on-inner-arrow-function.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-field-access-on-inner-arrow-function.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName of private field is visible on inner arrow function of class scope (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-fields-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  #f = 'Test262';
+
+  method() {
+    let arrowFunction = () => {
+      return this.#f;
+    }
+
+    return arrowFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private field from an ordinary object');

--- a/test/language/expressions/class/elements/private-field-access-on-inner-function.js
+++ b/test/language/expressions/class/elements/private-field-access-on-inner-function.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-field-access-on-inner-function.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName of private field is visible on inner function of class scope (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-fields-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  #f = 'Test262';
+
+  method() {
+    let self = this;
+    function innerFunction() {
+      return self.#f;
+    }
+
+    return innerFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private field from an ordinary object');

--- a/test/language/expressions/class/elements/private-getter-access-on-inner-arrow-function.js
+++ b/test/language/expressions/class/elements/private-getter-access-on-inner-arrow-function.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-access-on-inner-arrow-function.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName of private getter is visible on inner arrow function of class scope (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  get #m() { return 'Test262'; }
+
+  method() {
+    let arrowFunction = () => {
+      return this.#m;
+    }
+
+    return arrowFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private accessor from an ordinary object');

--- a/test/language/expressions/class/elements/private-getter-access-on-inner-function.js
+++ b/test/language/expressions/class/elements/private-getter-access-on-inner-function.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-access-on-inner-function.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName of private getter is visible on inner function of class scope (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  get #m() { return 'Test262'; }
+
+  method() {
+    let self = this;
+    function innerFunction() {
+      return self.#m;
+    }
+
+    return innerFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private accessor from an ordinary object');

--- a/test/language/expressions/class/elements/private-method-access-on-inner-arrow-function.js
+++ b/test/language/expressions/class/elements/private-method-access-on-inner-arrow-function.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-access-on-inner-arrow-function.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName of private method is visible on inner arrow function of class scope (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  #m() { return 'Test262'; }
+
+  method() {
+    let arrowFunction = () => {
+      return this.#m();
+    }
+
+    return arrowFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private method from an ordinary object');

--- a/test/language/expressions/class/elements/private-method-access-on-inner-function.js
+++ b/test/language/expressions/class/elements/private-method-access-on-inner-function.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-access-on-inner-function.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName of private method is visible on inner function of class scope (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  #m() { return 'Test262'; }
+
+  method() {
+    let self = this;
+    function innerFunction() {
+      return self.#m();
+    }
+
+    return innerFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private method from an ordinary object');

--- a/test/language/expressions/class/elements/private-setter-access-on-inner-arrow-function.js
+++ b/test/language/expressions/class/elements/private-setter-access-on-inner-arrow-function.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-access-on-inner-arrow-function.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName of private setter is visible on inner arrow function of class scope (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  set #m(v) { this._v = v; }
+
+  method() {
+    let arrowFunction = () => {
+      this.#m = 'Test262';
+    }
+
+    arrowFunction();
+  }
+}
+
+let c = new C();
+c.method();
+assert.sameValue(c._v, 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private setter from an ordinary object');

--- a/test/language/expressions/class/elements/private-setter-access-on-inner-function.js
+++ b/test/language/expressions/class/elements/private-setter-access-on-inner-function.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-access-on-inner-function.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName of private setter is visible on inner function of class scope (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  set #m(v) { this._v = v; }
+
+  method() {
+    let self = this;
+    function innerFunction() {
+      self.#m = 'Test262';
+    }
+
+    innerFunction();
+  }
+}
+
+let c = new C();
+c.method();
+assert.sameValue(c._v, 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private setter from an ordinary object');

--- a/test/language/statements/class/elements/private-field-access-on-inner-arrow-function.js
+++ b/test/language/statements/class/elements/private-field-access-on-inner-arrow-function.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-field-access-on-inner-arrow-function.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName of private field is visible on inner arrow function of class scope (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-fields-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  #f = 'Test262';
+
+  method() {
+    let arrowFunction = () => {
+      return this.#f;
+    }
+
+    return arrowFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private field from an ordinary object');

--- a/test/language/statements/class/elements/private-field-access-on-inner-function.js
+++ b/test/language/statements/class/elements/private-field-access-on-inner-function.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-field-access-on-inner-function.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName of private field is visible on inner function of class scope (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-fields-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  #f = 'Test262';
+
+  method() {
+    let self = this;
+    function innerFunction() {
+      return self.#f;
+    }
+
+    return innerFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private field from an ordinary object');

--- a/test/language/statements/class/elements/private-getter-access-on-inner-arrow-function.js
+++ b/test/language/statements/class/elements/private-getter-access-on-inner-arrow-function.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-access-on-inner-arrow-function.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName of private getter is visible on inner arrow function of class scope (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  get #m() { return 'Test262'; }
+
+  method() {
+    let arrowFunction = () => {
+      return this.#m;
+    }
+
+    return arrowFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private accessor from an ordinary object');

--- a/test/language/statements/class/elements/private-getter-access-on-inner-function.js
+++ b/test/language/statements/class/elements/private-getter-access-on-inner-function.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-getter-access-on-inner-function.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName of private getter is visible on inner function of class scope (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  get #m() { return 'Test262'; }
+
+  method() {
+    let self = this;
+    function innerFunction() {
+      return self.#m;
+    }
+
+    return innerFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private accessor from an ordinary object');

--- a/test/language/statements/class/elements/private-method-access-on-inner-arrow-function.js
+++ b/test/language/statements/class/elements/private-method-access-on-inner-arrow-function.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-access-on-inner-arrow-function.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName of private method is visible on inner arrow function of class scope (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  #m() { return 'Test262'; }
+
+  method() {
+    let arrowFunction = () => {
+      return this.#m();
+    }
+
+    return arrowFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private method from an ordinary object');

--- a/test/language/statements/class/elements/private-method-access-on-inner-function.js
+++ b/test/language/statements/class/elements/private-method-access-on-inner-function.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-access-on-inner-function.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName of private method is visible on inner function of class scope (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  #m() { return 'Test262'; }
+
+  method() {
+    let self = this;
+    function innerFunction() {
+      return self.#m();
+    }
+
+    return innerFunction();
+  }
+}
+
+let c = new C();
+assert.sameValue(c.method(), 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private method from an ordinary object');

--- a/test/language/statements/class/elements/private-setter-access-on-inner-arrow-function.js
+++ b/test/language/statements/class/elements/private-setter-access-on-inner-arrow-function.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-access-on-inner-arrow-function.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName of private setter is visible on inner arrow function of class scope (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  set #m(v) { this._v = v; }
+
+  method() {
+    let arrowFunction = () => {
+      this.#m = 'Test262';
+    }
+
+    arrowFunction();
+  }
+}
+
+let c = new C();
+c.method();
+assert.sameValue(c._v, 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private setter from an ordinary object');

--- a/test/language/statements/class/elements/private-setter-access-on-inner-function.js
+++ b/test/language/statements/class/elements/private-setter-access-on-inner-function.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-setter-access-on-inner-function.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName of private setter is visible on inner function of class scope (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-methods-private, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  set #m(v) { this._v = v; }
+
+  method() {
+    let self = this;
+    function innerFunction() {
+      self.#m = 'Test262';
+    }
+
+    innerFunction();
+  }
+}
+
+let c = new C();
+c.method();
+assert.sameValue(c._v, 'Test262');
+let o = {};
+assert.throws(TypeError, function() {
+  c.method.call(o);
+}, 'accessed private setter from an ordinary object');


### PR DESCRIPTION
We are adding test cases to verify that private members(fields, methods and accessors) are visible on scope of inner functions and arrow functions.