### PR TITLE
Adding tests to verify cases on PrivateFieldSet and PrivateFieldGet

### DIFF
--- a/test/language/statements/class/elements/get-access-of-missing-private-getter.js
+++ b/test/language/statements/class/elements/get-access-of-missing-private-getter.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Trying to get a private member without getter throws TypeError
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet ( P, O )
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+features: [class-methods-private, class]
+---*/
+
+class C {
+  set #f(v) {
+    throw new Test262Error();
+  }
+
+  getAccess() {
+    return this.#f;
+  }
+}
+
+let c = new C();
+assert.throws(TypeError, function() {
+  c.getAccess();
+}, 'get operation on private accessor without getter should throw TypeError');

--- a/test/language/statements/class/elements/get-access-of-missing-shadowed-private-getter.js
+++ b/test/language/statements/class/elements/get-access-of-missing-shadowed-private-getter.js
@@ -1,0 +1,89 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Trying to get from PrivateName without [[Get]] throws TypeError
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O )
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+features: [class-methods-private, class-fields-public, class]
+---*/
+
+class A {
+  get #f() {
+    throw new Test262Error();
+  }
+}
+
+class C extends A {
+  set #f(v) {
+    throw new Test262Error();
+  }
+
+  getAccess() {
+    return this.#f;
+  }
+}
+
+let c = new C();
+assert.throws(TypeError, function() {
+  c.getAccess();
+}, 'subclass private accessor should shadow super class private accessor');
+
+class B {
+  get #f() {
+    throw new Test262Error();
+  }
+
+  Inner = class {
+    set #f(v) {
+      throw new Test262Error();
+    }
+
+    getAccess() {
+      return this.#f;
+    }
+  }
+}
+
+let b = new B();
+let innerB = new b.Inner();
+assert.throws(TypeError, function() {
+  innerB.getAccess();
+}, 'inner class private accessor should shadow outer class private accessor');
+
+class D {
+  set #f(v) {
+    throw new Test262Error();
+  }
+
+  Inner = class {
+    get #f() {
+      throw new Test262Error();
+    }
+  }
+
+  getAccess() {
+    return this.#f;
+  }
+}
+
+let d = new D();
+assert.throws(TypeError, function() {
+  d.getAccess();
+}, 'inner class private accessor should not be visible to outer class private accessor');
+

--- a/test/language/statements/class/elements/set-access-of-missing-private-setter.js
+++ b/test/language/statements/class/elements/set-access-of-missing-private-setter.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Trying to set a private member without setter throws TypeError
+esid: sec-privatefieldset
+info: |
+  PrivateFieldSet ( P, O, value )
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Set entry.[[PrivateFieldValue]] to value.
+      d. Return.
+    4. If P.[[Kind]] is "method", throw a TypeError exception.
+    5. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If O.[[PrivateFieldBrands]] does not contain P.[[Brand]], throw a TypeError exception.
+      c. If P does not have a [[Set]] field, throw a TypeError exception.
+      d. Let setter be P.[[Set]].
+      e. Perform ? Call(setter, O, value).
+      f. Return.
+features: [class-methods-private, class]
+---*/
+
+class C {
+  get #f() {
+    throw new Test262Error();
+  }
+
+  setAccess() {
+    this.#f = 'Test262';
+  }
+}
+
+let c = new C();
+assert.throws(TypeError, function() {
+  c.setAccess();
+}, 'set operation on private accessor without setter should throw TypeError');

--- a/test/language/statements/class/elements/set-access-of-missing-shadowed-private-setter.js
+++ b/test/language/statements/class/elements/set-access-of-missing-shadowed-private-setter.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Trying to set in PrivateName without setter throws TypeError
+esid: sec-privatefieldset
+info: |
+  PrivateFieldSet ( P, O, value )
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Set entry.[[PrivateFieldValue]] to value.
+      d. Return.
+    4. If P.[[Kind]] is "method", throw a TypeError exception.
+    5. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If O.[[PrivateFieldBrands]] does not contain P.[[Brand]], throw a TypeError exception.
+      c. If P does not have a [[Set]] field, throw a TypeError exception.
+      d. Let setter be P.[[Set]].
+      e. Perform ? Call(setter, O, value).
+      f. Return.
+features: [class-methods-private, class-fields-public, class]
+---*/
+
+class A {
+  set #f(v) {
+    throw new Test262Error();
+  }
+}
+
+class B extends A {
+  get #f() {
+    throw new Test262Error();
+  }
+
+  setAccess() {
+    this.#f = 'Test262';
+  }
+}
+
+let b = new B();
+assert.throws(TypeError, function() {
+  b.setAccess();
+}, 'subclass private accessor should shadow super class private accessor');
+
+class C {
+  set #f(v) {
+    throw new Test262Error();
+  }
+
+  Inner = class {
+    get #f() {
+      throw new Test262Error();
+    }
+
+    setAccess() {
+      this.#f = 'Test262';
+    }
+  }
+}
+
+let c = new C();
+let innerC = new c.Inner();
+assert.throws(TypeError, function() {
+  innerC.setAccess();
+}, 'inner class private accessor should shadow outer class private accessor');
+
+class D {
+  get #f() {
+    throw new Test262Error();
+  }
+
+  Inner = class {
+    set #f(v) {
+      throw new Test262Error();
+    }
+  }
+
+  setAccess() {
+    this.#f = 'Test262';
+  }
+}
+
+let d = new D();
+assert.throws(TypeError, function() {
+  d.setAccess();
+}, 'inner class private accessor should not be visible to outer class private accessor');
+

