### PR TITLE
Correct syntax in generated tests

### DIFF
--- a/src/dstr-assignment-for-await/error-async-function-syntax/async-func-decl.template
+++ b/src/dstr-assignment-for-await/error-async-function-syntax/async-func-decl.template
@@ -26,5 +26,5 @@ info: |
 ---*/
 
 async function fn() {
-  for await (/*{ elems }*/ of [/*{ vals }*/])
+  for await (/*{ elems }*/ of [/*{ vals }*/]) {}
 }

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-yield-ident-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-yield-ident-invalid.js
@@ -30,5 +30,5 @@ info: |
 $DONOTEVALUATE();
 
 async function fn() {
-  for await ([ x = yield ] of [[]])
+  for await ([ x = yield ] of [[]]) {}
 }

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-array-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-array-invalid.js
@@ -30,5 +30,5 @@ info: |
 $DONOTEVALUATE();
 
 async function fn() {
-  for await ([[(x, y)]] of [[[]]])
+  for await ([[(x, y)]] of [[[]]]) {}
 }

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-array-yield-ident-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-array-yield-ident-invalid.js
@@ -30,5 +30,5 @@ info: |
 $DONOTEVALUATE();
 
 async function fn() {
-  for await ([[x[yield]]] of [[[]]])
+  for await ([[x[yield]]] of [[[]]]) {}
 }

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-obj-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-obj-invalid.js
@@ -30,5 +30,5 @@ info: |
 $DONOTEVALUATE();
 
 async function fn() {
-  for await ([{ get x() {} }] of [[{}]])
+  for await ([{ get x() {} }] of [[{}]]) {}
 }

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-obj-yield-ident-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-obj-yield-ident-invalid.js
@@ -30,5 +30,5 @@ info: |
 $DONOTEVALUATE();
 
 async function fn() {
-  for await ([{ x = yield }] of [[{}]])
+  for await ([{ x = yield }] of [[{}]]) {}
 }

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-target-simple-strict.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-target-simple-strict.js
@@ -30,5 +30,5 @@ info: |
 $DONOTEVALUATE();
 
 async function fn() {
-  for await ([arguments] of [[]])
+  for await ([arguments] of [[]]) {}
 }

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-target-yield-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-target-yield-invalid.js
@@ -30,5 +30,5 @@ info: |
 $DONOTEVALUATE();
 
 async function fn() {
-  for await ([ x[yield] ] of [[]])
+  for await ([ x[yield] ] of [[]]) {}
 }


### PR DESCRIPTION
Prior to the application of this patch, the modified test template
included an unintentional syntax error. This caused all generated tests
to spuriously satisfy the expectation for an error.

Correct the syntax in the test template and regenerate the tests,
ensuring that when engines report a syntax error, they are demonstrating
the behavior which the tests were designed to verify.