### PR TITLE
Add test for #349 and #351 PR

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/formatToParts/related-year.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/related-year.js
@@ -1,0 +1,20 @@
+// Copyright 2019 Google Inc.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-partitiondatetimepattern
+description: Checks the output of 'relatedYear' and 'yearName' type, and
+    the choose of pattern base on calendar.
+locale: [en-u-ca-chinese]
+---*/
+
+let df = new Intl.DateTimeFormat("en-u-ca-chinese", {year: "numeric"});
+let parts = df.formatToParts(new Date());
+var relatedYearCount = 0;
+var yearNameCount = 0;
+parts.forEach(function(part) {
+  relatedYearCount += (part.type == "relatedYear") ? 1 : 0;
+  yearNameCount += (part.type == "yearName") ? 1 : 0;
+});
+assert.sameValue(relatedYearCount > 0, true);
+assert.sameValue(yearNameCount > 0, true);


### PR DESCRIPTION
Test DateTimeFormat change pattern based on calendar and output relatedYear and yearName
based on the assumption that "en-u-ca-chinese" will output 'relatedYear' and 'yearName'.
https://github.com/tc39/ecma402/pull/349
https://github.com/tc39/ecma402/pull/351
@rwaldron @leobalter @Ms2ger @littledan

To address https://github.com/tc39/test262/issues/2332 and https://github.com/tc39/test262/issues/2333 