### PR TITLE
Add tests for duplicate private methods (early-error)

### DIFF
--- a/src/class-elements/grammar-privatemeth-duplicate-async-gen.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-async-gen.case
@@ -4,10 +4,10 @@
 /*---
 desc: It's a SyntaxError if a class contains a private async generator and a private field with the same name
 info: |
-    Static Semantics: Early Errors
+  Static Semantics: Early Errors
 
-    ClassBody : ClassElementList
-        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+  ClassBody : ClassElementList
+    It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 template: syntax/invalid
 features: [class-methods-private]
 ---*/

--- a/src/class-elements/grammar-privatemeth-duplicate-async-gen.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-async-gen.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2019 Qiming Ma (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains a private async generator and a private field with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private]
+---*/
+
+//- elements
+#m;
+async * #m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-async-gen.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-async-gen.case
@@ -9,7 +9,7 @@ info: |
   ClassBody : ClassElementList
     It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 template: syntax/invalid
-features: [class-methods-private class-fields-private async-iteration]
+features: [class-methods-private, class-fields-private, async-iteration]
 ---*/
 
 //- elements

--- a/src/class-elements/grammar-privatemeth-duplicate-async-gen.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-async-gen.case
@@ -9,7 +9,7 @@ info: |
   ClassBody : ClassElementList
     It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 template: syntax/invalid
-features: [class-methods-private]
+features: [class-methods-private class-fields-private async-iteration]
 ---*/
 
 //- elements

--- a/src/class-elements/grammar-privatemeth-duplicate-async.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-async.case
@@ -9,7 +9,7 @@ info: |
   ClassBody : ClassElementList
     It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 template: syntax/invalid
-features: [class-methods-private]
+features: [class-methods-private class-fields-private async-functions]
 ---*/
 
 //- elements

--- a/src/class-elements/grammar-privatemeth-duplicate-async.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-async.case
@@ -4,10 +4,10 @@
 /*---
 desc: It's a SyntaxError if a class contains a private async function and a private field with the same name
 info: |
-    Static Semantics: Early Errors
+  Static Semantics: Early Errors
 
-    ClassBody : ClassElementList
-        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+  ClassBody : ClassElementList
+    It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 template: syntax/invalid
 features: [class-methods-private]
 ---*/

--- a/src/class-elements/grammar-privatemeth-duplicate-async.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-async.case
@@ -9,7 +9,7 @@ info: |
   ClassBody : ClassElementList
     It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 template: syntax/invalid
-features: [class-methods-private class-fields-private async-functions]
+features: [class-methods-private, class-fields-private, async-functions]
 ---*/
 
 //- elements

--- a/src/class-elements/grammar-privatemeth-duplicate-async.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-async.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2019 Qiming Ma (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains a private async function and a private field with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private]
+---*/
+
+//- elements
+#m;
+async #m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-gen.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-gen.case
@@ -4,10 +4,10 @@
 /*---
 desc: It's a SyntaxError if a class contains a private generator and a private field with the same name
 info: |
-    Static Semantics: Early Errors
+  Static Semantics: Early Errors
 
-    ClassBody : ClassElementList
-        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+  ClassBody : ClassElementList
+    It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 template: syntax/invalid
 features: [class-methods-private]
 ---*/

--- a/src/class-elements/grammar-privatemeth-duplicate-gen.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-gen.case
@@ -1,0 +1,17 @@
+// Copyright (C) 2019 Qiming Ma (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: It's a SyntaxError if a class contains a private generator and a private field with the same name
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+template: syntax/invalid
+features: [class-methods-private]
+---*/
+
+//- elements
+#m;
+* #m() {}

--- a/src/class-elements/grammar-privatemeth-duplicate-gen.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-gen.case
@@ -9,7 +9,7 @@ info: |
   ClassBody : ClassElementList
     It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 template: syntax/invalid
-features: [class-methods-private class-fields-private generators]
+features: [class-methods-private, class-fields-private, generators]
 ---*/
 
 //- elements

--- a/src/class-elements/grammar-privatemeth-duplicate-gen.case
+++ b/src/class-elements/grammar-privatemeth-duplicate-gen.case
@@ -9,7 +9,7 @@ info: |
   ClassBody : ClassElementList
     It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 template: syntax/invalid
-features: [class-methods-private]
+features: [class-methods-private class-fields-private generators]
 ---*/
 
 //- elements

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
@@ -13,7 +13,7 @@ info: |
     Static Semantics: Early Errors
 
     ClassBody : ClassElementList
