### PR TITLE
 Abrupt completion cases

### DIFF
--- a/test/language/statements/class/elements/abrupt-completition-on-field-initializer.js
+++ b/test/language/statements/class/elements/abrupt-completition-on-field-initializer.js
@@ -46,7 +46,7 @@ assert.sameValue(neverExecuted, false);
 
 assert.throws(Test262Error, function() {
   class D {
-    static a = abruptcomplition();
+    static a = abruptComplition();
     static b = sideEffect();
   }
 }, 'static field initializer should end with abrupt complition');

--- a/test/language/statements/class/elements/abrupt-completition-on-field-initializer.js
+++ b/test/language/statements/class/elements/abrupt-completition-on-field-initializer.js
@@ -3,7 +3,7 @@
 
 /*---
 description: If an initializer returns an abrupt complition, other initializers should not execute
-esid: [[construct]]
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
 info: |
   [[Construct]] ( argumentsList, newTarget)
     ...
@@ -24,7 +24,7 @@ info: |
 features: [class-fields-public, class-static-fields-public, class]
 ---*/
 
-function abruptComplition() {
+function abruptCompletion() {
   throw new Test262Error();
 }
 
@@ -35,7 +35,7 @@ function sideEffect() {
 }
 
 class C {
-  a = abruptComplition();
+  a = abruptCompletion();
   b = sideEffect();
 }
 
@@ -46,7 +46,7 @@ assert.sameValue(neverExecuted, false);
 
 assert.throws(Test262Error, function() {
   class D {
-    static a = abruptComplition();
+    static a = abruptCompletion();
     static b = sideEffect();
   }
 }, 'static field initializer should end with abrupt complition');

--- a/test/language/statements/class/elements/abrupt-completition-on-field-initializer.js
+++ b/test/language/statements/class/elements/abrupt-completition-on-field-initializer.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: If an initializer returns an abrupt complition, other initializers should not execute
+description: If an initializer returns an abrupt completion, other initializers should not execute
 esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
 info: |
   [[Construct]] ( argumentsList, newTarget)
@@ -41,7 +41,7 @@ class C {
 
 assert.throws(Test262Error, function() {
   let c = new C();
-}, 'field initializer should end with abrupt complition');
+}, 'field initializer should end with abrupt completion');
 assert.sameValue(neverExecuted, false);
 
 assert.throws(Test262Error, function() {
@@ -49,5 +49,5 @@ assert.throws(Test262Error, function() {
     static a = abruptCompletion();
     static b = sideEffect();
   }
-}, 'static field initializer should end with abrupt complition');
+}, 'static field initializer should end with abrupt completion');
 assert.sameValue(neverExecuted, false);

--- a/test/language/statements/class/elements/abrupt-completition-on-field-initializer.js
+++ b/test/language/statements/class/elements/abrupt-completition-on-field-initializer.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: If an initializer returns an abrupt completition, other initializers should not execute
+esid: [[construct]]
+info: |
+  [[Construct]] ( argumentsList, newTarget)
+    ...
+    8. If kind is "base", then
+      a. Perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
+      b. Let result be InitializeInstanceFields(thisArgument, F).
+      c. If result is an abrupt completion, then
+        i. Remove calleeContext from execution context stack and restore callerContext as the running execution context.
+        ii. Return Completion(result).
+    ...
+
+  ClassTail : ClassHeritage { ClassBody }
+    ...
+    34. For each item fieldRecord in order from staticFields,
+      a. Perform ? DefineField(F, field).
+    ...
+
+features: [class-fields-public, class-static-fields-public, class]
+---*/
+
+function abruptCompletition() {
+  throw new Test262Error();
+}
+
+let neverExecuted = false;
+
+function sideEffect() {
+  neverExecuted = true;
+}
+
+class C {
+  a = abruptCompletition();
+  b = sideEffect();
+}
+
+assert.throws(Test262Error, function() {
+  let c = new C();
+}, 'field initializer should end with abrupt completition');
+assert.sameValue(neverExecuted, false);
+
+assert.throws(Test262Error, function() {
+  class D {
+    static a = abruptCompletition();
+    static b = sideEffect();
+  }
+}, 'static field initializer should end with abrupt completition');
+assert.sameValue(neverExecuted, false);

