### PR TITLE
Add some more Proxy/ownKeys invariants tests

### DIFF
--- a/test/built-ins/Object/getOwnPropertyNames/proxy-invariant-absent-not-configurable-symbol-key.js
+++ b/test/built-ins/Object/getOwnPropertyNames/proxy-invariant-absent-not-configurable-symbol-key.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.getownpropertynames
+description: >
+  Proxy [[OwnPropertyKeys]] trap does not skip symbol keys when validating invariant:
+  * The result List must contain the keys of all non-configurable own properties of
+    the target object.
+info: |
+  Object.getOwnPropertyNames ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, String).
+
+  GetOwnPropertyKeys ( O, type )
+
+  ...
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+
+  [[OwnPropertyKeys]] ( )
+
+  ...
+  11. Let targetKeys be ? target.[[OwnPropertyKeys]]().
+  ...
+  15. Let targetNonconfigurableKeys be a new empty List.
+  16. For each element key of targetKeys, do
+    a. Let desc be ? target.[[GetOwnProperty]](key).
+    b. If desc is not undefined and desc.[[Configurable]] is false, then
+      i. Append key as an element of targetNonconfigurableKeys.
+  ...
+  18. Let uncheckedResultKeys be a new List which is a copy of trapResult.
+  19. For each key that is an element of targetNonconfigurableKeys, do
+    a. If key is not an element of uncheckedResultKeys, throw a TypeError exception.
+features: [Proxy, Symbol]
+---*/
+
+var target = {};
+var symbol = Symbol();
+Object.defineProperty(target, symbol, {
+  value: 1,
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
+
+var proxy = new Proxy(target, {
+  ownKeys: function() {
+    return [];
+  },
+});
+
+assert.throws(TypeError, function() {
+  Object.getOwnPropertyNames(proxy);
+});

--- a/test/built-ins/Object/getOwnPropertyNames/proxy-invariant-duplicate-symbol-entry.js
+++ b/test/built-ins/Object/getOwnPropertyNames/proxy-invariant-duplicate-symbol-entry.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.getownpropertynames
+description: >
+  Proxy [[OwnPropertyKeys]] trap does not skip symbol keys when validating invariant:
+  * The returned List contains no duplicate entries.
+info: |
+  Object.getOwnPropertyNames ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, String).
+
+  GetOwnPropertyKeys ( O, type )
+
+  ...
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+
+  [[OwnPropertyKeys]] ( )
+
+  ...
+  8. Let trapResult be ? CreateListFromArrayLike(trapResultArray, « String, Symbol »).
+  9. If trapResult contains any duplicate entries, throw a TypeError exception.
+features: [Proxy, Symbol]
+---*/
+
+var symbol = Symbol();
+var proxy = new Proxy({}, {
+  ownKeys: function() {
+    return [symbol, symbol];
+  },
+});
+
+assert.throws(TypeError, function() {
+  Object.getOwnPropertyNames(proxy);
+});

--- a/test/built-ins/Object/getOwnPropertyNames/proxy-invariant-not-extensible-absent-symbol-key.js
+++ b/test/built-ins/Object/getOwnPropertyNames/proxy-invariant-not-extensible-absent-symbol-key.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.getownpropertynames
+description: >
+  Proxy [[OwnPropertyKeys]] trap does not skip symbol keys when validating invariant:
+  * If the target object is not extensible, then the result List must contain all the keys of
+    the own properties of the target object and no other values.
+info: |
+  Object.getOwnPropertyNames ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, String).
+
+  GetOwnPropertyKeys ( O, type )
+
+  ...
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+
+  [[OwnPropertyKeys]] ( )
+
+  ...
+  11. Let targetKeys be ? target.[[OwnPropertyKeys]]().
+  16. For each element key of targetKeys, do
+    a. Let desc be ? target.[[GetOwnProperty]](key).
+    b. If desc is not undefined and desc.[[Configurable]] is false, then
+      ...
+    c. Else,
+      i. Append key as an element of targetConfigurableKeys.
+  ...
+  18. Let uncheckedResultKeys be a new List which is a copy of trapResult.
+  ...
+  21. For each key that is an element of targetConfigurableKeys, do
+    a. If key is not an element of uncheckedResultKeys, throw a TypeError exception.
+features: [Proxy, Symbol]
+---*/
+
+var target = {};
+var symbol = Symbol();
+target[symbol] = 2;
+
+var proxy = new Proxy(target, {
+  ownKeys: function() {
+    return [];
+  },
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+  Object.getOwnPropertyNames(proxy);
+});

