### PR TITLE
Adding case to test invalid syntax when using PrivateName after '?.'

### DIFF
--- a/src/class-elements/grammar-private-field-optional-chaining.case
+++ b/src/class-elements/grammar-private-field-optional-chaining.case
@@ -1,0 +1,20 @@
+// Copyright (C) 2019 Caio Lima (Igalia SL). All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: PrivateName after '?.' is not valid syntax
+info: |
+  Updated Productions
+
+  MemberExpression[Yield]:
+    MemberExpression[?Yield].PrivateName
+template: syntax/invalid
+features: [class-fields-private, optional-chaining]
+---*/
+
+//- elements
+#m = 'test262';
+
+access(obj) {
+  return obj?.#m;
+}

--- a/test/language/expressions/class/elements/syntax/early-errors/grammar-private-field-optional-chaining.js
+++ b/test/language/expressions/class/elements/syntax/early-errors/grammar-private-field-optional-chaining.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-field-optional-chaining.case
+// - src/class-elements/syntax/invalid/cls-expr-elements-invalid-syntax.template
+/*---
+description: PrivateName after '?.' is not valid syntax (class expression)
+esid: prod-ClassElement
+features: [class-fields-private, optional-chaining, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Updated Productions
+
+    MemberExpression[Yield]:
+      MemberExpression[?Yield].PrivateName
+
+---*/
+
+
+$DONOTEVALUATE();
+
+var C = class {
+  #m = 'test262';
+
+  access(obj) {
+    return obj?.#m;
+  }
+};

--- a/test/language/statements/class/elements/syntax/early-errors/grammar-private-field-optional-chaining.js
+++ b/test/language/statements/class/elements/syntax/early-errors/grammar-private-field-optional-chaining.js
@@ -1,0 +1,29 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-private-field-optional-chaining.case
+// - src/class-elements/syntax/invalid/cls-decl-elements-invalid-syntax.template
+/*---
+description: PrivateName after '?.' is not valid syntax (class declaration)
+esid: prod-ClassElement
+features: [class-fields-private, optional-chaining, class]
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+info: |
+    Updated Productions
+
+    MemberExpression[Yield]:
+      MemberExpression[?Yield].PrivateName
+
+---*/
+
+
+$DONOTEVALUATE();
+
+class C {
+  #m = 'test262';
+
+  access(obj) {
+    return obj?.#m;
+  }
+}


### PR DESCRIPTION
It closes #2407.