### PR TITLE
Remove unnecessary "includes" directives

### DIFF
--- a/src/async-generators/yield-spread-obj.case
+++ b/src/async-generators/yield-spread-obj.case
@@ -11,8 +11,6 @@ info: |
     (...)
     ...AssignmentExpression[In, ?Yield]
 features: [object-spread]
-includes:
-  - compareArray.js
 flags: [async]
 ---*/
 

--- a/src/dynamic-import/ns-extensible.case
+++ b/src/dynamic-import/ns-extensible.case
@@ -3,7 +3,6 @@
 /*---
 desc: Module namespace objects are not extensible.
 template: namespace
-includes: [propertyHelper.js]
 ---*/
 
 //- import

--- a/src/generators/yield-spread-obj.case
+++ b/src/generators/yield-spread-obj.case
@@ -11,8 +11,6 @@ info: |
     (...)
     ...AssignmentExpression[In, ?Yield]
 features: [object-spread]
-includes:
-  - compareArray.js
 ---*/
 
 //- body

--- a/test/built-ins/Array/prototype/includes/values-are-not-cached.js
+++ b/test/built-ins/Array/prototype/includes/values-are-not-cached.js
@@ -11,7 +11,6 @@ info: |
   7. Repeat, while k < len
     a. Let elementK be the result of ? Get(O, ! ToString(k)).
   ...