--- a/test/built-ins/Object/getOwnPropertyNames/proxy-invariant-not-extensible-extra-symbol-key.js
+++ b/test/built-ins/Object/getOwnPropertyNames/proxy-invariant-not-extensible-extra-symbol-key.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.getownpropertynames
+description: >
+  Proxy [[OwnPropertyKeys]] trap does not skip symbol keys when validating invariant:
+  * If the target object is not extensible, then the result List must contain all the keys of
+    the own properties of the target object and no other values.
+info: |
+  Object.getOwnPropertyNames ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, String).
+
+  GetOwnPropertyKeys ( O, type )
+
+  ...
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+
+  [[OwnPropertyKeys]] ( )
+
+  ...
+  11. Let targetKeys be ? target.[[OwnPropertyKeys]]().
+  16. For each element key of targetKeys, do
+    a. Let desc be ? target.[[GetOwnProperty]](key).
+    b. If desc is not undefined and desc.[[Configurable]] is false, then
+      ...
+    c. Else,
+      i. Append key as an element of targetConfigurableKeys.
+  ...
+  18. Let uncheckedResultKeys be a new List which is a copy of trapResult.
+  ...
+  22. If uncheckedResultKeys is not empty, throw a TypeError exception.
+features: [Proxy, Symbol]
+---*/
+
+var target = {};
+var symbol = Symbol();
+var proxy = new Proxy(target, {
+  ownKeys: function() {
+    return [symbol];
+  },
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+  Object.getOwnPropertyNames(proxy);
+});

--- a/test/built-ins/Object/getOwnPropertySymbols/length.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es6id: 19.1.2.8
+esid: sec-object.getownpropertysymbols
 description: >
   Object.getOwnPropertySymbols.length is 1.
 info: |

--- a/test/built-ins/Object/getOwnPropertySymbols/name.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/name.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es6id: 19.1.2.8
+esid: sec-object.getownpropertysymbols
 description: >
   Object.getOwnPropertySymbols.name is "getOwnPropertySymbols".
 info: |

--- a/test/built-ins/Object/getOwnPropertySymbols/object-contains-symbol-property-with-description.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/object-contains-symbol-property-with-description.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-es6id: 19.1.2.8
+esid: sec-object.getownpropertysymbols
 description: >
     Object.getOwnPropertySymbols returns all symbol properties that have descriptions
 features: [Symbol]

--- a/test/built-ins/Object/getOwnPropertySymbols/object-contains-symbol-property-without-description.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/object-contains-symbol-property-without-description.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2013 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-es6id: 19.1.2.8
+esid: sec-object.getownpropertysymbols
 description: >
     Object.getOwnPropertySymbols returns all symbol properties that do not have descriptions
 features: [Symbol]

--- a/test/built-ins/Object/getOwnPropertySymbols/proxy-invariant-absent-not-configurable-string-key.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/proxy-invariant-absent-not-configurable-string-key.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.getownpropertysymbols
+description: >
+  Proxy [[OwnPropertyKeys]] trap does not skip string keys when validating invariant:
+  * The result List must contain the keys of all non-configurable own properties of
+    the target object.
+info: |
+  Object.getOwnPropertySymbols ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, Symbol).
+
+  GetOwnPropertyKeys ( O, type )
+
+  ...
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+
+  [[OwnPropertyKeys]] ( )
+
+  ...
+  11. Let targetKeys be ? target.[[OwnPropertyKeys]]().
+  ...
+  15. Let targetNonconfigurableKeys be a new empty List.
+  16. For each element key of targetKeys, do
+    a. Let desc be ? target.[[GetOwnProperty]](key).
+    b. If desc is not undefined and desc.[[Configurable]] is false, then
+      i. Append key as an element of targetNonconfigurableKeys.
+  ...
+  18. Let uncheckedResultKeys be a new List which is a copy of trapResult.
+  19. For each key that is an element of targetNonconfigurableKeys, do
+    a. If key is not an element of uncheckedResultKeys, throw a TypeError exception.
+features: [Proxy]
+---*/
+
+var target = {};
+Object.defineProperty(target, 'prop', {
+  value: 1,
+  writable: true,
+  enumerable: true,
+  configurable: false,
+});
+
+var proxy = new Proxy(target, {
+  ownKeys: function() {
+    return [];
+  },
+});
+
+assert.throws(TypeError, function() {
+  Object.getOwnPropertySymbols(proxy);
+});

