### PR TITLE
Add tests covering static private methods used from instance methods

### DIFF
--- a/src/class-elements/private-method-referenced-from-static-method.case
+++ b/src/class-elements/private-method-referenced-from-static-method.case
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Private method referenced from a static method
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+        ...
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    ...
+
+  PrivateBrandCheck(O, P)
+    1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+      a. Throw a TypeError exception.
+template: default
+features: [class-static-methods-private]
+---*/
+
+//- elements
+#f() { return 42; }
+static g() {
+  return this.#f();
+}
+
+//- assertions
+assert.sameValue(C.g.call(new C()), 42);
+assert.throws(TypeError, function() {
+  C.g();
+}, 'Accessed private method from an object which did not contain it');

--- a/src/class-elements/static-private-method-referenced-from-instance-method.case
+++ b/src/class-elements/static-private-method-referenced-from-instance-method.case
@@ -1,0 +1,34 @@
+// Copyright (C) 2019 Kubilay Kahveci (Bloomberg LP). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Static private method referenced from an instance method
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+        ...
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    ...
+
+  PrivateBrandCheck(O, P)
+    1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+      a. Throw a TypeError exception.
+template: default
+features: [class-static-methods-private]
+---*/
+
+//- elements
+static #f() { return 42; }
+g() {
+  return this.#f();
+}
+
+//- assertions
+assert.sameValue(new C().g.call(C), 42);
+assert.throws(TypeError, function() {
+  new C().g();
+}, 'Accessed static private method from an object which did not contain it');

--- a/test/language/expressions/class/elements/private-method-referenced-from-static-method.js
+++ b/test/language/expressions/class/elements/private-method-referenced-from-static-method.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-referenced-from-static-method.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Private method referenced from a static method (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-static-methods-private, class]
+flags: [generated]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+          ...
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      ...
+
+    PrivateBrandCheck(O, P)
+      1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+        a. Throw a TypeError exception.
+
+---*/
+
+
+var C = class {
+  #f() { return 42; }
+  static g() {
+    return this.#f();
+  }
+
+}
+
+assert.sameValue(C.g.call(new C()), 42);
+assert.throws(TypeError, function() {
+  C.g();
+}, 'Accessed private method from an object which did not contain it');

--- a/test/language/expressions/class/elements/static-private-method-referenced-from-instance-method.js
+++ b/test/language/expressions/class/elements/static-private-method-referenced-from-instance-method.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/static-private-method-referenced-from-instance-method.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Static private method referenced from an instance method (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-static-methods-private, class]
+flags: [generated]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+          ...
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      ...
+
+    PrivateBrandCheck(O, P)
+      1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+        a. Throw a TypeError exception.
+
+---*/
+
+
+var C = class {
+  static #f() { return 42; }
+  g() {
+    return this.#f();
+  }
+
+}
+
+assert.sameValue(new C().g.call(C), 42);
+assert.throws(TypeError, function() {
+  new C().g();
+}, 'Accessed static private method from an object which did not contain it');

--- a/test/language/statements/class/elements/private-method-referenced-from-static-method.js
+++ b/test/language/statements/class/elements/private-method-referenced-from-static-method.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-method-referenced-from-static-method.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Private method referenced from a static method (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-static-methods-private, class]
+flags: [generated]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+          ...
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      ...
+
+    PrivateBrandCheck(O, P)
+      1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+        a. Throw a TypeError exception.
+
+---*/
+
+
+class C {
+  #f() { return 42; }
+  static g() {
+    return this.#f();
+  }
+
+}
+
+assert.sameValue(C.g.call(new C()), 42);
+assert.throws(TypeError, function() {
+  C.g();
+}, 'Accessed private method from an object which did not contain it');

--- a/test/language/statements/class/elements/static-private-method-referenced-from-instance-method.js
+++ b/test/language/statements/class/elements/static-private-method-referenced-from-instance-method.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/static-private-method-referenced-from-instance-method.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Static private method referenced from an instance method (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-static-methods-private, class]
+flags: [generated]
+info: |
+    PrivateFieldGet (P, O)
+      1. Assert: P is a Private Name.
+      2. If O is not an object, throw a TypeError exception.
+      3. If P.[[Kind]] is "field",
+          ...
+      4. Perform ? PrivateBrandCheck(O, P).
+      5. If P.[[Kind]] is "method",
+        a. Return P.[[Value]].
+      ...
+
+    PrivateBrandCheck(O, P)
+      1. If O.[[PrivateBrands]] does not contain an entry e such that SameValue(e, P.[[Brand]]) is true,
+        a. Throw a TypeError exception.
+
+---*/
+
+
+class C {
+  static #f() { return 42; }
+  g() {
+    return this.#f();
+  }
+
+}
+
+assert.sameValue(new C().g.call(C), 42);
+assert.throws(TypeError, function() {
+  new C().g();
+}, 'Accessed static private method from an object which did not contain it');


### PR DESCRIPTION
Following the test plan posted in #1343.

> Semantics > Usage
> - It's OK at parse-time to reference a static private method from an instance method, or vice versa

@leobalter @rwaldron for review.
cc: @caiolima @jbhoosreddy