### PR TITLE
Improve JSON.parse reviver parameter coverage

### DIFF
--- a/test/built-ins/JSON/parse/reviver-array-get-prop-from-prototype.js
+++ b/test/built-ins/JSON/parse/reviver-array-get-prop-from-prototype.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+description: >
+  `name` property is obtained with [[Get]] from prototype chain.
+info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
+  7. If IsCallable(reviver) is true, then
+    [...]
+    d. Return ? InternalizeJSONProperty(root, rootName).
+
+  InternalizeJSONProperty ( holder, name )
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+    a. Let isArray be ? IsArray(val).
+    b. If isArray is true, then
+      [...]
+      iii. Repeat, while I < len,
+        1. Let newElement be ? InternalizeJSONProperty(val, ! ToString(I)).
+        2. If newElement is undefined, then
+          [...]
+        3. Else,
+          a. Perform ? CreateDataProperty(val, ! ToString(I), newElement).
+---*/
+
+Array.prototype[1] = 3;
+
+var json = '[1, 2]';
+var arr = JSON.parse(json, function(key, value) {
+  if (key === '0') {
+    assert(delete this[1]);
+  }
+
+  return value;
+});
+
+assert(delete Array.prototype[1]);
+assert.sameValue(arr[0], 1);
+assert(arr.hasOwnProperty('1'));
+assert.sameValue(arr[1], 3);

--- a/test/built-ins/JSON/parse/reviver-array-non-configurable-prop-create.js
+++ b/test/built-ins/JSON/parse/reviver-array-non-configurable-prop-create.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+description: >
+  [[DefineOwnProperty]] validates property descriptor before applying.
+  If [[DefineOwnProperty]] is unsuccessful, no exception is thrown.
+info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
+  7. If IsCallable(reviver) is true, then
+    [...]
+    d. Return ? InternalizeJSONProperty(root, rootName).
+
+  InternalizeJSONProperty ( holder, name )
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+    a. Let isArray be ? IsArray(val).
+    b. If isArray is true, then
+      [...]
+      iii. Repeat, while I < len,
+        1. Let newElement be ? InternalizeJSONProperty(val, ! ToString(I)).
+        2. If newElement is undefined, then
+          [...]
+        3. Else,
+          a. Perform ? CreateDataProperty(val, ! ToString(I), newElement).
+
+  CreateDataProperty ( O, P, V )
+
+  [...]
+  4. Return ? O.[[DefineOwnProperty]](P, newDesc).
+---*/
+
+var json = '[1, 2]';
+var arr = JSON.parse(json, function(key, value) {
+  if (key === '0') {
+    Object.defineProperty(this, '1', {configurable: false});
+  }
+  if (key === '1') return 22;
+
+  return value;
+});
+
+assert.sameValue(arr[0], 1);
+assert.sameValue(arr[1], 2);

--- a/test/built-ins/JSON/parse/reviver-array-non-configurable-prop-delete.js
+++ b/test/built-ins/JSON/parse/reviver-array-non-configurable-prop-delete.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+description: >
+  [[Delete]] does not remove non-configurable properties.
+  If [[Delete]] is unsuccessful, no exception is thrown.
+info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
+  7. If IsCallable(reviver) is true, then
+    [...]
+    d. Return ? InternalizeJSONProperty(root, rootName).
+
+  InternalizeJSONProperty ( holder, name )
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+    a. Let isArray be ? IsArray(val).
+    b. If isArray is true, then
+      [...]
+      iii. Repeat, while I < len,
+        1. Let newElement be ? InternalizeJSONProperty(val, ! ToString(I)).
+        2. If newElement is undefined, then
+          a. Perform ? val.[[Delete]](! ToString(I)).
+
+  OrdinaryDelete ( O, P )
+
+  [...]
+  4. If desc.[[Configurable]] is true, then
+    a. Remove the own property with name P from O.
+---*/
+
+var json = '[1, 2]';
+var arr = JSON.parse(json, function(key, value) {
+  if (key === '0') {
+    Object.defineProperty(this, '1', {configurable: false});
+  }
+  if (key === '1') return;
+
+  return value;
+});
+
+assert.sameValue(arr[0], 1);
+assert(arr.hasOwnProperty('1'));
+assert.sameValue(arr[1], 2);

--- a/test/built-ins/JSON/parse/reviver-object-get-prop-from-prototype.js
+++ b/test/built-ins/JSON/parse/reviver-object-get-prop-from-prototype.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+description: >
+  `name` property is obtained with [[Get]] from prototype chain.
+info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
+  7. If IsCallable(reviver) is true, then
+    [...]
+    d. Return ? InternalizeJSONProperty(root, rootName).
+
+  InternalizeJSONProperty ( holder, name )
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+    a. Let isArray be ? IsArray(val).
+    b. If isArray is true, then
+      [...]
+    c. Else,
+      i. Let keys be ? EnumerableOwnPropertyNames(val, "key").
+      ii. For each String P in keys, do
+        1. Let newElement be ? InternalizeJSONProperty(val, P).
+        2. If newElement is undefined, then
+          [...]
+        3. Else,
+          a. Perform ? CreateDataProperty(val, P, newElement).
+---*/
+
+Object.prototype.b = 3;
+
+var json = '{"a": 1, "b": 2}';
+var obj = JSON.parse(json, function(key, value) {
+  if (key === 'a') {
+    assert(delete this.b);
+  }
+
+  return value;
+});
+
+assert(delete Object.prototype.b);
+assert.sameValue(obj.a, 1);
+assert(obj.hasOwnProperty('b'));
+assert.sameValue(obj.b, 3);

