### PR TITLE
Adding tests for Array.prototype.copyWithin

### DIFF
--- a/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-start.js
+++ b/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-start.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2019 Google. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.copywithin
+description: >
+  SECURITY: start argument is coerced to an integer value
+  and side effects change the length of the array so that
+  the start is out of bounds
+info: |
+  22.1.3.3 Array.prototype.copyWithin (target, start [ , end ] )
+
+  ...
+  8. Let relativeStart be ToInteger(start).
+  ...
+includes: [compareArray.js]
+---*/
+
+
+// make a long integer Array
+function longDenseArray(){
+	var a = [0];
+	for(var i = 0; i < 1024; i++){
+		a[i] = i;
+	}
+	return a;
+}
+
+function shorten(){
+	currArray.length = 20;
+	return 1000;
+}
+
+var array = longDenseArray();
+array.length = 20;
+for(var i = 0; i < 20; i++){
+	array[i] = array[i+1000];
+}
+
+var currArray = longDenseArray();
+
+assert(
+  compareArray(
+    currArray.copyWithin(0, {valueOf: shorten}), array
+  ),
+  'coercion side-effect makes start out of bounds'
+);
+
+currArray = longDenseArray();
+Object.setPrototypeOf(currArray, longDenseArray());
+
+var array2 = longDenseArray();
+array2.length = 20;
+for(var i = 0; i < 24; i++){
+	array2[i] = Object.getPrototypeOf(currArray)[i+1000];
+}
+
+assert(
+  compareArray(
+    currArray.copyWithin(0, {valueOf: shorten}), array2
+  ),
+  'coercion side-effect makes start out of bounds with prototype'
+);

--- a/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-start.js
+++ b/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-start.js
@@ -30,11 +30,8 @@ function shorten(){
 	return 1000;
 }
 
-var array = longDenseArray();
+var array = [];
 array.length = 20;
-for(var i = 0; i < 20; i++){
-	array[i] = array[i+1000];
-}
 
 var currArray = longDenseArray();
 

--- a/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-target.js
+++ b/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-target.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Google. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.copywithin
+description: >
+  SECURITY: start argument is coerced to an integer value
+  and side effects change the length of the array so that
+  the target is out of bounds
+info: |
+  22.1.3.3 Array.prototype.copyWithin (target, start [ , end ] )
+
+  ...
+  8. Let relativeStart be ToInteger(start).
+  ...
+includes: [compareArray.js]
+---*/
+
+
+// make a long integer Array
+function longDenseArray(){
+	var a = [0];
+	for(var i = 0; i < 1024; i++){
+		a[i] = i;
+	}
+	return a;
+}
+
+function shorten(){
+	currArray.length = 20;
+	return 1;
+}
+
+var array = longDenseArray();
+array.length = 20;
+for(var i = 0; i < 19; i++){
+	array[i+1000] = array[i+1];
+}
+
+var currArray = longDenseArray();
+
+assert(
+  compareArray(
+    currArray.copyWithin(1000, {valueOf: shorten}), array
+  ),
+  'coercion side-effect makes target out of bounds'
+);


### PR DESCRIPTION
A security test for copyWithin. This checks that Array.prototype.copyWithin behaves correctly in the case that converting the start parameter to an integer has side effects. This caused a security bug in Moddable https://github.com/Moddable-OpenSource/moddable/issues/123