### PR TITLE
accessing private fields in TDZ should throw a ReferenceError

### DIFF
--- a/test/language/statements/class/elements/private-field-is-visible-in-computed-properties.js
+++ b/test/language/statements/class/elements/private-field-is-visible-in-computed-properties.js
@@ -46,9 +46,10 @@ info: |
 features: [class-fields-private, class]
 ---*/
 
+const self = this;
 assert.throws(ReferenceError, function() {
   class C {
-    [this.#f] = 'Test262';
+    [self.#f] = 'Test262';
     #f = 'foo';
   }
 }, 'access to a not defined private field in object should throw a ReferenceError');

--- a/test/language/statements/class/elements/private-field-is-visible-in-computed-properties.js
+++ b/test/language/statements/class/elements/private-field-is-visible-in-computed-properties.js
@@ -10,6 +10,10 @@ info: |
     2. Let classScope be NewDeclarativeEnvironment(lex).
     3. Let classScopeEnvRec be classScope's EnvironmentRecord.
     ...
+    8. If ClassBodyopt is present, then
+        a. For each element dn of the PrivateBoundIdentifiers of ClassBodyopt,
+          i. Perform classPrivateEnvRec.CreateImmutableBinding(dn, true).
+    ...
     15. Set the running execution context's LexicalEnvironment to classScope.
     16. Set the running execution context's PrivateEnvironment to classPrivateEnvironment.
     ...
@@ -17,13 +21,35 @@ info: |
       a. If IsStatic of e is false, then
         i. Let field be the result of ClassElementEvaluation for e with arguments proto and false.
     ...
+
+  MemberExpression : MemberExpression . PrivateIdentifier
+    ...
+    5. Return MakePrivateReference(bv, fieldNameString).
+
+  MakePrivateReference ( baseValue, privateIdentifier )
+    ...
+    2. Let privateNameBinding be ? ResolveBinding(privateIdentifier, env).
+    3. Let privateName be GetValue(privateNameBinding).
+    ...
+
+  GetValue (V)
+    ...
+    6. Else,
+      a. Assert: base is an Environment Record.
+      b. Return ? base.GetBindingValue(GetReferencedName(V), IsStrictReference(V)).
+
+  GetBindingValue ( N, S )
+    ...
+    3. If the binding for N in envRec is an uninitialized binding, throw a ReferenceError exception.
+    ...
+
 features: [class-fields-private, class]
 ---*/
 
-assert.throws(TypeError, function() {
+assert.throws(ReferenceError, function() {
   class C {
     [this.#f] = 'Test262';
     #f = 'foo';
   }
-}, 'access to a not defined private field in object should throw a TypeError');
+}, 'access to a not defined private field in object should throw a ReferenceError');
 


### PR DESCRIPTION
When accessing a private field that is declared afterwards in a computed property name, it is similar to accessing a variable in TDZ.

cc @caiolima 