### PR TITLE
Add Object.{freeze,preventExtensions,seal} abrupt completion tests

### DIFF
--- a/test/built-ins/Object/freeze/abrupt-completion.js
+++ b/test/built-ins/Object/freeze/abrupt-completion.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.freeze
+description: >
+  O.[[PreventExtensions]]() returns abrupt completion.
+info: |
+  Object.freeze ( O )
+
+  ...
+  2. Let status be ? SetIntegrityLevel(O, frozen).
+
+  SetIntegrityLevel ( O, level )
+
+  ...
+  3. Let status be ? O.[[PreventExtensions]]().
+features: [Proxy]
+---*/
+
+var p = new Proxy({}, {
+  preventExtensions: function() {
+    throw new Test262Error();
+  },
+});
+
+assert.throws(Test262Error, function() {
+  Object.freeze(p);
+});

--- a/test/built-ins/Object/preventExtensions/abrupt-completion.js
+++ b/test/built-ins/Object/preventExtensions/abrupt-completion.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.preventextensions
+description: >
+  O.[[PreventExtensions]]() returns abrupt completion.
+info: |
+  Object.preventExtensions ( O )
+
+  ...
+  2. Let status be ? O.[[PreventExtensions]]().
+features: [Proxy]
+---*/
+
+var p = new Proxy({}, {
+  preventExtensions: function() {
+    throw new Test262Error();
+  },
+});
+
+assert.throws(Test262Error, function() {
+  Object.preventExtensions(p);
+});

--- a/test/built-ins/Object/seal/abrupt-completion.js
+++ b/test/built-ins/Object/seal/abrupt-completion.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.seal
+description: >
+  O.[[PreventExtensions]]() returns abrupt completion.
+info: |
+  Object.seal ( O )
+
+  ...
+  2. Let status be ? SetIntegrityLevel(O, sealed).
+
+  SetIntegrityLevel ( O, level )
+
+  ...
+  3. Let status be ? O.[[PreventExtensions]]().
+features: [Proxy]
+---*/
+
+var p = new Proxy({}, {
+  preventExtensions: function() {
+    throw new Test262Error();
+  },
+});
+
+assert.throws(Test262Error, function() {
+  Object.seal(p);
+});


### PR DESCRIPTION
Follow-up of #2453.
JSC bug: [`Object.preventExtensions` should throw if not successful](https://bugs.webkit.org/show_bug.cgi?id=206131).