### PR TITLE
Test specific error in super-private-access-invalid.case

### DIFF
--- a/src/class-elements/super-private-access-invalid.case
+++ b/src/class-elements/super-private-access-invalid.case
@@ -23,6 +23,8 @@ features: [class-methods-private]
 extends B
 
 //- elements
+#x() {}
+
 method() {
   super.#x();
 }

--- a/test/language/expressions/class/elements/syntax/early-errors/super-private-access-invalid.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/super-private-access-invalid.js
@@ -28,6 +28,8 @@ $DONOTEVALUATE();
 
 var C = class extends B
 {
+  #x() {}
+
   method() {
     super.#x();
   }

--- a/test/language/statements/class/elements/syntax/early-errors/super-private-access-invalid.js
+++ b/test/language/statements/class/elements/syntax/early-errors/super-private-access-invalid.js
@@ -28,6 +28,8 @@ $DONOTEVALUATE();
 
 class C extends B
 {
+  #x() {}
+
   method() {
     super.#x();
   }


### PR DESCRIPTION
Without declaring `#x` in the class body, the thrown error could have been about the undeclared private name rather than about the SuperProperty.