### PR TITLE
Fixing private-getter-brand-check-multiple-evaluations-of-class-function-ctor to use private getter.

### DIFF
--- a/test/language/expressions/class/private-getter-brand-check-multiple-evaluations-of-class-function-ctor.js
+++ b/test/language/expressions/class/private-getter-brand-check-multiple-evaluations-of-class-function-ctor.js
@@ -21,10 +21,10 @@ features: [class, class-methods-private]
 
 let classStringExpression = `
 return class {
-  get m() { return 'test262'; }
+  get #m() { return 'test262'; }
 
   access(o) {
-    return o.m;
+    return o.#m;
   }
 }
 `;


### PR DESCRIPTION
This is just fixing a test to use private getter instead of regular getter.