--- a/test/language/statements/class/elements/abrupt-completition-on-field-initializer.js
+++ b/test/language/statements/class/elements/abrupt-completition-on-field-initializer.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: If an initializer returns an abrupt completition, other initializers should not execute
+description: If an initializer returns an abrupt complition, other initializers should not execute
 esid: [[construct]]
 info: |
   [[Construct]] ( argumentsList, newTarget)
@@ -24,7 +24,7 @@ info: |
 features: [class-fields-public, class-static-fields-public, class]
 ---*/
 
-function abruptCompletition() {
+function abruptComplition() {
   throw new Test262Error();
 }
 
@@ -35,19 +35,19 @@ function sideEffect() {
 }
 
 class C {
-  a = abruptCompletition();
+  a = abruptComplition();
   b = sideEffect();
 }
 
 assert.throws(Test262Error, function() {
   let c = new C();
-}, 'field initializer should end with abrupt completition');
+}, 'field initializer should end with abrupt complition');
 assert.sameValue(neverExecuted, false);
 
 assert.throws(Test262Error, function() {
   class D {
-    static a = abruptCompletition();
+    static a = abruptcomplition();
     static b = sideEffect();
   }
-}, 'static field initializer should end with abrupt completition');
+}, 'static field initializer should end with abrupt complition');
 assert.sameValue(neverExecuted, false);

--- a/test/language/statements/class/elements/computed-property-abrupt-completition.js
+++ b/test/language/statements/class/elements/computed-property-abrupt-completition.js
@@ -20,7 +20,7 @@ info: |
 features: [class-fields-public, class-static-fields-public, class]
 ---*/
 
-function abruptComplition() {
+function abruptCompletion() {
   throw new Test262Error();
 }
 
@@ -28,7 +28,7 @@ let neverExecuted = false;
 
 assert.throws(Test262Error, function() {
   class C {
-    [abruptComplition()];
+    [abruptCompletion()];
     [neverExecuted = true];
   }
 }, 'computed property should have abrupt complition');
@@ -36,7 +36,7 @@ assert.sameValue(neverExecuted, false);
 
 assert.throws(Test262Error, function() {
   class C {
-    static [abruptComplition()];
+    static [abruptCompletion()];
     [neverExecuted = true];
   }
 }, 'static computed property should have abrupt complition');

--- a/test/language/statements/class/elements/computed-property-abrupt-completition.js
+++ b/test/language/statements/class/elements/computed-property-abrupt-completition.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: PrivateFieldGet should return with abrupt completition
+esid: runtime-semantics-class-definition-evaluation
+info: |
+  ClassTail : ClassHeritage { ClassBody }
+    ...
+    28. For each ClassElement e in order from elements,
+      a. If IsStatic of e is false, then
+        i. Let field be the result of performing ClassElementEvaluation for e with arguments proto and false.
+      b. Else,
+        i. Let field be the result of performing PropertyDefinitionEvaluation for mClassElementEvaluation for e with arguments F and false.
+      c. If field is an abrupt completion, then
+        i. Set the running execution context's LexicalEnvironment to lex.
+        ii. Set the running execution context's PrivateEnvironment to outerPrivateEnvironment.
+        iii. Return Completion(field).
+    ...
+features: [class-fields-public, class-static-fields-public, class]
+---*/
+
+function abruptCompletition() {
+  throw new Test262Error();
+}
+
+let neverExecuted = false;
+
+assert.throws(Test262Error, function() {
+  class C {
+    [abruptCompletition()];
+    [neverExecuted = true];
+  }
+}, 'computed property should have abrupt completition');
+assert.sameValue(neverExecuted, false);
+
+assert.throws(Test262Error, function() {
+  class C {
+    static [abruptCompletition()];
+    [neverExecuted = true];
+  }
+}, 'static computed property should have abrupt completition');
+assert.sameValue(neverExecuted, false);

--- a/test/language/statements/class/elements/computed-property-abrupt-completition.js
+++ b/test/language/statements/class/elements/computed-property-abrupt-completition.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: PrivateFieldGet should return with abrupt complition
+description: PrivateFieldGet should return with abrupt completion
 esid: runtime-semantics-class-definition-evaluation
 info: |
   ClassTail : ClassHeritage { ClassBody }
@@ -31,7 +31,7 @@ assert.throws(Test262Error, function() {
     [abruptCompletion()];
     [neverExecuted = true];
   }
-}, 'computed property should have abrupt complition');
+}, 'computed property should have abrupt completion');
 assert.sameValue(neverExecuted, false);
 
 assert.throws(Test262Error, function() {
@@ -39,5 +39,5 @@ assert.throws(Test262Error, function() {
     static [abruptCompletion()];
     [neverExecuted = true];
   }
-}, 'static computed property should have abrupt complition');
+}, 'static computed property should have abrupt completion');
 assert.sameValue(neverExecuted, false);

