### PR TITLE
TypedArray copyWithin security tests

### DIFF
--- a/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-start.js
+++ b/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-start.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2019 Google. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.copywithin
+description: >
+  SECURITY: start argument is coerced to an integer value
+  and side effects change the length of the array so that
+  the start is out of bounds
+info: |
+  22.1.3.3 Array.prototype.copyWithin (target, start [ , end ] )
+
+  ...
+  8. Let relativeStart be ToInteger(start).
+  ...
+includes: [compareArray.js]
+---*/
+
+
+// make a long integer Array
+function longDenseArray(){
+	var a = [0];
+	for(var i = 0; i < 1024; i++){
+		a[i] = i;
+	}
+	return a;
+}
+
+function shorten(){
+	currArray.length = 20;
+	return 1000;
+}
+
+var array = longDenseArray();
+array.length = 20;
+for(var i = 0; i < 20; i++){
+	array[i] = array[i+1000];
+}
+
+var currArray = longDenseArray();
+
+assert(
+  compareArray(
+    currArray.copyWithin(0, {valueOf: shorten}), array
+  ),
+  'coercion side-effect makes start out of bounds'
+);
+
+currArray = longDenseArray();
+Object.setPrototypeOf(currArray, longDenseArray());
+
+var array2 = longDenseArray();
+array2.length = 20;
+for(var i = 0; i < 24; i++){
+	array2[i] = Object.getPrototypeOf(currArray)[i+1000];
+}
+
+assert(
+  compareArray(
+    currArray.copyWithin(0, {valueOf: shorten}), array2
+  ),
+  'coercion side-effect makes start out of bounds with prototype'
+);

--- a/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-start.js
+++ b/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-start.js
@@ -30,11 +30,8 @@ function shorten(){
 	return 1000;
 }
 
-var array = longDenseArray();
+var array = [];
 array.length = 20;
-for(var i = 0; i < 20; i++){
-	array[i] = array[i+1000];
-}
 
 var currArray = longDenseArray();
 

--- a/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-target.js
+++ b/test/built-ins/Array/prototype/copyWithin/coerced-values-start-change-target.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Google. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.copywithin
+description: >
+  SECURITY: start argument is coerced to an integer value
+  and side effects change the length of the array so that
+  the target is out of bounds
+info: |
+  22.1.3.3 Array.prototype.copyWithin (target, start [ , end ] )
+
+  ...
+  8. Let relativeStart be ToInteger(start).
+  ...
+includes: [compareArray.js]
+---*/
+
+
+// make a long integer Array
+function longDenseArray(){
+	var a = [0];
+	for(var i = 0; i < 1024; i++){
+		a[i] = i;
+	}
+	return a;
+}
+
+function shorten(){
+	currArray.length = 20;
+	return 1;
+}
+
+var array = longDenseArray();
+array.length = 20;
+for(var i = 0; i < 19; i++){
+	array[i+1000] = array[i+1];
+}
+
+var currArray = longDenseArray();
+
+assert(
+  compareArray(
+    currArray.copyWithin(1000, {valueOf: shorten}), array
+  ),
+  'coercion side-effect makes target out of bounds'
+);

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached-prototype.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached-prototype.js
@@ -24,7 +24,7 @@ info: |
   7. If end is undefined, let relativeEnd be len; else let relativeEnd be ?
   ToInteger(end).
   ...
-includes: [compareArray.js, testTypedArray.js, detachArrayBuffer.js]
+includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached-prototype.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached-prototype.js
@@ -7,22 +7,15 @@ description: >
   causing array detachment, but the value is still defined
   by a prototype
 info: |
-  22.2.3.5 %TypedArray%.prototype.copyWithin (target, start [ , end ] )
-
-  %TypedArray%.prototype.copyWithin is a distinct function that implements the
-  same algorithm as Array.prototype.copyWithin as defined in 22.1.3.3 except
-  that the this object's [[ArrayLength]] internal slot is accessed in place of
-  performing a [[Get]] of "length" and the actual copying of values in step 12
-  must be performed in a manner that preserves the bit-level encoding of the
-  source data.
-
+  22.2.3.5%TypedArray%.prototype.copyWithin ( target, start [ , end ] )
   ...
-
-  22.1.3.3 Array.prototype.copyWithin (target, start [ , end ] )
-
-  ...
-  7. If end is undefined, let relativeEnd be len; else let relativeEnd be ?
-  ToInteger(end).
+  8. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToInteger(end).
+  ... 
+  10. Let count be min(final - from, len - to).
+  11. If count > 0, then
+    a. NOTE: The copying must be performed in a manner that preserves the bit-level encoding of the source data.
+    b. Let buffer be O.[[ViewedArrayBuffer]].
+    c. If IsDetachedBuffer(buffer) is true, throw a TypeError exception. 
   ...
 includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
