### PR TITLE
test: continuing to flesh out optional chaining tests

### DIFF
--- a/test/language/expressions/optional-chaining/call-expression-super-no-base.js
+++ b/test/language/expressions/optional-chaining/call-expression-super-no-base.js
@@ -1,0 +1,23 @@
+// Copyright 2019 Google, Inc.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: prod-OptionalExpression
+description: >
+  should not suppress error if super called on class with no base
+info: |
+  Left-Hand-Side Expressions
+    OptionalExpression:
+      SuperCall OptionalChain
+features: [optional-chaining]
+negative:
+  type: SyntaxError
+  phase: parse
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  constructor () {
+    super()?.a;
+  }
+}

--- a/test/language/expressions/optional-chaining/call-expression.js
+++ b/test/language/expressions/optional-chaining/call-expression.js
@@ -11,10 +11,65 @@ info: |
 features: [optional-chaining]
 ---*/
 
+// CallExpression CoverCallExpressionAndAsyncArrowHead
 function fn () {
   return {a: 33};
 };
-
-// CallExpression Arguments
+const obj = {
+  fn () {
+    return 44;
+  }
+}
 assert.sameValue(33, fn()?.a);
 assert.sameValue(undefined, fn()?.b);
+assert.sameValue(44, obj.fn());
+
+// CallExpression SuperCall
+class A {}
+class B extends A {
+  constructor () {
+    assert.sameValue(undefined, super()?.a);
+  }
+}
+new B();
+
+// CallExpression Arguments
+function fn2 () {
+  return () => {
+    return {a: 66};
+  };
+}
+function fn3 () {
+  return () => {
+    return null;
+  };
+}
+assert.sameValue(66, fn2()()?.a);
+assert.sameValue(undefined, fn3()()?.a);
+
+// CallExpression [Expression]
+function fn4 () {
+  return [{a: 77}];
+}
+function fn5 () {
+  return [];
+}
+assert.sameValue(77, fn4()[0]?.a);
+assert.sameValue(undefined, fn5()[0]?.a);
+
+// CallExpression .IdentifierName
+function fn6 () {
+  return {
+    a: {
+      b: 88
+    }
+  };
+}
+assert.sameValue(88, fn6().a?.b);
+assert.sameValue(undefined, fn6().b?.c);
+
+// CallExpression TemplateLiteral
+function fn7 () {
+  return () => {};
+}
+assert.sameValue(undefined, fn7()`hello`?.a);

--- a/test/language/expressions/optional-chaining/member-expression.js
+++ b/test/language/expressions/optional-chaining/member-expression.js
@@ -13,44 +13,39 @@ features: [optional-chaining]
 
 // PrimaryExpression
 //   IdentifierReference
