### PR TITLE
tag subclass tests with WeakSet and WeakMap

### DIFF
--- a/test/language/statements/class/subclass/builtin-objects/WeakMap/regular-subclassing.js
+++ b/test/language/statements/class/subclass/builtin-objects/WeakMap/regular-subclassing.js
@@ -14,6 +14,7 @@ info: |
   the WeakMap constructor to create and initialize the subclass instance with
   the internal state necessary to support the WeakMap.prototype built-in
   methods.
+features: [WeakMap]
 ---*/
 
 class WM extends WeakMap {}

--- a/test/language/statements/class/subclass/builtin-objects/WeakMap/super-must-be-called.js
+++ b/test/language/statements/class/subclass/builtin-objects/WeakMap/super-must-be-called.js
@@ -14,6 +14,7 @@ info: |
   the WeakMap constructor to create and initialize the subclass instance with
   the internal state necessary to support the WeakMap.prototype built-in
   methods.
+features: [WeakMap]
 ---*/
 
 class M1 extends WeakMap {

--- a/test/language/statements/class/subclass/builtin-objects/WeakSet/regular-subclassing.js
+++ b/test/language/statements/class/subclass/builtin-objects/WeakSet/regular-subclassing.js
@@ -14,6 +14,7 @@ info: |
   the WeakSet constructor to create and initialize the subclass instance with
   the internal state necessary to support the WeakSet.prototype built-in
   methods.
+features: [WeakSet]
 ---*/
 
 class WS extends WeakSet {}

--- a/test/language/statements/class/subclass/builtin-objects/WeakSet/super-must-be-called.js
+++ b/test/language/statements/class/subclass/builtin-objects/WeakSet/super-must-be-called.js
@@ -14,6 +14,7 @@ info: |
   the WeakSet constructor to create and initialize the subclass instance with
   the internal state necessary to support the WeakSet.prototype built-in
   methods.
+features: [WeakSet]
 ---*/
 
 class WS1 extends WeakSet {


### PR DESCRIPTION
should the tests in `built-ins/WeakMap` and `built-ins/WeakSet` also be tagged? If so I can address that in a separate PR.