@@ -36,7 +29,7 @@ testWithTypedArrayConstructors(function(TA) {
   function detachAndReturnIndex(){
       $DETACHBUFFER(ta.buffer);
       Object.setPrototypeOf(ta, array);
-      return 900;
+      return 101;
   }
 
   array.length = 10000; // big arrays are more likely to cause a crash if they are accessed after they are freed
@@ -44,6 +37,6 @@ testWithTypedArrayConstructors(function(TA) {
   ta = new TA(array);
   assert.throws(TypeError, function(){ 
     ta.copyWithin(0, 100, {valueOf : detachAndReturnIndex}); },
-  "should thow TypeError as array is detached");
+  "should throw TypeError as array is detached");
   
 });

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached-prototype.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached-prototype.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2019 Google. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.copywithin
+description: >
+  SECURITY: end argument is coerced to an integer values
+  causing array detachment, but the value is still defined
+  by a prototype
+info: |
+  22.2.3.5 %TypedArray%.prototype.copyWithin (target, start [ , end ] )
+
+  %TypedArray%.prototype.copyWithin is a distinct function that implements the
+  same algorithm as Array.prototype.copyWithin as defined in 22.1.3.3 except
+  that the this object's [[ArrayLength]] internal slot is accessed in place of
+  performing a [[Get]] of "length" and the actual copying of values in step 12
+  must be performed in a manner that preserves the bit-level encoding of the
+  source data.
+
+  ...
+
+  22.1.3.3 Array.prototype.copyWithin (target, start [ , end ] )
+
+  ...
+  7. If end is undefined, let relativeEnd be len; else let relativeEnd be ?
+  ToInteger(end).
+  ...
+includes: [compareArray.js, testTypedArray.js, detachArrayBuffer.js]
+features: [TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  
+  var ta;
+  var array = [];
+
+  function detachAndReturnIndex(){
+      $DETACHBUFFER(ta.buffer);
+      Object.setPrototypeOf(ta, array);
+      return 900;
+  }
+
+  array.length = 10000; // big arrays are more likely to cause a crash if they are accessed after they are freed
+  array.fill(7, 0);
+  ta = new TA(array);
+  assert.throws(TypeError, function(){ 
+    ta.copyWithin(0, 100, {valueOf : detachAndReturnIndex}); },
+  "should thow TypeError as array is detached");
+  
+});

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2019 Google. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.copywithin
+description: >
+  SECURITY: end argument is coerced to an integer values
+  causing array detachment
+info: |
+  22.2.3.5 %TypedArray%.prototype.copyWithin (target, start [ , end ] )
+
+  %TypedArray%.prototype.copyWithin is a distinct function that implements the
+  same algorithm as Array.prototype.copyWithin as defined in 22.1.3.3 except
+  that the this object's [[ArrayLength]] internal slot is accessed in place of
+  performing a [[Get]] of "length" and the actual copying of values in step 12
+  must be performed in a manner that preserves the bit-level encoding of the
+  source data.
+
+  ...
+
+  22.1.3.3 Array.prototype.copyWithin (target, start [ , end ] )
+
+  ...
+  7. If end is undefined, let relativeEnd be len; else let relativeEnd be ?
+  ToInteger(end).
+  ...
+includes: [compareArray.js, testTypedArray.js, detachArrayBuffer.js]
+features: [TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  
+  var ta;
+  function detachAndReturnIndex(){
+      $DETACHBUFFER(ta.buffer);
+      return 900;
+  }
+
+  var array = [];
+  array.length = 10000; // big arrays are more likely to cause a crash if they are accessed after they are freed
+  array.fill(7, 0);
+  ta = new TA(array);
+  ta.copyWithin(0, 100, {valueOf : detachAndReturnIndex});
+  assert.sameValue(ta.length, 0, "Detached array has elements")
+});

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached.js
@@ -23,7 +23,7 @@ info: |
   7. If end is undefined, let relativeEnd be len; else let relativeEnd be ?
   ToInteger(end).
   ...
-includes: [compareArray.js, testTypedArray.js, detachArrayBuffer.js]
+includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached.js
@@ -6,22 +6,16 @@ description: >
   SECURITY: end argument is coerced to an integer values
   causing array detachment
 info: |
-  22.2.3.5 %TypedArray%.prototype.copyWithin (target, start [ , end ] )
-
-  %TypedArray%.prototype.copyWithin is a distinct function that implements the
-  same algorithm as Array.prototype.copyWithin as defined in 22.1.3.3 except
-  that the this object's [[ArrayLength]] internal slot is accessed in place of
-  performing a [[Get]] of "length" and the actual copying of values in step 12
-  must be performed in a manner that preserves the bit-level encoding of the
-  source data.
+  22.2.3.5 %TypedArray%.prototype.copyWithin ( target, start [ , end ] )
 
   ...
-
-  22.1.3.3 Array.prototype.copyWithin (target, start [ , end ] )
-
+  8. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToInteger(end).
   ...
-  7. If end is undefined, let relativeEnd be len; else let relativeEnd be ?
-  ToInteger(end).
+  10. Let count be min(final - from, len - to).
+  11. If count > 0, then
+    a. NOTE: The copying must be performed in a manner that preserves the bit-level encoding of the source data.
+    b. Let buffer be O.[[ViewedArrayBuffer]].
+    c. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
   ...
 includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
