### PR TITLE
Avoid usage of Object.keys when asserting order of returned values

### DIFF
--- a/src/dstr-assignment-for-await/obj-rest-same-name.case
+++ b/src/dstr-assignment-for-await/obj-rest-same-name.case
@@ -27,7 +27,7 @@ assert.sameValue(y, undefined);
 assert.sameValue(z.y, 39);
 assert.sameValue(z.z, 'cheeseburger');
 
-let keys = Object.keys(z);
+let keys = Object.getOwnPropertyNames(z);
 assert.sameValue(keys.length, 2);
 assert.sameValue(keys[0], 'y');
 assert.sameValue(keys[1], 'z');

--- a/src/dstr-assignment/obj-rest-same-name.case
+++ b/src/dstr-assignment/obj-rest-same-name.case
@@ -27,7 +27,7 @@ assert.sameValue(y, undefined);
 assert.sameValue(z.y, 39);
 assert.sameValue(z.z, 'cheeseburger');
 
-var keys = Object.keys(z);
+var keys = Object.getOwnPropertyNames(z);
 assert.sameValue(keys.length, 2);
 assert.sameValue(keys[0], 'y');
 assert.sameValue(keys[1], 'z');

--- a/src/dynamic-import/ns-get-nested-namespace-dflt-direct.case
+++ b/src/dynamic-import/ns-get-nested-namespace-dflt-direct.case
@@ -39,7 +39,7 @@ assert.sameValue(desc.enumerable, true, 'ns.productionNS2: is enumerable');
 assert.sameValue(desc.writable, true, 'ns.productionNS2: is writable');
 assert.sameValue(desc.configurable, false, 'ns.productionNS2: is non-configurable');
 
-var keys = Object.keys(ns.productionNS2);
+var keys = Object.getOwnPropertyNames(ns.productionNS2);
 
 assert.sameValue(keys.length, 2);
 assert.sameValue(keys[0], 'default');

--- a/src/dynamic-import/ns-get-nested-namespace-dflt-indirect.case
+++ b/src/dynamic-import/ns-get-nested-namespace-dflt-indirect.case
@@ -40,7 +40,7 @@ assert.sameValue(desc.enumerable, true, 'ns.namedNS2: is enumerable');
 assert.sameValue(desc.writable, true, 'ns.namedNS2: is writable');
 assert.sameValue(desc.configurable, false, 'ns.namedNS2: is non-configurable');
 
-var keys = Object.keys(ns.namedNS2);
+var keys = Object.getOwnPropertyNames(ns.namedNS2);
 
 assert.sameValue(keys.length, 2);
 assert.sameValue(keys[0], 'default');

--- a/test/built-ins/Object/assign/Override-notstringtarget.js
+++ b/test/built-ins/Object/assign/Override-notstringtarget.js
@@ -11,7 +11,7 @@ es6id:  19.1.2.1
 var target = 12;
 var result = Object.assign(target, "aaa", "bb2b", "1c");
 
-assert.sameValue(Object.keys(result).length, 4, "The length should be 4 in the final object.");
+assert.sameValue(Object.getOwnPropertyNames(result).length, 4, "The length should be 4 in the final object.");
 assert.sameValue(result[0], "1", "The value should be {\"0\":\"1\"}.");
 assert.sameValue(result[1], "c", "The value should be {\"1\":\"c\"}.");
 assert.sameValue(result[2], "2", "The value should be {\"2\":\"2\"}.");

--- a/test/built-ins/Object/assign/Override.js
+++ b/test/built-ins/Object/assign/Override.js
@@ -25,7 +25,7 @@ var result = Object.assign(target, "1a2c3", {
   a: 5
 });
 
-assert.sameValue(Object.keys(result).length, 7, "The length should be 7 in the final object.");
+assert.sameValue(Object.getOwnPropertyNames(result).length, 7, "The length should be 7 in the final object.");
 assert.sameValue(result.a, 5, "The value should be {a:5}.");
 assert.sameValue(result[0], "1", "The value should be {\"0\":\"1\"}.");
 assert.sameValue(result[1], "a", "The value should be {\"1\":\"a\"}.");

