### PR TITLE
Add test case for new ReferenceError after removal of per-parameter position var scope

### DIFF
--- a/src/function-forms/eval-var-scope-syntax-err.case
+++ b/src/function-forms/eval-var-scope-syntax-err.case
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 Valerie Young. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: sloppy direct eval in params introduces var
+template: error
+info: |
+
+  Runtime Semantics: IteratorBindingInitialization
+  FormalParameter : BindingElement
+
+  1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+
+features: [default-parameters]
+---*/
+
+//- params
+a = eval("var a = 42")
+//- error
+SyntaxError

--- a/test/language/expressions/arrow-function/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/arrow-function/eval-var-scope-syntax-err.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/arrow-function.template
+/*---
+description: sloppy direct eval in params introduces var (arrow function expression)
+esid: sec-arrow-function-definitions-runtime-semantics-evaluation
+features: [default-parameters]
+flags: [generated]
+info: |
+    ArrowFunction : ArrowParameters => ConciseBody
+
+    [...]
+    4. Let closure be FunctionCreate(Arrow, parameters, ConciseBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var f;
+f = (a = eval("var a = 42")) => {
+  
+  callCount = callCount + 1;
+};
+
+assert.throws(SyntaxError, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'arrow function body not evaluated');

--- a/test/language/expressions/async-arrow-function/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/async-arrow-function/eval-var-scope-syntax-err.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/async-arrow-function.template
+/*---
+description: sloppy direct eval in params introduces var (async arrow function expression)
+esid: sec-async-arrow-function-definitions
+features: [default-parameters, async-functions]
+flags: [generated, async]
+info: |
+    14.7 Async Arrow Function Definitions
+
+    AsyncArrowFunction :
+      ...
+      CoverCallExpressionAndAsyncArrowHead => AsyncConciseBody
+
+    AsyncConciseBody :
+      { AsyncFunctionBody }
+
+    ...
+
+    Supplemental Syntax
+
+    When processing an instance of the production AsyncArrowFunction :
+    CoverCallExpressionAndAsyncArrowHead => AsyncConciseBody the interpretation of
+    CoverCallExpressionAndAsyncArrowHead is refined using the following grammar:
+
+    AsyncArrowHead :
+      async ArrowFormalParameters
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+var f;
+f = async (a = eval("var a = 42")) => {
+  
+  callCount = callCount + 1;
+};
+
+f()
+  .then(_ => {
+    throw new Test262Error('function should not be resolved');
+  }, error => assert.sameValue(error.constructor, SyntaxError))
+  .then(() => {
+    assert.sameValue(callCount, 0, 'function body is not evaluated');
+  }, $DONE)
+  .then($DONE, $DONE);

--- a/test/language/expressions/async-function/named-eval-var-scope-syntax-err.js
+++ b/test/language/expressions/async-function/named-eval-var-scope-syntax-err.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/async-func-expr-named.template
+/*---
+description: sloppy direct eval in params introduces var (async function named expression)
+esid: sec-async-function-definitions
+features: [default-parameters, async-functions]
+flags: [generated, async]
+info: |
+    14.6 Async Function Definitions
+
+    AsyncFunctionExpression :
+      async function BindingIdentifier ( FormalParameters ) { AsyncFunctionBody }
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+var f = async function f(a = eval("var a = 42")) {
+  
+  callCount = callCount + 1;
+}
+
+f()
+  .then(_ => {
+    throw new Test262Error('function should not be resolved');
+  }, error => assert.sameValue(error.constructor, SyntaxError))
+  .then(() => {
+    assert.sameValue(callCount, 0, 'function body is not evaluated');
+  }, $DONE)
+  .then($DONE, $DONE);

--- a/test/language/expressions/async-function/nameless-eval-var-scope-syntax-err.js
+++ b/test/language/expressions/async-function/nameless-eval-var-scope-syntax-err.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/async-func-expr-nameless.template
+/*---
+description: sloppy direct eval in params introduces var (async function nameless expression)
+esid: sec-async-function-definitions
+features: [default-parameters, async-functions]
+flags: [generated, async]
+info: |
+    14.6 Async Function Definitions
+
+    AsyncFunctionExpression :
+      async function ( FormalParameters ) { AsyncFunctionBody }
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+var f = async function(a = eval("var a = 42")) {
+  
+  callCount = callCount + 1;
+}
+
+f()
+  .then(_ => {
+    throw new Test262Error('function should not be resolved');
+  }, error => assert.sameValue(error.constructor, SyntaxError))
+  .then(() => {
+    assert.sameValue(callCount, 0, 'function body is not evaluated');
+  }, $DONE)
+  .then($DONE, $DONE);

--- a/test/language/expressions/async-generator/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/async-generator/eval-var-scope-syntax-err.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/async-gen-func-expr.template
+/*---
+description: sloppy direct eval in params introduces var (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+var f;
+f = async function*(a = eval("var a = 42")) {
+  
+  callCount = callCount + 1;
+};
+
+assert.throws(SyntaxError, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/expressions/async-generator/named-eval-var-scope-syntax-err.js
+++ b/test/language/expressions/async-generator/named-eval-var-scope-syntax-err.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/async-gen-named-func-expr.template
+/*---
+description: sloppy direct eval in params introduces var (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+var f;
+f = async function* g(a = eval("var a = 42")) {
+  
+  callCount = callCount + 1;
+};
+
+assert.throws(SyntaxError, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/expressions/class/async-gen-method-static/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/class/async-gen-method-static/eval-var-scope-syntax-err.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-expr-async-gen-meth-static.template
+/*---
+description: sloppy direct eval in params introduces var (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static async *method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(SyntaxError, function() {
+  C.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/class/async-gen-method/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/class/async-gen-method/eval-var-scope-syntax-err.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-expr-async-gen-meth.template
+/*---
+description: sloppy direct eval in params introduces var (class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  async *method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(SyntaxError, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/class/async-method-static/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/class/async-method-static/eval-var-scope-syntax-err.js
@@ -1,0 +1,66 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-expr-async-meth-static.template
+/*---
+description: sloppy direct eval in params introduces var (static class expression async method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-functions]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+      b. Else,
+        Let status be the result of performing PropertyDefinitionEvaluation
+        for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncMethod : async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncMethod is strict mode code, let strict be true. Otherwise
+       let strict be false.
+    4. Let scope be the LexicalEnvironment of the running execution context.
+    5. Let closure be ! AsyncFunctionCreate(Method, UniqueFormalParameters, AsyncFunctionBody,
+       scope, strict).
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+
+var C = class {
+  static async method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+C.method()
+  .then(_ => {
+    throw new Test262Error('function should not be resolved');
+  }, error => assert.sameValue(error.constructor, SyntaxError))
+  .then(() => {
+    assert.sameValue(callCount, 0, 'function body is not evaluated');
+  }, $DONE)
+  .then($DONE, $DONE);

--- a/test/language/expressions/class/async-method/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/class/async-method/eval-var-scope-syntax-err.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-expr-async-meth.template
+/*---
+description: sloppy direct eval in params introduces var (class expression async method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-functions]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+        with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+      a. If IsStatic of m is false, then
+        i. Let status be the result of performing
+          PropertyDefinitionEvaluation for m with arguments proto and
+          false.
+      [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncMethod : async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncMethod is strict mode code, let strict be true. Otherwise
+       let strict be false.
+    4. Let scope be the LexicalEnvironment of the running execution context.
+    5. Let closure be ! AsyncFunctionCreate(Method, UniqueFormalParameters, AsyncFunctionBody,
+       scope, strict).
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+var C = class {
+  async method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+C.prototype.method()
+  .then(_ => {
+    throw new Test262Error('function should not be resolved');
+  }, error => assert.sameValue(error.constructor, SyntaxError))
+  .then(() => {
+    assert.sameValue(callCount, 0, 'function body is not evaluated');
+  }, $DONE)
+  .then($DONE, $DONE);

--- a/test/language/expressions/class/gen-method-static/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/class/gen-method-static/eval-var-scope-syntax-err.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-expr-gen-meth-static.template
+/*---
+description: sloppy direct eval in params introduces var (static class expression generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, generators]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static *method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(SyntaxError, function() {
+  C.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/class/gen-method/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/class/gen-method/eval-var-scope-syntax-err.js
@@ -1,0 +1,83 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-expr-gen-meth.template
+/*---
+description: sloppy direct eval in params introduces var (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, generators]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  *method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(SyntaxError, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/class/method-static/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/class/method-static/eval-var-scope-syntax-err.js
@@ -1,0 +1,79 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-expr-meth-static.template
+/*---
+description: sloppy direct eval in params introduces var (static class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(SyntaxError, function() {
+  C.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/class/method/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/class/method/eval-var-scope-syntax-err.js
@@ -1,0 +1,79 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-expr-meth.template
+/*---
+description: sloppy direct eval in params introduces var (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(SyntaxError, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/expressions/function/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/function/eval-var-scope-syntax-err.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/func-expr.template
+/*---
+description: sloppy direct eval in params introduces var (function expression)
+esid: sec-function-definitions-runtime-semantics-evaluation
+features: [default-parameters]
+flags: [generated]
+info: |
+    FunctionExpression : function ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let closure be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var f;
+f = function(a = eval("var a = 42")) {
+  
+  callCount = callCount + 1;
+};
+
+assert.throws(SyntaxError, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'function body not evaluated');

--- a/test/language/expressions/generators/eval-var-scope-syntax-err.js
+++ b/test/language/expressions/generators/eval-var-scope-syntax-err.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/gen-func-expr.template
+/*---
+description: sloppy direct eval in params introduces var (generator function expression)
+esid: sec-generator-function-definitions-runtime-semantics-evaluation
+features: [default-parameters, generators]
+flags: [generated]
+info: |
+    GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        3. Let closure be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var f;
+f = function*(a = eval("var a = 42")) {
+  
+  callCount = callCount + 1;
+};
+
+assert.throws(SyntaxError, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/expressions/object/method-definition/async-gen-meth-eval-var-scope-syntax-err.js
+++ b/test/language/expressions/object/method-definition/async-gen-meth-eval-var-scope-syntax-err.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/async-gen-meth.template
+/*---
+description: sloppy direct eval in params introduces var (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var obj = {
+  async *method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(SyntaxError, function() {
+  obj.method();
+});
+assert.sameValue(callCount, 0, 'generator method body not evaluated');

--- a/test/language/expressions/object/method-definition/async-meth-eval-var-scope-syntax-err.js
+++ b/test/language/expressions/object/method-definition/async-meth-eval-var-scope-syntax-err.js
@@ -1,0 +1,41 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/async-meth.template
+/*---
+description: sloppy direct eval in params introduces var (async method)
+esid: sec-async-function-definitions
+features: [default-parameters, async-functions]
+flags: [generated, async]
+info: |
+    14.6 Async Function Definitions
+
+    AsyncMethod :
+     async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+
+var obj = {
+  async method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+obj.method()
+  .then(_ => {
+    throw new Test262Error('function should not be resolved');
+  }, error => assert.sameValue(error.constructor, SyntaxError))
+  .then(() => {
+    assert.sameValue(callCount, 0, 'function body is not evaluated');
+  }, $DONE)
+  .then($DONE, $DONE);

--- a/test/language/expressions/object/method-definition/gen-meth-eval-var-scope-syntax-err.js
+++ b/test/language/expressions/object/method-definition/gen-meth-eval-var-scope-syntax-err.js
@@ -1,0 +1,65 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/gen-meth.template
+/*---
+description: sloppy direct eval in params introduces var (generator method)
+esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
+features: [default-parameters, generators]
+flags: [generated]
+info: |
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var obj = {
+  *method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(SyntaxError, function() {
+  obj.method();
+});
+assert.sameValue(callCount, 0, 'generator method body not evaluated');

--- a/test/language/expressions/object/method-definition/meth-eval-var-scope-syntax-err.js
+++ b/test/language/expressions/object/method-definition/meth-eval-var-scope-syntax-err.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/meth.template
+/*---
+description: sloppy direct eval in params introduces var (method)
+esid: sec-runtime-semantics-definemethod
+features: [default-parameters]
+flags: [generated]
+info: |
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters,
+       FunctionBody, scope, strict). If functionPrototype was passed as a
+       parameter then pass its value as the functionPrototype optional argument
+       of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+var obj = {
+  method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+};
+
+assert.throws(SyntaxError, function() {
+  obj.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/async-function/eval-var-scope-syntax-err.js
+++ b/test/language/statements/async-function/eval-var-scope-syntax-err.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/async-func-decl.template
+/*---
+description: sloppy direct eval in params introduces var (async function declaration)
+esid: sec-async-function-definitions
+features: [default-parameters, async-functions]
+flags: [generated, async]
+info: |
+    14.6 Async Function Definitions
+
+    AsyncFunctionDeclaration :
+      async function BindingIdentifier ( FormalParameters ) { AsyncFunctionBody }
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+async function f(a = eval("var a = 42")) {
+  
+  callCount = callCount + 1;
+}
+
+f()
+  .then(_ => {
+    throw new Test262Error('function should not be resolved');
+  }, error => assert.sameValue(error.constructor, SyntaxError))
+  .then(() => {
+    assert.sameValue(callCount, 0, 'function body is not evaluated');
+  }, $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/async-generator/eval-var-scope-syntax-err.js
+++ b/test/language/statements/async-generator/eval-var-scope-syntax-err.js
@@ -1,0 +1,38 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/async-gen-func-decl.template
+/*---
+description: sloppy direct eval in params introduces var (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+async function* f(a = eval("var a = 42")) {
+  
+  callCount = callCount + 1;
+}
+
+assert.throws(SyntaxError, function() {
+  f();
+});
+
+assert.sameValue(callCount, 0, 'generator function body not evaluated');

--- a/test/language/statements/class/async-gen-method-static/eval-var-scope-syntax-err.js
+++ b/test/language/statements/class/async-gen-method-static/eval-var-scope-syntax-err.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-decl-async-gen-meth-static.template
+/*---
+description: sloppy direct eval in params introduces var (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  static async *method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(SyntaxError, function() {
+  C.method();
+});
+
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/class/async-gen-method/eval-var-scope-syntax-err.js
+++ b/test/language/statements/class/async-gen-method/eval-var-scope-syntax-err.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-decl-async-gen-meth.template
+/*---
+description: sloppy direct eval in params introduces var (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+class C {
+  async *method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(SyntaxError, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/class/async-method-static/eval-var-scope-syntax-err.js
+++ b/test/language/statements/class/async-method-static/eval-var-scope-syntax-err.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-decl-async-meth-static.template
+/*---
+description: sloppy direct eval in params introduces var (static class declaration async method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters, async-functions]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncMethod : async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncMethod is strict mode code, let strict be true. Otherwise
+       let strict be false.
+    4. Let scope be the LexicalEnvironment of the running execution context.
+    5. Let closure be ! AsyncFunctionCreate(Method, UniqueFormalParameters, AsyncFunctionBody,
+       scope, strict).
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  static async method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+C.method()
+  .then(_ => {
+    throw new Test262Error('function should not be resolved');
+  }, error => assert.sameValue(error.constructor, SyntaxError))
+  .then(() => {
+    assert.sameValue(callCount, 0, 'function body is not evaluated');
+  }, $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/class/async-method/eval-var-scope-syntax-err.js
+++ b/test/language/statements/class/async-method/eval-var-scope-syntax-err.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-decl-async-meth.template
+/*---
+description: sloppy direct eval in params introduces var (class declaration async method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, async-functions]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncMethod : async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncMethod is strict mode code, let strict be true. Otherwise
+       let strict be false.
+    4. Let scope be the LexicalEnvironment of the running execution context.
+    5. Let closure be ! AsyncFunctionCreate(Method, UniqueFormalParameters, AsyncFunctionBody,
+       scope, strict).
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  async method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+C.prototype.method()
+  .then(_ => {
+    throw new Test262Error('function should not be resolved');
+  }, error => assert.sameValue(error.constructor, SyntaxError))
+  .then(() => {
+    assert.sameValue(callCount, 0, 'function body is not evaluated');
+  }, $DONE)
+  .then($DONE, $DONE);

--- a/test/language/statements/class/gen-method-static/eval-var-scope-syntax-err.js
+++ b/test/language/statements/class/gen-method-static/eval-var-scope-syntax-err.js
@@ -1,0 +1,82 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-decl-gen-meth-static.template
+/*---
+description: sloppy direct eval in params introduces var (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters, generators]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+class C {
+  static *method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(SyntaxError, function() {
+  C.method();
+});
+
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/class/gen-method/eval-var-scope-syntax-err.js
+++ b/test/language/statements/class/gen-method/eval-var-scope-syntax-err.js
@@ -1,0 +1,81 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-decl-gen-meth.template
+/*---
+description: sloppy direct eval in params introduces var (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [default-parameters, generators]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+class C {
+  *method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(SyntaxError, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/class/method-static/eval-var-scope-syntax-err.js
+++ b/test/language/statements/class/method-static/eval-var-scope-syntax-err.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-decl-meth-static.template
+/*---
+description: sloppy direct eval in params introduces var (static class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+class C {
+  static method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(SyntaxError, function() {
+  C.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/class/method/eval-var-scope-syntax-err.js
+++ b/test/language/statements/class/method/eval-var-scope-syntax-err.js
@@ -1,0 +1,78 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/cls-decl-meth.template
+/*---
+description: sloppy direct eval in params introduces var (class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+class C {
+  method(a = eval("var a = 42")) {
+    
+    callCount = callCount + 1;
+  }
+}
+
+assert.throws(SyntaxError, function() {
+  C.prototype.method();
+});
+assert.sameValue(callCount, 0, 'method body not evaluated');

--- a/test/language/statements/function/eval-var-scope-syntax-err.js
+++ b/test/language/statements/function/eval-var-scope-syntax-err.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/func-decl.template
+/*---
+description: sloppy direct eval in params introduces var (function declaration)
+esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [default-parameters]
+flags: [generated]
+info: |
+    FunctionDeclaration :
+        function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let F be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+function f(a = eval("var a = 42")) {
+  
+  callCount = callCount + 1;
+}
+assert.throws(SyntaxError, function() {
+  f();
+});
+assert.sameValue(callCount, 0, 'function body not evaluated');

--- a/test/language/statements/generators/eval-var-scope-syntax-err.js
+++ b/test/language/statements/generators/eval-var-scope-syntax-err.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/function-forms/eval-var-scope-syntax-err.case
+// - src/function-forms/error/gen-func-decl.template
+/*---
+description: sloppy direct eval in params introduces var (generator function declaration)
+esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [default-parameters, generators]
+flags: [generated]
+info: |
+    GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        2. Let F be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+
+    
+    Runtime Semantics: IteratorBindingInitialization
+    FormalParameter : BindingElement
+
+    1. Return the result of performing IteratorBindingInitialization for BindingElement with arguments iteratorRecord and environment.
+
+---*/
+
+var callCount = 0;
+function* f(a = eval("var a = 42")) {
+  
+  callCount = callCount + 1;
+}
+
+assert.throws(SyntaxError, function() {
+  f();
+});
+
+assert.sameValue(callCount, 0, 'generator function body not evaluated');


### PR DESCRIPTION
This test case is in response to the changes in https://github.com/tc39/ecma262/pull/1046 and discussion https://github.com/tc39/test262/pull/2445#discussion_r358789570