### PR TITLE
Add async generator default prototype tests

### DIFF
--- a/test/language/expressions/async-generator/default-proto.js
+++ b/test/language/expressions/async-generator/default-proto.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-asyncgenerator-definitions-evaluatebody
+description: >
+  Default [[Prototype]] value derived from realm of the async generator function.
+info: |
+  Runtime Semantics: EvaluateBody
+
+  ...
+  2. Let generator be ? OrdinaryCreateFromConstructor(functionObject, "%AsyncGeneratorPrototype%", « ... »).
+  3. Perform ! AsyncGeneratorStart(generator, FunctionBody).
+  4. Return Completion { [[Type]]: return, [[Value]]: generator, [[Target]]: empty }.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  ...
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [async-iteration, Symbol]
+---*/
+
+var fn = async function* () {};
+var AsyncGeneratorPrototype = Object.getPrototypeOf(fn.prototype);
+
+fn.prototype = undefined;
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is undefined');
+
+fn.prototype = null;
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is null');
+
+fn.prototype = false;
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is a Boolean');
+
+fn.prototype = '';
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is a String');
+
+fn.prototype = Symbol();
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is a Symbol');
+
+fn.prototype = 1;
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is a Number');

--- a/test/language/expressions/async-generator/eval-body-proto-realm.js
+++ b/test/language/expressions/async-generator/eval-body-proto-realm.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-asyncgenerator-definitions-evaluatebody
+description: >
+  Default [[Prototype]] value derived from realm of the async generator function.
+info: |
+  Runtime Semantics: EvaluateBody
+
+  ...
+  2. Let generator be ? OrdinaryCreateFromConstructor(functionObject, "%AsyncGeneratorPrototype%", « ... »).
+  3. Perform ! AsyncGeneratorStart(generator, FunctionBody).
+  4. Return Completion { [[Type]]: return, [[Value]]: generator, [[Target]]: empty }.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  ...
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [async-iteration, cross-realm, Symbol]
+---*/
+
+var other = $262.createRealm().global;
+var fn = other.eval('(0, async function* () {})');
+var AsyncGeneratorPrototype = Object.getPrototypeOf(fn.prototype);
+
+fn.prototype = undefined;
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is undefined');
+
+fn.prototype = null;
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is null');
+
+fn.prototype = true;
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is a Boolean');
+
+fn.prototype = 'str';
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is a String');
+
+fn.prototype = Symbol();
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is a Symbol');
+
+fn.prototype = 0;
+assert.sameValue(Object.getPrototypeOf(fn()), AsyncGeneratorPrototype, 'fn.prototype is a Number');


### PR DESCRIPTION
Similar tests for regular generators:

* [default-proto.js](https://github.com/tc39/test262/blob/master/test/language/expressions/generators/default-proto.js)
* [eval-body-proto-realm.js](https://github.com/tc39/test262/blob/master/test/language/expressions/generators/eval-body-proto-realm.js)

Related: #2334, #2335.