### PR TITLE
Adding cases of access private static fields/methods through direct eval

### DIFF
--- a/test/language/statements/class/elements/private-static-field-visible-to-direct-eval.js
+++ b/test/language/statements/class/elements/private-static-field-visible-to-direct-eval.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private static field is visible to direct eval code
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+
+  ClassElementName : PrivateIdentifier
+    1. Let privateIdentifier be StringValue of PrivateIdentifier.
+    2. Let privateName be NewPrivateName(privateIdentifier).
+    3. Let scope be the running execution context's PrivateEnvironment.
+    4. Let scopeEnvRec be scope's EnvironmentRecord.
+    5. Perform ! scopeEnvRec.InitializeBinding(privateIdentifier, privateName).
+    6. Return privateName.
+
+  MakePrivateReference ( baseValue, privateIdentifier )
+    1. Let env be the running execution context's PrivateEnvironment.
+    2. Let privateNameBinding be ? ResolveBinding(privateIdentifier, env).
+    3. Let privateName be GetValue(privateNameBinding).
+    4. Assert: privateName is a Private Name.
+    5. Return a value of type Reference whose base value is baseValue, whose referenced name is privateName, whose strict reference flag is true.
+features: [class-static-fields-private, class]
+---*/
+
+class C {
+  static #m = 44;
+
+  static getWithEval() {
+    return eval("this.#m");
+  }
+}
+
+class D {
+  static #m = 44;
+}
+
+assert.sameValue(C.getWithEval(), 44);
+
+assert.throws(TypeError, function() {
+  C.getWithEval.call(D);
+}, "invalid access to a private field");

--- a/test/language/statements/class/elements/private-static-method-visible-to-direct-eval.js
+++ b/test/language/statements/class/elements/private-static-method-visible-to-direct-eval.js
@@ -1,0 +1,61 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Private static method is visible to direct eval code
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+
+  ClassElementName : PrivateIdentifier
+    1. Let privateIdentifier be StringValue of PrivateIdentifier.
+    2. Let privateName be NewPrivateName(privateIdentifier).
+    3. Let scope be the running execution context's PrivateEnvironment.
+    4. Let scopeEnvRec be scope's EnvironmentRecord.
+    5. Perform ! scopeEnvRec.InitializeBinding(privateIdentifier, privateName).
+    6. Return privateName.
+
+  MakePrivateReference ( baseValue, privateIdentifier )
+    1. Let env be the running execution context's PrivateEnvironment.
+    2. Let privateNameBinding be ? ResolveBinding(privateIdentifier, env).
+    3. Let privateName be GetValue(privateNameBinding).
+    4. Assert: privateName is a Private Name.
+    5. Return a value of type Reference whose base value is baseValue, whose referenced name is privateName, whose strict reference flag is true.
+features: [class-static-methods-private, class]
+---*/
+
+class C {
+  static #m() {
+    return "Test262";
+  }
+
+  static accessWithEval() {
+    return eval("this.#m()");
+  }
+}
+
+class D {
+  static #m() {
+    throw new Test262Error();
+  }
+}
+
+assert.sameValue(C.accessWithEval(), "Test262");
+
+assert.throws(TypeError, function() {
+  C.accessWithEval.call(D);
+}, "invalid access to a private field");


### PR DESCRIPTION
Adding missing case where private static fields/methods are accessed through direct eval inside class scope. We already have those cases for instance private fields, methods and accessors.

Cc. @spectranaut @leobalter 