### PR TITLE
Use isConstructor in "executor-function-nonconstructor.js"

### DIFF
--- a/test/built-ins/Promise/executor-function-nonconstructor.js
+++ b/test/built-ins/Promise/executor-function-nonconstructor.js
@@ -2,13 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es6id: 25.4.1.5.1
-description: GetCapabilitiesExecutor functions are not constructors
+esid: sec-getcapabilitiesexecutor-functions
+description: GetCapabilitiesExecutor function is not constructor
 info: |
   17 ECMAScript Standard Built-in Objects:
     Built-in function objects that are not identified as constructors do not
     implement the [[Construct]] internal method unless otherwise specified
     in the description of a particular function.
+includes: [isConstructor.js]
+features: [Reflect.construct]
 ---*/
 
 var executorFunction;
@@ -20,6 +22,4 @@ function NotPromise(executor) {
 Promise.resolve.call(NotPromise);
 
 assert.sameValue(Object.prototype.hasOwnProperty.call(executorFunction, "prototype"), false);
-assert.throws(TypeError, function() {
-  new executorFunction();
-});
+assert.sameValue(isConstructor(executorFunction), false);


### PR DESCRIPTION
This test case was giving false-positive in JSC: [`GetCapabilitiesExecutor`](https://tc39.es/ecma262/#sec-getcapabilitiesexecutor-functions) throws `TypeError` when called second time (steps 4 and 5).