-        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+      It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 
 ---*/
 

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private async generator and a private field with the same name (class expression)
 esid: prod-ClassElement
-features: [class-methods-private, class]
+features: [class-methods-private class-fields-private async-iteration, class]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private async generator and a private field with the same name (class expression)
 esid: prod-ClassElement
-features: [class-methods-private class-fields-private async-iteration, class]
+features: [class-methods-private, class-fields-private, async-iteration, class]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-async-gen.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private async generator and a private field with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  #m;
+  async * #m() {}
+};

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
@@ -13,7 +13,7 @@ info: |
     Static Semantics: Early Errors
 
     ClassBody : ClassElementList
-        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+      It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 
 ---*/
 

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-async.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private async function and a private field with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  #m;
+  async #m() {}
+};

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private async function and a private field with the same name (class expression)
 esid: prod-ClassElement
-features: [class-methods-private class-fields-private async-functions, class]
+features: [class-methods-private, class-fields-private, async-functions, class]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private async function and a private field with the same name (class expression)
 esid: prod-ClassElement
-features: [class-methods-private, class]
+features: [class-methods-private class-fields-private async-functions, class]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-gen.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private generator and a private field with the same name (class expression)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  #m;
+  * #m() {}
+};

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
@@ -13,7 +13,7 @@ info: |
     Static Semantics: Early Errors
 
     ClassBody : ClassElementList
-        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+      It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 
 ---*/
 

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private generator and a private field with the same name (class expression)
 esid: prod-ClassElement
-features: [class-methods-private, class]
+features: [class-methods-private class-fields-private generators, class]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private generator and a private field with the same name (class expression)
 esid: prod-ClassElement
-features: [class-methods-private class-fields-private generators, class]
+features: [class-methods-private, class-fields-private, generators, class]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
@@ -13,7 +13,7 @@ info: |
     Static Semantics: Early Errors
 
     ClassBody : ClassElementList
-        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+      It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 
 ---*/
 

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-async-gen.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private async generator and a private field with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  #m;
+  async * #m() {}
+}

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private async generator and a private field with the same name (class declaration)
 esid: prod-ClassElement
-features: [class-methods-private class-fields-private async-iteration, class]
+features: [class-methods-private, class-fields-private, async-iteration, class]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async-gen.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private async generator and a private field with the same name (class declaration)
 esid: prod-ClassElement
-features: [class-methods-private, class]
+features: [class-methods-private class-fields-private async-iteration, class]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private async function and a private field with the same name (class declaration)
 esid: prod-ClassElement
-features: [class-methods-private class-fields-private async-functions, class]
+features: [class-methods-private, class-fields-private, async-functions, class]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
@@ -13,7 +13,7 @@ info: |
     Static Semantics: Early Errors
 
     ClassBody : ClassElementList
-        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+      It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 
 ---*/
 

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-async.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private async function and a private field with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  #m;
+  async #m() {}
+}

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-async.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private async function and a private field with the same name (class declaration)
 esid: prod-ClassElement
-features: [class-methods-private, class]
+features: [class-methods-private class-fields-private async-functions, class]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private generator and a private field with the same name (class declaration)
 esid: prod-ClassElement
-features: [class-methods-private class-fields-private generators, class]
+features: [class-methods-private, class-fields-private, generators, class]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
@@ -13,7 +13,7 @@ info: |
     Static Semantics: Early Errors
 
     ClassBody : ClassElementList
-        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+      It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
 
 ---*/
 

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
@@ -1,0 +1,26 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-privatemeth-duplicate-gen.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: It's a SyntaxError if a class contains a private generator and a private field with the same name (class declaration)
+esid: prod-ClassElement
+features: [class-methods-private, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Static Semantics: Early Errors
+
+    ClassBody : ClassElementList
+        It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  #m;
+  * #m() {}
+}

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-privatemeth-duplicate-gen.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if a class contains a private generator and a private field with the same name (class declaration)
 esid: prod-ClassElement
-features: [class-methods-private, class]
+features: [class-methods-private class-fields-private generators, class]
 flags: [generated]
 negative:
   phase: parse


### PR DESCRIPTION
This PR is for https://github.com/tc39/test262/issues/1343

> Static Semantics: Early Errors
> ClassBody : ClassElementList - It is a Syntax Error if PrivateBoundNames of ClassBody contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries.

We are currently missing test coverage for async functions, generators and async generators. This PR adds coverage for those.