### PR TITLE
Use canonical format for the description in the metatags

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/formatToParts/related-year.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/related-year.js
@@ -3,8 +3,9 @@
 
 /*---
 esid: sec-partitiondatetimepattern
-description: Checks the output of 'relatedYear' and 'yearName' type, and
-    the choose of pattern base on calendar.
+description: >
+  Checks the output of 'relatedYear' and 'yearName' type, and
+  the choose of pattern base on calendar.
 locale: [en-u-ca-chinese]
 ---*/
 

--- a/test/intl402/ListFormat/prototype/format/branding.js
+++ b/test/intl402/ListFormat/prototype/format/branding.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Verifies the branding check for the "format" function of the ListFormat prototype object.
+description: >
+    Verifies the branding check for the "format" function of the ListFormat prototype object.
 info: |
     Intl.ListFormat.prototype.format ([ list ])
 

--- a/test/intl402/ListFormat/prototype/format/en-us-default.js
+++ b/test/intl402/ListFormat/prototype/format/en-us-default.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Intl.ListFormat.prototype.format() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.format() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/format/en-us-disjunction.js
+++ b/test/intl402/ListFormat/prototype/format/en-us-disjunction.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Intl.ListFormat.prototype.format() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.format() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/format/en-us-narrow.js
+++ b/test/intl402/ListFormat/prototype/format/en-us-narrow.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Intl.ListFormat.prototype.format() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.format() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/format/en-us-short.js
+++ b/test/intl402/ListFormat/prototype/format/en-us-short.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Intl.ListFormat.prototype.format() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.format() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/format/en-us-unit.js
+++ b/test/intl402/ListFormat/prototype/format/en-us-unit.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Intl.ListFormat.prototype.format() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.format() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/format/es-es-long.js
+++ b/test/intl402/ListFormat/prototype/format/es-es-long.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Intl.ListFormat.prototype.format() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.format() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/format/es-es-narrow.js
+++ b/test/intl402/ListFormat/prototype/format/es-es-narrow.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Intl.ListFormat.prototype.format() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.format() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/format/es-es-short.js
+++ b/test/intl402/ListFormat/prototype/format/es-es-short.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Intl.ListFormat.prototype.format() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.format() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/format/iterable-getiterator-throw.js
+++ b/test/intl402/ListFormat/prototype/format/iterable-getiterator-throw.js
@@ -3,8 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
-    called by Intl.ListFormat.prototype.format() while the GetIterator
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable    called by Intl.ListFormat.prototype.format() while the GetIterator
     throws error.
 info: |
     StringListFromIterable

--- a/test/intl402/ListFormat/prototype/format/iterable-invalid.js
+++ b/test/intl402/ListFormat/prototype/format/iterable-invalid.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.format().
 info: |
     StringListFromIterable

--- a/test/intl402/ListFormat/prototype/format/iterable-iteratorclose.js
+++ b/test/intl402/ListFormat/prototype/format/iterable-iteratorclose.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.format() and check the IteratorClose
     calls return.
 info: |

--- a/test/intl402/ListFormat/prototype/format/iterable-iteratorstep-throw.js
+++ b/test/intl402/ListFormat/prototype/format/iterable-iteratorstep-throw.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.format() while iteratorStep throws error.
 info: |
     StringListFromIterable

--- a/test/intl402/ListFormat/prototype/format/iterable-iteratorvalue-throw.js
+++ b/test/intl402/ListFormat/prototype/format/iterable-iteratorvalue-throw.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.format() while iteratorValue throws error.
 info: |
     StringListFromIterable

--- a/test/intl402/ListFormat/prototype/format/iterable-undefined.js
+++ b/test/intl402/ListFormat/prototype/format/iterable-undefined.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.format(undefined).
 info: |
     StringListFromIterable

--- a/test/intl402/ListFormat/prototype/format/iterable.js
+++ b/test/intl402/ListFormat/prototype/format/iterable.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.format().
 info: |
     StringListFromIterable

--- a/test/intl402/ListFormat/prototype/format/length.js
+++ b/test/intl402/ListFormat/prototype/format/length.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the "length" property of Intl.ListFormat.prototype.format().
+description: >
+    Checks the "length" property of Intl.ListFormat.prototype.format().
 info: |
     Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 Language Specification, 10th edition, clause 17, or successor.
     The ListFormat constructor is a standard built-in property of the Intl object.