--- a/test/built-ins/JSON/parse/reviver-object-non-configurable-prop-create.js
+++ b/test/built-ins/JSON/parse/reviver-object-non-configurable-prop-create.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+description: >
+  [[DefineOwnProperty]] validates property descriptor before applying.
+  If [[DefineOwnProperty]] is unsuccessful, no exception is thrown.
+info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
+  7. If IsCallable(reviver) is true, then
+    [...]
+    d. Return ? InternalizeJSONProperty(root, rootName).
+
+  InternalizeJSONProperty ( holder, name )
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+    a. Let isArray be ? IsArray(val).
+    b. If isArray is true, then
+      [...]
+    c. Else,
+      i. Let keys be ? EnumerableOwnPropertyNames(val, "key").
+      ii. For each String P in keys, do
+        1. Let newElement be ? InternalizeJSONProperty(val, P).
+        2. If newElement is undefined, then
+          [...]
+        3. Else,
+          a. Perform ? CreateDataProperty(val, P, newElement).
+
+  CreateDataProperty ( O, P, V )
+
+  [...]
+  4. Return ? O.[[DefineOwnProperty]](P, newDesc).
+---*/
+
+var json = '{"a": 1, "b": 2}';
+var obj = JSON.parse(json, function(key, value) {
+  if (key === 'a') {
+    Object.defineProperty(this, 'b', {configurable: false});
+  }
+  if (key === 'b') return 22;
+
+  return value;
+});
+
+assert.sameValue(obj.a, 1);
+assert.sameValue(obj.b, 2);

--- a/test/built-ins/JSON/parse/reviver-object-non-configurable-prop-delete.js
+++ b/test/built-ins/JSON/parse/reviver-object-non-configurable-prop-delete.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-internalizejsonproperty
+description: >
+  [[Delete]] does not remove non-configurable properties.
+  If [[Delete]] is unsuccessful, no exception is thrown.
+info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
+  7. If IsCallable(reviver) is true, then
+    [...]
+    d. Return ? InternalizeJSONProperty(root, rootName).
+
+  InternalizeJSONProperty ( holder, name )
+
+  1. Let val be ? Get(holder, name).
+  2. If Type(val) is Object, then
+    a. Let isArray be ? IsArray(val).
+    b. If isArray is true, then
+      [...]
+    c. Else,
+      i. Let keys be ? EnumerableOwnPropertyNames(val, "key").
+      ii. For each String P in keys, do
+        1. Let newElement be ? InternalizeJSONProperty(val, P).
+        2. If newElement is undefined, then
+          a. Perform ? val.[[Delete]](P).
+
+  OrdinaryDelete ( O, P )
+
+  [...]
+  4. If desc.[[Configurable]] is true, then
+    a. Remove the own property with name P from O.
+---*/
+
+var json = '{"a": 1, "b": 2}';
+var obj = JSON.parse(json, function(key, value) {
+  if (key === 'a') {
+    Object.defineProperty(this, 'b', {configurable: false});
+  }
+  if (key === 'b') return;
+
+  return value;
+});
+
+assert.sameValue(obj.a, 1);
+assert(obj.hasOwnProperty('b'));
+assert.sameValue(obj.b, 2);

--- a/test/built-ins/JSON/parse/reviver-wrapper.js
+++ b/test/built-ins/JSON/parse/reviver-wrapper.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-json.parse
+description: >
+  Wrapper is plain extensible object with single data property.
+info: |
+  JSON.parse ( text [ , reviver ] )
+
+  [...]
+  7. If IsCallable(reviver) is true, then
+    a. Let root be ObjectCreate(%Object.prototype%).
+    b. Let rootName be the empty String.
+    c. Perform ! CreateDataPropertyOrThrow(root, rootName, unfiltered).
+includes: [propertyHelper.js]
+---*/
+
+Object.defineProperty(Object.prototype, '', {
+  set: function() {
+    throw new Test262Error('[[Set]] should not be called.');
+  },
+});
+
+var wrapper;
+JSON.parse('2', function() {
+  wrapper = this;
+});
+
+assert.sameValue(typeof wrapper, 'object');
+assert.sameValue(Object.getPrototypeOf(wrapper), Object.prototype);
+assert.sameValue(Object.getOwnPropertyNames(wrapper).length, 1);
+assert(Object.isExtensible(wrapper));
+
+verifyProperty(wrapper, '', {
+  value: 2,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});


### PR DESCRIPTION
JSC issues:
* [JSON.parse should not modify non-configurable properties](https://bugs.webkit.org/show_bug.cgi?id=163446)

Follow-up of #2196.