--- a/test/language/statements/class/elements/computed-property-abrupt-completition.js
+++ b/test/language/statements/class/elements/computed-property-abrupt-completition.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: PrivateFieldGet should return with abrupt completition
+description: PrivateFieldGet should return with abrupt complition
 esid: runtime-semantics-class-definition-evaluation
 info: |
   ClassTail : ClassHeritage { ClassBody }
@@ -20,7 +20,7 @@ info: |
 features: [class-fields-public, class-static-fields-public, class]
 ---*/
 
-function abruptCompletition() {
+function abruptComplition() {
   throw new Test262Error();
 }
 
@@ -28,16 +28,16 @@ let neverExecuted = false;
 
 assert.throws(Test262Error, function() {
   class C {
-    [abruptCompletition()];
+    [abruptComplition()];
     [neverExecuted = true];
   }
-}, 'computed property should have abrupt completition');
+}, 'computed property should have abrupt complition');
 assert.sameValue(neverExecuted, false);
 
 assert.throws(Test262Error, function() {
   class C {
-    static [abruptCompletition()];
+    static [abruptComplition()];
     [neverExecuted = true];
   }
-}, 'static computed property should have abrupt completition');
+}, 'static computed property should have abrupt complition');
 assert.sameValue(neverExecuted, false);

--- a/test/language/statements/class/elements/private-static-getter-abrupt-completition.js
+++ b/test/language/statements/class/elements/private-static-getter-abrupt-completition.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: PrivateFieldGet should return a abrupt complition
+description: PrivateFieldGet should return an abrupt complition
 esid: sec-privatefieldget
 info: |
   PrivateFieldGet (P, O)

--- a/test/language/statements/class/elements/private-static-getter-abrupt-completition.js
+++ b/test/language/statements/class/elements/private-static-getter-abrupt-completition.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: PrivateFieldGet shoudl return with abrupt completition
+description: PrivateFieldGet should return a abrupt completition
 esid: sec-privatefieldget
 info: |
   PrivateFieldGet (P, O)

--- a/test/language/statements/class/elements/private-static-getter-abrupt-completition.js
+++ b/test/language/statements/class/elements/private-static-getter-abrupt-completition.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: PrivateFieldGet shoudl return with abrupt completition
+esid: sec-privatefieldget
+info: |
+  PrivateFieldGet (P, O)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Return entry.[[PrivateFieldValue]].
+    4. Perform ? PrivateBrandCheck(O, P).
+    5. If P.[[Kind]] is "method",
+      a. Return P.[[Value]].
+    6. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If P does not have a [[Get]] field, throw a TypeError exception.
+      c. Let getter be P.[[Get]].
+      d. Return ? Call(getter, O).
+features: [class-methods-private, class]
+---*/
+
+class C {
+  get #m() {
+    throw new Test262Error();
+  }
+
+  access() {
+    this.#m;
+  }
+}
+
+let c = new C();
+assert.throws(Test262Error, function() {
+  c.access();
+}, 'private getter should have abrupt completition');

--- a/test/language/statements/class/elements/private-static-getter-abrupt-completition.js
+++ b/test/language/statements/class/elements/private-static-getter-abrupt-completition.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: PrivateFieldGet should return an abrupt complition
+description: PrivateFieldGet should return an abrupt completion
 esid: sec-privatefieldget
 info: |
   PrivateFieldGet (P, O)
@@ -36,4 +36,4 @@ class C {
 let c = new C();
 assert.throws(Test262Error, function() {
   c.access();
-}, 'private getter should have abrupt complition');
+}, 'private getter should have abrupt completion');

