### PR TITLE
Added cases to cover public static field initializer operations with 'this' biding.

### DIFF
--- a/src/class-elements/static-field-init-this-inside-arrow-function.case
+++ b/src/class-elements/static-field-init-this-inside-arrow-function.case
@@ -1,0 +1,59 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: this in static field initializers refers to class constructor
+info: |
+  Updated Productions
+
+  ClassElement :
+    ...
+    static FieldDefinition ;
+
+  FieldDefinition :
+    ClassElementName Initializer_opt
+
+  ClassDefinitionEvaluation:
+    ...
+
+    27. Let staticFields be a new empty List.
+    28. For each ClassElement e in order from elements,
+      a. If IsStatic of e is false, then
+      ...
+      b. Else,
+        i. Let field be the result of performing PropertyDefinitionEvaluation for m ClassElementEvaluation for e with arguments F and false.
+      c. If field is an abrupt completion, then
+        ...
+      d. If field is not empty,
+        i. If IsStatic of e is false, append field to instanceFields.
+        ii. Otherwise, append field to staticFields.
+
+    34. For each item fieldRecord in order from staticFields,
+      a. Perform ? DefineField(F, field).
+    ...
+
+  DefineField(receiver, fieldRecord)
+    1. Assert: Type(receiver) is Object.
+    2. Assert: fieldRecord is a Record as created by ClassFieldDefinitionEvaluation.
+    3. Let name be fieldRecord.[[Name]].
+    4. Let initializer be fieldRecord.[[Initializer]].
+    5. If initializer is not empty, then
+      a. Let initValue be ? Call(initializer, receiver).
+    6. Else, let initValue be undefined.
+    7. If fieldRecord.[[IsAnonymousFunctionDefinition]] is true, then
+      a. Let hasNameProperty be ? HasOwnProperty(initValue, "name").
+      b. If hasNameProperty is false, perform SetFunctionName(initValue, fieldName).
+    8. If fieldName is a Private Name,
+      a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+    9. Else,
+      a. Assert: IsPropertyKey(fieldName) is true.
+      b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+    10. Return.
+template: default
+features: [class-static-fields-public]
+---*/
+
+//- elements
+static f = () => this;
+//- assertions
+assert.sameValue(C.f(), C);

--- a/src/class-elements/static-field-init-with-this.case
+++ b/src/class-elements/static-field-init-with-this.case
@@ -1,0 +1,63 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Static fields initializer has `this` biding
+info: |
+  Updated Productions
+
+  ClassElement :
+    ...
+    static FieldDefinition ;
+
+  FieldDefinition :
+    ClassElementName Initializer_opt
+
+  ClassDefinitionEvaluation:
+    ...
+
+    27. Let staticFields be a new empty List.
+    28. For each ClassElement e in order from elements,
+      a. If IsStatic of e is false, then
+      ...
+      b. Else,
+        i. Let field be the result of performing PropertyDefinitionEvaluation for m ClassElementEvaluation for e with arguments F and false.
+      c. If field is an abrupt completion, then
+        ...
+      d. If field is not empty,
+        i. If IsStatic of e is false, append field to instanceFields.
+        ii. Otherwise, append field to staticFields.
+
+    34. For each item fieldRecord in order from staticFields,
+      a. Perform ? DefineField(F, field).
+    ...
+
+  DefineField(receiver, fieldRecord)
+    1. Assert: Type(receiver) is Object.
+    2. Assert: fieldRecord is a Record as created by ClassFieldDefinitionEvaluation.
+    3. Let name be fieldRecord.[[Name]].
+    4. Let initializer be fieldRecord.[[Initializer]].
+    5. If initializer is not empty, then
+      a. Let initValue be ? Call(initializer, receiver).
+    6. Else, let initValue be undefined.
+    7. If fieldRecord.[[IsAnonymousFunctionDefinition]] is true, then
+      a. Let hasNameProperty be ? HasOwnProperty(initValue, "name").
+      b. If hasNameProperty is false, perform SetFunctionName(initValue, fieldName).
+    8. If fieldName is a Private Name,
+      a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+    9. Else,
+      a. Assert: IsPropertyKey(fieldName) is true.
+      b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+    10. Return.
+template: default
+features: [class-static-fields-public]
+---*/
+
+//- elements
+static f = 'test';
+static g = this.f + '262';
+static h = eval('this.g') + 'test';
+//- assertions
+assert.sameValue(C.f, 'test');
+assert.sameValue(C.g, 'test262');
+assert.sameValue(C.h, 'test262test');

