### PR TITLE
Added case file to intercalated static/non-static computed fields

### DIFF
--- a/src/class-elements/intercalated-static-non-static-computed-fields.case
+++ b/src/class-elements/intercalated-static-non-static-computed-fields.case
@@ -42,7 +42,7 @@ let i = 0;
 static [i++] = i++;
 [i++] = i++;
 //- assertions
-let c = new c();
+let c = new C();
 
 // It is important to notice that static field initializer will run before any instance initializer
 verifyProperty(c, "0", {

--- a/src/class-elements/intercalated-static-non-static-computed-fields.case
+++ b/src/class-elements/intercalated-static-non-static-computed-fields.case
@@ -1,0 +1,73 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed class fields are executed in the order they are delcared, regardless it is static or instance field 
+info: |
+  ClassTail : ClassHeritage { ClassBody }
+    ...
+    28. For each ClassElement e in order from elements,
+      a. If IsStatic of e is false, then
+        i. Let field be the result of performing ClassElementEvaluation for e with arguments proto and false.
+      b. Else,
+        i. Let field be the result of performing PropertyDefinitionEvaluation for mClassElementEvaluation for e with arguments F and false.
+      c. If field is an abrupt completion, then
+        ...
+      d. If field is not empty,
+        i. If IsStatic of e is false, append field to instanceFields.
+        ii. Otherwise, append field to staticFields.
+     ...
+     34. For each item fieldRecord in order from staticFields,
+       a. Perform ? DefineField(F, field).
+     ...
+
+  [[Construct]] (argumentsList, newTarget)
+    ...
+    8. If kind is "base", then
+      a. Perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
+      b. Let result be InitializeInstanceFields(thisArgument, F).
+      c. If result is an abrupt completion, then
+        i. Remove calleeContext from execution context stack and restore callerContext as the running execution context.
+        ii. Return Completion(result).
+template: default
+includes: [propertyHelper.js]
+features: [class-static-fields-public, class-fields-public]
+---*/
+
+//- setup
+
+let i = 0;
+//- elements
+[i++] = i++;
+static [i++] = i++;
+[i++] = i++;
+//- assertions
+let c = new c();
+
+// It is important to notice that static field initializer will run before any instance initializer
+verifyProperty(c, "0", {
+  value: 4,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "2", {
+  value: 5,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(C, "1", {
+  value: 3,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(i, 6);
+assert.sameValue(c.hasOwnProperty('1'), false);
+assert.sameValue(C.hasOwnProperty('0'), false);
+assert.sameValue(C.hasOwnProperty('2'), false);
+

--- a/test/language/expressions/class/elements/intercalated-static-non-static-computed-fields.js
+++ b/test/language/expressions/class/elements/intercalated-static-non-static-computed-fields.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/intercalated-static-non-static-computed-fields.case
+// - src/class-elements/default/cls-expr.template
+/*---
+description: Computed class fields are executed in the order they are delcared, regardless it is static or instance field (field definitions in a class expression)
+esid: prod-FieldDefinition
+features: [class-static-fields-public, class-fields-public, class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassTail : ClassHeritage { ClassBody }
+      ...
+      28. For each ClassElement e in order from elements,
+        a. If IsStatic of e is false, then
+          i. Let field be the result of performing ClassElementEvaluation for e with arguments proto and false.
+        b. Else,
+          i. Let field be the result of performing PropertyDefinitionEvaluation for mClassElementEvaluation for e with arguments F and false.
+        c. If field is an abrupt completion, then
+          ...
+        d. If field is not empty,
+          i. If IsStatic of e is false, append field to instanceFields.
+          ii. Otherwise, append field to staticFields.
+       ...
+       34. For each item fieldRecord in order from staticFields,
+         a. Perform ? DefineField(F, field).
+       ...
+
+    [[Construct]] (argumentsList, newTarget)
+      ...
+      8. If kind is "base", then
+        a. Perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
+        b. Let result be InitializeInstanceFields(thisArgument, F).
+        c. If result is an abrupt completion, then
+          i. Remove calleeContext from execution context stack and restore callerContext as the running execution context.
+          ii. Return Completion(result).
+
+---*/
+
+let i = 0;
+
+
+var C = class {
+  [i++] = i++;
+  static [i++] = i++;
+  [i++] = i++;
+}
+
+let c = new c();
+
+// It is important to notice that static field initializer will run before any instance initializer
+verifyProperty(c, "0", {
+  value: 4,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "2", {
+  value: 5,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(C, "1", {
+  value: 3,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(i, 6);
+assert.sameValue(c.hasOwnProperty('1'), false);
+assert.sameValue(C.hasOwnProperty('0'), false);
+assert.sameValue(C.hasOwnProperty('2'), false);
+

--- a/test/language/expressions/class/elements/intercalated-static-non-static-computed-fields.js
+++ b/test/language/expressions/class/elements/intercalated-static-non-static-computed-fields.js
@@ -45,7 +45,7 @@ var C = class {
   [i++] = i++;
 }
 
-let c = new c();
+let c = new C();
 
 // It is important to notice that static field initializer will run before any instance initializer
 verifyProperty(c, "0", {

--- a/test/language/statements/class/elements/intercalated-static-non-static-computed-fields.js
+++ b/test/language/statements/class/elements/intercalated-static-non-static-computed-fields.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/intercalated-static-non-static-computed-fields.case
+// - src/class-elements/default/cls-decl.template
+/*---
+description: Computed class fields are executed in the order they are delcared, regardless it is static or instance field (field definitions in a class declaration)
+esid: prod-FieldDefinition
+features: [class-static-fields-public, class-fields-public, class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    ClassTail : ClassHeritage { ClassBody }
+      ...
+      28. For each ClassElement e in order from elements,
+        a. If IsStatic of e is false, then
+          i. Let field be the result of performing ClassElementEvaluation for e with arguments proto and false.
+        b. Else,
+          i. Let field be the result of performing PropertyDefinitionEvaluation for mClassElementEvaluation for e with arguments F and false.
+        c. If field is an abrupt completion, then
+          ...
+        d. If field is not empty,
+          i. If IsStatic of e is false, append field to instanceFields.
+          ii. Otherwise, append field to staticFields.
+       ...
+       34. For each item fieldRecord in order from staticFields,
+         a. Perform ? DefineField(F, field).
+       ...
+
+    [[Construct]] (argumentsList, newTarget)
+      ...
+      8. If kind is "base", then
+        a. Perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
+        b. Let result be InitializeInstanceFields(thisArgument, F).
+        c. If result is an abrupt completion, then
+          i. Remove calleeContext from execution context stack and restore callerContext as the running execution context.
+          ii. Return Completion(result).
+
+---*/
+
+let i = 0;
+
+
+class C {
+  [i++] = i++;
+  static [i++] = i++;
+  [i++] = i++;
+}
+
+let c = new c();
+
+// It is important to notice that static field initializer will run before any instance initializer
+verifyProperty(c, "0", {
+  value: 4,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(c, "2", {
+  value: 5,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+verifyProperty(C, "1", {
+  value: 3,
+  enumerable: true,
+  writable: true,
+  configurable: true
+});
+
+assert.sameValue(i, 6);
+assert.sameValue(c.hasOwnProperty('1'), false);
+assert.sameValue(C.hasOwnProperty('0'), false);
+assert.sameValue(C.hasOwnProperty('2'), false);
+

--- a/test/language/statements/class/elements/intercalated-static-non-static-computed-fields.js
+++ b/test/language/statements/class/elements/intercalated-static-non-static-computed-fields.js
@@ -45,7 +45,7 @@ class C {
   [i++] = i++;
 }
 
-let c = new c();
+let c = new C();
 
 // It is important to notice that static field initializer will run before any instance initializer
 verifyProperty(c, "0", {


### PR DESCRIPTION
According to spec, the execution of computed property fields follow their order of declaration.
Cc @leobalter @spectranaut 