### PR TITLE
Remove obsolete lint exceptions.

### DIFF
--- a/lint.exceptions
+++ b/lint.exceptions
@@ -7,8 +7,3 @@
 # test/language/made-up-file.js FRONTMATTER LICENSE
 #
 # Note that lines prefixed with the "hash" symbol (#) will be ignored.
-test/language/directive-prologue/10.1.1-5gs.js NEGATIVE
-test/language/directive-prologue/10.1.1-2gs.js NEGATIVE
-test/language/directive-prologue/14.1-5gs.js NEGATIVE
-test/language/directive-prologue/14.1-4gs.js NEGATIVE
-test/language/directive-prologue/10.1.1-8gs.js NEGATIVE


### PR DESCRIPTION
These became unnecessary at some point.