### PR TITLE
Add tests for combinations of StatementList

### DIFF
--- a/src/statementList/array-literal-with-item.case
+++ b/src/statementList/array-literal-with-item.case
@@ -1,0 +1,30 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Array Literal with items
+template: default
+info: |
+  Statement:
+    BlockStatement
+    VariableStatement
+    EmptyStatement
+    ExpressionStatement
+    ...
+  
+  ExpressionStatement:
+    [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+      Expression ;
+
+  ArrayLiteral[Yield, Await]:
+    [ Elision_opt ]
+    [ ElementList ]
+    [ ElementList , Elision_opt ]
+---*/
+
+//- StatementListItem
+[42];
+//- EvalAssertions
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(result.length, 1);
+assert.sameValue(result[0], 42);

--- a/src/statementList/array-literal.case
+++ b/src/statementList/array-literal.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Array Literal
+template: default
+info: |
+  Statement:
+    BlockStatement
+    VariableStatement
+    EmptyStatement
+    ExpressionStatement
+    ...
+  
+  ExpressionStatement:
+    [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+      Expression ;
+
+  ArrayLiteral[Yield, Await]:
+    [ Elision_opt ]
+    [ ElementList ]
+    [ ElementList , Elision_opt ]
+---*/
+
+//- StatementListItem
+[];
+//- EvalAssertions
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(result.length, 0);

--- a/src/statementList/arrow-function-assignment-expr.case
+++ b/src/statementList/arrow-function-assignment-expr.case
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Arrow Function with an AssignmentExpression
+template: default
+info: |
+  Statement:
+    BlockStatement
+    VariableStatement
+    EmptyStatement
+    ExpressionStatement
+    ...
+  
+  ExpressionStatement:
+    [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+      Expression ;
+
+  ...
+
+  AssignmentExpression:
+    ConditionalExpression
+    [+Yield]YieldExpression
+    ArrowFunction
+
+  ArrowFunction:
+    ArrowParameters [no LineTerminator here] => ConciseBody
+
+  ConciseBody:
+    [lookahead ≠ {] AssignmentExpression
+    { FunctionBody }
+features: [arrow-function]
+---*/
+
+//- StatementListItem
+() => 42;
+//- EvalAssertions
+assert.sameValue(result(), 42);

--- a/src/statementList/arrow-function-functionbody.case
+++ b/src/statementList/arrow-function-functionbody.case
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Arrow Function with a Function Body
+template: default
+info: |
+  Statement:
+    BlockStatement
+    VariableStatement
+    EmptyStatement
+    ExpressionStatement
+    ...
+  
+  ExpressionStatement:
+    [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+      Expression ;
+
+  ...
+
+  AssignmentExpression:
+    ConditionalExpression
+    [+Yield]YieldExpression
+    ArrowFunction
+
+  ArrowFunction:
+    ArrowParameters [no LineTerminator here] => ConciseBody
+
+  ConciseBody:
+    [lookahead ≠ {] AssignmentExpression
+    { FunctionBody }
+features: [arrow-function]
+---*/
+
+//- StatementListItem
+() => { return 42; };
+//- EvalAssertions
+assert.sameValue(result(), 42);

--- a/src/statementList/block-with-labels.case
+++ b/src/statementList/block-with-labels.case
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Block with a label
+template: default
+info: |
+  Statement:
+    BlockStatement
+    VariableStatement
+    EmptyStatement
+    ExpressionStatement
+    ...
+  
+  // lookahead here prevents capturing an Object literal
+  ExpressionStatement:
+    [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+      Expression ;
+---*/
+
+//- StatementListItem
+{x: 42};
+//- EvalAssertions
+assert.sameValue(result, 42, 'it does not evaluate to an Object with the property x');

--- a/src/statementList/block.case
+++ b/src/statementList/block.case
@@ -1,0 +1,26 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Block
+template: default
+info: |
+  Statement:
+    BlockStatement
+    VariableStatement
+    EmptyStatement
+    ExpressionStatement
+    ...
+
+  // lookahead here prevents capturing an Object literal
+  ExpressionStatement:
+    [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+      Expression ;
+---*/
+
+//- StatementListItem
+{}
+//- EvalAssertions
+assert.sameValue(result, undefined);
+//- EvalAssertionsCompletion
+assert.sameValue(result, expected);

--- a/src/statementList/default/block-with-statement.template
+++ b/src/statementList/default/block-with-statement.template
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statementList/block-with-statment-
+name: Valid syntax of StatementList starting with a BlockStatement
+esid: prod-StatementList
+info: |
+  StatementList:
+    StatementListItem
+    StatementList StatementListItem
+
+  StatementListItem:
+    Statement
+    Declaration
+  
+  Statement:
+    BlockStatement
+
+  BlockStatement:
+    Block
+
+  Block:
+    { StatementList_opt }
+---*/
+
+// length is a label!
+{length: 3000}/*{ StatementListItem }*/;

--- a/src/statementList/default/block.template
+++ b/src/statementList/default/block.template
@@ -1,0 +1,27 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statementList/block-
+name: Valid syntax of StatementList starting with a BlockStatement
+esid: prod-StatementList
+info: |
+  StatementList:
+    StatementListItem
+    StatementList StatementListItem
+
+  StatementListItem:
+    Statement
+    Declaration
+  
+  Statement:
+    BlockStatement
+
+  BlockStatement:
+    Block
+
+  Block:
+    { StatementList_opt }
+---*/
+
+{}/*{ StatementListItem }*/;

--- a/src/statementList/default/class-declaration.template
+++ b/src/statementList/default/class-declaration.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statementList/class-
+name: Valid syntax of StatementList starting with a Class Declaration
+esid: prod-StatementList
+info: |
+  StatementList:
+    StatementListItem
+    StatementList StatementListItem
+
+  StatementListItem:
+    Statement
+    Declaration
+  
+  Declaration:
+    ClassDeclaration
+features: [class]
+---*/
+
+class C {}/*{ StatementListItem }*/;

--- a/src/statementList/default/eval-block-with-statement.template
+++ b/src/statementList/default/eval-block-with-statement.template
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statementList/eval-block-with-statment-
+name: Evaluate produciton of StatementList starting with a BlockStatement
+esid: prod-StatementList
+info: |
+  StatementList:
+    StatementListItem
+    StatementList StatementListItem
+
+  StatementListItem:
+    Statement
+    Declaration
+  
+  Statement:
+    BlockStatement
+
+  BlockStatement:
+    Block
+
+  Block:
+    { StatementList_opt }
+---*/
+
+// length is a label!
+var result = eval('{length: 3000}/*{ StatementListItem }*/;');
+
+// Reuse this value for items with empty completions
+var expected = 3000;
+
+/*{ EvalAssertionsCompletion }*/

--- a/src/statementList/default/eval-block.template
+++ b/src/statementList/default/eval-block.template
@@ -1,0 +1,29 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statementList/eval-block-
+name: Eval production of StatementList starting with a BlockStatement
+esid: prod-StatementList
+info: |
+  StatementList:
+    StatementListItem
+    StatementList StatementListItem
+
+  StatementListItem:
+    Statement
+    Declaration
+  
+  Statement:
+    BlockStatement
+
+  BlockStatement:
+    Block
+
+  Block:
+    { StatementList_opt }
+---*/
+
+var result = eval('{}/*{ StatementListItem }*/');
+
+/*{ EvalAssertions }*/

--- a/src/statementList/default/eval-class-declaration.template
+++ b/src/statementList/default/eval-class-declaration.template
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statementList/eval-class-
+name: Valid syntax of StatementList starting with a Class Declaration
+esid: prod-StatementList
+info: |
+  StatementList:
+    StatementListItem
+    StatementList StatementListItem
+
+  StatementListItem:
+    Statement
+    Declaration
+  
+  Declaration:
+    ClassDeclaration
+features: [class]
+---*/
+
+var result = eval('class C {}/*{ StatementListItem }*/;');
+
+/*{ EvalAssertions }*/

--- a/src/statementList/default/eval-function-declaration.template
+++ b/src/statementList/default/eval-function-declaration.template
@@ -1,0 +1,26 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statementList/eval-fn-
+name: Eval production of StatementList starting with a Function Declaration
+esid: prod-StatementList
+info: |
+  StatementList:
+    StatementListItem
+    StatementList StatementListItem
+
+  StatementListItem:
+    Statement
+    Declaration
+  
+  Declaration:
+    HoistableDeclaration
+
+  FunctionDeclaration:
+    function BindingIdentifier ( FormalParameters ) { FunctionBody }
+---*/
+
+var result = eval('function fn() {}/*{ StatementListItem }*/;');
+
+/*{ EvalAssertions }*/

--- a/src/statementList/default/function-declaration.template
+++ b/src/statementList/default/function-declaration.template
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statementList/fn-
+name: Valid syntax of StatementList starting with a Function Declaration
+esid: prod-StatementList
+info: |
+  StatementList:
+    StatementListItem
+    StatementList StatementListItem
+
+  StatementListItem:
+    Statement
+    Declaration
+  
+  Declaration:
+    HoistableDeclaration
+
+  FunctionDeclaration:
+    function BindingIdentifier ( FormalParameters ) { FunctionBody }
+---*/
+
+function fn() {}/*{ StatementListItem }*/;

--- a/src/statementList/expr-arrow-function-boolean-literal.case
+++ b/src/statementList/expr-arrow-function-boolean-literal.case
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Expression with an Arrow Function and Boolean literal
+template: default
+info: |
+  Statement:
+    BlockStatement
+    VariableStatement
+    EmptyStatement
+    ExpressionStatement
+    ...
+  
+  ExpressionStatement:
+    [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+      Expression ;
+
+  Expression:
+    AssignmentExpression
+    Expression , AssignmentExpression
+
+  AssignmentExpression:
+    ConditionalExpression
+    [+Yield]YieldExpression
+    ArrowFunction
+
+  ArrowFunction:
+    ArrowParameters [no LineTerminator here] => ConciseBody
+
+  ConciseBody:
+    [lookahead ≠ {] AssignmentExpression
+    { FunctionBody }
+features: [arrow-function]
+---*/
+
+//- StatementListItem
+() => 1, 42;
+//- EvalAssertions
+assert.sameValue(result, 42);

--- a/src/statementList/let-declaration.case
+++ b/src/statementList/let-declaration.case
@@ -1,0 +1,22 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: LexicalDeclaration using Let
+template: default
+info: |
+  Declaration:
+    LexicalDeclaration
+
+  LexicalDeclaration:
+    LetOrConst BindingList ;
+
+  BindingList:
+    LexicalBinding
+    BindingList , LexicalBinding
+---*/
+
+//- StatementListItem
+let a, b = 42, c;b;
+//- EvalAssertions
+assert.sameValue(result, 42);

--- a/src/statementList/regexp-literal-flags.case
+++ b/src/statementList/regexp-literal-flags.case
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Regular Expression Literal with Flags
+template: default
+info: |
+  Statement:
+    BlockStatement
+    VariableStatement
+    EmptyStatement
+    ExpressionStatement
+    ...
+  
+  ExpressionStatement[Yield, Await]:
+    [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+      Expression ;
+
+  RegularExpressionLiteral ::
+    / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+//- StatementListItem
+/1/g;
+//- EvalAssertions
+assert.sameValue(Object.getPrototypeOf(result), RegExp.prototype);
+assert.sameValue(result.flags, 'g');
+assert.sameValue(result.toString(), '/1/g');

--- a/src/statementList/regexp-literal.case
+++ b/src/statementList/regexp-literal.case
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Regular Expression Literal
+template: default
+info: |
+  Statement:
+    BlockStatement
+    VariableStatement
+    EmptyStatement
+    ExpressionStatement
+    ...
+  
+  ExpressionStatement[Yield, Await]:
+    [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+      Expression ;
+
+  RegularExpressionLiteral ::
+    / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+//- StatementListItem
+/1/;
+//- EvalAssertions
+assert.sameValue(Object.getPrototypeOf(result), RegExp.prototype);
+assert.sameValue(result.flags, '');
+assert.sameValue(result.toString(), '/1/');

--- a/test/language/statementList/block-array-literal-with-item.js
+++ b/test/language/statementList/block-array-literal-with-item.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal-with-item.case
+// - src/statementList/default/block.template
+/*---
+description: Array Literal with items (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+{}[42];;

--- a/test/language/statementList/block-array-literal.js
+++ b/test/language/statementList/block-array-literal.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal.case
+// - src/statementList/default/block.template
+/*---
+description: Array Literal (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+{}[];;

--- a/test/language/statementList/block-arrow-function-assignment-expr.js
+++ b/test/language/statementList/block-arrow-function-assignment-expr.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-assignment-expr.case
+// - src/statementList/default/block.template
+/*---
+description: Arrow Function with an AssignmentExpression (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+{}() => 42;;

--- a/test/language/statementList/block-arrow-function-functionbody.js
+++ b/test/language/statementList/block-arrow-function-functionbody.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-functionbody.case
+// - src/statementList/default/block.template
+/*---
+description: Arrow Function with a Function Body (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+{}() => { return 42; };;

--- a/test/language/statementList/block-block-with-labels.js
+++ b/test/language/statementList/block-block-with-labels.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block-with-labels.case
+// - src/statementList/default/block.template
+/*---
+description: Block with a label (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+{}{x: 42};;

--- a/test/language/statementList/block-block.js
+++ b/test/language/statementList/block-block.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block.case
+// - src/statementList/default/block.template
+/*---
+description: Block (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+{}{};

--- a/test/language/statementList/block-expr-arrow-function-boolean-literal.js
+++ b/test/language/statementList/block-expr-arrow-function-boolean-literal.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/expr-arrow-function-boolean-literal.case
+// - src/statementList/default/block.template
+/*---
+description: Expression with an Arrow Function and Boolean literal (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    Expression:
+      AssignmentExpression
+      Expression , AssignmentExpression
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+{}() => 1, 42;;

--- a/test/language/statementList/block-let-declaration.js
+++ b/test/language/statementList/block-let-declaration.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/let-declaration.case
+// - src/statementList/default/block.template
+/*---
+description: LexicalDeclaration using Let (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Declaration:
+      LexicalDeclaration
+
+    LexicalDeclaration:
+      LetOrConst BindingList ;
+
+    BindingList:
+      LexicalBinding
+      BindingList , LexicalBinding
+---*/
+
+
+{}let a, b = 42, c;b;;

--- a/test/language/statementList/block-regexp-literal-flags.js
+++ b/test/language/statementList/block-regexp-literal-flags.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal-flags.case
+// - src/statementList/default/block.template
+/*---
+description: Regular Expression Literal with Flags (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+{}/1/g;;

--- a/test/language/statementList/block-regexp-literal.js
+++ b/test/language/statementList/block-regexp-literal.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal.case
+// - src/statementList/default/block.template
+/*---
+description: Regular Expression Literal (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+{}/1/;;

--- a/test/language/statementList/block-with-statment-array-literal-with-item.js
+++ b/test/language/statementList/block-with-statment-array-literal-with-item.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal-with-item.case
+// - src/statementList/default/block-with-statement.template
+/*---
+description: Array Literal with items (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+// length is a label!
+{length: 3000}[42];;

--- a/test/language/statementList/block-with-statment-array-literal.js
+++ b/test/language/statementList/block-with-statment-array-literal.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal.case
+// - src/statementList/default/block-with-statement.template
+/*---
+description: Array Literal (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+// length is a label!
+{length: 3000}[];;

--- a/test/language/statementList/block-with-statment-arrow-function-assignment-expr.js
+++ b/test/language/statementList/block-with-statment-arrow-function-assignment-expr.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-assignment-expr.case
+// - src/statementList/default/block-with-statement.template
+/*---
+description: Arrow Function with an AssignmentExpression (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+// length is a label!
+{length: 3000}() => 42;;

--- a/test/language/statementList/block-with-statment-arrow-function-functionbody.js
+++ b/test/language/statementList/block-with-statment-arrow-function-functionbody.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-functionbody.case
+// - src/statementList/default/block-with-statement.template
+/*---
+description: Arrow Function with a Function Body (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+// length is a label!
+{length: 3000}() => { return 42; };;

--- a/test/language/statementList/block-with-statment-block-with-labels.js
+++ b/test/language/statementList/block-with-statment-block-with-labels.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block-with-labels.case
+// - src/statementList/default/block-with-statement.template
+/*---
+description: Block with a label (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+// length is a label!
+{length: 3000}{x: 42};;

--- a/test/language/statementList/block-with-statment-block.js
+++ b/test/language/statementList/block-with-statment-block.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block.case
+// - src/statementList/default/block-with-statement.template
+/*---
+description: Block (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+// length is a label!
+{length: 3000}{};

--- a/test/language/statementList/block-with-statment-expr-arrow-function-boolean-literal.js
+++ b/test/language/statementList/block-with-statment-expr-arrow-function-boolean-literal.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/expr-arrow-function-boolean-literal.case
+// - src/statementList/default/block-with-statement.template
+/*---
+description: Expression with an Arrow Function and Boolean literal (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    Expression:
+      AssignmentExpression
+      Expression , AssignmentExpression
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+// length is a label!
+{length: 3000}() => 1, 42;;

--- a/test/language/statementList/block-with-statment-let-declaration.js
+++ b/test/language/statementList/block-with-statment-let-declaration.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/let-declaration.case
+// - src/statementList/default/block-with-statement.template
+/*---
+description: LexicalDeclaration using Let (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Declaration:
+      LexicalDeclaration
+
+    LexicalDeclaration:
+      LetOrConst BindingList ;
+
+    BindingList:
+      LexicalBinding
+      BindingList , LexicalBinding
+---*/
+
+
+// length is a label!
+{length: 3000}let a, b = 42, c;b;;

--- a/test/language/statementList/block-with-statment-regexp-literal-flags.js
+++ b/test/language/statementList/block-with-statment-regexp-literal-flags.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal-flags.case
+// - src/statementList/default/block-with-statement.template
+/*---
+description: Regular Expression Literal with Flags (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+// length is a label!
+{length: 3000}/1/g;;

--- a/test/language/statementList/block-with-statment-regexp-literal.js
+++ b/test/language/statementList/block-with-statment-regexp-literal.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal.case
+// - src/statementList/default/block-with-statement.template
+/*---
+description: Regular Expression Literal (Valid syntax of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+// length is a label!
+{length: 3000}/1/;;

--- a/test/language/statementList/class-array-literal-with-item.js
+++ b/test/language/statementList/class-array-literal-with-item.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal-with-item.case
+// - src/statementList/default/class-declaration.template
+/*---
+description: Array Literal with items (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+class C {}[42];;

--- a/test/language/statementList/class-array-literal.js
+++ b/test/language/statementList/class-array-literal.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal.case
+// - src/statementList/default/class-declaration.template
+/*---
+description: Array Literal (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+class C {}[];;

--- a/test/language/statementList/class-arrow-function-assignment-expr.js
+++ b/test/language/statementList/class-arrow-function-assignment-expr.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-assignment-expr.case
+// - src/statementList/default/class-declaration.template
+/*---
+description: Arrow Function with an AssignmentExpression (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [arrow-function, class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+class C {}() => 42;;

--- a/test/language/statementList/class-arrow-function-functionbody.js
+++ b/test/language/statementList/class-arrow-function-functionbody.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-functionbody.case
+// - src/statementList/default/class-declaration.template
+/*---
+description: Arrow Function with a Function Body (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [arrow-function, class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+class C {}() => { return 42; };;

--- a/test/language/statementList/class-block-with-labels.js
+++ b/test/language/statementList/class-block-with-labels.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block-with-labels.case
+// - src/statementList/default/class-declaration.template
+/*---
+description: Block with a label (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+class C {}{x: 42};;

--- a/test/language/statementList/class-block.js
+++ b/test/language/statementList/class-block.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block.case
+// - src/statementList/default/class-declaration.template
+/*---
+description: Block (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+class C {}{};

--- a/test/language/statementList/class-expr-arrow-function-boolean-literal.js
+++ b/test/language/statementList/class-expr-arrow-function-boolean-literal.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/expr-arrow-function-boolean-literal.case
+// - src/statementList/default/class-declaration.template
+/*---
+description: Expression with an Arrow Function and Boolean literal (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [arrow-function, class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    Expression:
+      AssignmentExpression
+      Expression , AssignmentExpression
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+class C {}() => 1, 42;;

--- a/test/language/statementList/class-let-declaration.js
+++ b/test/language/statementList/class-let-declaration.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/let-declaration.case
+// - src/statementList/default/class-declaration.template
+/*---
+description: LexicalDeclaration using Let (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Declaration:
+      LexicalDeclaration
+
+    LexicalDeclaration:
+      LetOrConst BindingList ;
+
+    BindingList:
+      LexicalBinding
+      BindingList , LexicalBinding
+---*/
+
+
+class C {}let a, b = 42, c;b;;

--- a/test/language/statementList/class-regexp-literal-flags.js
+++ b/test/language/statementList/class-regexp-literal-flags.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal-flags.case
+// - src/statementList/default/class-declaration.template
+/*---
+description: Regular Expression Literal with Flags (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+class C {}/1/g;;

--- a/test/language/statementList/class-regexp-literal.js
+++ b/test/language/statementList/class-regexp-literal.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal.case
+// - src/statementList/default/class-declaration.template
+/*---
+description: Regular Expression Literal (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+class C {}/1/;;

--- a/test/language/statementList/eval-block-array-literal-with-item.js
+++ b/test/language/statementList/eval-block-array-literal-with-item.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal-with-item.case
+// - src/statementList/default/eval-block.template
+/*---
+description: Array Literal with items (Eval production of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+var result = eval('{}[42];');
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(result.length, 1);
+assert.sameValue(result[0], 42);

--- a/test/language/statementList/eval-block-array-literal.js
+++ b/test/language/statementList/eval-block-array-literal.js
@@ -1,0 +1,47 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal.case
+// - src/statementList/default/eval-block.template
+/*---
+description: Array Literal (Eval production of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+var result = eval('{}[];');
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(result.length, 0);

--- a/test/language/statementList/eval-block-arrow-function-assignment-expr.js
+++ b/test/language/statementList/eval-block-arrow-function-assignment-expr.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-assignment-expr.case
+// - src/statementList/default/eval-block.template
+/*---
+description: Arrow Function with an AssignmentExpression (Eval production of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+var result = eval('{}() => 42;');
+
+assert.sameValue(result(), 42);

--- a/test/language/statementList/eval-block-arrow-function-functionbody.js
+++ b/test/language/statementList/eval-block-arrow-function-functionbody.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-functionbody.case
+// - src/statementList/default/eval-block.template
+/*---
+description: Arrow Function with a Function Body (Eval production of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+var result = eval('{}() => { return 42; };');
+
+assert.sameValue(result(), 42);

--- a/test/language/statementList/eval-block-block-with-labels.js
+++ b/test/language/statementList/eval-block-block-with-labels.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block-with-labels.case
+// - src/statementList/default/eval-block.template
+/*---
+description: Block with a label (Eval production of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+var result = eval('{}{x: 42};');
+
+assert.sameValue(result, 42, 'it does not evaluate to an Object with the property x');

--- a/test/language/statementList/eval-block-block.js
+++ b/test/language/statementList/eval-block-block.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block.case
+// - src/statementList/default/eval-block.template
+/*---
+description: Block (Eval production of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+var result = eval('{}{}');
+
+assert.sameValue(result, undefined);

--- a/test/language/statementList/eval-block-expr-arrow-function-boolean-literal.js
+++ b/test/language/statementList/eval-block-expr-arrow-function-boolean-literal.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/expr-arrow-function-boolean-literal.case
+// - src/statementList/default/eval-block.template
+/*---
+description: Expression with an Arrow Function and Boolean literal (Eval production of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    Expression:
+      AssignmentExpression
+      Expression , AssignmentExpression
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+var result = eval('{}() => 1, 42;');
+
+assert.sameValue(result, 42);

--- a/test/language/statementList/eval-block-let-declaration.js
+++ b/test/language/statementList/eval-block-let-declaration.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/let-declaration.case
+// - src/statementList/default/eval-block.template
+/*---
+description: LexicalDeclaration using Let (Eval production of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Declaration:
+      LexicalDeclaration
+
+    LexicalDeclaration:
+      LetOrConst BindingList ;
+
+    BindingList:
+      LexicalBinding
+      BindingList , LexicalBinding
+---*/
+
+
+var result = eval('{}let a, b = 42, c;b;');
+
+assert.sameValue(result, 42);

--- a/test/language/statementList/eval-block-regexp-literal-flags.js
+++ b/test/language/statementList/eval-block-regexp-literal-flags.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal-flags.case
+// - src/statementList/default/eval-block.template
+/*---
+description: Regular Expression Literal with Flags (Eval production of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+var result = eval('{}/1/g;');
+
+assert.sameValue(Object.getPrototypeOf(result), RegExp.prototype);
+assert.sameValue(result.flags, 'g');
+assert.sameValue(result.toString(), '/1/g');

--- a/test/language/statementList/eval-block-regexp-literal.js
+++ b/test/language/statementList/eval-block-regexp-literal.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal.case
+// - src/statementList/default/eval-block.template
+/*---
+description: Regular Expression Literal (Eval production of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+var result = eval('{}/1/;');
+
+assert.sameValue(Object.getPrototypeOf(result), RegExp.prototype);
+assert.sameValue(result.flags, '');
+assert.sameValue(result.toString(), '/1/');

--- a/test/language/statementList/eval-block-with-statment-array-literal-with-item.js
+++ b/test/language/statementList/eval-block-with-statment-array-literal-with-item.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal-with-item.case
+// - src/statementList/default/eval-block-with-statement.template
+/*---
+description: Array Literal with items (Evaluate produciton of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+// length is a label!
+var result = eval('{length: 3000}[42];;');
+
+// Reuse this value for items with empty completions
+var expected = 3000;
+
+

--- a/test/language/statementList/eval-block-with-statment-array-literal.js
+++ b/test/language/statementList/eval-block-with-statment-array-literal.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal.case
+// - src/statementList/default/eval-block-with-statement.template
+/*---
+description: Array Literal (Evaluate produciton of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+// length is a label!
+var result = eval('{length: 3000}[];;');
+
+// Reuse this value for items with empty completions
+var expected = 3000;
+
+

--- a/test/language/statementList/eval-block-with-statment-arrow-function-assignment-expr.js
+++ b/test/language/statementList/eval-block-with-statment-arrow-function-assignment-expr.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-assignment-expr.case
+// - src/statementList/default/eval-block-with-statement.template
+/*---
+description: Arrow Function with an AssignmentExpression (Evaluate produciton of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+// length is a label!
+var result = eval('{length: 3000}() => 42;;');
+
+// Reuse this value for items with empty completions
+var expected = 3000;
+
+

--- a/test/language/statementList/eval-block-with-statment-arrow-function-functionbody.js
+++ b/test/language/statementList/eval-block-with-statment-arrow-function-functionbody.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-functionbody.case
+// - src/statementList/default/eval-block-with-statement.template
+/*---
+description: Arrow Function with a Function Body (Evaluate produciton of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+// length is a label!
+var result = eval('{length: 3000}() => { return 42; };;');
+
+// Reuse this value for items with empty completions
+var expected = 3000;
+
+

--- a/test/language/statementList/eval-block-with-statment-block-with-labels.js
+++ b/test/language/statementList/eval-block-with-statment-block-with-labels.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block-with-labels.case
+// - src/statementList/default/eval-block-with-statement.template
+/*---
+description: Block with a label (Evaluate produciton of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+// length is a label!
+var result = eval('{length: 3000}{x: 42};;');
+
+// Reuse this value for items with empty completions
+var expected = 3000;
+
+

--- a/test/language/statementList/eval-block-with-statment-block.js
+++ b/test/language/statementList/eval-block-with-statment-block.js
@@ -1,0 +1,46 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block.case
+// - src/statementList/default/eval-block-with-statement.template
+/*---
+description: Block (Evaluate produciton of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+// length is a label!
+var result = eval('{length: 3000}{};');
+
+// Reuse this value for items with empty completions
+var expected = 3000;
+
+assert.sameValue(result, expected);

--- a/test/language/statementList/eval-block-with-statment-expr-arrow-function-boolean-literal.js
+++ b/test/language/statementList/eval-block-with-statment-expr-arrow-function-boolean-literal.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/expr-arrow-function-boolean-literal.case
+// - src/statementList/default/eval-block-with-statement.template
+/*---
+description: Expression with an Arrow Function and Boolean literal (Evaluate produciton of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    Expression:
+      AssignmentExpression
+      Expression , AssignmentExpression
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+// length is a label!
+var result = eval('{length: 3000}() => 1, 42;;');
+
+// Reuse this value for items with empty completions
+var expected = 3000;
+
+

--- a/test/language/statementList/eval-block-with-statment-let-declaration.js
+++ b/test/language/statementList/eval-block-with-statment-let-declaration.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/let-declaration.case
+// - src/statementList/default/eval-block-with-statement.template
+/*---
+description: LexicalDeclaration using Let (Evaluate produciton of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Declaration:
+      LexicalDeclaration
+
+    LexicalDeclaration:
+      LetOrConst BindingList ;
+
+    BindingList:
+      LexicalBinding
+      BindingList , LexicalBinding
+---*/
+
+
+// length is a label!
+var result = eval('{length: 3000}let a, b = 42, c;b;;');
+
+// Reuse this value for items with empty completions
+var expected = 3000;
+
+

--- a/test/language/statementList/eval-block-with-statment-regexp-literal-flags.js
+++ b/test/language/statementList/eval-block-with-statment-regexp-literal-flags.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal-flags.case
+// - src/statementList/default/eval-block-with-statement.template
+/*---
+description: Regular Expression Literal with Flags (Evaluate produciton of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+// length is a label!
+var result = eval('{length: 3000}/1/g;;');
+
+// Reuse this value for items with empty completions
+var expected = 3000;
+
+

--- a/test/language/statementList/eval-block-with-statment-regexp-literal.js
+++ b/test/language/statementList/eval-block-with-statment-regexp-literal.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal.case
+// - src/statementList/default/eval-block-with-statement.template
+/*---
+description: Regular Expression Literal (Evaluate produciton of StatementList starting with a BlockStatement)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Statement:
+      BlockStatement
+
+    BlockStatement:
+      Block
+
+    Block:
+      { StatementList_opt }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+// length is a label!
+var result = eval('{length: 3000}/1/;;');
+
+// Reuse this value for items with empty completions
+var expected = 3000;
+
+

--- a/test/language/statementList/eval-class-array-literal-with-item.js
+++ b/test/language/statementList/eval-class-array-literal-with-item.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal-with-item.case
+// - src/statementList/default/eval-class-declaration.template
+/*---
+description: Array Literal with items (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+var result = eval('class C {}[42];;');
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(result.length, 1);
+assert.sameValue(result[0], 42);

--- a/test/language/statementList/eval-class-array-literal.js
+++ b/test/language/statementList/eval-class-array-literal.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal.case
+// - src/statementList/default/eval-class-declaration.template
+/*---
+description: Array Literal (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+var result = eval('class C {}[];;');
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(result.length, 0);

--- a/test/language/statementList/eval-class-arrow-function-assignment-expr.js
+++ b/test/language/statementList/eval-class-arrow-function-assignment-expr.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-assignment-expr.case
+// - src/statementList/default/eval-class-declaration.template
+/*---
+description: Arrow Function with an AssignmentExpression (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [arrow-function, class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+var result = eval('class C {}() => 42;;');
+
+assert.sameValue(result(), 42);

--- a/test/language/statementList/eval-class-arrow-function-functionbody.js
+++ b/test/language/statementList/eval-class-arrow-function-functionbody.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-functionbody.case
+// - src/statementList/default/eval-class-declaration.template
+/*---
+description: Arrow Function with a Function Body (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [arrow-function, class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+var result = eval('class C {}() => { return 42; };;');
+
+assert.sameValue(result(), 42);

--- a/test/language/statementList/eval-class-block-with-labels.js
+++ b/test/language/statementList/eval-class-block-with-labels.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block-with-labels.case
+// - src/statementList/default/eval-class-declaration.template
+/*---
+description: Block with a label (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+var result = eval('class C {}{x: 42};;');
+
+assert.sameValue(result, 42, 'it does not evaluate to an Object with the property x');

--- a/test/language/statementList/eval-class-block.js
+++ b/test/language/statementList/eval-class-block.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block.case
+// - src/statementList/default/eval-class-declaration.template
+/*---
+description: Block (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+var result = eval('class C {}{};');
+
+assert.sameValue(result, undefined);

--- a/test/language/statementList/eval-class-expr-arrow-function-boolean-literal.js
+++ b/test/language/statementList/eval-class-expr-arrow-function-boolean-literal.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/expr-arrow-function-boolean-literal.case
+// - src/statementList/default/eval-class-declaration.template
+/*---
+description: Expression with an Arrow Function and Boolean literal (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [arrow-function, class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    Expression:
+      AssignmentExpression
+      Expression , AssignmentExpression
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+var result = eval('class C {}() => 1, 42;;');
+
+assert.sameValue(result, 42);

--- a/test/language/statementList/eval-class-let-declaration.js
+++ b/test/language/statementList/eval-class-let-declaration.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/let-declaration.case
+// - src/statementList/default/eval-class-declaration.template
+/*---
+description: LexicalDeclaration using Let (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Declaration:
+      LexicalDeclaration
+
+    LexicalDeclaration:
+      LetOrConst BindingList ;
+
+    BindingList:
+      LexicalBinding
+      BindingList , LexicalBinding
+---*/
+
+
+var result = eval('class C {}let a, b = 42, c;b;;');
+
+assert.sameValue(result, 42);

--- a/test/language/statementList/eval-class-regexp-literal-flags.js
+++ b/test/language/statementList/eval-class-regexp-literal-flags.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal-flags.case
+// - src/statementList/default/eval-class-declaration.template
+/*---
+description: Regular Expression Literal with Flags (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+var result = eval('class C {}/1/g;;');
+
+assert.sameValue(Object.getPrototypeOf(result), RegExp.prototype);
+assert.sameValue(result.flags, 'g');
+assert.sameValue(result.toString(), '/1/g');

--- a/test/language/statementList/eval-class-regexp-literal.js
+++ b/test/language/statementList/eval-class-regexp-literal.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal.case
+// - src/statementList/default/eval-class-declaration.template
+/*---
+description: Regular Expression Literal (Valid syntax of StatementList starting with a Class Declaration)
+esid: prod-StatementList
+features: [class]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      ClassDeclaration
+
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+var result = eval('class C {}/1/;;');
+
+assert.sameValue(Object.getPrototypeOf(result), RegExp.prototype);
+assert.sameValue(result.flags, '');
+assert.sameValue(result.toString(), '/1/');

--- a/test/language/statementList/eval-fn-array-literal-with-item.js
+++ b/test/language/statementList/eval-fn-array-literal-with-item.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal-with-item.case
+// - src/statementList/default/eval-function-declaration.template
+/*---
+description: Array Literal with items (Eval production of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+var result = eval('function fn() {}[42];;');
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(result.length, 1);
+assert.sameValue(result[0], 42);

--- a/test/language/statementList/eval-fn-array-literal.js
+++ b/test/language/statementList/eval-fn-array-literal.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal.case
+// - src/statementList/default/eval-function-declaration.template
+/*---
+description: Array Literal (Eval production of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+var result = eval('function fn() {}[];;');
+
+assert.sameValue(Object.getPrototypeOf(result), Array.prototype);
+assert.sameValue(result.length, 0);

--- a/test/language/statementList/eval-fn-arrow-function-assignment-expr.js
+++ b/test/language/statementList/eval-fn-arrow-function-assignment-expr.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-assignment-expr.case
+// - src/statementList/default/eval-function-declaration.template
+/*---
+description: Arrow Function with an AssignmentExpression (Eval production of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+var result = eval('function fn() {}() => 42;;');
+
+assert.sameValue(result(), 42);

--- a/test/language/statementList/eval-fn-arrow-function-functionbody.js
+++ b/test/language/statementList/eval-fn-arrow-function-functionbody.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-functionbody.case
+// - src/statementList/default/eval-function-declaration.template
+/*---
+description: Arrow Function with a Function Body (Eval production of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+var result = eval('function fn() {}() => { return 42; };;');
+
+assert.sameValue(result(), 42);

--- a/test/language/statementList/eval-fn-block-with-labels.js
+++ b/test/language/statementList/eval-fn-block-with-labels.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block-with-labels.case
+// - src/statementList/default/eval-function-declaration.template
+/*---
+description: Block with a label (Eval production of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+var result = eval('function fn() {}{x: 42};;');
+
+assert.sameValue(result, 42, 'it does not evaluate to an Object with the property x');

--- a/test/language/statementList/eval-fn-block.js
+++ b/test/language/statementList/eval-fn-block.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block.case
+// - src/statementList/default/eval-function-declaration.template
+/*---
+description: Block (Eval production of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+var result = eval('function fn() {}{};');
+
+assert.sameValue(result, undefined);

--- a/test/language/statementList/eval-fn-expr-arrow-function-boolean-literal.js
+++ b/test/language/statementList/eval-fn-expr-arrow-function-boolean-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/expr-arrow-function-boolean-literal.case
+// - src/statementList/default/eval-function-declaration.template
+/*---
+description: Expression with an Arrow Function and Boolean literal (Eval production of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    Expression:
+      AssignmentExpression
+      Expression , AssignmentExpression
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+var result = eval('function fn() {}() => 1, 42;;');
+
+assert.sameValue(result, 42);

--- a/test/language/statementList/eval-fn-let-declaration.js
+++ b/test/language/statementList/eval-fn-let-declaration.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/let-declaration.case
+// - src/statementList/default/eval-function-declaration.template
+/*---
+description: LexicalDeclaration using Let (Eval production of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Declaration:
+      LexicalDeclaration
+
+    LexicalDeclaration:
+      LetOrConst BindingList ;
+
+    BindingList:
+      LexicalBinding
+      BindingList , LexicalBinding
+---*/
+
+
+var result = eval('function fn() {}let a, b = 42, c;b;;');
+
+assert.sameValue(result, 42);

--- a/test/language/statementList/eval-fn-regexp-literal-flags.js
+++ b/test/language/statementList/eval-fn-regexp-literal-flags.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal-flags.case
+// - src/statementList/default/eval-function-declaration.template
+/*---
+description: Regular Expression Literal with Flags (Eval production of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+var result = eval('function fn() {}/1/g;;');
+
+assert.sameValue(Object.getPrototypeOf(result), RegExp.prototype);
+assert.sameValue(result.flags, 'g');
+assert.sameValue(result.toString(), '/1/g');

--- a/test/language/statementList/eval-fn-regexp-literal.js
+++ b/test/language/statementList/eval-fn-regexp-literal.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal.case
+// - src/statementList/default/eval-function-declaration.template
+/*---
+description: Regular Expression Literal (Eval production of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+var result = eval('function fn() {}/1/;;');
+
+assert.sameValue(Object.getPrototypeOf(result), RegExp.prototype);
+assert.sameValue(result.flags, '');
+assert.sameValue(result.toString(), '/1/');

--- a/test/language/statementList/fn-array-literal-with-item.js
+++ b/test/language/statementList/fn-array-literal-with-item.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal-with-item.case
+// - src/statementList/default/function-declaration.template
+/*---
+description: Array Literal with items (Valid syntax of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+function fn() {}[42];;

--- a/test/language/statementList/fn-array-literal.js
+++ b/test/language/statementList/fn-array-literal.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/array-literal.case
+// - src/statementList/default/function-declaration.template
+/*---
+description: Array Literal (Valid syntax of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ArrayLiteral[Yield, Await]:
+      [ Elision_opt ]
+      [ ElementList ]
+      [ ElementList , Elision_opt ]
+---*/
+
+
+function fn() {}[];;

--- a/test/language/statementList/fn-arrow-function-assignment-expr.js
+++ b/test/language/statementList/fn-arrow-function-assignment-expr.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-assignment-expr.case
+// - src/statementList/default/function-declaration.template
+/*---
+description: Arrow Function with an AssignmentExpression (Valid syntax of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+function fn() {}() => 42;;

--- a/test/language/statementList/fn-arrow-function-functionbody.js
+++ b/test/language/statementList/fn-arrow-function-functionbody.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/arrow-function-functionbody.case
+// - src/statementList/default/function-declaration.template
+/*---
+description: Arrow Function with a Function Body (Valid syntax of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    ...
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+function fn() {}() => { return 42; };;

--- a/test/language/statementList/fn-block-with-labels.js
+++ b/test/language/statementList/fn-block-with-labels.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block-with-labels.case
+// - src/statementList/default/function-declaration.template
+/*---
+description: Block with a label (Valid syntax of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+function fn() {}{x: 42};;

--- a/test/language/statementList/fn-block.js
+++ b/test/language/statementList/fn-block.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/block.case
+// - src/statementList/default/function-declaration.template
+/*---
+description: Block (Valid syntax of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    // lookahead here prevents capturing an Object literal
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+---*/
+
+
+function fn() {}{};

--- a/test/language/statementList/fn-expr-arrow-function-boolean-literal.js
+++ b/test/language/statementList/fn-expr-arrow-function-boolean-literal.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/expr-arrow-function-boolean-literal.case
+// - src/statementList/default/function-declaration.template
+/*---
+description: Expression with an Arrow Function and Boolean literal (Valid syntax of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+features: [arrow-function]
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    Expression:
+      AssignmentExpression
+      Expression , AssignmentExpression
+
+    AssignmentExpression:
+      ConditionalExpression
+      [+Yield]YieldExpression
+      ArrowFunction
+
+    ArrowFunction:
+      ArrowParameters [no LineTerminator here] => ConciseBody
+
+    ConciseBody:
+      [lookahead ≠ {] AssignmentExpression
+      { FunctionBody }
+
+---*/
+
+
+function fn() {}() => 1, 42;;

--- a/test/language/statementList/fn-let-declaration.js
+++ b/test/language/statementList/fn-let-declaration.js
@@ -1,0 +1,35 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/let-declaration.case
+// - src/statementList/default/function-declaration.template
+/*---
+description: LexicalDeclaration using Let (Valid syntax of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Declaration:
+      LexicalDeclaration
+
+    LexicalDeclaration:
+      LetOrConst BindingList ;
+
+    BindingList:
+      LexicalBinding
+      BindingList , LexicalBinding
+---*/
+
+
+function fn() {}let a, b = 42, c;b;;

--- a/test/language/statementList/fn-regexp-literal-flags.js
+++ b/test/language/statementList/fn-regexp-literal-flags.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal-flags.case
+// - src/statementList/default/function-declaration.template
+/*---
+description: Regular Expression Literal with Flags (Valid syntax of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+function fn() {}/1/g;;

--- a/test/language/statementList/fn-regexp-literal.js
+++ b/test/language/statementList/fn-regexp-literal.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/statementList/regexp-literal.case
+// - src/statementList/default/function-declaration.template
+/*---
+description: Regular Expression Literal (Valid syntax of StatementList starting with a Function Declaration)
+esid: prod-StatementList
+flags: [generated]
+info: |
+    StatementList:
+      StatementListItem
+      StatementList StatementListItem
+
+    StatementListItem:
+      Statement
+      Declaration
+
+    Declaration:
+      HoistableDeclaration
+
+    FunctionDeclaration:
+      function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+    Statement:
+      BlockStatement
+      VariableStatement
+      EmptyStatement
+      ExpressionStatement
+      ...
+
+    ExpressionStatement[Yield, Await]:
+      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
+        Expression ;
+
+    RegularExpressionLiteral ::
+      / RegularExpressionBody / RegularExpressionFlags
+---*/
+
+
+function fn() {}/1/;;


### PR DESCRIPTION
This is a small combination of StatementList that can be expanded with other cases.

It is inspired by the suggestion from @jorendorff in #2230 from a case that looks like ASI: `{} /1/`.

This patch doesn't close that issue as it still misses a test for `of / 2` (division).