### PR TITLE
Fixing tests that access PrivateNames from another realm

### DIFF
--- a/test/language/expressions/class/private-getter-brand-check-multiple-evaluations-of-class-realm-function-ctor.js
+++ b/test/language/expressions/class/private-getter-brand-check-multiple-evaluations-of-class-realm-function-ctor.js
@@ -30,9 +30,12 @@ return class {
 `;
 
 let createAndInstantiateClass = function () {
-  let classFactoryFunction = new ($262.createRealm().global.Function)(classStringExpression);
+  let realm = $262.createRealm();
+  let classFactoryFunction = new (realm.global.Function)(classStringExpression);
   let Class = classFactoryFunction();
-  return new Class();
+  let obj =  new Class();
+  obj.realm = realm;
+  return obj;
 };
 
 let c1 = createAndInstantiateClass();
@@ -41,10 +44,10 @@ let c2 = createAndInstantiateClass();
 assert.sameValue(c1.access(c1), 'test262');
 assert.sameValue(c2.access(c2), 'test262');
 
-assert.throws(TypeError, function() {
+assert.throws(c1.realm.global.TypeError, function() {
   c1.access(c2);
 }, 'invalid access of c1 private method');
 
-assert.throws(TypeError, function() {
+assert.throws(c2.realm.global.TypeError, function() {
   c2.access(c1);
 }, 'invalid access of c2 private method');

--- a/test/language/expressions/class/private-getter-brand-check-multiple-evaluations-of-class-realm.js
+++ b/test/language/expressions/class/private-getter-brand-check-multiple-evaluations-of-class-realm.js
@@ -20,8 +20,10 @@ features: [class, class-methods-private]
 flags: [noStrict]
 ---*/
 
-let eval1 = $262.createRealm().global.eval;
-let eval2 = $262.createRealm().global.eval;
+let realm1 = $262.createRealm();
+let realm2 = $262.createRealm();
+let eval1 = realm1.global.eval;
+let eval2 = realm2.global.eval;
 
 let classStringExpression = `(
 class {
@@ -43,10 +45,10 @@ let c2 = createAndInstantiateClass(eval2);
 assert.sameValue(c1.access(c1), 'test262');
 assert.sameValue(c2.access(c2), 'test262');
 
-assert.throws(TypeError, function() {
+assert.throws(realm1.global.TypeError, function() {
   c1.access(c2);
 }, 'invalid access of c1 private method');
 
-assert.throws(TypeError, function() {
+assert.throws(realm2.global.TypeError, function() {
   c2.access(c1);
 }, 'invalid access of c2 private method');

--- a/test/language/expressions/class/private-method-brand-check-multiple-evaluations-of-class-realm-function-ctor.js
+++ b/test/language/expressions/class/private-method-brand-check-multiple-evaluations-of-class-realm-function-ctor.js
@@ -30,9 +30,12 @@ return class C {
 `;
 
 let createAndInstantiateClass = function () {
-  let classFactoryFunction = new ($262.createRealm().global.Function)(classStringExpression);
+  let realm = $262.createRealm();
+  let classFactoryFunction = new (realm.global.Function)(classStringExpression);
   let Class = classFactoryFunction();
-  return new Class();
+  let obj = new Class();
+  obj.realm = realm;
+  return obj;
 };
 
 let c1 = createAndInstantiateClass();
@@ -41,10 +44,10 @@ let c2 = createAndInstantiateClass();
 assert.sameValue(c1.access(c1), 'test262');
 assert.sameValue(c2.access(c2), 'test262');
 
-assert.throws(TypeError, function() {
+assert.throws(c1.realm.global.TypeError, function() {
   c1.access(c2);
 }, 'invalid access of c1 private method');
 
-assert.throws(TypeError, function() {
+assert.throws(c2.realm.global.TypeError, function() {
   c2.access(c1);
 }, 'invalid access of c2 private method');

--- a/test/language/expressions/class/private-method-brand-check-multiple-evaluations-of-class-realm.js
+++ b/test/language/expressions/class/private-method-brand-check-multiple-evaluations-of-class-realm.js
@@ -20,8 +20,10 @@ features: [class, class-methods-private]
 flags: [noStrict]
 ---*/
 
-let eval1 = $262.createRealm().global.eval;
-let eval2 = $262.createRealm().global.eval;
+let realm1 = $262.createRealm();
+let realm2 = $262.createRealm();
+let eval1 = realm1.global.eval;
+let eval2 = realm2.global.eval;
 
 let classStringExpression = `(
 class {
@@ -43,10 +45,10 @@ let c2 = createAndInstantiateClass(eval2);
 assert.sameValue(c1.access(c1), 'test262');
 assert.sameValue(c2.access(c2), 'test262');
 
-assert.throws(TypeError, function() {
+assert.throws(realm1.global.TypeError, function() {
   c1.access(c2);
 }, 'invalid access of c1 private method');
 
-assert.throws(TypeError, function() {
+assert.throws(realm2.global.TypeError, function() {
   c2.access(c1);
 }, 'invalid access of c2 private method');

--- a/test/language/expressions/class/private-setter-brand-check-multiple-evaluations-of-class-realm-function-ctor.js
+++ b/test/language/expressions/class/private-setter-brand-check-multiple-evaluations-of-class-realm-function-ctor.js
@@ -30,9 +30,12 @@ return class {
 `;
 
 let createAndInstantiateClass = function () {
-  let classFactoryFunction = new ($262.createRealm().global.Function)(classStringExpression);
+  let realm = $262.createRealm();
+  let classFactoryFunction = new (realm.global.Function)(classStringExpression);
   let Class = classFactoryFunction();
-  return new Class();
+  let obj = new Class();
+  obj.realm = realm;
+  return obj;
 };
 
 let c1 = createAndInstantiateClass();
@@ -43,10 +46,10 @@ assert.sameValue(c1._v, 'test262');
 c2.access(c2, 'test262');
 assert.sameValue(c2._v, 'test262');
 
-assert.throws(TypeError, function() {
+assert.throws(c1.realm.global.TypeError, function() {
   c1.access(c2, 'foo');
 }, 'invalid access of c1 private method');
 
-assert.throws(TypeError, function() {
+assert.throws(c2.realm.global.TypeError, function() {
   c2.access(c1, 'foo');
 }, 'invalid access of c2 private method');

--- a/test/language/expressions/class/private-setter-brand-check-multiple-evaluations-of-class-realm.js
+++ b/test/language/expressions/class/private-setter-brand-check-multiple-evaluations-of-class-realm.js
@@ -20,8 +20,10 @@ features: [class, class-methods-private]
 flags: [noStrict]
 ---*/
 
-let eval1 = $262.createRealm().global.eval;
-let eval2 = $262.createRealm().global.eval;
+let realm1 = $262.createRealm();
+let realm2 = $262.createRealm();
+let eval1 = realm1.global.eval;
+let eval2 = realm2.global.eval;
 
 let classStringExpression = `(
 class {
@@ -45,10 +47,10 @@ assert.sameValue(c1._v, 'test262');
 c2.access(c2, 'test262');
 assert.sameValue(c2._v, 'test262');
 
-assert.throws(TypeError, function() {
+assert.throws(realm1.global.TypeError, function() {
   c1.access(c2, 'foo');
 }, 'invalid access of c1 private method');
 
-assert.throws(TypeError, function() {
+assert.throws(realm2.global.TypeError, function() {
   c2.access(c1, 'foo');
 }, 'invalid access of c2 private method');


### PR DESCRIPTION
It closes #2257.

We need to check the correct `TypeError` when asserting private access from functions evaluated in another real.