### PR TITLE
Decouple module tests from having cyclic capabilities

### DIFF
--- a/test/language/module-code/eval-export-dflt-cls-anon.js
+++ b/test/language/module-code/eval-export-dflt-cls-anon.js
@@ -26,8 +26,7 @@ info: |
 flags: [module]
 ---*/
 
-export default class { valueOf() { return 45; } }
-import C from './eval-export-dflt-cls-anon.js';
+import C from './eval-export-dflt-cls-anon_FIXTURE.js';
 
 assert.sameValue(new C().valueOf(), 45, 'binding initialized');
 assert.sameValue(C.name, 'default', 'correct name is assigned');

--- a/test/language/module-code/eval-export-dflt-cls-anon_FIXTURE.js
+++ b/test/language/module-code/eval-export-dflt-cls-anon_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export default class { valueOf() { return 45; } }

--- a/test/language/module-code/eval-export-dflt-cls-name-meth.js
+++ b/test/language/module-code/eval-export-dflt-cls-name-meth.js
@@ -26,8 +26,7 @@ info: |
 flags: [module]
 ---*/
 
-export default class { static name() { return 'name method'; } }
-import C from './eval-export-dflt-cls-name-meth.js';
+import C from './eval-export-dflt-cls-name-meth_FIXTURE.js';
 
 assert.sameValue(
   C.name(), 'name method', '`name` property is not over-written'

--- a/test/language/module-code/eval-export-dflt-cls-name-meth_FIXTURE.js
+++ b/test/language/module-code/eval-export-dflt-cls-name-meth_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export default class { static name() { return 'name method'; } }

--- a/test/language/module-code/eval-export-dflt-expr-cls-anon.js
+++ b/test/language/module-code/eval-export-dflt-expr-cls-anon.js
@@ -25,8 +25,7 @@ info: |
 flags: [module]
 ---*/
 
-export default (class { valueOf() { return 45; } });
-import C from './eval-export-dflt-expr-cls-anon.js';
+import C from './eval-export-dflt-expr-cls-anon_FIXTURE.js';
 
 assert.sameValue(new C().valueOf(), 45, 'binding initialized');
 assert.sameValue(C.name, 'default', 'correct name is assigned');

--- a/test/language/module-code/eval-export-dflt-expr-cls-anon_FIXTURE.js
+++ b/test/language/module-code/eval-export-dflt-expr-cls-anon_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export default (class { valueOf() { return 45; } });

--- a/test/language/module-code/eval-export-dflt-expr-cls-name-meth.js
+++ b/test/language/module-code/eval-export-dflt-expr-cls-name-meth.js
@@ -27,8 +27,7 @@ info: |
 flags: [module]
 ---*/
 
-export default (class { static name() { return 'name method'; } });
-import C from './eval-export-dflt-expr-cls-name-meth.js';
+import C from './eval-export-dflt-expr-cls-name-meth_FIXTURE.js';
 
 assert.sameValue(
   C.name(), 'name method', '`name` property is not over-written'

--- a/test/language/module-code/eval-export-dflt-expr-cls-name-meth_FIXTURE.js
+++ b/test/language/module-code/eval-export-dflt-expr-cls-name-meth_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export default (class { static name() { return 'name method'; } });


### PR DESCRIPTION
Hello, I'm opening this draft PR because I'm currently testing a module loader against test262. This module loader at the moment does not support cyclic dependencies. Unfortunately, many test262 module tests export and import everything in the same file and self-reference themselves. This is practical because it does not require to add fixture files but it does put a hard dependency of having a module loader able to handle cycles even with the intent of testing a different feature of the module loader. I just started working on this, please let me know if the approach is not sound. Thank you!