### PR TITLE
Check static private methods on super class are called with correct receiver

### DIFF
--- a/src/class-elements/static-private-method-subclass-receiver.case
+++ b/src/class-elements/static-private-method-subclass-receiver.case
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Static private methods on the super-class cannot be called with sub-class as the receiver
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+        ...
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    ...
+
+  PrivateBrandCheck(O, P)
+    1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+      a. Throw a TypeError exception.
+template: default
+features: [class-static-methods-private]
+---*/
+
+//- elements
+static f() { return this.#g(); }
+static #g() { return 42; }
+
+//- assertions
+class D extends C {}
+assert.sameValue(C.f(), 42);
+assert.throws(TypeError, function() {
+    D.f();
+}, 'D does not contain static private method #g');

--- a/test/language/expressions/class/elements/static-private-method-subclass-receiver.js
+++ b/test/language/expressions/class/elements/static-private-method-subclass-receiver.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/static-private-method-subclass-receiver.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Static private methods on the super-class cannot be called with sub-class as the receiver (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-static-methods-private, class]
+flags: [generated]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+          ...
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      ...
+
+    PrivateBrandCheck(O, P)
+      1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+        a. Throw a TypeError exception.
+
+---*/
+
+
+var C = class {
+  static f() { return this.#g(); }
+  static #g() { return 42; }
+
+}
+
+class D extends C {}
+assert.sameValue(C.f(), 42);
+assert.throws(TypeError, function() {
+    D.f();
+}, 'D does not contain static private method #g');

--- a/test/language/statements/class/elements/static-private-method-subclass-receiver.js
+++ b/test/language/statements/class/elements/static-private-method-subclass-receiver.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/static-private-method-subclass-receiver.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Static private methods on the super-class cannot be called with sub-class as the receiver (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-static-methods-private, class]
+flags: [generated]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+          ...
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      ...
+
+    PrivateBrandCheck(O, P)
+      1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+        a. Throw a TypeError exception.
+
+---*/
+
+
+class C {
+  static f() { return this.#g(); }
+  static #g() { return 42; }
+
+}
+
+class D extends C {}
+assert.sameValue(C.f(), 42);
+assert.throws(TypeError, function() {
+    D.f();
+}, 'D does not contain static private method #g');


### PR DESCRIPTION
Adds coverage for (static) private methods according to the test plan posted in #1343.

> Semantics > Error on missing method
> - Subclass receiver for static private

@leobalter @rwaldron for review.
cc: @caiolima @jbhoosreddy