### PR TITLE
Add tests for .toString() of private methods

### DIFF
--- a/test/built-ins/Function/prototype/toString/private-method-class-expression.js
+++ b/test/built-ins/Function/prototype/toString/private-method-class-expression.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Function.prototype.toString on a private method
+features: [class-methods-private]
+includes: [nativeFunctionMatcher.js]
+---*/
+
+let c = new (class {
+  /* before */#f /* a */ ( /* b */ ) /* c */ { /* d */ }/* after */
+  assert(expected) {
+    assertToStringOrNativeFunction(this.#f, expected);
+  }
+});
+
+c.assert("#f /* a */ ( /* b */ ) /* c */ { /* d */ }");

--- a/test/built-ins/Function/prototype/toString/private-method-class-statement.js
+++ b/test/built-ins/Function/prototype/toString/private-method-class-statement.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Function.prototype.toString on a private method
+features: [class-methods-private]
+includes: [nativeFunctionMatcher.js]
+---*/
+
+class C {
+  /* before */#f /* a */ ( /* b */ ) /* c */ { /* d */ }/* after */
+  assert(expected) {
+    assertToStringOrNativeFunction(this.#f, expected);
+  }
+}
+
+let c = new C();
+c.assert("#f /* a */ ( /* b */ ) /* c */ { /* d */ }");

--- a/test/built-ins/Function/prototype/toString/private-static-method-class-expression.js
+++ b/test/built-ins/Function/prototype/toString/private-static-method-class-expression.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Function.prototype.toString on a static private method
+features: [class-static-methods-private]
+includes: [nativeFunctionMatcher.js]
+---*/
+
+let C = class {
+  /* before */static #f /* a */ ( /* b */ ) /* c */ { /* d */ }/* after */
+  static assert(expected) {
+    assertToStringOrNativeFunction(this.#f, expected);
+  }
+};
+
+C.assert("#f /* a */ ( /* b */ ) /* c */ { /* d */ }");

--- a/test/built-ins/Function/prototype/toString/private-static-method-class-statement.js
+++ b/test/built-ins/Function/prototype/toString/private-static-method-class-statement.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Function.prototype.toString on a static private method
+features: [class-static-methods-private]
+includes: [nativeFunctionMatcher.js]
+---*/
+
+class C {
+  /* before */static #f /* a */ ( /* b */ ) /* c */ { /* d */ }/* after */
+  static assert(expected) {
+    assertToStringOrNativeFunction(this.#f, expected);
+  }
+}
+
+C.assert("#f /* a */ ( /* b */ ) /* c */ { /* d */ }");


### PR DESCRIPTION
Adds coverage for (static) private methods according to the test plan posted in #1343.

> Usage > The `.toString()` of the private method is the exact string of its declaration

@leobalter @rwaldron for review.
cc: @caiolima @jbhoosreddy