### PR TITLE
Gracefully handle errors from ToString in harness/assert

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -11,7 +11,7 @@ function assert(mustBeTrue, message) {
   }
 
   if (message === undefined) {
-    message = 'Expected true but got ' + String(mustBeTrue);
+    message = 'Expected true but got ' + assert._toString(mustBeTrue);
   }
   $ERROR(message);
 }

--- a/harness/assert.js
+++ b/harness/assert.js
@@ -91,3 +91,15 @@ assert.throws = function (expectedErrorConstructor, func, message) {
   message += 'Expected a ' + expectedErrorConstructor.name + ' to be thrown but no exception was thrown at all';
   $ERROR(message);
 };
+
+assert._toString = function (value) {
+  try {
+    return String(value);
+  } catch (err) {
+    if (err.name === 'TypeError') {
+      return Object.prototype.toString.call(value);
+    }
+
+    throw err;
+  }
+};

--- a/harness/assert.js
+++ b/harness/assert.js
@@ -58,7 +58,7 @@ assert.notSameValue = function (actual, unexpected, message) {
     message += ' ';
   }
 
-  message += 'Expected SameValue(«' + String(actual) + '», «' + String(unexpected) + '») to be false';
+  message += 'Expected SameValue(«' + assert._toString(actual) + '», «' + assert._toString(unexpected) + '») to be false';
 
   $ERROR(message);
 };

--- a/harness/assert.js
+++ b/harness/assert.js
@@ -42,7 +42,7 @@ assert.sameValue = function (actual, expected, message) {
     message += ' ';
   }
 
-  message += 'Expected SameValue(«' + String(actual) + '», «' + String(expected) + '») to be true';
+  message += 'Expected SameValue(«' + assert._toString(actual) + '», «' + assert._toString(expected) + '») to be true';
 
   $ERROR(message);
 };

--- a/test/harness/assert-notsamevalue-tostring.js
+++ b/test/harness/assert-notsamevalue-tostring.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  When composing a message, errors from ToString are handled.
+features: [async-functions]
+---*/
+
+var threw = false;
+var asyncFunProto = Object.getPrototypeOf(async function() {});
+
+try {
+  assert.notSameValue(asyncFunProto, asyncFunProto);
+} catch (err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR('Expected a Test262Error, but a "' + err.constructor.name + '" was thrown.');
+  }
+}
+
+if (!threw) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-samevalue-tostring.js
+++ b/test/harness/assert-samevalue-tostring.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  When composing a message, errors from ToString are handled.
+features: [async-functions]
+---*/
+
+var threw = false;
+var asyncFunProto = Object.getPrototypeOf(async function() {});
+
+try {
+  assert.sameValue(asyncFunProto, 1);
+} catch (err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR('Expected a Test262Error, but a "' + err.constructor.name + '" was thrown.');
+  }
+}
+
+if (!threw) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}

--- a/test/harness/assert-tostring.js
+++ b/test/harness/assert-tostring.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  When composing a message, errors from ToString are handled.
+features: [async-functions]
+---*/
+
+var threw = false;
+var asyncFunProto = Object.getPrototypeOf(async function() {});
+
+try {
+  assert(asyncFunProto);
+} catch (err) {
+  threw = true;
+  if (err.constructor !== Test262Error) {
+    $ERROR('Expected a Test262Error, but a "' + err.constructor.name + '" was thrown.');
+  }
+}
+
+if (!threw) {
+  $ERROR('Expected a Test262Error, but no error was thrown.');
+}


### PR DESCRIPTION
[Motivation](https://github.com/tc39/test262/pull/2342#issuecomment-530604306).

Follow-up of #2342.