### PR TITLE
add test for NativeError.prototype.toString

### DIFF
--- a/test/built-ins/NativeErrors/toString.js
+++ b/test/built-ins/NativeErrors/toString.js
@@ -18,6 +18,6 @@ var nativeErrors = [
 for (let i = 0; i < nativeErrors.length; i += 1) {
   var NativeError = nativeErrors[i];
 
-  assert(!NativeError.prototype.hasOwnProperty('toString'));
+  assert.sameValue(NativeError.prototype.hasOwnProperty('toString'), false);
   assert.sameValue(NativeError.prototype.toString, Error.prototype.toString);
 }

--- a/test/built-ins/NativeErrors/toString.js
+++ b/test/built-ins/NativeErrors/toString.js
@@ -1,0 +1,23 @@
+// Copyright 2019 Ecma International. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: NativeError prototypes do not have an own toString method.
+info: |
+  19.5.6.3 Properties of the NativeError Prototype Objects
+
+  Each NativeError prototype object:
+    ...
+    has a [[Prototype]] internal slot whose value is %Error.prototype%.
+---*/
+
+var nativeErrors = [
+  EvalError, RangeError, ReferenceError, SyntaxError, TypeError, URIError
+];
+
+for (let i = 0; i < nativeErrors.length; i += 1) {
+  var NativeError = nativeErrors[i];
+
+  assert(!NativeError.prototype.hasOwnProperty('toString'));
+  assert.sameValue(NativeError.prototype.toString, Error.prototype.toString);
+}


### PR DESCRIPTION
Refs https://github.com/tc39/ecma262/issues/1794

```
$ eshost -ts -e "[EvalError.prototype.hasOwnProperty('toString') ? 'own' : 'inherited', EvalError.prototype.toString === Error.prototype.toString ? 'eq' : 'ne']"
┌────────────────┬──────────────┐
│ ChakraCore     │ own,ne       │
│ JavaScriptCore │              │
├────────────────┼──────────────┤
│ engine262      │ inherited,eq │
│ engine262+     │              │
│ QuickJS        │              │
│ SpiderMonkey   │              │
│ XS             │              │
├────────────────┼──────────────┤
│ V8             │ own,eq       │
└────────────────┴──────────────┘
```