### PR TITLE
Add integer index tests for Proxy "set" and "has" traps

### DIFF
--- a/test/built-ins/Proxy/has/call-in-prototype-index.js
+++ b/test/built-ins/Proxy/has/call-in-prototype-index.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p
+description: >
+  Ordinary [[HasProperty]] forwards call to Proxy "has" trap with correct arguments.
+  (integer index property name)
+info: |
+  OrdinaryHasProperty ( O, P )
+
+  ...
+  4. Let parent be ? O.[[GetPrototypeOf]]().
+  5. If parent is not null, then
+    a. Return ? parent.[[HasProperty]](P).
+
+  [[HasProperty]] ( P )
+
+  ...
+  8. Let booleanTrapResult be ! ToBoolean(? Call(trap, handler, « target, P »)).
+  ...
+  10. Return booleanTrapResult.
+includes: [proxyTrapsHelper.js]
+features: [Proxy]
+---*/
+
+var _handler, _target, _prop;
+var proto = [14];
+var target = Object.create(proto);
+var handler = allowProxyTraps({
+  has: function(target, prop) {
+    _handler = this;
+    _target = target;
+    _prop = prop;
+
+    return false;
+  },
+});
+var proxy = new Proxy(target, handler);
+var array = [];
+Object.setPrototypeOf(array, proxy);
+
+assert.sameValue(1 in array, false);
+assert.sameValue(_handler, handler, 'handler is context');
+assert.sameValue(_target, target, 'target is the first parameter');
+assert.sameValue(_prop, '1', 'given prop is the second paramter');

--- a/test/built-ins/Proxy/has/call-in-prototype.js
+++ b/test/built-ins/Proxy/has/call-in-prototype.js
@@ -23,7 +23,8 @@ features: [Proxy]
 ---*/
 
 var _handler, _target, _prop;
-var target = {};
+var proto = {prop: 1};
+var target = Object.create(proto);
 var handler = allowProxyTraps({
   has: function(target, prop) {
     _handler = this;

--- a/test/built-ins/Proxy/set/call-parameters-prototype-index.js
+++ b/test/built-ins/Proxy/set/call-parameters-prototype-index.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver
+description: >
+  Ordinary [[Set]] forwards call to Proxy "set" trap with correct arguments.
+  (integer index property name)
+info: |
+  OrdinarySet ( O, P, V, Receiver )
+
+  ...
+  3. Return OrdinarySetWithOwnDescriptor(O, P, V, Receiver, ownDesc).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  ...
+  2. If ownDesc is undefined, then
+    a. Let parent be ? O.[[GetPrototypeOf]]().
+    b. If parent is not null, then
+      i. Return ? parent.[[Set]](P, V, Receiver).
+
+  [[Set]] ( P, V, Receiver )
+
+  ...
+  8. Let booleanTrapResult be ! ToBoolean(? Call(trap, handler, « target, P, V, Receiver »)).
+  ...
+  12. Return true.
+includes: [proxyTrapsHelper.js]
+features: [Proxy]
+---*/
+
+var _handler, _target, _prop, _value, _receiver;
+var target = {};
+var handler = allowProxyTraps({
+  set: function(target, prop, value, receiver) {
+    _handler = this;
+    _target = target;
+    _prop = prop;
+    _value = value;
+    _receiver = receiver;
+    return true;
+  },
+});
+
+var proxy = new Proxy(target, handler);
+var array = new Array(1);
+Object.setPrototypeOf(array, proxy);
+
+array[0] = 1;
+
+assert.sameValue(_handler, handler, 'handler object is the trap context');
+assert.sameValue(_target, target, 'first argument is the target object');
+assert.sameValue(_prop, '0', 'second argument is the property name');
+assert.sameValue(_value, 1, 'third argument is the new value');
+assert.sameValue(_receiver, array, 'fourth argument is the receiver object');


### PR DESCRIPTION
Motivation: JSC has distinct code paths for integer index property names.
As an example, please see [the fix of `OrdinaryHasProperty` to handle Proxy in prototype](https://trac.webkit.org/changeset/251940/webkit).
Follow-up of #2347 and #2382.