--- a/test/built-ins/Object/fromEntries/key-order.js
+++ b/test/built-ins/Object/fromEntries/key-order.js
@@ -16,7 +16,7 @@ var entries = [
 ];
 
 var result = Object.fromEntries(entries);
-assert.sameValue(result['z'], 1);
-assert.sameValue(result['y'], 4);
-assert.sameValue(result['x'], 3);
-assert.compareArray(Object.keys(result), ['z', 'y', 'x']);
+assert.sameValue(result.z, 1);
+assert.sameValue(result.y, 4);
+assert.sameValue(result.x, 3);
+assert.compareArray(Object.getOwnPropertyNames(result), ['z', 'y', 'x']);

--- a/test/built-ins/Proxy/ownKeys/call-parameters-object-keys.js
+++ b/test/built-ins/Proxy/ownKeys/call-parameters-object-keys.js
@@ -18,12 +18,12 @@ var handler = {
   ownKeys: function(t) {
     _handler = this;
     _target = t;
-    return Object.keys(t);
+    return Object.getOwnPropertyNames(t);
   }
 };
 var p = new Proxy(target, handler);
 
-var keys = Object.keys(p);
+var keys = Object.getOwnPropertyNames(p);
 
 assert.sameValue(keys[0], "foo");
 assert.sameValue(keys[1], "bar");