--- a/test/language/statements/class/elements/private-static-getter-abrupt-completition.js
+++ b/test/language/statements/class/elements/private-static-getter-abrupt-completition.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: PrivateFieldGet should return a abrupt completition
+description: PrivateFieldGet should return a abrupt complition
 esid: sec-privatefieldget
 info: |
   PrivateFieldGet (P, O)
@@ -36,4 +36,4 @@ class C {
 let c = new C();
 assert.throws(Test262Error, function() {
   c.access();
-}, 'private getter should have abrupt completition');
+}, 'private getter should have abrupt complition');

--- a/test/language/statements/class/elements/private-static-setter-abrupt-completition.js
+++ b/test/language/statements/class/elements/private-static-setter-abrupt-completition.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: PrivateFieldSet should return a abrupt completition
+description: PrivateFieldSet should return a abrupt complition
 esid: sec-privatefieldset
 info: |
   PrivateFieldSet (P, O, value)
@@ -37,4 +37,4 @@ class C {
 let c = new C();
 assert.throws(Test262Error, function() {
   c.access();
-}, 'private setter should have abrupt completition');
+}, 'private setter should have abrupt complition');

--- a/test/language/statements/class/elements/private-static-setter-abrupt-completition.js
+++ b/test/language/statements/class/elements/private-static-setter-abrupt-completition.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: PrivateFieldGet shoudl return with abrupt completition
+esid: sec-privatefieldget
+info: |
+  PrivateFieldSet (P, O, value)
+    1. Assert: P is a Private Name.
+    2. If O is not an object, throw a TypeError exception.
+    3. If P.[[Kind]] is "field",
+      a. Let entry be PrivateFieldFind(P, O).
+      b. If entry is empty, throw a TypeError exception.
+      c. Set entry.[[PrivateFieldValue]] to value.
+      d. Return.
+    4. If P.[[Kind]] is "method", throw a TypeError exception.
+    5. Else,
+      a. Assert: P.[[Kind]] is "accessor".
+      b. If O.[[PrivateFieldBrands]] does not contain P.[[Brand]], throw a TypeError exception.
+      c. If P does not have a [[Set]] field, throw a TypeError exception.
+      d. Let setter be P.[[Set]].
+      e. Perform ? Call(setter, O, value).
+      f. Return.
+features: [class-methods-private, class]
+---*/
+
+class C {
+  set #m(_) {
+    throw new Test262Error();
+  }
+
+  access() {
+    this.#m = 'Test262';
+  }
+}
+
+let c = new C();
+assert.throws(Test262Error, function() {
+  c.access();
+}, 'private setter should have abrupt completition');

--- a/test/language/statements/class/elements/private-static-setter-abrupt-completition.js
+++ b/test/language/statements/class/elements/private-static-setter-abrupt-completition.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: PrivateFieldSet should return an abrupt complition
+description: PrivateFieldSet should return an abrupt completion
 esid: sec-privatefieldset
 info: |
   PrivateFieldSet (P, O, value)
@@ -37,4 +37,4 @@ class C {
 let c = new C();
 assert.throws(Test262Error, function() {
   c.access();
-}, 'private setter should have abrupt complition');
+}, 'private setter should have abrupt completion');

--- a/test/language/statements/class/elements/private-static-setter-abrupt-completition.js
+++ b/test/language/statements/class/elements/private-static-setter-abrupt-completition.js
@@ -2,8 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: PrivateFieldGet shoudl return with abrupt completition
-esid: sec-privatefieldget
+description: PrivateFieldSet should return a abrupt completition
+esid: sec-privatefieldset
 info: |
   PrivateFieldSet (P, O, value)
     1. Assert: P is a Private Name.

--- a/test/language/statements/class/elements/private-static-setter-abrupt-completition.js
+++ b/test/language/statements/class/elements/private-static-setter-abrupt-completition.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: PrivateFieldSet should return a abrupt complition
+description: PrivateFieldSet should return an abrupt complition
 esid: sec-privatefieldset
 info: |
   PrivateFieldSet (P, O, value)


### PR DESCRIPTION
We are adding cases where we have abrupt completion for computed properties and field initializers. We are also adding cases where accessors returns abrupt completion.

Cc @leobalter @spectranaut 