### PR TITLE
Adding case where PrivateName is used inside computed property.

### DIFF
--- a/src/class-elements/grammar-privatename-in-computed-property-missing.case
+++ b/src/class-elements/grammar-privatename-in-computed-property-missing.case
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Use of udeclared PrivateName in ComputedProperty is a syntax error
+info: |
+  ClassTail : ClassHeritage { ClassBody }
+    1. Let lex be the LexicalEnvironment of the running execution context.
+    2. Let classScope be NewDeclarativeEnvironment(lex).
+    3. Let classScopeEnvRec be classScope's EnvironmentRecord.
+    ...
+    15. Set the running execution context's LexicalEnvironment to classScope.
+    16. Set the running execution context's PrivateEnvironment to classPrivateEnvironment.
+    ...
+    27. For each ClassElement e in order from elements
+      a. If IsStatic of e is false, then
+        i. Let field be the result of ClassElementEvaluation for e with arguments proto and false.
+    ...
+features: [class-fields-private]
+template: syntax/invalid
+---*/
+
+//- elements
+[this.#f] = 'Test262'

--- a/src/class-elements/grammar-privatename-in-computed-property-missing.case
+++ b/src/class-elements/grammar-privatename-in-computed-property-missing.case
@@ -2,21 +2,40 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-desc: Use of udeclared PrivateName in ComputedProperty is a syntax error
+desc: Use of undeclared PrivateName in ComputedProperty is a syntax error
 info: |
-  ClassTail : ClassHeritage { ClassBody }
-    1. Let lex be the LexicalEnvironment of the running execution context.
-    2. Let classScope be NewDeclarativeEnvironment(lex).
-    3. Let classScopeEnvRec be classScope's EnvironmentRecord.
-    ...
-    15. Set the running execution context's LexicalEnvironment to classScope.
-    16. Set the running execution context's PrivateEnvironment to classPrivateEnvironment.
-    ...
-    27. For each ClassElement e in order from elements
-      a. If IsStatic of e is false, then
-        i. Let field be the result of ClassElementEvaluation for e with arguments proto and false.
-    ...
-features: [class-fields-private]
+  ClassElementName:
+    PropertyName
+    PrivateIdentifier
+
+  PropertyName:
+    LiteralPropertyName
+    ComputedPropertyName
+
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+
+  AssignmentExpression ... MemberExpression
+
+  MemberExpression:
+    MemberExpression . PrivateName
+
+  Static Semantics: AllPrivateIdentifiersValid
+    AllPrivateIdentifiersValid is an abstract operation which takes names as an argument.
+
+    MemberExpression : MemberExpression . PrivateIdentifier
+      1. If StringValue of PrivateIdentifier is in names, return true.
+      2. Return false.
+
+    ClassBody : ClassElementList
+      1. Let newNames be the concatenation of names with PrivateBoundIdentifiers of ClassBody.
+      2. Return AllPrivateIdentifiersValid of ClassElementList with the argument newNames.
+
+  Static Semantics: Early Errors
+
+  ScriptBody : StatementList
+    It is a Syntax Error if AllPrivateIdentifiersValid of StatementList with an empty List as an argument is false unless the source code is eval code that is being processed by a direct eval.
+features: [class-fields-private, class-fields-public]
 template: syntax/invalid
 ---*/
 

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatename-in-computed-property-missing.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatename-in-computed-property-missing.js
@@ -1,0 +1,33 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatename-in-computed-property-missing.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: Use of udeclared PrivateName in ComputedProperty is a syntax error (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ClassTail : ClassHeritage { ClassBody }
+      1. Let lex be the LexicalEnvironment of the running execution context.
+      2. Let classScope be NewDeclarativeEnvironment(lex).
+      3. Let classScopeEnvRec be classScope's EnvironmentRecord.
+      ...
+      15. Set the running execution context's LexicalEnvironment to classScope.
+      16. Set the running execution context's PrivateEnvironment to classPrivateEnvironment.
+      ...
+      27. For each ClassElement e in order from elements
+        a. If IsStatic of e is false, then
+          i. Let field be the result of ClassElementEvaluation for e with arguments proto and false.
+      ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  [this.#f] = 'Test262'
+};

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatename-in-computed-property-missing.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatename-in-computed-property-missing.js
@@ -2,26 +2,45 @@
 // - src/class-elements/grammar-privatename-in-computed-property-missing.case
 // - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
 /*---
-description: Use of udeclared PrivateName in ComputedProperty is a syntax error (class expression)
+description: Use of undeclared PrivateName in ComputedProperty is a syntax error (class expression)
 esid: prod-ClassElement
-features: [class-fields-private, class]
+features: [class-fields-private, class-fields-public, class]
 flags: [generated]
 negative:
   phase: parse
   type: SyntaxError
 info: |
-    ClassTail : ClassHeritage { ClassBody }
-      1. Let lex be the LexicalEnvironment of the running execution context.
-      2. Let classScope be NewDeclarativeEnvironment(lex).
-      3. Let classScopeEnvRec be classScope's EnvironmentRecord.
-      ...
-      15. Set the running execution context's LexicalEnvironment to classScope.
-      16. Set the running execution context's PrivateEnvironment to classPrivateEnvironment.
-      ...
-      27. For each ClassElement e in order from elements
-        a. If IsStatic of e is false, then
-          i. Let field be the result of ClassElementEvaluation for e with arguments proto and false.
-      ...
+    ClassElementName:
+      PropertyName
+      PrivateIdentifier
+
+    PropertyName:
+      LiteralPropertyName
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+
+    AssignmentExpression ... MemberExpression
+
+    MemberExpression:
+      MemberExpression . PrivateName
+
+    Static Semantics: AllPrivateIdentifiersValid
+      AllPrivateIdentifiersValid is an abstract operation which takes names as an argument.
+
+      MemberExpression : MemberExpression . PrivateIdentifier
+        1. If StringValue of PrivateIdentifier is in names, return true.
+        2. Return false.
+
+      ClassBody : ClassElementList
+        1. Let newNames be the concatenation of names with PrivateBoundIdentifiers of ClassBody.
+        2. Return AllPrivateIdentifiersValid of ClassElementList with the argument newNames.
+
+    Static Semantics: Early Errors
+
+    ScriptBody : StatementList
+      It is a Syntax Error if AllPrivateIdentifiersValid of StatementList with an empty List as an argument is false unless the source code is eval code that is being processed by a direct eval.
 
 ---*/
 

--- a/test/language/statements/class/elements/prviate-accessor-is-visible-in-computed-properties.js
+++ b/test/language/statements/class/elements/prviate-accessor-is-visible-in-computed-properties.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private getter of a class is visible in its ComputetProperty scope
+esid: prod-ClassTail
+info: |
+  ClassTail : ClassHeritage { ClassBody }
+    1. Let lex be the LexicalEnvironment of the running execution context.
+    2. Let classScope be NewDeclarativeEnvironment(lex).
+    3. Let classScopeEnvRec be classScope's EnvironmentRecord.
+    ...
+    15. Set the running execution context's LexicalEnvironment to classScope.
+    16. Set the running execution context's PrivateEnvironment to classPrivateEnvironment.
+    ...
+    27. For each ClassElement e in order from elements
+      a. If IsStatic of e is false, then
+        i. Let field be the result of ClassElementEvaluation for e with arguments proto and false.
+    ...
+features: [class-methods-private, class-fields-public, class]
+---*/
+
+assert.throws(TypeError, function() {
+  class C {
+    get #f() {
+      throw new Test262Error();
+    }
+
+    [this.#f] = 'Test262';
+  }
+}, 'access to a private acessor from ordinary object');
+

--- a/test/language/statements/class/elements/prviate-field-is-visible-in-computed-properties.js
+++ b/test/language/statements/class/elements/prviate-field-is-visible-in-computed-properties.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: PrivateName of a class is visible in its ComputetProperty scope
+esid: prod-ClassTail
+info: |
+  ClassTail : ClassHeritage { ClassBody }
+    1. Let lex be the LexicalEnvironment of the running execution context.
+    2. Let classScope be NewDeclarativeEnvironment(lex).
+    3. Let classScopeEnvRec be classScope's EnvironmentRecord.
+    ...
+    15. Set the running execution context's LexicalEnvironment to classScope.
+    16. Set the running execution context's PrivateEnvironment to classPrivateEnvironment.
+    ...
+    27. For each ClassElement e in order from elements
+      a. If IsStatic of e is false, then
+        i. Let field be the result of ClassElementEvaluation for e with arguments proto and false.
+    ...
+features: [class-fields-private, class]
+---*/
+
+assert.throws(TypeError, function() {
+  class C {
+    [this.#f] = 'Test262';
+    #f = 'foo';
+  }
+}, 'access to a not defined private field in object should throw a TypeError');
+

--- a/test/language/statements/class/elements/prviate-method-is-visible-in-computed-properties.js
+++ b/test/language/statements/class/elements/prviate-method-is-visible-in-computed-properties.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private method of a class is visible in its ComputetProperty scope
+esid: prod-ClassTail
+info: |
+  ClassTail : ClassHeritage { ClassBody }
+    1. Let lex be the LexicalEnvironment of the running execution context.
+    2. Let classScope be NewDeclarativeEnvironment(lex).
+    3. Let classScopeEnvRec be classScope's EnvironmentRecord.
+    ...
+    15. Set the running execution context's LexicalEnvironment to classScope.
+    16. Set the running execution context's PrivateEnvironment to classPrivateEnvironment.
+    ...
+    27. For each ClassElement e in order from elements
+      a. If IsStatic of e is false, then
+        i. Let field be the result of ClassElementEvaluation for e with arguments proto and false.
+    ...
+features: [class-methods-private, class-fields-public, class]
+---*/
+
+assert.throws(TypeError, function() {
+  class C {
+    #m() {
+      throw new Test262Error();
+    }
+
+    [this.#m()] = 'Test262';
+  }
+}, 'access to a private method from ordinary object');
+

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatename-in-computed-property-missing.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatename-in-computed-property-missing.js
@@ -1,0 +1,33 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatename-in-computed-property-missing.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: Use of udeclared PrivateName in ComputedProperty is a syntax error (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    ClassTail : ClassHeritage { ClassBody }
+      1. Let lex be the LexicalEnvironment of the running execution context.
+      2. Let classScope be NewDeclarativeEnvironment(lex).
+      3. Let classScopeEnvRec be classScope's EnvironmentRecord.
+      ...
+      15. Set the running execution context's LexicalEnvironment to classScope.
+      16. Set the running execution context's PrivateEnvironment to classPrivateEnvironment.
+      ...
+      27. For each ClassElement e in order from elements
+        a. If IsStatic of e is false, then
+          i. Let field be the result of ClassElementEvaluation for e with arguments proto and false.
+      ...
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  [this.#f] = 'Test262'
+}

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatename-in-computed-property-missing.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatename-in-computed-property-missing.js
@@ -2,26 +2,45 @@
 // - src/class-elements/grammar-privatename-in-computed-property-missing.case
 // - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
 /*---
-description: Use of udeclared PrivateName in ComputedProperty is a syntax error (class declaration)
+description: Use of undeclared PrivateName in ComputedProperty is a syntax error (class declaration)
 esid: prod-ClassElement
-features: [class-fields-private, class]
+features: [class-fields-private, class-fields-public, class]
 flags: [generated]
 negative:
   phase: parse
   type: SyntaxError
 info: |
-    ClassTail : ClassHeritage { ClassBody }
-      1. Let lex be the LexicalEnvironment of the running execution context.
-      2. Let classScope be NewDeclarativeEnvironment(lex).
-      3. Let classScopeEnvRec be classScope's EnvironmentRecord.
-      ...
-      15. Set the running execution context's LexicalEnvironment to classScope.
-      16. Set the running execution context's PrivateEnvironment to classPrivateEnvironment.
-      ...
-      27. For each ClassElement e in order from elements
-        a. If IsStatic of e is false, then
-          i. Let field be the result of ClassElementEvaluation for e with arguments proto and false.
-      ...
+    ClassElementName:
+      PropertyName
+      PrivateIdentifier
+
+    PropertyName:
+      LiteralPropertyName
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+
+    AssignmentExpression ... MemberExpression
+
+    MemberExpression:
+      MemberExpression . PrivateName
+
+    Static Semantics: AllPrivateIdentifiersValid
+      AllPrivateIdentifiersValid is an abstract operation which takes names as an argument.
+
+      MemberExpression : MemberExpression . PrivateIdentifier
+        1. If StringValue of PrivateIdentifier is in names, return true.
+        2. Return false.
+
+      ClassBody : ClassElementList
+        1. Let newNames be the concatenation of names with PrivateBoundIdentifiers of ClassBody.
+        2. Return AllPrivateIdentifiersValid of ClassElementList with the argument newNames.
+
+    Static Semantics: Early Errors
+
+    ScriptBody : StatementList
+      It is a Syntax Error if AllPrivateIdentifiersValid of StatementList with an empty List as an argument is false unless the source code is eval code that is being processed by a direct eval.
 
 ---*/
 


### PR DESCRIPTION
PrivateNames are visible on `ComputedProperty` evaluation of classes. This PR is adding tests to verify those cases for private fields, methods and accessors.