--- a/test/built-ins/Proxy/ownKeys/not-extensible-return-keys.js
+++ b/test/built-ins/Proxy/ownKeys/not-extensible-return-keys.js
@@ -26,7 +26,7 @@ var p = new Proxy(target, {
 
 Object.preventExtensions(target);
 
-var keys = Object.keys(p);
+var keys = Object.getOwnPropertyNames(p);
 
 assert.sameValue(keys[0], "foo");
 assert.sameValue(keys[1], "bar");

--- a/test/built-ins/Proxy/ownKeys/trap-is-undefined.js
+++ b/test/built-ins/Proxy/ownKeys/trap-is-undefined.js
@@ -15,7 +15,7 @@ var target = {
 };
 var p = new Proxy(target, {});
 
-var keys = Object.keys(p);
+var keys = Object.getOwnPropertyNames(p);
 
 assert.sameValue(keys[0], "foo");
 assert.sameValue(keys[1], "bar");

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/return-from-accessor-descriptor.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/return-from-accessor-descriptor.js
@@ -47,7 +47,7 @@ var result = Reflect.getOwnPropertyDescriptor(o1, 'p');
 
 assert(
   compareArray(
-    Object.keys(result), ['get', 'set', 'enumerable', 'configurable']
+    Object.getOwnPropertyNames(result), ['get', 'set', 'enumerable', 'configurable']
   )
 );
 assert.sameValue(result.enumerable, false);

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/return-from-data-descriptor.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/return-from-data-descriptor.js
@@ -23,7 +23,7 @@ var result = Reflect.getOwnPropertyDescriptor(o1, 'p');
 
 assert(
   compareArray(
-    Object.keys(result), ['value', 'writable', 'enumerable', 'configurable']
+    Object.getOwnPropertyNames(result), ['value', 'writable', 'enumerable', 'configurable']
   )
 );
 assert.sameValue(result.value, 'foo');

--- a/test/built-ins/Reflect/getOwnPropertyDescriptor/symbol-property.js
+++ b/test/built-ins/Reflect/getOwnPropertyDescriptor/symbol-property.js
@@ -29,7 +29,7 @@ var result = Reflect.getOwnPropertyDescriptor(o, s);
 
 assert(
   compareArray(
-    Object.keys(result), ['value', 'writable', 'enumerable', 'configurable']
+    Object.getOwnPropertyNames(result), ['value', 'writable', 'enumerable', 'configurable']
   )
 );
 assert.sameValue(result.value, 42);

--- a/test/language/computed-property-names/basics/number.js
+++ b/test/language/computed-property-names/basics/number.js
@@ -22,6 +22,6 @@ assert.sameValue(object[1], 'B', "The value of `object[1]` is `'B'`. Defined in 
 assert.sameValue(object.c, 'C', "The value of `object.c` is `'C'`. Defined in `object` as `c: 'C'`");
 assert.sameValue(object[2], 'D', "The value of `object[2]` is `'D'`. Defined in `object` as `[ID(2)]: 'D'`");
 assert(
-  compareArray(Object.keys(object), ['1', '2', 'a', 'c']),
-  "`compareArray(Object.keys(object), ['1', '2', 'a', 'c'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(object), ['1', '2', 'a', 'c']),
+  "`compareArray(Object.getOwnPropertyNames(object), ['1', '2', 'a', 'c'])` returns `true`"
 );

--- a/test/language/computed-property-names/basics/string.js
+++ b/test/language/computed-property-names/basics/string.js
@@ -21,6 +21,6 @@ assert.sameValue(object.b, 'B', "The value of `object.b` is `'B'`. Defined in `o
 assert.sameValue(object.c, 'C', "The value of `object.c` is `'C'`. Defined in `object` as `c: 'C'`");
 assert.sameValue(object.d, 'D', "The value of `object.d` is `'D'`. Defined in `object` as `[ID('d')]: 'D'`");
 assert(
-  compareArray(Object.keys(object), ['a', 'b', 'c', 'd']),
-  "`compareArray(Object.keys(object), ['a', 'b', 'c', 'd'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(object), ['a', 'b', 'c', 'd']),
+  "`compareArray(Object.getOwnPropertyNames(object), ['a', 'b', 'c', 'd'])` returns `true`"
 );

--- a/test/language/computed-property-names/basics/symbol.js
+++ b/test/language/computed-property-names/basics/symbol.js
@@ -25,8 +25,8 @@ assert.sameValue(object[sym1], 'B', "The value of `object[sym1]` is `'B'`. Defin
 assert.sameValue(object.c, 'C', "The value of `object.c` is `'C'`. Defined in `object` as `c: 'C'`");
 assert.sameValue(object[sym2], 'D', "The value of `object[sym2]` is `'D'`. Defined in `object` as `[ID(sym2)]: 'D'`");
 assert(
-  compareArray(Object.keys(object), ['a', 'c']),
-  "`compareArray(Object.keys(object), ['a', 'c'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(object), ['a', 'c']),
+  "`compareArray(Object.getOwnPropertyNames(object), ['a', 'c'])` returns `true`"
 );
 assert(
   compareArray(Object.getOwnPropertySymbols(object), [sym1, sym2]),

--- a/test/language/computed-property-names/class/method/number.js
+++ b/test/language/computed-property-names/class/method/number.js
@@ -21,10 +21,9 @@ assert.sameValue(new C().a(), 'A', "`new C().a()` returns `'A'`, from `a() { ret
 assert.sameValue(new C()[1](), 'B', "`new C()[1]()` returns `'B'`, from `[1]() { return 'B'; }`");
 assert.sameValue(new C().c(), 'C', "`new C().c()` returns `'C'`, from `c() { return 'C'; }`");
 assert.sameValue(new C()[2](), 'D', "`new C()[2]()` returns `'D'`, from `[ID(2)]() { return 'D'; }`");
-assert(
-  compareArray(Object.keys(C.prototype), []),
-  "`compareArray(Object.keys(C.prototype), [])` returns `true`"
-);
+
+assert.sameValue(Object.keys(C.prototype).length, 0, "No enum keys from C.prototype");
+
 assert(
   compareArray(Object.getOwnPropertyNames(C.prototype), ['1', '2', 'constructor', 'a', 'c']),
   "`compareArray(Object.getOwnPropertyNames(C.prototype), ['1', '2', 'constructor', 'a', 'c'])` returns `true`"

--- a/test/language/computed-property-names/class/method/string.js
+++ b/test/language/computed-property-names/class/method/string.js
@@ -21,10 +21,7 @@ assert.sameValue(new C().a(), 'A', "`new C().a()` returns `'A'`. Defined as `a()
 assert.sameValue(new C().b(), 'B', "`new C().b()` returns `'B'`. Defined as `['b']() { return 'B'; }`");
 assert.sameValue(new C().c(), 'C', "`new C().c()` returns `'C'`. Defined as `c() { return 'C'; }`");
 assert.sameValue(new C().d(), 'D', "`new C().d()` returns `'D'`. Defined as `[ID('d')]() { return 'D'; }`");
-assert(
-  compareArray(Object.keys(C.prototype), []),
-  "`compareArray(Object.keys(C.prototype), [])` returns `true`"
-);
+assert.sameValue(Object.keys(C.prototype).length, 0, "No enum keys from C.prototype");
 assert(
   compareArray(Object.getOwnPropertyNames(C.prototype), ['constructor', 'a', 'b', 'c', 'd']),
   "`compareArray(Object.getOwnPropertyNames(C.prototype), ['constructor', 'a', 'b', 'c', 'd'])` returns `true`"

--- a/test/language/computed-property-names/class/method/symbol.js
+++ b/test/language/computed-property-names/class/method/symbol.js
@@ -24,10 +24,7 @@ assert.sameValue(new C().a(), 'A', "`new C().a()` returns `'A'`. Defined as `a()
 assert.sameValue(new C()[sym1](), 'B', "`new C()[sym1]()` returns `'B'`. Defined as `[sym1]() { return 'B'; }`");
 assert.sameValue(new C().c(), 'C', "`new C().c()` returns `'C'`. Defined as `c() { return 'C'; }`");
 assert.sameValue(new C()[sym2](), 'D', "`new C()[sym2]()` returns `'D'`. Defined as `[ID(sym2)]() { return 'D'; }`");
-assert(
-  compareArray(Object.keys(C.prototype), []),
-  "`compareArray(Object.keys(C.prototype), [])` returns `true`"
-);
+assert.sameValue(Object.keys(C.prototype).length, 0, "No enum keys from C.prototype");
 assert(
   compareArray(Object.getOwnPropertyNames(C.prototype), ['constructor', 'a', 'c']),
   "`compareArray(Object.getOwnPropertyNames(C.prototype), ['constructor', 'a', 'c'])` returns `true`"

--- a/test/language/computed-property-names/object/method/number.js
+++ b/test/language/computed-property-names/object/method/number.js
@@ -22,6 +22,6 @@ assert.sameValue(object[1](), 'B', "`object[1]()` returns `'B'`. Defined as `[1]
 assert.sameValue(object.c(), 'C', "`object.c()` returns `'C'`. Defined as `c() { return 'C'; }`");
 assert.sameValue(object[2](), 'D', "`object[2]()` returns `'D'`. Defined as `[ID(2)]() { return 'D'; }`");
 assert(
-  compareArray(Object.keys(object), ['1', '2', 'a', 'c']),
-  "`compareArray(Object.keys(object), ['1', '2', 'a', 'c'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(object), ['1', '2', 'a', 'c']),
+  "`compareArray(Object.getOwnPropertyNames(object), ['1', '2', 'a', 'c'])` returns `true`"
 );

--- a/test/language/computed-property-names/object/method/string.js
+++ b/test/language/computed-property-names/object/method/string.js
@@ -22,6 +22,6 @@ assert.sameValue(object.b(), 'B', "`object.b()` returns `'B'`. Defined as `['b']
 assert.sameValue(object.c(), 'C', "`object.c()` returns `'C'`. Defined as `c() { return 'C'; }`");
 assert.sameValue(object.d(), 'D', "`object.d()` returns `'D'`. Defined as `[ID('d')]() { return 'D'; }`");
 assert(
-  compareArray(Object.keys(object), ['a', 'b', 'c', 'd']),
-  "`compareArray(Object.keys(object), ['a', 'b', 'c', 'd'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(object), ['a', 'b', 'c', 'd']),
+  "`compareArray(Object.getOwnPropertyNames(object), ['a', 'b', 'c', 'd'])` returns `true`"
 );

--- a/test/language/computed-property-names/object/method/symbol.js
+++ b/test/language/computed-property-names/object/method/symbol.js
@@ -25,8 +25,8 @@ assert.sameValue(object[sym1](), 'B', "`object[sym1]()` returns `'B'`. Defined a
 assert.sameValue(object.c(), 'C', "`object.c()` returns `'C'`. Defined as `c() { return 'C'; }`");
 assert.sameValue(object[sym2](), 'D', "`object[sym2]()` returns `'D'`. Defined as `[ID(sym2)]() { return 'D'; }`");
 assert(
-  compareArray(Object.keys(object), ['a', 'c']),
-  "`compareArray(Object.keys(object), ['a', 'c'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(object), ['a', 'c']),
+  "`compareArray(Object.getOwnPropertyNames(object), ['a', 'c'])` returns `true`"
 );
 assert(
   compareArray(Object.getOwnPropertySymbols(object), [sym1, sym2]),

--- a/test/language/computed-property-names/to-name-side-effects/class.js
+++ b/test/language/computed-property-names/to-name-side-effects/class.js
@@ -7,15 +7,19 @@ description: >
 includes: [compareArray.js]
 ---*/
 var counter = 0;
+var key1ToString = [];
+var key2ToString = [];
 var key1 = {
   toString: function() {
-    assert.sameValue(counter++, 0, "The result of `counter++` is `0`");
+    key1ToString.push(counter);
+    counter += 1;
     return 'b';
   }
 };
 var key2 = {
   toString: function() {
-    assert.sameValue(counter++, 1, "The result of `counter++` is `1`");
+    key2ToString.push(counter);
+    counter += 1;
     return 'd';
   }
 };
@@ -25,15 +29,16 @@ class C {
   c() { return 'C'; }
   [key2]() { return 'D'; }
 }
+
+assert.compareArray(key1ToString, [0], "order set for key1");
+assert.compareArray(key2ToString, [1], "order set for key2");
+
 assert.sameValue(counter, 2, "The value of `counter` is `2`");
 assert.sameValue(new C().a(), 'A', "`new C().a()` returns `'A'`. Defined as `a() { return 'A'; }`");
 assert.sameValue(new C().b(), 'B', "`new C().b()` returns `'B'`. Defined as `[key1]() { return 'B'; }`");
 assert.sameValue(new C().c(), 'C', "`new C().c()` returns `'C'`. Defined as `c() { return 'C'; }`");
 assert.sameValue(new C().d(), 'D', "`new C().d()` returns `'D'`. Defined as `[key2]() { return 'D'; }`");
-assert(
-  compareArray(Object.keys(C.prototype), []),
-  "`compareArray(Object.keys(C.prototype), [])` returns `true`"
-);
+assert.sameValue(Object.keys(C.prototype).length, 0, "No enum keys from C.prototype");
 assert(
   compareArray(Object.getOwnPropertyNames(C.prototype), ['constructor', 'a', 'b', 'c', 'd']),
   "`compareArray(Object.getOwnPropertyNames(C.prototype), ['constructor', 'a', 'b', 'c', 'd'])` returns `true`"

--- a/test/language/computed-property-names/to-name-side-effects/numbers-class.js
+++ b/test/language/computed-property-names/to-name-side-effects/numbers-class.js
@@ -7,16 +7,20 @@ description: >
 includes: [compareArray.js]
 ---*/
 var counter = 0;
+var key1vof = [];
+var key2vof = [];
 var key1 = {
   valueOf: function() {
-    assert.sameValue(counter++, 0, "The result of `counter++` is `0`");
+    key1vof.push(counter);
+    counter += 1;
     return 1;
   },
   toString: null
 };
 var key2 = {
   valueOf: function() {
-    assert.sameValue(counter++, 1, "The result of `counter++` is `1`");
+    key2vof.push(counter);
+    counter += 1;
     return 2;
   },
   toString: null
@@ -28,15 +32,16 @@ class C {
   c() { return 'C'; }
   [key2]() { return 'D'; }
 }
+
+assert.compareArray(key1vof, [0], "order set for key1");
+assert.compareArray(key2vof, [1], "order set for key2");
+
 assert.sameValue(counter, 2, "The value of `counter` is `2`");
 assert.sameValue(new C().a(), 'A', "`new C().a()` returns `'A'`. Defined as `a() { return 'A'; }`");
 assert.sameValue(new C()[1](), 'B', "`new C()[1]()` returns `'B'`. Defined as `[key1]() { return 'B'; }`");
 assert.sameValue(new C().c(), 'C', "`new C().c()` returns `'C'`. Defined as `c() { return 'C'; }`");
 assert.sameValue(new C()[2](), 'D', "`new C()[2]()` returns `'D'`. Defined as `[key2]() { return 'D'; }`");
-assert(
-  compareArray(Object.keys(C.prototype), []),
-  "`compareArray(Object.keys(C.prototype), [])` returns `true`"
-);
+assert.sameValue(Object.keys(C.prototype).length, 0, "No enum keys from C.prototype");
 assert(
   compareArray(Object.getOwnPropertyNames(C.prototype), ['1', '2', 'constructor', 'a', 'c']),
   "`compareArray(Object.getOwnPropertyNames(C.prototype), ['1', '2', 'constructor', 'a', 'c'])` returns `true`"

--- a/test/language/computed-property-names/to-name-side-effects/numbers-object.js
+++ b/test/language/computed-property-names/to-name-side-effects/numbers-object.js
@@ -34,6 +34,6 @@ assert.sameValue(object[1], 'B', "The value of `object[1]` is `'B'`. Defined as 
 assert.sameValue(object.c, 'C', "The value of `object.c` is `'C'`. Defined as `c: 'C'`");
 assert.sameValue(object[2], 'D', "The value of `object[2]` is `'D'`. Defined as `[key2]: 'D'`");
 assert(
-  compareArray(Object.keys(object), ['1', '2', 'a', 'c']),
-  "`compareArray(Object.keys(object), ['1', '2', 'a', 'c'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(object), ['1', '2', 'a', 'c']),
+  "`compareArray(Object.getOwnPropertyNames(object), ['1', '2', 'a', 'c'])` returns `true`"
 );

--- a/test/language/computed-property-names/to-name-side-effects/object.js
+++ b/test/language/computed-property-names/to-name-side-effects/object.js
@@ -31,6 +31,6 @@ assert.sameValue(object.b(), 'B', "`object.b()` returns `'B'`. Defined as `[key1
 assert.sameValue(object.c(), 'C', "`object.c()` returns `'C'`. Defined as `c() { return 'C'; }`");
 assert.sameValue(object.d(), 'D', "`object.d()` returns `'D'`. Defined as `[key2]() { return 'D'; }`");
 assert(
-  compareArray(Object.keys(object), ['a', 'b', 'c', 'd']),
-  "`compareArray(Object.keys(object), ['a', 'b', 'c', 'd'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(object), ['a', 'b', 'c', 'd']),
+  "`compareArray(Object.getOwnPropertyNames(object), ['a', 'b', 'c', 'd'])` returns `true`"
 );

--- a/test/language/expressions/assignment/dstr/obj-rest-same-name.js
+++ b/test/language/expressions/assignment/dstr/obj-rest-same-name.js
@@ -33,7 +33,7 @@ assert.sameValue(y, undefined);
 assert.sameValue(z.y, 39);
 assert.sameValue(z.z, 'cheeseburger');
 
-var keys = Object.keys(z);
+var keys = Object.getOwnPropertyNames(z);
 assert.sameValue(keys.length, 2);
 assert.sameValue(keys[0], 'y');
 assert.sameValue(keys[1], 'z');

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-nested-namespace-dflt-direct.js
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-nested-namespace-dflt-direct.js
@@ -102,7 +102,7 @@ async function fn() {
     assert.sameValue(desc.writable, true, 'ns.productionNS2: is writable');
     assert.sameValue(desc.configurable, false, 'ns.productionNS2: is non-configurable');
 
-    var keys = Object.keys(ns.productionNS2);
+    var keys = Object.getOwnPropertyNames(ns.productionNS2);
 
     assert.sameValue(keys.length, 2);
     assert.sameValue(keys[0], 'default');

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-nested-namespace-dflt-indirect.js
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-nested-namespace-dflt-indirect.js
@@ -102,7 +102,7 @@ async function fn() {
     assert.sameValue(desc.writable, true, 'ns.namedNS2: is writable');
     assert.sameValue(desc.configurable, false, 'ns.namedNS2: is non-configurable');
 
-    var keys = Object.keys(ns.namedNS2);
+    var keys = Object.getOwnPropertyNames(ns.namedNS2);
 
     assert.sameValue(keys.length, 2);
     assert.sameValue(keys[0], 'default');

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-nested-namespace-dflt-direct.js
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-nested-namespace-dflt-direct.js
@@ -101,7 +101,7 @@ import('./get-nested-namespace-dflt-skip-prod_FIXTURE.js').then(ns => {
     assert.sameValue(desc.writable, true, 'ns.productionNS2: is writable');
     assert.sameValue(desc.configurable, false, 'ns.productionNS2: is non-configurable');
 
-    var keys = Object.keys(ns.productionNS2);
+    var keys = Object.getOwnPropertyNames(ns.productionNS2);
 
     assert.sameValue(keys.length, 2);
     assert.sameValue(keys[0], 'default');

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-nested-namespace-dflt-indirect.js
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-nested-namespace-dflt-indirect.js
@@ -101,7 +101,7 @@ import('./get-nested-namespace-dflt-skip-named_FIXTURE.js').then(ns => {
     assert.sameValue(desc.writable, true, 'ns.namedNS2: is writable');
     assert.sameValue(desc.configurable, false, 'ns.namedNS2: is non-configurable');
 
-    var keys = Object.keys(ns.namedNS2);
+    var keys = Object.getOwnPropertyNames(ns.namedNS2);
 
     assert.sameValue(keys.length, 2);
     assert.sameValue(keys[0], 'default');

--- a/test/language/expressions/object/computed-property-evaluation-order.js
+++ b/test/language/expressions/object/computed-property-evaluation-order.js
@@ -15,7 +15,7 @@ var o = {
   [++counter]: ++counter,
 }
 
-var keys = Object.keys(o);
+var keys = Object.getOwnPropertyNames(o);
 
 assert.sameValue(keys.length, 3, '3 PropertyDefinitions should result in 3 properties');
 assert.sameValue(keys[0], '1');

--- a/test/language/statements/for-await-of/async-func-decl-dstr-obj-rest-same-name.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-obj-rest-same-name.js
@@ -40,7 +40,7 @@ async function fn() {
     assert.sameValue(z.y, 39);
     assert.sameValue(z.z, 'cheeseburger');
 
-    let keys = Object.keys(z);
+    let keys = Object.getOwnPropertyNames(z);
     assert.sameValue(keys.length, 2);
     assert.sameValue(keys[0], 'y');
     assert.sameValue(keys[1], 'z');

--- a/test/language/statements/for-await-of/async-gen-decl-dstr-obj-rest-same-name.js
+++ b/test/language/statements/for-await-of/async-gen-decl-dstr-obj-rest-same-name.js
@@ -40,7 +40,7 @@ async function * fn() {
     assert.sameValue(z.y, 39);
     assert.sameValue(z.z, 'cheeseburger');
 
-    let keys = Object.keys(z);
+    let keys = Object.getOwnPropertyNames(z);
     assert.sameValue(keys.length, 2);
     assert.sameValue(keys[0], 'y');
     assert.sameValue(keys[1], 'z');

--- a/test/language/statements/for-of/dstr/obj-rest-same-name.js
+++ b/test/language/statements/for-of/dstr/obj-rest-same-name.js
@@ -40,7 +40,7 @@ for ({ x, ...z } of [o]) {
   assert.sameValue(z.y, 39);
   assert.sameValue(z.z, 'cheeseburger');
 
-  var keys = Object.keys(z);
+  var keys = Object.getOwnPropertyNames(z);
   assert.sameValue(keys.length, 2);
   assert.sameValue(keys[0], 'y');
   assert.sameValue(keys[1], 'z');


### PR DESCRIPTION
Fixes #2226