### PR TITLE
Lint: Support Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,18 @@ jobs:
       # - run:
       #     name: "Run deploy"
       #     command: ./tools/scripts/deploy.sh
+  "Project lint unit tests on Python 3":
+    docker:
+      - image: circleci/python:3.7.4
+    working_directory: ~/test262
+    steps:
+      - checkout
+      - run:
+          name: "Install requirements for linter tool"
+          command: python -m pip install --user --requirement tools/lint/requirements.txt
+      - run:
+          name: "Test the lint tool"
+          command: ./tools/lint/test/run.py
   "V8: New or modified tests execution":
     docker:
       - image: *node_latest
@@ -125,6 +137,7 @@ workflows:
   Tools:
     jobs:
       - "Project lint, generation tests and build"
+      - "Project lint unit tests on Python 3"
   Tests execution:
     jobs:
       - "ChakraCore: New or modified tests execution"

--- a/tools/lint/lib/checks/harnessfeatures.py
+++ b/tools/lint/lib/checks/harnessfeatures.py
@@ -55,9 +55,10 @@ class CheckHarnessFeatures(Check):
             return
 
         if len(result['missing']) > 0:
+            missing = ', '.join(sorted(result['missing']))
             if len(result['features']) == 0:
-                return 'Missing: `features: [%s]`' % ', '.join(list(result['missing']))
+                return 'Missing: `features: [%s]`' % missing
             else:
-                return 'Missing from `features`: %s' % ', '.join(list(result['missing']))
+                return 'Missing from `features`: %s' % missing
         else:
             return

--- a/tools/lint/lib/checks/negative.py
+++ b/tools/lint/lib/checks/negative.py
@@ -5,7 +5,7 @@ _THROW_STMT = re.compile(
       r'^\$DONOTEVALUATE\(\);$',
       re.MULTILINE)
 
-_THROW_STMT_LEGACY = re.compile(
+_THROW_STMT_RAW = re.compile(
       r'^throw "Test262: This statement should not be evaluated\.";$',
       re.MULTILINE)
 
@@ -32,7 +32,7 @@ class CheckNegative(Check):
 
         if negative["phase"] in ["parse", "resolution"]:
             if meta.get('flags') and 'raw' in meta['flags']:
-                if not _THROW_STMT_LEGACY.search(source):
+                if not _THROW_STMT_RAW.search(source):
                     return 'Negative tests of type "early" must include a `throw` statement'
             elif not _THROW_STMT.search(source):
                 return 'Negative tests of type "early" must include a $DONOTEVALUATE() call'

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2017 Mike Pennisi. All rights reserved.
 # This code is governed by the BSD license found in the LICENSE file.
 
+from __future__ import print_function
+
 import argparse
 import inflect
 import os
@@ -91,7 +93,7 @@ if __name__ == '__main__':
 
     files = [path for _path in args.path for path in collect_files(_path)]
     file_count = len(files)
-    print 'Linting %s %s' % (file_count, ie.plural('file', file_count))
+    print('Linting %s %s' % (file_count, ie.plural('file', file_count)))
 
     all_errors = lint(files)
     unexpected_errors = dict(all_errors)
@@ -103,7 +105,7 @@ if __name__ == '__main__':
             del unexpected_errors[file_name]
 
     error_count = len(unexpected_errors)
-    print 'Linting complete. %s %s found.' % (error_count, ie.plural('error', error_count))
+    print('Linting complete. %s %s found.' % (error_count, ie.plural('error', error_count)))
 
     if error_count == 0:
         sys.exit(0)

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
     all_errors = lint(files)
     unexpected_errors = dict(all_errors)
 
-    for file_name, failures in all_errors.iteritems():
+    for file_name, failures in all_errors.items():
         if file_name not in exceptions:
             continue
         if set(failures.keys()) == exceptions[file_name]:
@@ -108,8 +108,8 @@ if __name__ == '__main__':
     if error_count == 0:
         sys.exit(0)
 
-    for file_name, failures in iter(sorted(unexpected_errors.iteritems())):
-        for ID, message in failures.iteritems():
+    for file_name, failures in iter(sorted(unexpected_errors.items())):
+        for ID, message in failures.items():
             eprint('%s: %s - %s' % (os.path.abspath(file_name), ID, message))
 
     sys.exit(1)

--- a/tools/lint/test/fixtures/harness_features_multiple_includes.js
+++ b/tools/lint/test/fixtures/harness_features_multiple_includes.js
@@ -1,4 +1,4 @@
-HARNESS_FEATURES - Missing: `features: [Symbol.toPrimitive, BigInt]`
+HARNESS_FEATURES - Missing: `features: [BigInt, Symbol.toPrimitive]`
 ^ expected errors | v input
 // Copyright (C) 2017 Rick Waldron. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.

--- a/tools/lint/test/run.py
+++ b/tools/lint/test/run.py
@@ -78,11 +78,12 @@ def create_file_test(name, fspath):
         result = self.lint([tmp_file])
         if len(expected) == 0:
             self.assertEqual(result['returncode'], 0)
-            self.assertEqual(result['stderr'], '')
+            self.assertEqual(result['stderr'], b'')
         else:
             self.assertNotEqual(result['returncode'], 0)
+            stderr = result['stderr'].decode("utf-8")
             for err in expected:
-                self.assertIn(err, result['stderr'])
+                self.assertIn(err, stderr)
 
     return test
 


### PR DESCRIPTION
In light of the planned end-of-life of Python 2 at the end of the year, this ensures that the lint tool supports Python 3 as well. The CI continues running the lint using Python 2, while the unit tests for the lint tool itself are run using both Python 2 and 3, to avoid regressions.