### PR TITLE
Fix static method access in private-static-method-brand-check-multipl…

### DIFF
--- a/test/language/expressions/class/private-static-method-brand-check-multiple-evaluations-of-class-realm.js
+++ b/test/language/expressions/class/private-static-method-brand-check-multiple-evaluations-of-class-realm.js
@@ -32,7 +32,7 @@ let classStringExpression = `(
 class {
   static #m() { return 'test262'; }
 
-  access() {
+  static access() {
     return this.#m();
   }
 }


### PR DESCRIPTION
…e-evaluations-of-class-realm.js

It seems that the method `access` is intended to be static or otherwise `C1.access()` and `C2.access()` below should throw.

cc @caiolima 