### PR TITLE
Correct bug in property helper

### DIFF
--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -92,6 +92,7 @@ function verifyProperty(obj, name, desc, options) {
 }
 
 function isConfigurable(obj, name) {
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
   try {
     delete obj[name];
   } catch (e) {
@@ -99,7 +100,7 @@ function isConfigurable(obj, name) {
       $ERROR("Expected TypeError, got " + e);
     }
   }
-  return !Object.prototype.hasOwnProperty.call(obj, name);
+  return !hasOwnProperty.call(obj, name);
 }
 
 function isEnumerable(obj, name) {

--- a/test/harness/propertyhelper-verifyconfigurable-configurable-object.js
+++ b/test/harness/propertyhelper-verifyconfigurable-configurable-object.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2019 Bocoup. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is configurable satisfy the assertion.
+includes: [propertyHelper.js]
+---*/
+
+Object.defineProperty(this, 'Object', {
+  configurable: true,
+  value: Object
+});
+
+verifyConfigurable(this, 'Object');

--- a/test/harness/verifyProperty-configurable-object.js
+++ b/test/harness/verifyProperty-configurable-object.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2019 Bocoup. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Objects whose specified property is configurable satisfy the assertion.
+includes: [propertyHelper.js]
+---*/
+
+Object.defineProperty(this, 'Object', {
+  configurable: true,
+  value: Object
+});
+
+verifyProperty(this, 'Object', {
+  configurable: true
+});


### PR DESCRIPTION
Allow the property helper to be used to verify the configurability of
the global "Object" property.