@@ -39,6 +33,7 @@ testWithTypedArrayConstructors(function(TA) {
   array.length = 10000; // big arrays are more likely to cause a crash if they are accessed after they are freed
   array.fill(7, 0);
   ta = new TA(array);
-  ta.copyWithin(0, 100, {valueOf : detachAndReturnIndex});
-  assert.sameValue(ta.length, 0, "Detached array has elements")
+  assert.throws(TypeError, function(){ 
+    ta.copyWithin(0, 100, {valueOf : detachAndReturnIndex});
+  "should throw TypeError as array is detached");
 });

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-start-detached.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-start-detached.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 Google. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.copywithin
+description: >
+  SECURITY: start argument is coerced to an integer value, which detached
+  the array
+info: |
+  22.2.3.5 %TypedArray%.prototype.copyWithin (target, start [ , end ] )
+
+  %TypedArray%.prototype.copyWithin is a distinct function that implements the
+  same algorithm as Array.prototype.copyWithin as defined in 22.1.3.3 except
+  that the this object's [[ArrayLength]] internal slot is accessed in place of
+  performing a [[Get]] of "length" and the actual copying of values in step 12
+  must be performed in a manner that preserves the bit-level encoding of the
+  source data.
+
+  ...
+
+  22.1.3.3 Array.prototype.copyWithin (target, start [ , end ] )
+
+  ...
+  5. Let relativeStart be ? ToInteger(start).
+  ...
+includes: [compareArray.js, testTypedArray.js]
+features: [TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  
+  var ta;
+  function detachAndReturnIndex(){
+      $DETACHBUFFER(ta.buffer);
+      return 100;
+  }
+
+  var array = [];
+  array.length = 10000; // big arrays are more likely to cause a crash if they are accessed after they are freed
+  array.fill(7, 0);
+  ta = new TA(array);
+  ta.copyWithin(0, {valueOf : detachAndReturnIndex}, 1000);
+  assert.sameValue(ta.length, 0, "Detached array has elements")
+});

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-start-detached.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-start-detached.js
@@ -22,7 +22,7 @@ info: |
   ...
   5. Let relativeStart be ? ToInteger(start).
   ...
-includes: [compareArray.js, testTypedArray.js]
+includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
 ---*/
 

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-start-detached.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-start-detached.js
@@ -6,21 +6,16 @@ description: >
   SECURITY: start argument is coerced to an integer value, which detached
   the array
 info: |
-  22.2.3.5 %TypedArray%.prototype.copyWithin (target, start [ , end ] )
-
-  %TypedArray%.prototype.copyWithin is a distinct function that implements the
-  same algorithm as Array.prototype.copyWithin as defined in 22.1.3.3 except
-  that the this object's [[ArrayLength]] internal slot is accessed in place of
-  performing a [[Get]] of "length" and the actual copying of values in step 12
-  must be performed in a manner that preserves the bit-level encoding of the
-  source data.
+  22.2.3.5 %TypedArray%.prototype.copyWithin ( target, start [ , end ] )
 
   ...
-
-  22.1.3.3 Array.prototype.copyWithin (target, start [ , end ] )
-
+  6. Let relativeStart be ? ToInteger(start).
   ...
-  5. Let relativeStart be ? ToInteger(start).
+  10. Let count be min(final - from, len - to).
+  11. If count > 0, then
+    a. NOTE: The copying must be performed in a manner that preserves the bit-level encoding of the source data.
+    b. Let buffer be O.[[ViewedArrayBuffer]].
+    c. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
   ...
 includes: [testTypedArray.js, detachArrayBuffer.js]
 features: [TypedArray]
@@ -38,6 +33,9 @@ testWithTypedArrayConstructors(function(TA) {
   array.length = 10000; // big arrays are more likely to cause a crash if they are accessed after they are freed
   array.fill(7, 0);
   ta = new TA(array);
-  ta.copyWithin(0, {valueOf : detachAndReturnIndex}, 1000);
-  assert.sameValue(ta.length, 0, "Detached array has elements")
+  assert.throws(TypeError, function(){ 
+    ta.copyWithin(0, {valueOf : detachAndReturnIndex}, 1000);
+    "should throw TypeError as array is detached");
+  
+  });
 });


### PR DESCRIPTION
Adding tests for TypedArray.prototype.copyWithin, as it has had security issues in the past, for example https://bugs.chromium.org/p/project-zero/issues/detail?id=862

All three tests behave inconsistently on the browser JS engines.

test262/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached.js

Passes on v8, fails on SpiderMonkey and JSC

test262/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached-prototype.js

Passes on SpiderMonkey and JSC, fails on v8

test262/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-start-detached.js

Passes on v8, fails on SpiderMonkey and JSC

I believe the behavior in the tests is correct according to the specification, but I would appreciate if someone else could check, as the method is fairly complicated.

The root problem here is that when copyWithin is applied to TypeArrays, detachment checks are needed, but the specification does not say where to place them. 