--- a/src/class-elements/static-field-redeclaration.case
+++ b/src/class-elements/static-field-redeclaration.case
@@ -1,0 +1,65 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Static fields can be redeclared
+info: |
+  Updated Productions
+
+  ClassElement :
+    ...
+    static FieldDefinition ;
+
+  FieldDefinition :
+    ClassElementName Initializer_opt
+
+  ClassDefinitionEvaluation:
+    ...
+
+    27. Let staticFields be a new empty List.
+    28. For each ClassElement e in order from elements,
+      a. If IsStatic of e is false, then
+      ...
+      b. Else,
+        i. Let field be the result of performing PropertyDefinitionEvaluation for m ClassElementEvaluation for e with arguments F and false.
+      c. If field is an abrupt completion, then
+        ...
+      d. If field is not empty,
+        i. If IsStatic of e is false, append field to instanceFields.
+        ii. Otherwise, append field to staticFields.
+
+    34. For each item fieldRecord in order from staticFields,
+      a. Perform ? DefineField(F, field).
+    ...
+
+  DefineField(receiver, fieldRecord)
+    1. Assert: Type(receiver) is Object.
+    2. Assert: fieldRecord is a Record as created by ClassFieldDefinitionEvaluation.
+    3. Let name be fieldRecord.[[Name]].
+    4. Let initializer be fieldRecord.[[Initializer]].
+    5. If initializer is not empty, then
+      a. Let initValue be ? Call(initializer, receiver).
+    6. Else, let initValue be undefined.
+    7. If fieldRecord.[[IsAnonymousFunctionDefinition]] is true, then
+      a. Let hasNameProperty be ? HasOwnProperty(initValue, "name").
+      b. If hasNameProperty is false, perform SetFunctionName(initValue, fieldName).
+    8. If fieldName is a Private Name,
+      a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+    9. Else,
+      a. Assert: IsPropertyKey(fieldName) is true.
+      b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+    10. Return.
+template: default
+features: [class-static-fields-public]
+---*/
+
+//- elements
+static f = 'test';
+static f = this.f + '262';
+static g() {
+  return 45;
+};
+static g = this.g();
+//- assertions
+assert.sameValue(C.f, 'test262');
+assert.sameValue(C.g, 45);

