### PR TITLE
CI: Don't mark CI as broken if a new test fails.

### DIFF
--- a/tools/scripts/ci_test.sh
+++ b/tools/scripts/ci_test.sh
@@ -13,12 +13,5 @@ if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
   echo ""
 
   echo "Running the tests with test262-harness"
-  test262-harness -t 1 --hostType=$hostType --hostPath=$hostPath --hostArgs="$hostArgs" -- $paths | tee exec.out
-
-  if grep -q '^[1-9][0-9]* failed$' exec.out; then
-    rm exec.out
-    exit 1
-  fi
-
-  rm exec.out
+  test262-harness -t 1 --hostType=$hostType --hostPath=$hostPath --hostArgs="$hostArgs" -- $paths
 fi


### PR DESCRIPTION
In general, the CI job should only be marked as broken (with a red cross) if
the result should block the PR from landing (or if the result should at least
be carefully reviewed before landing).

Having failing tests in some implementations, on the other hand, does not block
the PR. On the contrary, it means the test is valuable, because it proves the
presence of a bug in the implementation.

The current setup is unnecessarily confusing, particularly for newcomers to the
project.