--- a/test/intl402/ListFormat/prototype/format/name.js
+++ b/test/intl402/ListFormat/prototype/format/name.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the "name" property of Intl.ListFormat.prototype.format().
+description: >
+    Checks the "name" property of Intl.ListFormat.prototype.format().
 info: |
     Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 Language Specification, 10th edition, clause 17, or successor.
     Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification.

--- a/test/intl402/ListFormat/prototype/format/prop-desc.js
+++ b/test/intl402/ListFormat/prototype/format/prop-desc.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the "format" property of the ListFormat prototype object.
+description: >
+    Checks the "format" property of the ListFormat prototype object.
 info: |
     Intl.ListFormat.prototype.format ([ list ])
 

--- a/test/intl402/ListFormat/prototype/formatToParts/branding.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/branding.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Verifies the branding check for the "formatToParts" function of the ListFormat prototype object.
+description: >
+    Verifies the branding check for the "formatToParts" function of the ListFormat prototype object.
 info: |
     Intl.ListFormat.prototype.formatToParts([ list ])
 

--- a/test/intl402/ListFormat/prototype/formatToParts/en-us-default.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/en-us-default.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/formatToParts/en-us-disjunction.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/en-us-disjunction.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/formatToParts/en-us-narrow.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/en-us-narrow.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/formatToParts/en-us-short.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/en-us-short.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/formatToParts/en-us-unit.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/en-us-unit.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/formatToParts/es-es-long.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/es-es-long.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/formatToParts/es-es-narrow.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/es-es-narrow.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/formatToParts/es-es-short.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/es-es-short.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
+description: >
+    Checks the behavior of Intl.ListFormat.prototype.formatToParts() in English.
 features: [Intl.ListFormat]
 locale: [en-US]
 ---*/

--- a/test/intl402/ListFormat/prototype/formatToParts/iterable-getiterator-throw.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/iterable-getiterator-throw.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.formatToParts() while the GetIterator
     throws error.
 info: |

--- a/test/intl402/ListFormat/prototype/formatToParts/iterable-invalid.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/iterable-invalid.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.formatToParts().
 info: |
     StringListFromIterable

--- a/test/intl402/ListFormat/prototype/formatToParts/iterable-iteratorclose.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/iterable-iteratorclose.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.formatToParts() and check the IteratorClose
     calls return.
 info: |

--- a/test/intl402/ListFormat/prototype/formatToParts/iterable-iteratorstep-throw.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/iterable-iteratorstep-throw.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.formatToParts() while iteratorStep throws error.
 info: |
     StringListFromIterable

--- a/test/intl402/ListFormat/prototype/formatToParts/iterable-iteratorvalue-throw.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/iterable-iteratorvalue-throw.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.formatToParts() while iteratorValue throws error.
 info: |
     StringListFromIterable

--- a/test/intl402/ListFormat/prototype/formatToParts/iterable-undefined.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/iterable-undefined.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.format
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.formatToParts(undefined).
 info: |
     StringListFromIterable

--- a/test/intl402/ListFormat/prototype/formatToParts/iterable.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/iterable.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the behavior of Abstract Operation StringListFromIterable
+description: >
+    Checks the behavior of Abstract Operation StringListFromIterable
     called by Intl.ListFormat.prototype.formatToParts().
 info: |
     StringListFromIterable

--- a/test/intl402/ListFormat/prototype/formatToParts/length.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/length.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the "length" property of Intl.ListFormat.prototype.formatToParts().
+description: >
+    Checks the "length" property of Intl.ListFormat.prototype.formatToParts().
 info: |
     Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 Language Specification, 10th edition, clause 17, or successor.
     The ListFormat constructor is a standard built-in property of the Intl object.

--- a/test/intl402/ListFormat/prototype/formatToParts/name.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/name.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the "name" property of Intl.ListFormat.prototype.formatToParts().
+description: >
+    Checks the "name" property of Intl.ListFormat.prototype.formatToParts().
 info: |
     Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 Language Specification, 10th edition, clause 17, or successor.
     Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification.

--- a/test/intl402/ListFormat/prototype/formatToParts/prop-desc.js
+++ b/test/intl402/ListFormat/prototype/formatToParts/prop-desc.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-Intl.ListFormat.prototype.formatToParts
-description: Checks the "formatToParts" property of the ListFormat prototype object.
+description: >
+    Checks the "formatToParts" property of the ListFormat prototype object.
 info: |
     Intl.ListFormat.prototype.formatToParts ()
 


### PR DESCRIPTION
Ref #2387

cc @rkirsling 