--- a/test/built-ins/Object/getOwnPropertySymbols/proxy-invariant-duplicate-string-entry.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/proxy-invariant-duplicate-string-entry.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.getownpropertysymbols
+description: >
+  Proxy [[OwnPropertyKeys]] trap does not skip string keys when validating invariant:
+  * The returned List contains no duplicate entries.
+info: |
+  Object.getOwnPropertySymbols ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, Symbol).
+
+  GetOwnPropertyKeys ( O, type )
+
+  ...
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+
+  [[OwnPropertyKeys]] ( )
+
+  ...
+  8. Let trapResult be ? CreateListFromArrayLike(trapResultArray, « String, Symbol »).
+  9. If trapResult contains any duplicate entries, throw a TypeError exception.
+features: [Proxy]
+---*/
+
+var proxy = new Proxy({}, {
+  ownKeys: function() {
+    return ['a', 'a'];
+  },
+});
+
+assert.throws(TypeError, function() {
+  Object.getOwnPropertySymbols(proxy);
+});

--- a/test/built-ins/Object/getOwnPropertySymbols/proxy-invariant-not-extensible-absent-string-key.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/proxy-invariant-not-extensible-absent-string-key.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.getownpropertysymbols
+description: >
+  Proxy [[OwnPropertyKeys]] trap does not skip string keys when validating invariant:
+  * If the target object is not extensible, then the result List must contain all the keys of
+    the own properties of the target object and no other values.
+info: |
+  Object.getOwnPropertySymbols ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, Symbol).
+
+  GetOwnPropertyKeys ( O, type )
+
+  ...
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+
+  [[OwnPropertyKeys]] ( )
+
+  ...
+  11. Let targetKeys be ? target.[[OwnPropertyKeys]]().
+  16. For each element key of targetKeys, do
+    a. Let desc be ? target.[[GetOwnProperty]](key).
+    b. If desc is not undefined and desc.[[Configurable]] is false, then
+      ...
+    c. Else,
+      i. Append key as an element of targetConfigurableKeys.
+  ...
+  18. Let uncheckedResultKeys be a new List which is a copy of trapResult.
+  ...
+  21. For each key that is an element of targetConfigurableKeys, do
+    a. If key is not an element of uncheckedResultKeys, throw a TypeError exception.
+features: [Proxy]
+---*/
+
+var target = {prop: 2};
+var proxy = new Proxy(target, {
+  ownKeys: function() {
+    return [];
+  },
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+  Object.getOwnPropertySymbols(proxy);
+});

--- a/test/built-ins/Object/getOwnPropertySymbols/proxy-invariant-not-extensible-extra-string-key.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/proxy-invariant-not-extensible-extra-string-key.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.getownpropertysymbols
+description: >
+  Proxy [[OwnPropertyKeys]] trap does not skip string keys when validating invariant:
+  * If the target object is not extensible, then the result List must contain all the keys of
+    the own properties of the target object and no other values.
+info: |
+  Object.getOwnPropertySymbols ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, Symbol).
+
+  GetOwnPropertyKeys ( O, type )
+
+  ...
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+
+  [[OwnPropertyKeys]] ( )
+
+  ...
+  11. Let targetKeys be ? target.[[OwnPropertyKeys]]().
+  16. For each element key of targetKeys, do
+    a. Let desc be ? target.[[GetOwnProperty]](key).
+    b. If desc is not undefined and desc.[[Configurable]] is false, then
+      ...
+    c. Else,
+      i. Append key as an element of targetConfigurableKeys.
+  ...
+  18. Let uncheckedResultKeys be a new List which is a copy of trapResult.
+  ...
+  22. If uncheckedResultKeys is not empty, throw a TypeError exception.
+features: [Proxy]
+---*/
+
+var target = {};
+var proxy = new Proxy(target, {
+  ownKeys: function() {
+    return ['prop'];
+  },
+});
+
+Object.preventExtensions(target);
+
+assert.throws(TypeError, function() {
+  Object.getOwnPropertySymbols(proxy);
+});

