### PR TITLE
Update FinalizationGroup tests now that register throws if target and holdings are the same value

### DIFF
--- a/test/built-ins/FinalizationGroup/prototype/register/holdings-same-as-target.js
+++ b/test/built-ins/FinalizationGroup/prototype/register/holdings-same-as-target.js
@@ -9,18 +9,13 @@ info: |
 
   1. Let finalizationGroup be the this value.
   2. If Type(finalizationGroup) is not Object, throw a TypeError exception.
-  3. If Type(target) is not Object, throw a TypeError exception.
-  4. If finalizationGroup does not have a [[Cells]] internal slot, throw a TypeError exception.
-  5. If Type(unregisterToken) is not Object,
-    a. If unregisterToken is not undefined, throw a TypeError exception.
-    b. Set unregisterToken to empty.
-  6. Let cell be the Record { [[Target]] : target, [[Holdings]]: holdings, [[UnregisterToken]]: unregisterToken }.
-  7. Append cell to finalizationGroup.[[Cells]].
-  8. Return undefined.
+  3. If finalizationGroup does not have a [[Cells]] internal slot, throw a TypeError exception.
+  4. If Type(target) is not Object, throw a TypeError exception.
+  5. If SameValue(target, holdings), throw a TypeError exception.
 features: [FinalizationGroup]
 ---*/
 
 var fg = new FinalizationGroup(function() {});
 
 var target = {};
-assert.sameValue(fg.register(target, target), undefined);
+assert.throws(TypeError, () => fg.register(target, target));

--- a/test/built-ins/FinalizationGroup/prototype/register/return-undefined-register-itself.js
+++ b/test/built-ins/FinalizationGroup/prototype/register/return-undefined-register-itself.js
@@ -9,20 +9,22 @@ info: |
 
   1. Let finalizationGroup be the this value.
   2. If Type(finalizationGroup) is not Object, throw a TypeError exception.
-  3. If Type(target) is not Object, throw a TypeError exception.
-  4. If finalizationGroup does not have a [[Cells]] internal slot, throw a TypeError exception.
-  5. If Type(unregisterToken) is not Object,
+  3. If finalizationGroup does not have a [[Cells]] internal slot, throw a TypeError exception.
+  4. If Type(target) is not Object, throw a TypeError exception.
+  5. If SameValue(target, holdings), throw a TypeError exception.
+  6. If Type(unregisterToken) is not Object,
     a. If unregisterToken is not undefined, throw a TypeError exception.
     b. Set unregisterToken to empty.
-  6. Let cell be the Record { [[Target]] : target, [[Holdings]]: holdings, [[UnregisterToken]]: unregisterToken }.
-  7. Append cell to finalizationGroup.[[Cells]].
-  8. Return undefined.
+  7. Let cell be the Record { [[Target]] : target, [[Holdings]]: holdings, [[UnregisterToken]]: unregisterToken }.
+  8. Append cell to finalizationGroup.[[Cells]].
+  9. Return undefined.
 features: [FinalizationGroup]
 ---*/
 
 var fn = function() {};
 var fg = new FinalizationGroup(fn);
+var holdings = {};
 
 assert.sameValue(fg.register(fg), undefined, 'Register itself');
-assert.sameValue(fg.register(fg, fg), undefined, 'Register itself with holdings');
-assert.sameValue(fg.register(fg, fg, fg), undefined, 'Register itself with holdings and unregisterToken');
+assert.sameValue(fg.register(fg, holdings), undefined, 'Register itself with holdings');
+assert.sameValue(fg.register(fg, holdings, fg), undefined, 'Register itself with holdings and unregisterToken');

--- a/test/built-ins/FinalizationGroup/prototype/register/unregisterToken-same-as-holdings-and-target.js
+++ b/test/built-ins/FinalizationGroup/prototype/register/unregisterToken-same-as-holdings-and-target.js
@@ -9,18 +9,19 @@ info: |
 
   1. Let finalizationGroup be the this value.
   2. If Type(finalizationGroup) is not Object, throw a TypeError exception.
-  3. If Type(target) is not Object, throw a TypeError exception.
-  4. If finalizationGroup does not have a [[Cells]] internal slot, throw a TypeError exception.
-  5. If Type(unregisterToken) is not Object,
+  3. If finalizationGroup does not have a [[Cells]] internal slot, throw a TypeError exception.
+  4. If Type(target) is not Object, throw a TypeError exception.
+  5. If SameValue(target, holdings), throw a TypeError exception.
+  6. If Type(unregisterToken) is not Object,
     a. If unregisterToken is not undefined, throw a TypeError exception.
     b. Set unregisterToken to empty.
-  6. Let cell be the Record { [[Target]] : target, [[Holdings]]: holdings, [[UnregisterToken]]: unregisterToken }.
-  7. Append cell to finalizationGroup.[[Cells]].
-  8. Return undefined.
+  7. Let cell be the Record { [[Target]] : target, [[Holdings]]: holdings, [[UnregisterToken]]: unregisterToken }.
+  8. Append cell to finalizationGroup.[[Cells]].
+  9. Return undefined.
 features: [FinalizationGroup]
 ---*/
 
 var fg = new FinalizationGroup(function() {});
 
 var target = {};
-assert.sameValue(fg.register(target, target, target), undefined);
+assert.throws(TypeError, () => fg.register(target, target, target));

--- a/test/built-ins/FinalizationGroup/target-not-callable-throws.js
+++ b/test/built-ins/FinalizationGroup/target-not-callable-throws.js
@@ -11,7 +11,7 @@ info: |
   1. If NewTarget is undefined, throw a TypeError exception.
   2. If IsCallable(cleanupCallback) is false, throw a TypeError exception.
   ...
-features: [FinalizationGroup]
+features: [FinalizationGroup, WeakRef]
 ---*/
 
 assert.sameValue(


### PR DESCRIPTION
This change happened in: https://github.com/tc39/proposal-weakrefs/pull/165