### PR TITLE
Fix expected test values

### DIFF
--- a/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
+++ b/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
@@ -61,12 +61,16 @@ var testData = [
         canonical: "cs",
     },
     {
+        // ECMA-402 currently requires that variant subtags are not canonicalized.
+        // https://github.com/tc39/ecma402/issues/330
         tag: "hy-arevela",
-        canonical: "hy",
+        canonical: "hy-arevela",
     },
     {
+        // ECMA-402 currently requires that variant subtags are not canonicalized.
+        // https://github.com/tc39/ecma402/issues/330
         tag: "hy-arevmda",
-        canonical: "hyw",
+        canonical: "hy-arevmda",
     },
 ];
 

--- a/test/intl402/Locale/getters.js
+++ b/test/intl402/Locale/getters.js
@@ -114,7 +114,7 @@ assert.sameValue(loc.calendar, "gregory");
 assert.sameValue(loc.collation, "standard");
 assert.sameValue(loc.hourCycle, "h11");
 if ("caseFirst" in loc) {
-    assert.sameValue(loc.caseFirst, "true");
+    assert.sameValue(loc.caseFirst, "");
 }
 if ("numeric" in loc) {
     assert.sameValue(loc.numeric, false);


### PR DESCRIPTION
These two slipped through the cracks in #2097:

test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
- Variant subtag canonicalisation is currrently not allowed.

test/intl402/Locale/getters.js
- Only the first "loc.caseFirst" test in this file was updated in #2097.