### PR TITLE
Avoid false positive

### DIFF
--- a/test/built-ins/Object/defineProperty/15.2.3.6-4-243-2.js
+++ b/test/built-ins/Object/defineProperty/15.2.3.6-4-243-2.js
@@ -23,17 +23,11 @@ Object.defineProperty(arrObj, "1", {
   configurable: true
 });
 
-try {
+assert.throws(TypeError, function() {
   arrObj[1] = 4;
-} catch (e) {
-  verifyEqualTo(arrObj, "1", getFunc());
+});
+verifyEqualTo(arrObj, "1", getFunc());
 
-  verifyNotEnumerable(arrObj, "1");
+verifyNotEnumerable(arrObj, "1");
 
-  verifyConfigurable(arrObj, "1");
-
-  if (!(e instanceof TypeError)) {
-    $ERROR("Expected TypeError, got " + e);
-  }
-
-}
+verifyConfigurable(arrObj, "1");


### PR DESCRIPTION
Prior to this patch, the modified test would pass if no exception was
produced. Use the `assert.throws` utility function to concisely express
the expectation more completely.