### PR TITLE
fix TypedArray.prototype.sort test

### DIFF
--- a/test/built-ins/TypedArray/prototype/sort/sorted-values.js
+++ b/test/built-ins/TypedArray/prototype/sort/sorted-values.js
@@ -25,10 +25,17 @@ testWithTypedArrayConstructors(function(TA) {
 
   sample = new TA([3, 4, 3, 1, 0, 1, 2]).sort();
   assert(compareArray(sample, [0, 1, 1, 2, 3, 3, 4]), "repeating numbers");
+});
 
+testWithTypedArrayConstructors(function(TA) {
+  sample = new TA([1, 0, -0, 2]).sort();
+  assert(compareArray(sample, [-0, 0, 1, 2]), "0s");
+}, floatArrayConstructors);
+
+testWithTypedArrayConstructors(function(TA) {
   sample = new TA([1, 0, -0, 2]).sort();
   assert(compareArray(sample, [0, 0, 1, 2]), "0s");
-});
+}, intArrayConstructors);
 
 testWithTypedArrayConstructors(function(TA) {
   var sample = new TA([-4, 3, 4, -3, 2, -2, 1, 0]).sort();

--- a/test/built-ins/TypedArray/prototype/sort/sorted-values.js
+++ b/test/built-ins/TypedArray/prototype/sort/sorted-values.js
@@ -28,12 +28,12 @@ testWithTypedArrayConstructors(function(TA) {
 });
 
 testWithTypedArrayConstructors(function(TA) {
-  sample = new TA([1, 0, -0, 2]).sort();
+  var sample = new TA([1, 0, -0, 2]).sort();
   assert(compareArray(sample, [-0, 0, 1, 2]), "0s");
 }, floatArrayConstructors);
 
 testWithTypedArrayConstructors(function(TA) {
-  sample = new TA([1, 0, -0, 2]).sort();
+  var sample = new TA([1, 0, -0, 2]).sort();
   assert(compareArray(sample, [0, 0, 1, 2]), "0s");
 }, intArrayConstructors);
 

--- a/test/built-ins/TypedArray/prototype/sort/sorted-values.js
+++ b/test/built-ins/TypedArray/prototype/sort/sorted-values.js
@@ -51,9 +51,6 @@ testWithTypedArrayConstructors(function(TA) {
   sample = new TA([0.5, 0, 1.5, -0.5, -1, -1.5, 1]).sort();
   assert(compareArray(sample, [-1.5, -1, -0.5, 0, 0.5, 1, 1.5]), "non integers + negatives");
 
-  sample = new TA([1, 0, -0, 2]).sort();
-  assert(compareArray(sample, [0, 0, 1, 2]), "0 and -0");
-
   sample = new TA([3, 4, Infinity, -Infinity, 1, 2]).sort();
   assert(compareArray(sample, [-Infinity, 1, 2, 3, 4, Infinity]), "infinities");
 


### PR DESCRIPTION
```js
[
  Uint8Array, Uint32Array, Uint8ClampedArray, Uint16Array,
  Uint32Array, Int8Array, Int16Array, Int32Array, Float32Array, Float64Array
]
  .map((x) => new x([1, 0, -0, 2]).sort())
  .map((x) => x.constructor.name + ' ' + [...x]
    .map((n) => Object.is(n, -0) ? '-0' : n))
  .join('\n');
```

```
┌────────────────┬───────────────────────────┐
│ ChakraCore     │ Uint8Array 0,0,1,2        │
│ XS             │ Uint32Array 0,0,1,2       │
│                │ Uint8ClampedArray 0,0,1,2 │
│                │ Uint16Array 0,0,1,2       │
│                │ Uint32Array 0,0,1,2       │
│                │ Int8Array 0,0,1,2         │
│                │ Int16Array 0,0,1,2        │
│                │ Int32Array 0,0,1,2        │
│                │ Float32Array 0,-0,1,2     │
│                │ Float64Array 0,-0,1,2     │
├────────────────┼───────────────────────────┤
│ engine262      │ Uint8Array 0,0,1,2        │
│ engine262+     │ Uint32Array 0,0,1,2       │
│ JavaScriptCore │ Uint8ClampedArray 0,0,1,2 │
│ SpiderMonkey   │ Uint16Array 0,0,1,2       │
│ V8             │ Uint32Array 0,0,1,2       │
│                │ Int8Array 0,0,1,2         │
│                │ Int16Array 0,0,1,2        │
│                │ Int32Array 0,0,1,2        │
│                │ Float32Array -0,0,1,2     │
│                │ Float64Array -0,0,1,2     │
└────────────────┴───────────────────────────┘
```