### PR TITLE
Adding tests to verify early error when mixing private static and instance accessors

### DIFF
--- a/test/language/statements/class/private-non-static-getter-static-setter-early-error.js
+++ b/test/language/statements/class/private-non-static-getter-static-setter-early-error.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    It is a Syntax Error if we declare a private instance getter and private static setter
+features: [class-static-methods-private, class-methods-private]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  get #f();
+  static set #f(v) {}
+}
+

--- a/test/language/statements/class/private-non-static-setter-static-getter-early-error.js
+++ b/test/language/statements/class/private-non-static-setter-static-getter-early-error.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    It is a Syntax Error if we declare a private instance setter and a static private getter
+features: [class-static-methods-private, class-methods-private]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  set #f(v) {}
+  static get #f();
+}
+

--- a/test/language/statements/class/private-static-getter-non-static-setter-early-error.js
+++ b/test/language/statements/class/private-static-getter-non-static-setter-early-error.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    It is a Syntax Error if we declare a private static getter and a private instance setter
+features: [class-static-methods-private, class-methods-private]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  static get #f();
+  set #f(v) {}
+}
+

--- a/test/language/statements/class/private-static-setter-non-static-getter-early-error.js
+++ b/test/language/statements/class/private-static-setter-non-static-getter-early-error.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: pending
+description: >
+    It is a Syntax Error if we declare a static private setter and a private instance getter
+features: [class-static-methods-private, class-methods-private]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+class C {
+  static set #f(v) {}
+  get #f();
+}
+


### PR DESCRIPTION
This is not defined into the spec yet, but it seems to be a bug, according to [https://github.com/tc39/proposal-static-class-features/issues/48](https://github.com/tc39/proposal-static-class-features/issues/48). Maybe this PR needs to wait until this issue is fixed.

Cc @leobalter @littledan