### PR TITLE
Fix expected order of properties

### DIFF
--- a/test/language/computed-property-names/class/static/method-number.js
+++ b/test/language/computed-property-names/class/static/method-number.js
@@ -21,6 +21,6 @@ assert(
   "`compareArray(Object.keys(C), [])` returns `true`"
 );
 assert(
-  compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'name', 'prototype', 'a', 'c']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'name', 'prototype', 'a', 'c'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'prototype', 'name', 'a', 'c']),
+  "`compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'prototype', 'name', 'a', 'c'])` returns `true`"
 );

--- a/test/language/computed-property-names/class/static/method-string.js
+++ b/test/language/computed-property-names/class/static/method-string.js
@@ -21,6 +21,6 @@ assert(
   "`compareArray(Object.keys(C), [])` returns `true`"
 );
 assert(
-  compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'b', 'c', 'd']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'b', 'c', 'd'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'name', 'a', 'b', 'c', 'd']),
+  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'name', 'a', 'b', 'c', 'd'])` returns `true`"
 );

--- a/test/language/computed-property-names/class/static/method-symbol.js
+++ b/test/language/computed-property-names/class/static/method-symbol.js
@@ -24,8 +24,8 @@ assert(
   "`compareArray(Object.keys(C), [])` returns `true`"
 );
 assert(
-  compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'c']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'c'])` returns `true`"
+  compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'name', 'a', 'c']),
+  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'prototype', 'name', 'a', 'c'])` returns `true`"
 );
 assert(
   compareArray(Object.getOwnPropertySymbols(C), [sym1, sym2]),


### PR DESCRIPTION
its a four-way split so might as well just make it match the spec

```
┌────────────────┬───────────────────────────────┐
│ ChakraCore     │ 1,2,prototype,name,a,c,length │
├────────────────┼───────────────────────────────┤
│ engine262      │ 1,2,length,prototype,name,a,c │
│ engine262+     │                               │
├────────────────┼───────────────────────────────┤
│ JavaScriptCore │ 1,2,length,name,prototype,a,c │
│ QuickJS        │                               │
│ XS             │                               │
├────────────────┼───────────────────────────────┤
│ SpiderMonkey   │ 1,2,prototype,a,c,length,name │
├────────────────┼───────────────────────────────┤
│ V8             │ 1,2,length,prototype,a,c,name │
└────────────────┴───────────────────────────────┘
```