--- a/test/built-ins/Object/keys/proxy-non-enumerable-prop-invariant-2.js
+++ b/test/built-ins/Object/keys/proxy-non-enumerable-prop-invariant-2.js
@@ -43,13 +43,14 @@ Object.defineProperty(target, 'prop', {
   enumerable: false,
   configurable: true,
 });
-Object.preventExtensions(target);
 
 var proxy = new Proxy(target, {
   ownKeys: function() {
     return [];
   },
 });
+
+Object.preventExtensions(target);
 
 assert.throws(TypeError, function() {
   Object.keys(proxy);

--- a/test/built-ins/Object/keys/proxy-non-enumerable-prop-invariant-3.js
+++ b/test/built-ins/Object/keys/proxy-non-enumerable-prop-invariant-3.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.keys
+description: >
+  Proxy [[OwnPropertyKeys]] trap does not skip non-enumerable keys when validating invariant:
+  * If the target object is not extensible, then the result List must contain all the keys of
+    the own properties of the target object and no other values.
+info: |
+  Object.keys ( O )
+
+  ...
+  2. Let nameList be ? EnumerableOwnPropertyNames(obj, "key").
+
+  EnumerableOwnPropertyNames ( O, kind )
+
+  ...
+  2. Let ownKeys be ? O.[[OwnPropertyKeys]]().
+
+  [[OwnPropertyKeys]] ( )
+
+  ...
+  11. Let targetKeys be ? target.[[OwnPropertyKeys]]().
+  16. For each element key of targetKeys, do
+    a. Let desc be ? target.[[GetOwnProperty]](key).
+    b. If desc is not undefined and desc.[[Configurable]] is false, then
+      ...
+    c. Else,
+      i. Append key as an element of targetConfigurableKeys.
+  ...
+  18. Let uncheckedResultKeys be a new List which is a copy of trapResult.
+  ...
+  22. If uncheckedResultKeys is not empty, throw a TypeError exception.
+features: [Proxy]
+---*/
+
+var target = {};
+Object.defineProperty(target, 'prop', {
+  value: 3,
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var proxy = new Proxy(target, {
+  ownKeys: function() {
+    return ['prop'];
+  },
+});
+
+Object.preventExtensions(target);
+
+var keys = Object.keys(proxy);
+assert.sameValue(keys.length, 0);

--- a/test/built-ins/Proxy/ownKeys/call-parameters-object-keys.js
+++ b/test/built-ins/Proxy/ownKeys/call-parameters-object-keys.js
@@ -5,7 +5,7 @@ esid: sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
 description: >
     [[OwnPropertyKeys]] ( )
 
-    8. Let trapResultArray be Call(trap, handler, «target»).
+    7. Let trapResultArray be ? Call(trap, handler, « target »).
 features: [Proxy]
 ---*/
 
@@ -18,12 +18,12 @@ var handler = {
   ownKeys: function(t) {
     _handler = this;
     _target = t;
-    return Object.getOwnPropertyNames(t);
+    return Object.keys(t);
   }
 };
 var p = new Proxy(target, handler);
 
-var keys = Object.getOwnPropertyNames(p);
+var keys = Object.keys(p);
 
 assert.sameValue(keys[0], "foo");
 assert.sameValue(keys[1], "bar");


### PR DESCRIPTION
JSC issues:
* [Proxy's `[[OwnPropertyKeys]]` is incorrect in `DontEnumPropertiesMode::Exclude`](https://bugs.webkit.org/show_bug.cgi?id=203818)

Follow-up of #2384.