### PR TITLE
Add missing BigInt to Number conversion case

### DIFF
--- a/test/built-ins/Number/bigint-conversion.js
+++ b/test/built-ins/Number/bigint-conversion.js
@@ -9,3 +9,15 @@ features: [BigInt]
 
 assert.sameValue(Number(0n), 0);
 assert.sameValue(+(new Number(0n)), +(new Number(0)));
+
+assert.sameValue(Number(2n**53n), 9007199254740992);
+assert.sameValue(Number(2n**53n + 1n), 9007199254740992);
+assert.sameValue(Number(2n**53n + 2n), 9007199254740994);
+assert.sameValue(Number(2n**53n + 3n), 9007199254740996);
+assert.sameValue(Number(2n**53n + 4n), 9007199254740996);
+
+assert.sameValue(Number(-(2n**53n)), -9007199254740992);
+assert.sameValue(Number(-(2n**53n + 1n)), -9007199254740992);
+assert.sameValue(Number(-(2n**53n + 2n)), -9007199254740994);
+assert.sameValue(Number(-(2n**53n + 3n)), -9007199254740996);
+assert.sameValue(Number(-(2n**53n + 4n)), -9007199254740996);


### PR DESCRIPTION
There is an infinite set of `BigInt` values that can be represented as Numbers. This is the case when a `BigInt` is out of safe integer range, for example. This PR is adding such cases to `Number(BigInt)` constructor case. Some [bugs](https://bugzilla.mozilla.org/show_bug.cgi?id=1558538) with those edge cases were reported on implementations already.

P.S.: This PR is inspired by the bug mentioned above.