### PR TITLE
Test coverage for `proposal-optional-chaining`

### DIFF
--- a/test/language/punctuators/optional-chaining/computed-property-access.js
+++ b/test/language/punctuators/optional-chaining/computed-property-access.js
@@ -1,0 +1,11 @@
+/*---
+esid: pending
+features: [optional-chaining]
+info: |
+  Access computed properties using optional chaining.
+---*/
+let x = 'my-key';
+let keyAbsent = undefined;
+let keyPresent = { 'my-key': 5 };
+assert(keyAbsent ?.[x] === undefined, 'Expected to get undefined value');
+assert(keyPresent ?.[x] === 5, 'Expected to obtain property value');

--- a/test/language/punctuators/optional-chaining/decimal-digit-is-syntax-error.js
+++ b/test/language/punctuators/optional-chaining/decimal-digit-is-syntax-error.js
@@ -1,0 +1,13 @@
+/*---
+esid: pending
+features: [optional-chaining]
+info: |
+  Optional-chaining operator followed by a numeric character is always a syntax error.
+description: Disallow numbers after `?.` operator
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+let a = null;
+a ? .5;

--- a/test/language/punctuators/optional-chaining/deep-optional-chain.js
+++ b/test/language/punctuators/optional-chaining/deep-optional-chain.js
@@ -1,0 +1,16 @@
+/*---
+esid: pending
+features: [optional-chaining]
+info: |
+  Deep optional property access should always return `undefined` if the chain breaks,
+  even if the breakage was caused by a `null` value.
+---*/
+
+let testValue = {
+  a: {
+    b: null
+  }
+};
+
+assert(testValue ?.a ?.b === null, 'Chain should resolve to `null` value');
+assert(testValue ?.a ?.b ?.c === undefined, 'Optional chain should return `undefined`');

--- a/test/language/punctuators/optional-chaining/disallow-keyword-optional-property-access.js
+++ b/test/language/punctuators/optional-chaining/disallow-keyword-optional-property-access.js
@@ -1,0 +1,11 @@
+/*---
+esid: pending
+features: [optional-chaining]
+info: |
+  It is a SyntaxError to attempt to optionally access properties on keywords.
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+let a = import ?.property;

--- a/test/language/punctuators/optional-chaining/disallow-optional-constructors.js
+++ b/test/language/punctuators/optional-chaining/disallow-optional-constructors.js
@@ -1,0 +1,13 @@
+/*---
+esid: pending
+features: [optional-chaining]
+info: |
+  Optionally calling a constructor is disallowed
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+function A() { }
+
+new A ?.();

--- a/test/language/punctuators/optional-chaining/disallow-optional-super.js
+++ b/test/language/punctuators/optional-chaining/disallow-optional-super.js
@@ -1,0 +1,19 @@
+/*---
+esid: pending
+features: [optional-chaining]
+info: |
+  Optional access to super properties is disallowed
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+class Parent {
+  method() { }
+}
+
+class Child extends Parent {
+  method() {
+    super?.method();
+  }
+}

--- a/test/language/punctuators/optional-chaining/error-before-template-production.js
+++ b/test/language/punctuators/optional-chaining/error-before-template-production.js
@@ -1,0 +1,18 @@
+/*---
+esid: pending
+info: |
+  Prevent automatic semicolon insertion rules from creating ambiguous behavior
+  before a template string. The purpose is to maintain consistency with similar
+  code without optional chaining operator:
+
+     a.b
+     `c`
+description: Optional chain before template string is a syntax error.
+features: [optional-chaining]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+let result = a ?.b
+  `c`;

--- a/test/language/punctuators/optional-chaining/forbid-in-write-context.js
+++ b/test/language/punctuators/optional-chaining/forbid-in-write-context.js
@@ -1,0 +1,14 @@
+/*---
+esid: pending
+info: |
+  Optional chaining is forbidden in write contexts such as `a?.b = c`.
+  This is handled by defining properly the IsSimpleAssignmentTarget
+  static semantics rule.
+description: Try to use optional chaining in LHS of assignment
+features: [optional-chaining]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+a ?.b = c;

--- a/test/language/punctuators/optional-chaining/method-call.js
+++ b/test/language/punctuators/optional-chaining/method-call.js
@@ -1,0 +1,15 @@
+/*---
+esid: pending
+features: [optional-chaining]
+info: |
+  Calling a method using the optional-chaining syntax.
+---*/
+
+let a = {
+  methodExists() {
+    return 5;
+  }
+};
+
+assert(a.methodExists ?.() === 5, 'Should call method if it exists');
+assert(a.methodDoesNotExist ?.() === undefined, 'Should return `undefined` for missing methods');

--- a/test/language/punctuators/optional-chaining/permit-optional-delete.js
+++ b/test/language/punctuators/optional-chaining/permit-optional-delete.js
@@ -1,0 +1,14 @@
+/*---
+esid: pending
+info: |
+  Optional deletion as in: `delete a ?.b` is supported.
+description: Try to use optional chaining in `delete` statement
+features: [optional-chaining]
+---*/
+
+let a = null;
+assert(delete a ?.b === undefined, 'Permit optional delete from falsey value');
+
+let c = { d: 5 };
+assert(delete c ?.d === true, 'Optional delete should proceed normally if property/value are present');
+assert(('d' in c) === false, 'Property delete should have succeeded');

--- a/test/language/punctuators/optional-chaining/property-access.js
+++ b/test/language/punctuators/optional-chaining/property-access.js
@@ -1,0 +1,14 @@
+/*---
+esid: pending
+features: [optional-chaining]
+info: |
+  Optional-chaining for property keys.
+description: Typical property access
+---*/
+let nullValue = null;
+let undefinedValue = undefined;
+let keyPresent = { key: 5 };
+
+assert(nullValue ?.key === undefined, 'Expected to get undefined value');
+assert(undefinedValue ?.key === undefined, 'Expected to get undefined value');
+assert(keyPresent ?.key === 5, 'Expected to obtain property value');

--- a/test/language/punctuators/optional-chaining/short-circuiting.js
+++ b/test/language/punctuators/optional-chaining/short-circuiting.js
@@ -1,0 +1,22 @@
+/*---
+esid: pending
+features: [optional-chaining]
+info: |
+  If the expression on the LHS of `?.` evaluates to null/undefined, the RHS is not evaluated.
+description: Optional-chaining short-circuiting
+---*/
+
+let x = 0;
+
+let a = null;
+a ?.[++x];
+
+assert(x === 0, 'RHS should not be evaluated if `?.` on LHS gives `undefined` value');
+
+let y = 0;
+a = { [1]: { b: {} } }
+
+a ?.[++x] ?.b.callMethod ?.(++y);
+assert(x === 1, 'Evaluation should continue if `?.` property access succeeds');
+assert(y === 0, 'RHS should not be evaluated in long chain if prior property access failed');
+


### PR DESCRIPTION
Started to write tests for `proposal-optional-chaining`. I've added the required metadata into the file headers, but I'm not sure if I've done it properly so I'd be happy to rework it if someone gives me pointers.

I've tested this by passing the following script as `--transformer`.

<details>
<summary>transform.js</summary>
<pre>
    const babel = require("@babel/core");
    const optionalChaining = require('@babel/plugin-proposal-optional-chaining');
    module.exports = (source) => {
      try {
        const result = babel.transform(source, {
          babelrc: false,
          plugins: [optionalChaining],
          parserOpts: {
            plugins: ['optionalChaining']
          }
        });
        return result.code;
      } catch (error) {
        return `throw new SyntaxError(${JSON.stringify(error.message)});`;
      }
    }
</pre>
</details>