### PR TITLE
FinalizationGroup: Improve tests for cleanupSome/unregister interactions

### DIFF
--- a/test/built-ins/FinalizationGroup/prototype/cleanupSome/cleanup-prevented-with-unregister.js
+++ b/test/built-ins/FinalizationGroup/prototype/cleanupSome/cleanup-prevented-with-unregister.js
@@ -27,24 +27,25 @@ includes: [async-gc.js]
 flags: [async, non-deterministic]
 ---*/
 
-var called = 0;
+var token = {};
 var fg = new FinalizationGroup(function() {});
 
 function emptyCells() {
   var target = {};
-  var token = {};
   fg.register(target, 'target!', token);
 
   var prom = asyncGC(target);
   target = null;
 
-  var res = fg.unregister(token);
-  assert.sameValue(res, true, 'unregister target before iterating over it in cleanup');
-
   return prom;
 }
 
 emptyCells().then(function() {
+  var called = 0;
+
+  var res = fg.unregister(token);
+  assert.sameValue(res, true, 'unregister target before iterating over it in cleanup');
+
   fg.cleanupSome(function cb(iterator) {
     called += 1;
   });

--- a/test/built-ins/FinalizationGroup/prototype/unregister/unregister-cleaned-up-cell.js
+++ b/test/built-ins/FinalizationGroup/prototype/unregister/unregister-cleaned-up-cell.js
@@ -1,0 +1,72 @@
+// Copyright (C) 2019 Mathieu Hofman. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-group.prototype.unregister
+description: Cannot unregister a cell that has been cleaned up
+info: |
+  FinalizationGroup.prototype.cleanupSome ( [ callback ] )
+
+  1. Let finalizationGroup be the this value.
+  ...
+  5. Perform ! CleanupFinalizationGroup(finalizationGroup, callback).
+  ...
+
+  CleanupFinalizationGroup ( finalizationGroup [ , callback ] )
+
+  ...
+  3. Let iterator be ! CreateFinalizationGroupCleanupIterator(finalizationGroup).
+  ...
+  6. Let result be Call(callback, undefined, « iterator »).
+  ...
+
+  %FinalizationGroupCleanupIteratorPrototype%.next ( )
+
+  8. If finalizationGroup.[[Cells]] contains a Record cell such that cell.[[Target]] is empty,
+    a. Choose any such cell.
+    b. Remove cell from finalizationGroup.[[Cells]].
+    c. Return CreateIterResultObject(cell.[[Holdings]], false).
+  9. Otherwise, return CreateIterResultObject(undefined, true).
+
+  FinalizationGroup.prototype.unregister ( unregisterToken )
+
+  1. Let removed be false.
+  2. For each Record { [[Target]], [[Holdings]], [[UnregisterToken]] } cell that is an element of finalizationGroup.[[Cells]], do
+    a. If SameValue(cell.[[UnregisterToken]], unregisterToken) is true, then
+      i. Remove cell from finalizationGroup.[[Cells]].
+      ii. Set removed to true.
+  3. Return removed.
+features: [FinalizationGroup, host-gc-required]
+includes: [async-gc.js]
+flags: [async, non-deterministic]
+---*/
+
+var value = 'target!';
+var token = {};
+var fg = new FinalizationGroup(function() {});
+
+function emptyCells() {
+  var target = {};
+  fg.register(target, value, token);
+
+  var prom = asyncGC(target);
+  target = null;
+
+  return prom;
+}
+
+emptyCells().then(function() {
+  var called = 0;
+  var holdings;
+  fg.cleanupSome(function cb(iterator) {
+    called += 1;
+    holdings = [...iterator];
+  });
+
+  assert.sameValue(called, 1);
+  assert.sameValue(holdings.length, 1);
+  assert.sameValue(holdings[0], value);
+
+  var res = fg.unregister(token);
+  assert.sameValue(res, false, 'unregister after iterating over it in cleanup');
+}).then($DONE, resolveAsyncGC);


### PR DESCRIPTION
Add cleanup test for unregister: should return false when the cell has already been cleaned up
Change test for unregister preventing cleanup to call unregister after gc is performed.

These [issues were found in SpiderMonkey](https://bugzilla.mozilla.org/show_bug.cgi?id=1600488)'s implementation but not caught by test262.