### PR TITLE
Remove expectation of UM 49 to ISO 639 conversion that not exist in the spec

### DIFF
--- a/test/intl402/Locale/constructor-options-region-valid.js
+++ b/test/intl402/Locale/constructor-options-region-valid.js
@@ -31,8 +31,8 @@ features: [Intl.Locale]
 const validRegionOptions = [
   [undefined, undefined],
   ['FR', 'en-FR'],
-  ['554', 'en-NZ'],
-  [554, 'en-NZ'],
+  ['554', 'en-554'],
+  [554, 'en-554'],
 ];
 for (const [region, expected] of validRegionOptions) {
   let options = { region };


### PR DESCRIPTION
Nowhere in the spec transform 554 to NZ so the locale should stay as en-554 instead of en-NZ.