### PR TITLE
add test for BigInt literals used as literal property names

### DIFF
--- a/test/language/expressions/object/property-name-bigint-literals.js
+++ b/test/language/expressions/object/property-name-bigint-literals.js
@@ -2,10 +2,11 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-  description: >
-      BigInt literals may be used as a literal property name in an object
-      literal.
-  es6id: 12.2.6
+esid: sec-object-initializer
+description: >
+    BigInt literals may be used as a literal property name in an object
+    literal.
+features: [BigInt, destructuring-binding]
 ---*/
 
 var { 9007199254740991n: it } = { 9007199254740991n: 1 };

--- a/test/language/expressions/object/property-name-bigint-literals.js
+++ b/test/language/expressions/object/property-name-bigint-literals.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2013 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+  description: >
+      BigInt literals may be used as a literal property name in an object
+      literal.
+  es6id: 12.2.6
+---*/
+
+var { 9007199254740991n: it } = { 9007199254740991n: 1 };
+
+assert.sameValue(it, 1, "Destructing the BigInt literal property name returns `1`");


### PR DESCRIPTION
BigInt literals may be used as a literal property name in an object literal.

Refs: https://tc39.es/ecma262/#prod-LiteralPropertyName
Refs: https://tc39.es/ecma262/#prod-NumericLiteral