### PR TITLE
Adding security tests for TypedArray.prototype.fill

### DIFF
--- a/test/built-ins/TypedArray/prototype/fill/coerced-end-detach.js
+++ b/test/built-ins/TypedArray/prototype/fill/coerced-end-detach.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2020 Google. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.fill
+description: Security Throws a TypeError if end coercion detaches 
+  the buffer
+info: |
+  22.2.3.8 %TypedArray%.prototype.fill (value [ , start [ , end ] ] )
+
+  9. If relativeEnd < 0, let final be max((len + relativeEnd), 0); else let final be min(relativeEnd, len).
+  10. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+ 
+includes: [testTypedArray.js, detachArrayBuffer.js]
+features: [TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(10);
+
+  function detachAndReturnIndex(){
+    $DETACHBUFFER(sample.buffer);
+    return 10;
+  }
+
+  assert.throws(TypeError, function() {
+    sample.fill(0x77, 0, {valueOf: detachAndReturnIndex});
+  }, "Detachment when coercing end should throw TypeError");
+});

--- a/test/built-ins/TypedArray/prototype/fill/coerced-start-detach.js
+++ b/test/built-ins/TypedArray/prototype/fill/coerced-start-detach.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Google. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.fill
+description: Security Throws a TypeError if start coercion detaches 
+  the buffer
+info: |
+  22.2.3.8 %TypedArray%.prototype.fill (value [ , start [ , end ] ] )
+
+  6. Let relativeStart be ? ToInteger(start).
+  ...
+  10. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+ 
+includes: [testTypedArray.js, detachArrayBuffer.js]
+features: [TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(10);
+
+  function detachAndReturnIndex(){
+    $DETACHBUFFER(sample.buffer);
+    return 0;
+  }
+
+  assert.throws(TypeError, function() {
+    sample.fill(0x77, {valueOf: detachAndReturnIndex}, 10);
+  }, "Detachment when coercing start should throw TypeError");
+});

--- a/test/built-ins/TypedArray/prototype/fill/coerced-value-detach.js
+++ b/test/built-ins/TypedArray/prototype/fill/coerced-value-detach.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Google. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.fill
+description: Security Throws a TypeError if value coercion detaches 
+  the buffer
+info: |
+  22.2.3.8 %TypedArray%.prototype.fill (value [ , start [ , end ] ] )
+
+  5. Otherwise, set value to ? ToNumber(value).
+  ...
+  10. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
+ 
+includes: [testTypedArray.js, detachArrayBuffer.js]
+features: [TypedArray]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var sample = new TA(10);
+
+  function detachAndReturnIndex(){
+    $DETACHBUFFER(sample.buffer);
+    return 0x77;
+  }
+
+  assert.throws(TypeError, function() {
+    sample.fill({valueOf: detachAndReturnIndex}, 0, 10);
+  }, "Detachment when coercing value should throw TypeError");
+});


### PR DESCRIPTION
Adding security tests for TypedArray.prototype.fill based on CVE-2016-4734. These fail on V8 right now.