-includes: [compareArray.js]
 ---*/
 
 function getCleanObj() {

--- a/test/built-ins/ArrayIteratorPrototype/next/detach-typedarray-in-progress.js
+++ b/test/built-ins/ArrayIteratorPrototype/next/detach-typedarray-in-progress.js
@@ -18,7 +18,7 @@ testWithTypedArrayConstructors(TA => {
   var i = 0;
   assert.throws(TypeError, () => {
     for (let key of typedArray.keys()) {
-      $262.detachArrayBuffer(typedArray.buffer);
+      $DETACHBUFFER(typedArray.buffer);
       i++;
     }
   });

--- a/test/built-ins/AsyncGeneratorPrototype/return/return-promise.js
+++ b/test/built-ins/AsyncGeneratorPrototype/return/return-promise.js
@@ -18,7 +18,6 @@ info: |
   ...
   9. Return promiseCapability.[[Promise]].
 
-includes: [propertyHelper.js]
 features: [async-iteration]
 ---*/
 

--- a/test/built-ins/Atomics/notify/count-from-nans.js
+++ b/test/built-ins/Atomics/notify/count-from-nans.js
@@ -20,7 +20,7 @@ info: |
   2. If number is NaN, return +0.
   ...
 
-includes: [nans.js, atomicsHelper.js]
+includes: [nans.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 

--- a/test/built-ins/Atomics/notify/non-shared-bufferdatate-non-shared-int-views.js
+++ b/test/built-ins/Atomics/notify/non-shared-bufferdatate-non-shared-int-views.js
@@ -5,7 +5,6 @@
 esid: sec-atomics.notify
 description: >
   Test Atomics.notify on non-shared integer TypedArrays
-includes: [testTypedArray.js]
 features: [ArrayBuffer, Atomics, TypedArray]
 ---*/
 

--- a/test/built-ins/Atomics/notify/non-shared-int-views.js
+++ b/test/built-ins/Atomics/notify/non-shared-int-views.js
@@ -5,7 +5,6 @@
 esid: sec-atomics.notify
 description: >
   Test Atomics.notify on non-shared integer TypedArrays
-includes: [testTypedArray.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 

--- a/test/built-ins/Atomics/wait/negative-index-throws.js
+++ b/test/built-ins/Atomics/wait/negative-index-throws.js
@@ -14,7 +14,6 @@ info: |
         ...
         2.b If integerIndex < 0, throw a RangeError exception
 
-includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, TypedArray]
 ---*/
 

--- a/test/built-ins/Atomics/wait/object-for-timeout.js
+++ b/test/built-ins/Atomics/wait/object-for-timeout.js
@@ -15,7 +15,6 @@ info: |
       Let primValue be ? ToPrimitive(argument, hint Number).
       Return ? ToNumber(primValue).
 
-includes: [atomicsHelper.js]
 features: [Atomics, SharedArrayBuffer, Symbol, Symbol.toPrimitive, TypedArray]
 flags: [CanBlockIsTrue]
 ---*/

--- a/test/built-ins/Date/parse/time-value-maximum-range.js
+++ b/test/built-ins/Date/parse/time-value-maximum-range.js
@@ -18,7 +18,6 @@ info: |
   smaller: exactly -100,000,000 days to 100,000,000 days measured relative to
   midnight at the beginning of 01 January, 1970 UTC. This gives a range of
   8,640,000,000,000,000 milliseconds to either side of 01 January, 1970 UTC.
-includes: [propertyHelper.js]
 ---*/
 
 const minDateStr = "-271821-04-20T00:00:00.000Z";

--- a/test/built-ins/Date/parse/zero.js
+++ b/test/built-ins/Date/parse/zero.js
@@ -18,7 +18,6 @@ info: |
   Date.parse(x.toString())
   Date.parse(x.toUTCString())
   Date.parse(x.toISOString())
-includes: [propertyHelper.js]
 ---*/
 
 const zero = new Date(0);

--- a/test/built-ins/FinalizationGroup/prototype/cleanupSome/iterator-holdings-multiple-values.js
+++ b/test/built-ins/FinalizationGroup/prototype/cleanupSome/iterator-holdings-multiple-values.js
@@ -29,7 +29,7 @@ info: |
     c. Return CreateIterResultObject(cell.[[Holdings]], false).
   9. Otherwise, return CreateIterResultObject(undefined, true).
 features: [FinalizationGroup, Symbol, host-gc-required]
-includes: [compareArray.js, async-gc.js]
+includes: [async-gc.js]
 flags: [async, non-deterministic]
 ---*/
 

--- a/test/built-ins/Function/prototype/toString/built-in-function-object.js
+++ b/test/built-ins/Function/prototype/toString/built-in-function-object.js
@@ -13,7 +13,7 @@ info: |
   NativeFunction:
     function IdentifierName_opt ( FormalParameters ) { [ native code ] }
 
-includes: [fnGlobalObject.js, nativeFunctionMatcher.js, wellKnownIntrinsicObjects.js]
+includes: [nativeFunctionMatcher.js, wellKnownIntrinsicObjects.js]
 features: [arrow-function]
 ---*/
 

--- a/test/built-ins/Object/defineProperties/15.2.3.7-6-a-28.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-6-a-28.js
@@ -18,9 +18,7 @@ Object.defineProperties(obj, {
   }
 });
 
-if (isWritable(obj, "prop")) {
-  $ERROR('Expected obj["prop"] not to be writable.');
-}
+verifyNotWritable(obj, "prop");
 
 if (!obj.hasOwnProperty("prop")) {
   $ERROR('Expected obj.hasOwnProperty("prop") to be true, actually ' + obj.hasOwnProperty("prop"));

--- a/test/built-ins/Promise/allSettled/resolve-non-thenable.js
+++ b/test/built-ins/Promise/allSettled/resolve-non-thenable.js
@@ -10,7 +10,7 @@ info: |
     a. Let valuesArray be ! CreateArrayFromList(values).
     b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
 flags: [async]
-includes: [compareArray.js, promiseHelper.js]
+includes: [promiseHelper.js]
 features: [Promise.allSettled]
 ---*/
 

--- a/test/built-ins/RegExp/match-indices/indices-array-element.js
+++ b/test/built-ins/RegExp/match-indices/indices-array-element.js
@@ -3,7 +3,6 @@
 
 /*---
 description: A matching element of indices is an Array with exactly two number properties.
-includes: [compareArray.js]
 esid: sec-getmatchindicesarray
 features: [regexp-match-indices]
 info: |

--- a/test/built-ins/String/prototype/matchAll/regexp-is-undefined-or-null-invokes-matchAll.js
+++ b/test/built-ins/String/prototype/matchAll/regexp-is-undefined-or-null-invokes-matchAll.js
@@ -12,7 +12,6 @@ info: |
     4. Let rx be ? RegExpCreate(R, "g").
     5. Return ? Invoke(rx, @@matchAll, « S »).
 features: [String.prototype.matchAll]
-includes: [compareArray.js, compareIterator.js, regExpUtils.js]
 ---*/
 
 var callCount = 0;

--- a/test/built-ins/String/prototype/matchAll/regexp-prototype-has-no-matchAll.js
+++ b/test/built-ins/String/prototype/matchAll/regexp-prototype-has-no-matchAll.js
@@ -15,7 +15,6 @@ info: |
     5. Return ? Invoke(rx, @@matchAll, « S »).
 
 features: [Symbol.matchAll, String.prototype.matchAll]
-includes: [compareArray.js, compareIterator.js, regExpUtils.js]
 ---*/
 
 assert.sameValue(typeof String.prototype.matchAll, "function");

--- a/test/built-ins/Symbol/prototype/description/description-symboldescriptivestring.js
+++ b/test/built-ins/Symbol/prototype/description/description-symboldescriptivestring.js
@@ -14,7 +14,6 @@ info: |
   Assert: Type(desc) is String.
   Return the string-concatenation of "Symbol(", desc, and ")".
 
-includes: [propertyHelper.js]
 features: [Symbol.prototype.description]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/map/BigInt/callbackfn-no-interaction-over-non-integer-properties.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/callbackfn-no-interaction-over-non-integer-properties.js
@@ -14,7 +14,7 @@ info: |
     b. Let kValue be ? Get(O, Pk).
     c. Let mappedValue be ? Call(callbackfn, T, « kValue, k, O »).
   ...
-includes: [testBigIntTypedArray.js, compareArray.js]
+includes: [testBigIntTypedArray.js]
 features: [BigInt, Symbol, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/map/callbackfn-no-interaction-over-non-integer-properties.js
+++ b/test/built-ins/TypedArray/prototype/map/callbackfn-no-interaction-over-non-integer-properties.js
@@ -14,7 +14,7 @@ info: |
     b. Let kValue be ? Get(O, Pk).
     c. Let mappedValue be ? Call(callbackfn, T, « kValue, k, O »).
   ...
-includes: [testTypedArray.js, compareArray.js]
+includes: [testTypedArray.js]
 features: [Symbol, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/set/BigInt/bigint-tobigint64.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/bigint-tobigint64.js
@@ -49,7 +49,6 @@ info: |
     2. Let int64bit be n modulo 2^64.
     3. If int64bit ≥ 2^63, return int64bit - 2^64; otherwise return int64bit.
 
-includes: [testBigIntTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/set/BigInt/bigint-tobiguint64.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/bigint-tobiguint64.js
@@ -49,7 +49,6 @@ info: |
     2. Let int64bit be n modulo 2^64.
     3. Return int64bit.
 
-includes: [testBigIntTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/results-with-empty-length.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/results-with-empty-length.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-%typedarray%.prototype.slice
 description: slice may return a new empty instance
-includes: [testBigIntTypedArray.js, compareArray.js]
+includes: [testBigIntTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/slice/BigInt/results-with-same-length.js
+++ b/test/built-ins/TypedArray/prototype/slice/BigInt/results-with-same-length.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-%typedarray%.prototype.slice
 description: slice may return a new instance with the same length
-includes: [testBigIntTypedArray.js, compareArray.js]
+includes: [testBigIntTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/slice/results-with-empty-length.js
+++ b/test/built-ins/TypedArray/prototype/slice/results-with-empty-length.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-%typedarray%.prototype.slice
 description: slice may return a new empty instance
-includes: [testTypedArray.js, compareArray.js]
+includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/slice/results-with-same-length.js
+++ b/test/built-ins/TypedArray/prototype/slice/results-with-same-length.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-%typedarray%.prototype.slice
 description: slice may return a new instance with the same length
-includes: [testTypedArray.js, compareArray.js]
+includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/sort/sorted-values-nan.js
+++ b/test/built-ins/TypedArray/prototype/sort/sorted-values-nan.js
@@ -13,7 +13,7 @@ info: |
 
   NOTE: Because NaN always compares greater than any other value, NaN property
   values always sort to the end of the result when comparefn is not provided.
-includes: [testTypedArray.js, compareArray.js]
+includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/results-with-empty-length.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/results-with-empty-length.js
@@ -8,7 +8,7 @@ info: |
 
   ...
   17. Return ? TypedArraySpeciesCreate(O, argumentsList).
-includes: [testBigIntTypedArray.js, compareArray.js]
+includes: [testBigIntTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/subarray/BigInt/results-with-same-length.js
+++ b/test/built-ins/TypedArray/prototype/subarray/BigInt/results-with-same-length.js
@@ -8,7 +8,7 @@ info: |
 
   ...
   17. Return ? TypedArraySpeciesCreate(O, argumentsList).
-includes: [testBigIntTypedArray.js, compareArray.js]
+includes: [testBigIntTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/subarray/results-with-empty-length.js
+++ b/test/built-ins/TypedArray/prototype/subarray/results-with-empty-length.js
@@ -8,7 +8,7 @@ info: |
 
   ...
   17. Return ? TypedArraySpeciesCreate(O, argumentsList).
-includes: [testTypedArray.js, compareArray.js]
+includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/subarray/results-with-same-length.js
+++ b/test/built-ins/TypedArray/prototype/subarray/results-with-same-length.js
@@ -8,7 +8,7 @@ info: |
 
   ...
   17. Return ? TypedArraySpeciesCreate(O, argumentsList).
-includes: [testTypedArray.js, compareArray.js]
+includes: [testTypedArray.js]
 features: [TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArrayConstructors/ctors-bigint/object-arg/bigint-tobigint64.js
+++ b/test/built-ins/TypedArrayConstructors/ctors-bigint/object-arg/bigint-tobigint64.js
@@ -59,7 +59,6 @@ info: |
     2. Let int64bit be n modulo 2^64.
     3. If int64bit ≥ 2^63, return int64bit - 2^64; otherwise return int64bit.
 
-includes: [testBigIntTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArrayConstructors/ctors-bigint/object-arg/bigint-tobiguint64.js
+++ b/test/built-ins/TypedArrayConstructors/ctors-bigint/object-arg/bigint-tobiguint64.js
@@ -59,7 +59,6 @@ info: |
     2. Let int64bit be n modulo 2^64.
     3. Return int64bit.
 
-includes: [testBigIntTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/tonumber-value-detached-buffer.js
+++ b/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/tonumber-value-detached-buffer.js
@@ -36,7 +36,7 @@ testWithBigIntTypedArrayConstructors(function(TA) {
     {
       value: {
         valueOf: function() {
-          $262.detachArrayBuffer(ta.buffer);
+          $DETACHBUFFER(ta.buffer);
           return 42n;
         }
       }

--- a/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/tonumber-value-detached-buffer.js
+++ b/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/tonumber-value-detached-buffer.js
@@ -36,7 +36,7 @@ testWithTypedArrayConstructors(function(TA) {
     {
       value: {
         valueOf: function() {
-          $262.detachArrayBuffer(ta.buffer);
+          $DETACHBUFFER(ta.buffer);
           return 42;
         }
       }

--- a/test/built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/abrupt-from-ordinary-has-parent-hasproperty.js
+++ b/test/built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/abrupt-from-ordinary-has-parent-hasproperty.js
@@ -23,7 +23,7 @@ info: |
   5. If parent is not null, then
     a. Return ? parent.[[HasProperty]](P).
   6. Return false.
-includes: [testBigIntTypedArray.js, detachArrayBuffer.js]
+includes: [testBigIntTypedArray.js]
 features: [BigInt, Reflect, Proxy, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArrayConstructors/internals/HasProperty/abrupt-from-ordinary-has-parent-hasproperty.js
+++ b/test/built-ins/TypedArrayConstructors/internals/HasProperty/abrupt-from-ordinary-has-parent-hasproperty.js
@@ -23,7 +23,7 @@ info: |
   5. If parent is not null, then
     a. Return ? parent.[[HasProperty]](P).
   6. Return false.
-includes: [testTypedArray.js, detachArrayBuffer.js]
+includes: [testTypedArray.js]
 features: [Reflect, Proxy, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/bigint-tobigint64.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/bigint-tobigint64.js
@@ -65,7 +65,6 @@ info: |
     2. Let int64bit be n modulo 2^64.
     3. If int64bit ≥ 2^63, return int64bit - 2^64; otherwise return int64bit.
 
-includes: [testBigIntTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/bigint-tobiguint64.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/bigint-tobiguint64.js
@@ -65,7 +65,6 @@ info: |
     2. Let int64bit be n modulo 2^64.
     3. Return int64bit.
 
-includes: [testBigIntTypedArray.js]
 features: [BigInt, TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/tonumber-value-detached-buffer.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/BigInt/tonumber-value-detached-buffer.js
@@ -32,7 +32,7 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     Reflect.set(ta, 0, {
       valueOf: function() {
-        $262.detachArrayBuffer(ta.buffer);
+        $DETACHBUFFER(ta.buffer);
         return 42n;
       }
     });

--- a/test/built-ins/TypedArrayConstructors/internals/Set/tonumber-value-detached-buffer.js
+++ b/test/built-ins/TypedArrayConstructors/internals/Set/tonumber-value-detached-buffer.js
@@ -32,7 +32,7 @@ testWithTypedArrayConstructors(function(TA) {
   assert.throws(TypeError, function() {
     Reflect.set(ta, 0, {
       valueOf: function() {
-        $262.detachArrayBuffer(ta.buffer);
+        $DETACHBUFFER(ta.buffer);
         return 42;
       }
     });

--- a/test/built-ins/WeakMap/iterable.js
+++ b/test/built-ins/WeakMap/iterable.js
@@ -11,7 +11,6 @@ info: |
   9. Repeat
     k. Let status be Call(adder, map, «k.[[value]], v.[[value]]»).
     l. If status is an abrupt completion, return IteratorClose(iter, status).
-includes: [compareArray.js]
 ---*/
 
 var first = {};

--- a/test/built-ins/WeakSet/iterable.js
+++ b/test/built-ins/WeakSet/iterable.js
@@ -11,7 +11,6 @@ info: |
   9. Repeat
     f. Let status be Call(adder, set, «nextValue»).
     g. If status is an abrupt completion, return IteratorClose(iter, status).
-includes: [compareArray.js]
 ---*/
 
 var first = {};

--- a/test/intl402/DateTimeFormat/numbering-system-calendar-options.js
+++ b/test/intl402/DateTimeFormat/numbering-system-calendar-options.js
@@ -7,7 +7,6 @@ description: >
     Tests that the options numberingSystem and calendar can be  set through
     either the locale or the options.
 author: Norbert Lindenberg, Daniel Ehrenberg
-includes: [testIntl.js]
 ---*/
 
 let defaultLocale = new Intl.DateTimeFormat().resolvedOptions().locale;

--- a/test/intl402/Intl/getCanonicalLocales/error-cases.js
+++ b/test/intl402/Intl/getCanonicalLocales/error-cases.js
@@ -8,7 +8,6 @@ info: |
   8.2.1 Intl.getCanonicalLocales (locales)
   1. Let ll be ? CanonicalizeLocaleList(locales).
   2. Return CreateArrayFromList(ll).
-includes: [compareArray.js]
 features: [Symbol]
 ---*/
 

--- a/test/intl402/ListFormat/constructor/constructor/locales-valid.js
+++ b/test/intl402/ListFormat/constructor/constructor/locales-valid.js
@@ -7,7 +7,6 @@ description: Checks various cases for the locales argument to the ListFormat con
 info: |
     InitializeListFormat (listFormat, locales, options)
     1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-includes: [testIntl.js]
 features: [Intl.ListFormat]
 ---*/
 

--- a/test/intl402/NumberFormat/numbering-system-options.js
+++ b/test/intl402/NumberFormat/numbering-system-options.js
@@ -7,7 +7,6 @@ description: >
     Tests that the options numberingSystem and calendar can be  set through
     either the locale or the options.
 author: Norbert Lindenberg, Daniel Ehrenberg
-includes: [testIntl.js]
 ---*/
 
 let defaultLocale = new Intl.NumberFormat().resolvedOptions().locale;

--- a/test/intl402/PluralRules/prototype/resolvedOptions/pluralCategories.js
+++ b/test/intl402/PluralRules/prototype/resolvedOptions/pluralCategories.js
@@ -6,7 +6,7 @@ esid: sec-Intl.PluralRules.prototype.resolvedOptions
 description: >
     Tests that Intl.PluralRules.prototype.resolvedOptions creates a new array
     for the pluralCategories property on every call.
-includes: [testIntl.js, propertyHelper.js, compareArray.js]
+includes: [propertyHelper.js, compareArray.js]
 ---*/
 
 const allowedValues = ["zero", "one", "two", "few", "many", "other"];

--- a/test/intl402/RelativeTimeFormat/constructor/constructor/locales-valid.js
+++ b/test/intl402/RelativeTimeFormat/constructor/constructor/locales-valid.js
@@ -7,7 +7,6 @@ description: Checks various cases for the locales argument to the RelativeTimeFo
 info: |
     InitializeRelativeTimeFormat (relativeTimeFormat, locales, options)
     3. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-includes: [testIntl.js]
 features: [Intl.RelativeTimeFormat]
 ---*/
 

--- a/test/intl402/Segmenter/constructor/constructor/locales-valid.js
+++ b/test/intl402/Segmenter/constructor/constructor/locales-valid.js
@@ -8,7 +8,6 @@ info: |
     Intl.Segmenter ([ locales [ , options ]])
 
     3. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-includes: [testIntl.js]
 features: [Intl.Segmenter]
 ---*/
 

--- a/test/language/expressions/async-generator/named-yield-spread-obj.js
+++ b/test/language/expressions/async-generator/named-yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Named async generator 
 esid: prod-AsyncGeneratorExpression
 features: [object-spread, async-iteration]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     Async Generator Function Definitions
 

--- a/test/language/expressions/async-generator/yield-spread-obj.js
+++ b/test/language/expressions/async-generator/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Unnamed async generato
 esid: prod-AsyncGeneratorExpression
 features: [object-spread, async-iteration]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     Async Generator Function Definitions
 

--- a/test/language/expressions/class/async-gen-method-static/yield-spread-obj.js
+++ b/test/language/expressions/class/async-gen-method-static/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Static async generator
 esid: prod-AsyncGeneratorMethod
 features: [object-spread, async-iteration]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     ClassElement :
       static MethodDefinition

--- a/test/language/expressions/class/async-gen-method/yield-spread-obj.js
+++ b/test/language/expressions/class/async-gen-method/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Async generator method
 esid: prod-AsyncGeneratorMethod
 features: [object-spread, async-iteration]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     ClassElement :
       MethodDefinition

--- a/test/language/expressions/class/elements/async-gen-private-method-static/yield-spread-obj.js
+++ b/test/language/expressions/class/elements/async-gen-private-method-static/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Static async generator
 esid: prod-AsyncGeneratorPrivateMethod
 features: [object-spread, async-iteration, class-static-methods-private]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     ClassElement :
       static PrivateMethodDefinition

--- a/test/language/expressions/class/elements/async-gen-private-method/yield-spread-obj.js
+++ b/test/language/expressions/class/elements/async-gen-private-method/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Async generator method
 esid: prod-AsyncGeneratorPrivateMethod
 features: [object-spread, async-iteration, class-methods-private]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     ClassElement :
       PrivateMethodDefinition

--- a/test/language/expressions/class/elements/fields-multiple-definitions-static-private-methods-proxy.js
+++ b/test/language/expressions/class/elements/fields-multiple-definitions-static-private-methods-proxy.js
@@ -5,7 +5,6 @@
 description: Static private methods not accessible via default Proxy handler
 esid: prod-FieldDefinition
 features: [class, class-static-methods-private]
-includes: [propertyHelper.js]
 info: |
     ClassElement :
       ...

--- a/test/language/expressions/class/elements/gen-private-method-static/yield-spread-obj.js
+++ b/test/language/expressions/class/elements/gen-private-method-static/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Static generator priva
 esid: prod-GeneratorPrivateMethod
 features: [object-spread, generators, class-static-methods-private]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     ClassElement :
       static PrivateMethodDefinition

--- a/test/language/expressions/class/elements/gen-private-method/yield-spread-obj.js
+++ b/test/language/expressions/class/elements/gen-private-method/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Generator private meth
 esid: prod-GeneratorPrivateMethod
 features: [object-spread, generators, class-methods-private]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     ClassElement :
       PrivateMethodDefinition

--- a/test/language/expressions/class/gen-method-static/yield-spread-obj.js
+++ b/test/language/expressions/class/gen-method-static/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Static generator metho
 esid: prod-GeneratorMethod
 features: [object-spread, generators]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     ClassElement :
       static MethodDefinition

--- a/test/language/expressions/class/gen-method/yield-spread-obj.js
+++ b/test/language/expressions/class/gen-method/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Generator method as a 
 esid: prod-GeneratorMethod
 features: [object-spread, generators]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     ClassElement :
       MethodDefinition

--- a/test/language/expressions/dynamic-import/namespace/await-ns-extensible.js
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-extensible.js
@@ -6,7 +6,6 @@ description: Module namespace objects are not extensible. (value from await reso
 esid: sec-finishdynamicimport
 features: [dynamic-import]
 flags: [generated, async]
-includes: [propertyHelper.js]
 info: |
     Runtime Semantics: FinishDynamicImport ( referencingScriptOrModule, specifier, promiseCapability, completion )
 

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-extensible.js
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-extensible.js
@@ -6,7 +6,6 @@ description: Module namespace objects are not extensible. (value from promise th
 esid: sec-finishdynamicimport
 features: [dynamic-import]
 flags: [generated, async]
-includes: [propertyHelper.js]
 info: |
     Runtime Semantics: FinishDynamicImport ( referencingScriptOrModule, specifier, promiseCapability, completion )
 

--- a/test/language/expressions/generators/named-yield-spread-obj.js
+++ b/test/language/expressions/generators/named-yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Named generator expres
 esid: prod-GeneratorExpression
 features: [object-spread, generators]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     14.4 Generator Function Definitions
 

--- a/test/language/expressions/generators/yield-spread-obj.js
+++ b/test/language/expressions/generators/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Unnamed generator expr
 esid: prod-GeneratorExpression
 features: [object-spread, generators]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     14.4 Generator Function Definitions
 

--- a/test/language/expressions/object/method-definition/async-gen-yield-spread-obj.js
+++ b/test/language/expressions/object/method-definition/async-gen-yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Async generator method
 esid: prod-AsyncGeneratorMethod
 features: [object-spread, async-iteration]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     Async Generator Function Definitions
 

--- a/test/language/expressions/object/method-definition/gen-yield-spread-obj.js
+++ b/test/language/expressions/object/method-definition/gen-yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Generator method)
 esid: prod-GeneratorMethod
 features: [object-spread, generators]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     14.4 Generator Function Definitions
 

--- a/test/language/statements/async-generator/yield-spread-obj.js
+++ b/test/language/statements/async-generator/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Async generator Functi
 esid: prod-AsyncGeneratorDeclaration
 features: [object-spread, async-iteration]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     Async Generator Function Definitions
 

--- a/test/language/statements/class/async-gen-method-static/yield-spread-obj.js
+++ b/test/language/statements/class/async-gen-method-static/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Static async generator
 esid: prod-AsyncGeneratorMethod
 features: [object-spread, async-iteration]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     ClassElement :
       static MethodDefinition

--- a/test/language/statements/class/async-gen-method/yield-spread-obj.js
+++ b/test/language/statements/class/async-gen-method/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Async Generator method
 esid: prod-AsyncGeneratorMethod
 features: [object-spread, async-iteration]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     ClassElement :
       MethodDefinition

--- a/test/language/statements/class/elements/async-gen-private-method-static/yield-spread-obj.js
+++ b/test/language/statements/class/elements/async-gen-private-method-static/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Static async generator
 esid: prod-AsyncGeneratorPrivateMethod
 features: [object-spread, async-iteration, class-static-methods-private]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     ClassElement :
       static PrivateMethodDefinition

--- a/test/language/statements/class/elements/async-gen-private-method/yield-spread-obj.js
+++ b/test/language/statements/class/elements/async-gen-private-method/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Async Generator method
 esid: prod-AsyncGeneratorPrivateMethod
 features: [object-spread, async-iteration, class-methods-private]
 flags: [generated, async]
-includes: [compareArray.js]
 info: |
     ClassElement :
       PrivateMethodDefinition

--- a/test/language/statements/class/elements/class-field-on-frozen-objects.js
+++ b/test/language/statements/class/elements/class-field-on-frozen-objects.js
@@ -13,7 +13,6 @@ info: |
       a. Assert: IsPropertyKey(fieldName) is true.
       b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
     10. Return.
-includes: [compareArray.js]
 features: [class, class-fields-public]
 flags: [onlyStrict]
 ---*/

--- a/test/language/statements/class/elements/fields-computed-name-propname-constructor.js
+++ b/test/language/statements/class/elements/fields-computed-name-propname-constructor.js
@@ -39,7 +39,6 @@ info: |
     3. Let newDesc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: true,
       [[Configurable]]: true }.
     4. Return ? O.[[DefineOwnProperty]](P, newDesc).
-includes: [propertyHelper.js]
 ---*/
 
 var x = "constructor";

--- a/test/language/statements/class/elements/gen-private-method-static/yield-spread-obj.js
+++ b/test/language/statements/class/elements/gen-private-method-static/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Static generator priva
 esid: prod-GeneratorPrivateMethod
 features: [object-spread, generators, class-static-methods-private]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     ClassElement :
       static PrivateMethodDefinition

--- a/test/language/statements/class/elements/gen-private-method/yield-spread-obj.js
+++ b/test/language/statements/class/elements/gen-private-method/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Generator private meth
 esid: prod-GeneratorPrivateMethod
 features: [object-spread, generators, class-methods-private]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     ClassElement :
       PrivateMethodDefinition

--- a/test/language/statements/class/elements/private-class-field-on-frozen-objects.js
+++ b/test/language/statements/class/elements/private-class-field-on-frozen-objects.js
@@ -13,7 +13,6 @@ info: |
       a. Assert: IsPropertyKey(fieldName) is true.
       b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
     10. Return.
-includes: [compareArray.js]
 features: [class, class-fields-private, class-fields-public]
 flags: [onlyStrict]
 ---*/

--- a/test/language/statements/class/elements/public-class-field-initialization-is-visible-to-proxy.js
+++ b/test/language/statements/class/elements/public-class-field-initialization-is-visible-to-proxy.js
@@ -13,7 +13,6 @@ info: |
       a. Assert: IsPropertyKey(fieldName) is true.
       b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
     10. Return.
-includes: [propertyHelper.js]
 features: [class, class-fields-public]
 ---*/
 

--- a/test/language/statements/class/gen-method-static/yield-spread-obj.js
+++ b/test/language/statements/class/gen-method-static/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Static generator metho
 esid: prod-GeneratorMethod
 features: [object-spread, generators]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     ClassElement :
       static MethodDefinition

--- a/test/language/statements/class/gen-method/yield-spread-obj.js
+++ b/test/language/statements/class/gen-method/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Generator method as a 
 esid: prod-GeneratorMethod
 features: [object-spread, generators]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     ClassElement :
       MethodDefinition

--- a/test/language/statements/generators/yield-spread-obj.js
+++ b/test/language/statements/generators/yield-spread-obj.js
@@ -6,7 +6,6 @@ description: Use yield value in a object spread position (Generator Function dec
 esid: prod-GeneratorDeclaration
 features: [object-spread, generators]
 flags: [generated]
-includes: [compareArray.js]
 info: |
     14.4 Generator Function Definitions
 


### PR DESCRIPTION
The values defined by the referenced files are not used by these tests.
This makes their inclusion superfluous, which needlessly increases the
time to execute the tests and may confuse some readers.

Also,

Update tests to use APIs defined by included files

The `$DETACHBUFFER` function is the preferred mechanism for detaching array buffers.

Likewise, `verifyNotWritable` is the preferred mechanism for asserting lack of writability.