--- a/test/language/statements/class/elements/set-access-of-private-method.js
+++ b/test/language/statements/class/elements/set-access-of-private-method.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Trying to set a private method throws TypeError
+esid: sec-privatefieldset
+info: |
+  PrivateFieldSet ( P, O, value )
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Set entry.[[PrivateFieldValue]] to value.
+      d. Return.
+    4. If P.[[Kind]] is "method", throw a TypeError exception.
+    5. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If O.[[PrivateFieldBrands]] does not contain P.[[Brand]], throw a TypeError exception.
+      c. If P does not have a [[Set]] field, throw a TypeError exception.
+      d. Let setter be P.[[Set]].
+      e. Perform ? Call(setter, O, value).
+      f. Return.
+features: [class-methods-private, class]
+---*/
+
+class C {
+  #f() {
+    throw new Test262Error();
+  }
+
+  setAccess() {
+    this.#f = 'Test262';
+  }
+}
+
+let c = new C();
+assert.throws(TypeError, function() {
+  c.setAccess();
+}, 'set operation on private method should throw TypeError');
+

--- a/test/language/statements/class/elements/set-access-of-shadowed-private-method.js
+++ b/test/language/statements/class/elements/set-access-of-shadowed-private-method.js
@@ -1,0 +1,90 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Trying to set private method throws TypeError
+esid: sec-privatefieldset
+info: |
+  PrivateFieldSet ( P, O, value )
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Set entry.[[PrivateFieldValue]] to value.
+      d. Return.
+    4. If P.[[Kind]] is "method", throw a TypeError exception.
+    5. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If O.[[PrivateFieldBrands]] does not contain P.[[Brand]], throw a TypeError exception.
+      c. If P does not have a [[Set]] field, throw a TypeError exception.
+      d. Let setter be P.[[Set]].
+      e. Perform ? Call(setter, O, value).
+      f. Return.
+features: [class-methods-private, class-fields-public, class]
+---*/
+
+class A {
+  set #f(v) {
+    throw new Test262Error();
+  }
+}
+
+class B extends A {
+  #f() {
+    throw new Test262Error();
+  }
+
+  setAccess() {
+    this.#f = 'Test262';
+  }
+}
+
+let b = new B();
+assert.throws(TypeError, function() {
+  b.setAccess();
+}, 'subclass private method should shadow super class private accessor');
+
+class C {
+  set #f(v) {
+    throw new Test262Error();
+  }
+
+  Inner = class {
+    #f() {
+      throw new Test262Error();
+    }
+
+    setAccess() {
+      this.#f = 'Test262';
+    }
+  }
+}
+
+let c = new C();
+let innerC = new c.Inner();
+assert.throws(TypeError, function() {
+  innerC.setAccess();
+}, 'inner class private method should shadow outer class private accessor');
+
+class D {
+  #f() {
+    throw new Test262Error();
+  }
+
+  Inner = class {
+    set #f(v) {
+      throw new Test262Error();
+    }
+  }
+
+  setAccess() {
+    this.#f = 'Test262';
+  }
+}
+
+let d = new D();
+assert.throws(TypeError, function() {
+  d.setAccess();
+}, 'inner class private accessor should not be visible to outer class');
+


### PR DESCRIPTION
According to [spec text](https://tc39.es/proposal-private-methods/#sec-privatefieldget), `PrivateFieldGet` and `PrivateFieldSet` should throw `TypeError` in some cases where we have invalid kind of access. This applies on following cases:

1. Tyring to get from a `PrivateName` without `[[Get]]` internal slot (i.e a private accessor with a setter, but not a getter).
2.  Tyring to set in a `PrivateName` without `[[Set]]` internal slot (i.e a private accessor with a getter, but not a setter).
3. Tyring to set in a `PrivateName` that is a method.

It is also adding cases to validate that shadowed private accessors/methods are thread as different `PrivateNames`. 