-
-const arr = [10, 11];
-const fn = (arg1, arg2) => {
-  return arg1 + arg2;
+//   this
+function fn2 () {
+  return this?.a
 }
-const i = 0;
-const obj = {
-  a: 'hello',
-  b: {val: 13},
-  c(arg1) {
-    return arg1 * 2;
-  },
-  arr: [11, 12]
-};
+assert.sameValue(33, fn2.call({a: 33}));
+//   Literal
+assert.sameValue(undefined, "hello"?.a);
+assert.sameValue(undefined, null?.a);
+//   ArrayLiteral
+// TODO(bcoe): investigate why the following assertion fails
+// in babel plugin:
+// assert.sameValue(2, [1, 2]?.[1]));
+//   ObjectLiteral
+assert.sameValue(44, {a: 44}?.a);
+//   FunctionExpression
+assert.sameValue('a', (function a () {}?.name));
+//   ClassExpression
+assert.sameValue('Foo', (class Foo {}?.name));
+//   GeneratorFunction
+assert.sameValue('a', (function * a () {}?.name));
+//   AsyncFunctionExpression
+assert.sameValue('a', (async function a () {}?.name));
+//   AsyncGeneratorExpression
+assert.sameValue('a', (async function * a () {}?.name));
+//   RegularExpressionLiteral
+assert.sameValue(true, /[a-z]/?.test('a'));
+//   TemplateLiteral
+assert.sameValue('h', `hello`?.[0]);
+//   CoverParenthesizedExpressionAndArrowParameterList
+assert.sameValue(undefined, ({a: 33}, null)?.a);
+assert.sameValue(33, (undefined, {a: 33})?.a);
 
-// OptionalChain: ?.[Expression]
-assert.sameValue(11, arr?.[i + 1]);
-
-// OptionalChain: ?.IdentifierName
-assert.sameValue('hello', obj?.a);
-
-// OptionalChain: ?.Arguments
-assert.sameValue(30, fn?.(10, 20));
-
-// OptionalChain: OptionalChain [Expression]
-assert.sameValue(12, obj?.arr[i + 1]);
-assert.throws(TypeError, function() {
-  obj?.d[i + 1];
-});
-
-// OptionalChain: OptionalChain .IdentifierName
-assert.sameValue(13, obj?.b.val);
-assert.throws(TypeError, function() {
-  obj?.d.e;
-});
-
-// OptionalChain: OptionalChain Arguments
-assert.sameValue(20, obj?.c(10));
-assert.throws(TypeError, function() {
-  obj?.d();
-});
+//  MemberExpression [ Expression ]
+const arr = [{a: 33}];
+assert.sameValue(33, arr[0]?.a);
+assert.sameValue(undefined, arr[1]?.a);

--- a/test/language/expressions/optional-chaining/member-expression.js
+++ b/test/language/expressions/optional-chaining/member-expression.js
@@ -22,9 +22,7 @@ assert.sameValue(33, fn2.call({a: 33}));
 assert.sameValue(undefined, "hello"?.a);
 assert.sameValue(undefined, null?.a);
 //   ArrayLiteral
-// TODO(bcoe): investigate why the following assertion fails
-// in babel plugin:
-// assert.sameValue(2, [1, 2]?.[1]));
+assert.sameValue(2, [1, 2]?.[1]);
 //   ObjectLiteral
 assert.sameValue(44, {a: 44}?.a);
 //   FunctionExpression

--- a/test/language/expressions/optional-chaining/member-expression.js
+++ b/test/language/expressions/optional-chaining/member-expression.js
@@ -13,6 +13,8 @@ features: [optional-chaining]
 
 // PrimaryExpression
 //   IdentifierReference
+const a = {b: 22};
+assert.sameValue(22, a?.b);
 //   this
 function fn () {
   return this?.a
@@ -64,6 +66,9 @@ assert.sameValue(undefined, f3`hello world`?.a);
 //  MemberExpression SuperProperty
 class A {
   a () {}
+  undf () {
+    return super.a?.c;
+  }
 }
 class B extends A {
   dot () {
@@ -72,14 +77,15 @@ class B extends A {
   expr () {
     return super['a'].name;
   }
-  undf () {
+  undf2 () {
     return super.b?.c;
   }
 }
 const subcls = new B();
 assert.sameValue('a', subcls.dot());
 assert.sameValue('a', subcls.expr());
-assert.sameValue(undefined, subcls.undf());
+assert.sameValue(undefined, subcls.undf2());
+assert.sameValue(undefined, (new A()).undf());
 
 // MemberExpression MetaProperty
 class C {

--- a/test/language/expressions/optional-chaining/member-expression.js
+++ b/test/language/expressions/optional-chaining/member-expression.js
@@ -14,10 +14,10 @@ features: [optional-chaining]
 // PrimaryExpression
 //   IdentifierReference
 //   this
-function fn2 () {
+function fn () {
   return this?.a
 }
-assert.sameValue(33, fn2.call({a: 33}));
+assert.sameValue(33, fn.call({a: 33}));
 //   Literal
 assert.sameValue(undefined, "hello"?.a);
 assert.sameValue(undefined, null?.a);
@@ -47,3 +47,52 @@ assert.sameValue(33, (undefined, {a: 33})?.a);
 const arr = [{a: 33}];
 assert.sameValue(33, arr[0]?.a);
 assert.sameValue(undefined, arr[1]?.a);
+
+//  MemberExpression .IdentifierName
+const obj = {a: {b: 44}};
+assert.sameValue(44, obj.a?.b);
+assert.sameValue(undefined, obj.c?.b);
+
+//  MemberExpression TemplateLiteral
+function f2 () {
+  return {a: 33};
+}
+function f3 () {}
+assert.sameValue(33, f2`hello world`?.a);
+assert.sameValue(undefined, f3`hello world`?.a);
+
+//  MemberExpression SuperProperty
+class A {
+  a () {}
+}
+class B extends A {
+  dot () {
+    return super.a?.name;
+  }
+  expr () {
+    return super['a'].name;
+  }
+  undf () {
+    return super.b?.c;
+  }
+}
+const subcls = new B();
+assert.sameValue('a', subcls.dot());
+assert.sameValue('a', subcls.expr());
+assert.sameValue(undefined, subcls.undf());
+
+// MemberExpression MetaProperty
+class C {
+  constructor () {
+    assert.sameValue(undefined, new.target?.a);
+  }
+}
+new C();
+
+// new MemberExpression Arguments
+class D {
+  constructor (val) {
+    this.a = val;
+  }
+}
+assert.sameValue(99, new D(99)?.a);

--- a/test/language/expressions/optional-chaining/optional-chain.js
+++ b/test/language/expressions/optional-chaining/optional-chain.js
@@ -1,0 +1,59 @@
+// Copyright 2019 Google, Inc.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: prod-OptionalExpression
+desc: >
+  various optional chain expansions
+info: |
+  OptionalChain[Yield, Await]:
+    ?.[Expression
+    ?.IdentifierName
+    ?.Arguments
+    ?.TemplateLiteral
+    OptionalChain [Expression]
+    OptionalChain .IdentifierName
+    OptionalChain Arguments[?Yield, ?Await]
+    OptionalChain TemplateLiteral
+features: [optional-chaining]
+---*/
+
+const arr = [10, 11];
+const obj = {
+  a: 'hello',
+  b: {val: 13},
+  c(arg1) {
+    return arg1 * 2;
+  },
+  arr: [11, 12]
+};
+const i = 0;
+
+// OptionalChain: ?.[Expression]
+assert.sameValue(11, arr?.[i + 1]);
+
+// OptionalChain: ?.IdentifierName
+assert.sameValue('hello', obj?.a);
+
+// OptionalChain: ?.Arguments
+const fn = (arg1, arg2) => {
+  return arg1 + arg2;
+}
+assert.sameValue(30, fn?.(10, 20));
+
+// OptionalChain: OptionalChain [Expression]
+assert.sameValue(12, obj?.arr[i + 1]);
+assert.throws(TypeError, function() {
+  obj?.d[i + 1];
+});
+
+// OptionalChain: OptionalChain .IdentifierName
+assert.sameValue(13, obj?.b.val);
+assert.throws(TypeError, function() {
+  obj?.d.e;
+});
+
+// OptionalChain: OptionalChain Arguments
+assert.sameValue(20, obj?.c(10));
+assert.throws(TypeError, function() {
+  obj?.d();
+});

--- a/test/language/expressions/optional-chaining/optional-chain.js
+++ b/test/language/expressions/optional-chaining/optional-chain.js
@@ -6,7 +6,7 @@ description: >
   various optional chain expansions
 info: |
   OptionalChain[Yield, Await]:
-    ?.[Expression
+    ?.[Expression]
     ?.IdentifierName
     ?.Arguments
     ?.TemplateLiteral

--- a/test/language/expressions/optional-chaining/optional-chain.js
+++ b/test/language/expressions/optional-chaining/optional-chain.js
@@ -42,18 +42,9 @@ assert.sameValue(30, fn?.(10, 20));
 
 // OptionalChain: OptionalChain [Expression]
 assert.sameValue(12, obj?.arr[i + 1]);
-assert.throws(TypeError, function() {
-  obj?.d[i + 1];
-});
 
 // OptionalChain: OptionalChain .IdentifierName
 assert.sameValue(13, obj?.b.val);
-assert.throws(TypeError, function() {
-  obj?.d.e;
-});
 
 // OptionalChain: OptionalChain Arguments
 assert.sameValue(20, obj?.c(10));
-assert.throws(TypeError, function() {
-  obj?.d();
-});

--- a/test/language/expressions/optional-chaining/optional-chain.js
+++ b/test/language/expressions/optional-chaining/optional-chain.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: prod-OptionalExpression
-desc: >
+description: >
   various optional chain expansions
 info: |
   OptionalChain[Yield, Await]:

--- a/test/language/expressions/optional-chaining/optional-expression.js
+++ b/test/language/expressions/optional-chaining/optional-expression.js
@@ -21,7 +21,7 @@ function fn () {
   return {};
 }
 
-// MemberExpression
-assert.sameValue(22, (obj?.a)?.b);
-// CallExpression
-assert.sameValue(undefined, (fn()?.a)?.b);
+// OptionalExpression (MemberExpression OptionalChain) OptionalChain
+assert.sameValue(22, obj?.a?.b);
+// OptionalExpression (CallExpression OptionalChain) OptionalChain
+assert.sameValue(undefined, fn()?.a?.b);

--- a/test/language/expressions/optional-chaining/update-expression-postfix.js
+++ b/test/language/expressions/optional-chaining/update-expression-postfix.js
@@ -1,0 +1,23 @@
+// Copyright 2019 Google, Inc.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: prod-OptionalExpression
+description: >
+  optional chaining is forbidden in write contexts
+info: |
+  UpdateExpression[Yield, Await]:
+    LeftHandSideExpression++
+    LeftHandSideExpression--
+    ++UnaryExpression
+    --UnaryExpression
+features: [optional-chaining]
+negative:
+  type: SyntaxError
+  phase: parse
+---*/
+
+$DONOTEVALUATE();
+
+// LeftHandSideExpression ++
+const a = {};
+a?.b++;

--- a/test/language/expressions/optional-chaining/update-expression-prefix.js
+++ b/test/language/expressions/optional-chaining/update-expression-prefix.js
@@ -1,0 +1,23 @@
+// Copyright 2019 Google, Inc.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: prod-OptionalExpression
+description: >
+  optional chaining is forbidden in write contexts
+info: |
+  UpdateExpression[Yield, Await]:
+    LeftHandSideExpression++
+    LeftHandSideExpression--
+    ++UnaryExpression
+    --UnaryExpression
+features: [optional-chaining]
+negative:
+  type: SyntaxError
+  phase: parse
+---*/
+
+$DONOTEVALUATE();
+
+// --UnaryExpression
+const a = {};
+--a?.b;


### PR DESCRIPTION
continuing to add tests for optional chaining, working from [this gist](https://gist.github.com/bcoe/b0e6ae3f93f8c8b8f8559f4428187f25).

see: https://github.com/tc39/test262/issues/2263