### PR TITLE
Add tests for nested private fields

### DIFF
--- a/src/class-elements/private-field-on-nested-class.case
+++ b/src/class-elements/private-field-on-nested-class.case
@@ -1,0 +1,42 @@
+// Copyright (C) 2019 Shu-yu Guo. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName CallExpression usage (private field)
+info: |
+  Updated Productions
+
+  CallExpression[Yield, Await]:
+    CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+    SuperCall[?Yield, ?Await]
+    CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+    CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+    CallExpression[?Yield, ?Await].IdentifierName
+    CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+    CallExpression[?Yield, ?Await].PrivateName
+
+template: default
+features: [class-fields-private, class-fields-public]
+---*/
+
+//- elements
+#outer = 'test262';
+
+B_withoutPrivateField = class {
+  method(o) {
+    return o.#outer;
+  }
+}
+
+B_withPrivateField = class {
+  #inner = 42;
+  method(o) {
+    return o.#outer;
+  }
+}
+//- assertions
+let c = new C();
+let innerB1 = new c.B_withoutPrivateField();
+assert.sameValue(innerB1.method(c), 'test262');
+let innerB2 = new c.B_withPrivateField();
+assert.sameValue(innerB2.method(c), 'test262');

--- a/test/language/expressions/class/elements/private-field-on-nested-class.js
+++ b/test/language/expressions/class/elements/private-field-on-nested-class.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-field-on-nested-class.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: PrivateName CallExpression usage (private field) (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+var C = class {
+  #outer = 'test262';
+
+  B_withoutPrivateField = class {
+    method(o) {
+      return o.#outer;
+    }
+  }
+
+  B_withPrivateField = class {
+    #inner = 42;
+    method(o) {
+      return o.#outer;
+    }
+  }
+}
+
+let c = new C();
+let innerB1 = new c.B_withoutPrivateField();
+assert.sameValue(innerB1.method(c), 'test262');
+let innerB2 = new c.B_withPrivateField();
+assert.sameValue(innerB2.method(c), 'test262');

--- a/test/language/statements/class/elements/private-field-on-nested-class.js
+++ b/test/language/statements/class/elements/private-field-on-nested-class.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/private-field-on-nested-class.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: PrivateName CallExpression usage (private field) (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-fields-private, class-fields-public, class]
+flags: [generated]
+info: |
+    Updated Productions
+
+    CallExpression[Yield, Await]:
+      CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]
+      SuperCall[?Yield, ?Await]
+      CallExpression[?Yield, ?Await]Arguments[?Yield, ?Await]
+      CallExpression[?Yield, ?Await][Expression[+In, ?Yield, ?Await]]
+      CallExpression[?Yield, ?Await].IdentifierName
+      CallExpression[?Yield, ?Await]TemplateLiteral[?Yield, ?Await]
+      CallExpression[?Yield, ?Await].PrivateName
+
+---*/
+
+
+class C {
+  #outer = 'test262';
+
+  B_withoutPrivateField = class {
+    method(o) {
+      return o.#outer;
+    }
+  }
+
+  B_withPrivateField = class {
+    #inner = 42;
+    method(o) {
+      return o.#outer;
+    }
+  }
+}
+
+let c = new C();
+let innerB1 = new c.B_withoutPrivateField();
+assert.sameValue(innerB1.method(c), 'test262');
+let innerB2 = new c.B_withPrivateField();
+assert.sameValue(innerB2.method(c), 'test262');


### PR DESCRIPTION
This came up with a V8 bug where private fields weren't resolved properly from nested classes where both the inner and the outer class had private fields.