--- a/test/language/expressions/class/elements/static-field-init-this-inside-arrow-function.js
+++ b/test/language/expressions/class/elements/static-field-init-this-inside-arrow-function.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/static-field-init-this-inside-arrow-function.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: this in static field initializers refers to class constructor (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-static-fields-public, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    ClassElement :
+      ...
+      static FieldDefinition ;
+
+    FieldDefinition :
+      ClassElementName Initializer_opt
+
+    ClassDefinitionEvaluation:
+      ...
+
+      27. Let staticFields be a new empty List.
+      28. For each ClassElement e in order from elements,
+        a. If IsStatic of e is false, then
+        ...
+        b. Else,
+          i. Let field be the result of performing PropertyDefinitionEvaluation for m ClassElementEvaluation for e with arguments F and false.
+        c. If field is an abrupt completion, then
+          ...
+        d. If field is not empty,
+          i. If IsStatic of e is false, append field to instanceFields.
+          ii. Otherwise, append field to staticFields.
+
+      34. For each item fieldRecord in order from staticFields,
+        a. Perform ? DefineField(F, field).
+      ...
+
+    DefineField(receiver, fieldRecord)
+      1. Assert: Type(receiver) is Object.
+      2. Assert: fieldRecord is a Record as created by ClassFieldDefinitionEvaluation.
+      3. Let name be fieldRecord.[[Name]].
+      4. Let initializer be fieldRecord.[[Initializer]].
+      5. If initializer is not empty, then
+        a. Let initValue be ? Call(initializer, receiver).
+      6. Else, let initValue be undefined.
+      7. If fieldRecord.[[IsAnonymousFunctionDefinition]] is true, then
+        a. Let hasNameProperty be ? HasOwnProperty(initValue, "name").
+        b. If hasNameProperty is false, perform SetFunctionName(initValue, fieldName).
+      8. If fieldName is a Private Name,
+        a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+      9. Else,
+        a. Assert: IsPropertyKey(fieldName) is true.
+        b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+      10. Return.
+
+---*/
+
+
+var C = class {
+  static f = () => this;
+}
+
+assert.sameValue(C.f(), C);

--- a/test/language/expressions/class/elements/static-field-init-with-this.js
+++ b/test/language/expressions/class/elements/static-field-init-with-this.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/static-field-init-with-this.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Static fields initializer has `this` biding (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-static-fields-public, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    ClassElement :
+      ...
+      static FieldDefinition ;
+
+    FieldDefinition :
+      ClassElementName Initializer_opt
+
+    ClassDefinitionEvaluation:
+      ...
+
+      27. Let staticFields be a new empty List.
+      28. For each ClassElement e in order from elements,
+        a. If IsStatic of e is false, then
+        ...
+        b. Else,
+          i. Let field be the result of performing PropertyDefinitionEvaluation for m ClassElementEvaluation for e with arguments F and false.
+        c. If field is an abrupt completion, then
+          ...
+        d. If field is not empty,
+          i. If IsStatic of e is false, append field to instanceFields.
+          ii. Otherwise, append field to staticFields.
+
+      34. For each item fieldRecord in order from staticFields,
+        a. Perform ? DefineField(F, field).
+      ...
+
+    DefineField(receiver, fieldRecord)
+      1. Assert: Type(receiver) is Object.
+      2. Assert: fieldRecord is a Record as created by ClassFieldDefinitionEvaluation.
+      3. Let name be fieldRecord.[[Name]].
+      4. Let initializer be fieldRecord.[[Initializer]].
+      5. If initializer is not empty, then
+        a. Let initValue be ? Call(initializer, receiver).
+      6. Else, let initValue be undefined.
+      7. If fieldRecord.[[IsAnonymousFunctionDefinition]] is true, then
+        a. Let hasNameProperty be ? HasOwnProperty(initValue, "name").
+        b. If hasNameProperty is false, perform SetFunctionName(initValue, fieldName).
+      8. If fieldName is a Private Name,
+        a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+      9. Else,
+        a. Assert: IsPropertyKey(fieldName) is true.
+        b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+      10. Return.
+
+---*/
+
+
+var C = class {
+  static f = 'test';
+  static g = this.f + '262';
+  static h = eval('this.g') + 'test';
+}
+
+assert.sameValue(C.f, 'test');
+assert.sameValue(C.g, 'test262');
+assert.sameValue(C.h, 'test262test');

--- a/test/language/expressions/class/elements/static-field-redeclaration.js
+++ b/test/language/expressions/class/elements/static-field-redeclaration.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/static-field-redeclaration.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Static fields can be redeclared (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-static-fields-public, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    ClassElement :
+      ...
+      static FieldDefinition ;
+
+    FieldDefinition :
+      ClassElementName Initializer_opt
+
+    ClassDefinitionEvaluation:
+      ...
+
+      27. Let staticFields be a new empty List.
+      28. For each ClassElement e in order from elements,
+        a. If IsStatic of e is false, then
+        ...
+        b. Else,
+          i. Let field be the result of performing PropertyDefinitionEvaluation for m ClassElementEvaluation for e with arguments F and false.
+        c. If field is an abrupt completion, then
+          ...
+        d. If field is not empty,
+          i. If IsStatic of e is false, append field to instanceFields.
+          ii. Otherwise, append field to staticFields.
+
+      34. For each item fieldRecord in order from staticFields,
+        a. Perform ? DefineField(F, field).
+      ...
+
+    DefineField(receiver, fieldRecord)
+      1. Assert: Type(receiver) is Object.
+      2. Assert: fieldRecord is a Record as created by ClassFieldDefinitionEvaluation.
+      3. Let name be fieldRecord.[[Name]].
+      4. Let initializer be fieldRecord.[[Initializer]].
+      5. If initializer is not empty, then
+        a. Let initValue be ? Call(initializer, receiver).
+      6. Else, let initValue be undefined.
+      7. If fieldRecord.[[IsAnonymousFunctionDefinition]] is true, then
+        a. Let hasNameProperty be ? HasOwnProperty(initValue, "name").
+        b. If hasNameProperty is false, perform SetFunctionName(initValue, fieldName).
+      8. If fieldName is a Private Name,
+        a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+      9. Else,
+        a. Assert: IsPropertyKey(fieldName) is true.
+        b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+      10. Return.
+
+---*/
+
+
+var C = class {
+  static f = 'test';
+  static f = this.f + '262';
+  static g() {
+    return 45;
+  };
+  static g = this.g();
+}
+
+assert.sameValue(C.f, 'test262');
+assert.sameValue(C.g, 45);

--- a/test/language/statements/class/elements/static-field-init-this-inside-arrow-function.js
+++ b/test/language/statements/class/elements/static-field-init-this-inside-arrow-function.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/static-field-init-this-inside-arrow-function.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: this in static field initializers refers to class constructor (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-static-fields-public, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    ClassElement :
+      ...
+      static FieldDefinition ;
+
+    FieldDefinition :
+      ClassElementName Initializer_opt
+
+    ClassDefinitionEvaluation:
+      ...
+
+      27. Let staticFields be a new empty List.
+      28. For each ClassElement e in order from elements,
+        a. If IsStatic of e is false, then
+        ...
+        b. Else,
+          i. Let field be the result of performing PropertyDefinitionEvaluation for m ClassElementEvaluation for e with arguments F and false.
+        c. If field is an abrupt completion, then
+          ...
+        d. If field is not empty,
+          i. If IsStatic of e is false, append field to instanceFields.
+          ii. Otherwise, append field to staticFields.
+
+      34. For each item fieldRecord in order from staticFields,
+        a. Perform ? DefineField(F, field).
+      ...
+
+    DefineField(receiver, fieldRecord)
+      1. Assert: Type(receiver) is Object.
+      2. Assert: fieldRecord is a Record as created by ClassFieldDefinitionEvaluation.
+      3. Let name be fieldRecord.[[Name]].
+      4. Let initializer be fieldRecord.[[Initializer]].
+      5. If initializer is not empty, then
+        a. Let initValue be ? Call(initializer, receiver).
+      6. Else, let initValue be undefined.
+      7. If fieldRecord.[[IsAnonymousFunctionDefinition]] is true, then
+        a. Let hasNameProperty be ? HasOwnProperty(initValue, "name").
+        b. If hasNameProperty is false, perform SetFunctionName(initValue, fieldName).
+      8. If fieldName is a Private Name,
+        a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+      9. Else,
+        a. Assert: IsPropertyKey(fieldName) is true.
+        b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+      10. Return.
+
+---*/
+
+
+class C {
+  static f = () => this;
+}
+
+assert.sameValue(C.f(), C);

--- a/test/language/statements/class/elements/static-field-init-with-this.js
+++ b/test/language/statements/class/elements/static-field-init-with-this.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/static-field-init-with-this.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Static fields initializer has `this` biding (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-static-fields-public, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    ClassElement :
+      ...
+      static FieldDefinition ;
+
+    FieldDefinition :
+      ClassElementName Initializer_opt
+
+    ClassDefinitionEvaluation:
+      ...
+
+      27. Let staticFields be a new empty List.
+      28. For each ClassElement e in order from elements,
+        a. If IsStatic of e is false, then
+        ...
+        b. Else,
+          i. Let field be the result of performing PropertyDefinitionEvaluation for m ClassElementEvaluation for e with arguments F and false.
+        c. If field is an abrupt completion, then
+          ...
+        d. If field is not empty,
+          i. If IsStatic of e is false, append field to instanceFields.
+          ii. Otherwise, append field to staticFields.
+
+      34. For each item fieldRecord in order from staticFields,
+        a. Perform ? DefineField(F, field).
+      ...
+
+    DefineField(receiver, fieldRecord)
+      1. Assert: Type(receiver) is Object.
+      2. Assert: fieldRecord is a Record as created by ClassFieldDefinitionEvaluation.
+      3. Let name be fieldRecord.[[Name]].
+      4. Let initializer be fieldRecord.[[Initializer]].
+      5. If initializer is not empty, then
+        a. Let initValue be ? Call(initializer, receiver).
+      6. Else, let initValue be undefined.
+      7. If fieldRecord.[[IsAnonymousFunctionDefinition]] is true, then
+        a. Let hasNameProperty be ? HasOwnProperty(initValue, "name").
+        b. If hasNameProperty is false, perform SetFunctionName(initValue, fieldName).
+      8. If fieldName is a Private Name,
+        a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+      9. Else,
+        a. Assert: IsPropertyKey(fieldName) is true.
+        b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+      10. Return.
+
+---*/
+
+
+class C {
+  static f = 'test';
+  static g = this.f + '262';
+  static h = eval('this.g') + 'test';
+}
+
+assert.sameValue(C.f, 'test');
+assert.sameValue(C.g, 'test262');
+assert.sameValue(C.h, 'test262test');

--- a/test/language/statements/class/elements/static-field-initializer-error.js
+++ b/test/language/statements/class/elements/static-field-initializer-error.js
@@ -44,7 +44,7 @@ info: |
 features: [class-static-fields-public, class]
 ---*/
 
-initThrows() {
+function initThrows() {
   throw new Test262Error();
 }
 

--- a/test/language/statements/class/elements/static-field-initializer-error.js
+++ b/test/language/statements/class/elements/static-field-initializer-error.js
@@ -52,7 +52,7 @@ assert.throws(Test262Error, function() {
   class C {
     static f = initThrows();
     static g;
-  }
+  };
 
   assert(false, 'this should never execute');
 }, 'static field initializer should throw exception');

--- a/test/language/statements/class/elements/static-field-initializer-error.js
+++ b/test/language/statements/class/elements/static-field-initializer-error.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Class evaluation is incomplete when initializer resutls in an abrupt completition
+esid: sec-define-field
+info: |
+  ClassDefinitionEvaluation:
+    ...
+
+    27. Let staticFields be a new empty List.
+    28. For each ClassElement e in order from elements,
+      a. If IsStatic of e is false, then
+      ...
+      b. Else,
+        i. Let field be the result of performing PropertyDefinitionEvaluation for m ClassElementEvaluation for e with arguments F and false.
+      c. If field is an abrupt completion, then
+        ...
+      d. If field is not empty,
+        i. If IsStatic of e is false, append field to instanceFields.
+        ii. Otherwise, append field to staticFields.
+
+    34. For each item fieldRecord in order from staticFields,
+      a. Perform ? DefineField(F, field).
+    ...
+
+  DefineField(receiver, fieldRecord)
+    1. Assert: Type(receiver) is Object.
+    2. Assert: fieldRecord is a Record as created by ClassFieldDefinitionEvaluation.
+    3. Let name be fieldRecord.[[Name]].
+    4. Let initializer be fieldRecord.[[Initializer]].
+    5. If initializer is not empty, then
+      a. Let initValue be ? Call(initializer, receiver).
+    6. Else, let initValue be undefined.
+    7. If fieldRecord.[[IsAnonymousFunctionDefinition]] is true, then
+      a. Let hasNameProperty be ? HasOwnProperty(initValue, "name").
+      b. If hasNameProperty is false, perform SetFunctionName(initValue, fieldName).
+    8. If fieldName is a Private Name,
+      a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+    9. Else,
+      a. Assert: IsPropertyKey(fieldName) is true.
+      b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+    10. Return.
+features: [class-static-fields-public, class]
+---*/
+
+initThrows() {
+  throw new Test262Error();
+}
+
+assert.throws(Test262Error, function() {
+  class C {
+    static f = initThrows();
+    static g;
+  }
+
+  assert(false, 'this should never execute');
+}, 'static field initializer should throw exception');

--- a/test/language/statements/class/elements/static-field-redeclaration.js
+++ b/test/language/statements/class/elements/static-field-redeclaration.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/static-field-redeclaration.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Static fields can be redeclared (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-static-fields-public, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    ClassElement :
+      ...
+      static FieldDefinition ;
+
+    FieldDefinition :
+      ClassElementName Initializer_opt
+
+    ClassDefinitionEvaluation:
+      ...
+
+      27. Let staticFields be a new empty List.
+      28. For each ClassElement e in order from elements,
+        a. If IsStatic of e is false, then
+        ...
+        b. Else,
+          i. Let field be the result of performing PropertyDefinitionEvaluation for m ClassElementEvaluation for e with arguments F and false.
+        c. If field is an abrupt completion, then
+          ...
+        d. If field is not empty,
+          i. If IsStatic of e is false, append field to instanceFields.
+          ii. Otherwise, append field to staticFields.
+
+      34. For each item fieldRecord in order from staticFields,
+        a. Perform ? DefineField(F, field).
+      ...
+
+    DefineField(receiver, fieldRecord)
+      1. Assert: Type(receiver) is Object.
+      2. Assert: fieldRecord is a Record as created by ClassFieldDefinitionEvaluation.
+      3. Let name be fieldRecord.[[Name]].
+      4. Let initializer be fieldRecord.[[Initializer]].
+      5. If initializer is not empty, then
+        a. Let initValue be ? Call(initializer, receiver).
+      6. Else, let initValue be undefined.
+      7. If fieldRecord.[[IsAnonymousFunctionDefinition]] is true, then
+        a. Let hasNameProperty be ? HasOwnProperty(initValue, "name").
+        b. If hasNameProperty is false, perform SetFunctionName(initValue, fieldName).
+      8. If fieldName is a Private Name,
+        a. Perform ? PrivateFieldAdd(fieldName, receiver, initValue).
+      9. Else,
+        a. Assert: IsPropertyKey(fieldName) is true.
+        b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+      10. Return.
+
+---*/
+
+
+class C {
+  static f = 'test';
+  static f = this.f + '262';
+  static g() {
+    return 45;
+  };
+  static g = this.g();
+}
+
+assert.sameValue(C.f, 'test262');
+assert.sameValue(C.g, 45);


### PR DESCRIPTION
Following the spec, `this` is referring to class constructor when used into static field initializer. We are adding tests with this usage to validate such behavior. It also includes tests of:

- `this` referenve inside direct eval;
- Redeclaration;
- Initialization that throws exception;
-  `this` reference inside arrow function;