### PR TITLE
Add length/name/isConstructor tests for Promise built-in functions

### DIFF
--- a/test/built-ins/Promise/create-resolving-functions-reject.js
+++ b/test/built-ins/Promise/create-resolving-functions-reject.js
@@ -19,7 +19,7 @@ Promise.resolve(1).then(function() {
 });
 
 Promise.prototype.then = function(_resolve, reject) {
-  assert.sameValue(!isConstructor(reject));
+  assert(!isConstructor(reject));
   assert.sameValue(reject.length, 1);
   assert.sameValue(reject.name, '');
 

--- a/test/built-ins/Promise/create-resolving-functions-reject.js
+++ b/test/built-ins/Promise/create-resolving-functions-reject.js
@@ -15,13 +15,14 @@ flags: [async]
 ---*/
 
 Promise.resolve(1).then(function() {
-  return Promise.resolve(2);
-});
+  return Promise.resolve();
+}).then($DONE, $DONE);
 
-Promise.prototype.then = function(_resolve, reject) {
+var then = Promise.prototype.then;
+Promise.prototype.then = function(resolve, reject) {
   assert(!isConstructor(reject));
   assert.sameValue(reject.length, 1);
   assert.sameValue(reject.name, '');
 
-  $DONE();
+  return then.call(this, resolve, reject);
 };

--- a/test/built-ins/Promise/create-resolving-functions-reject.js
+++ b/test/built-ins/Promise/create-resolving-functions-reject.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-createresolvingfunctions
+description: >
+  reject is anonymous built-in function with length of 1.
+info: |
+  CreateResolvingFunctions ( promise )
+
+  ...
+  7. Let reject be ! CreateBuiltinFunction(stepsReject, « [[Promise]], [[AlreadyResolved]] »).
+features: [Reflect.construct]
+includes: [isConstructor.js]
+flags: [async]
+---*/
+
+Promise.resolve(1).then(function() {
+  return Promise.resolve(2);
+});
+
+Promise.prototype.then = function(_resolve, reject) {
+  assert.sameValue(!isConstructor(reject));
+  assert.sameValue(reject.length, 1);
+  assert.sameValue(reject.name, '');
+
+  $DONE();
+};

--- a/test/built-ins/Promise/create-resolving-functions-resolve.js
+++ b/test/built-ins/Promise/create-resolving-functions-resolve.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-createresolvingfunctions
+description: >
+  resolve is anonymous built-in function with length of 1.
+info: |
+  CreateResolvingFunctions ( promise )
+
+  ...
+  3. Let resolve be ! CreateBuiltinFunction(stepsResolve, « [[Promise]], [[AlreadyResolved]] »).
+features: [Reflect.construct]
+includes: [isConstructor.js]
+flags: [async]
+---*/
+
+Promise.resolve(1).then(function() {
+  return Promise.resolve(2);
+});
+
+Promise.prototype.then = function(resolve) {
+  assert.sameValue(!isConstructor(resolve));
+  assert.sameValue(resolve.length, 1);
+  assert.sameValue(resolve.name, '');
+
+  $DONE();
+};

--- a/test/built-ins/Promise/create-resolving-functions-resolve.js
+++ b/test/built-ins/Promise/create-resolving-functions-resolve.js
@@ -15,13 +15,14 @@ flags: [async]
 ---*/
 
 Promise.resolve(1).then(function() {
-  return Promise.resolve(2);
-});
+  return Promise.resolve();
+}).then($DONE, $DONE);
 
-Promise.prototype.then = function(resolve) {
+var then = Promise.prototype.then;
+Promise.prototype.then = function(resolve, reject) {
   assert(!isConstructor(resolve));
   assert.sameValue(resolve.length, 1);
   assert.sameValue(resolve.name, '');
 
-  $DONE();
+  return then.call(this, resolve, reject);
 };

--- a/test/built-ins/Promise/create-resolving-functions-resolve.js
+++ b/test/built-ins/Promise/create-resolving-functions-resolve.js
@@ -19,7 +19,7 @@ Promise.resolve(1).then(function() {
 });
 
 Promise.prototype.then = function(resolve) {
-  assert.sameValue(!isConstructor(resolve));
+  assert(!isConstructor(resolve));
   assert.sameValue(resolve.length, 1);
   assert.sameValue(resolve.name, '');
 

--- a/test/built-ins/Promise/prototype/finally/invokes-then-with-function.js
+++ b/test/built-ins/Promise/prototype/finally/invokes-then-with-function.js
@@ -4,7 +4,8 @@
 author: Jordan Harband
 description: Promise.prototype.finally invokes `then` method
 esid: sec-promise.prototype.finally
-features: [Promise.prototype.finally]
+features: [Promise.prototype.finally, Reflect.construct]
+includes: [isConstructor.js]
 ---*/
 
 var target = new Promise(function() {});
@@ -27,8 +28,6 @@ target.then = function(a, b) {
 };
 
 var originalFinallyHandler = function() {};
-var anonName = Object(function() {}).name;
-
 var result = Promise.prototype.finally.call(target, originalFinallyHandler, 2, 3);
 
 assert.sameValue(callCount, 1, 'Invokes `then` method exactly once');
@@ -45,7 +44,8 @@ assert.sameValue(
 );
 assert.notSameValue(firstArg, originalFinallyHandler, 'Invokes `then` method with a different fulfillment handler');
 assert.sameValue(firstArg.length, 1, 'fulfillment handler has a length of 1');
-assert.sameValue(firstArg.name, anonName, 'fulfillment handler is anonymous');
+assert.sameValue(firstArg.name, '', 'fulfillment handler is anonymous');
+assert(!isConstructor(firstArg), 'fulfillment handler is not constructor');
 
 assert.sameValue(
   typeof secondArg,
@@ -54,6 +54,7 @@ assert.sameValue(
 );
 assert.notSameValue(secondArg, originalFinallyHandler, 'Invokes `then` method with a different rejection handler');
 assert.sameValue(secondArg.length, 1, 'rejection handler has a length of 1');
-assert.sameValue(secondArg.name, anonName, 'rejection handler is anonymous');
+assert.sameValue(secondArg.name, '', 'rejection handler is anonymous');
+assert(!isConstructor(secondArg), 'rejection handler is not constructor');
 
 assert.sameValue(result, returnValue, 'Returns the result of the invocation of `then`');

--- a/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls-argument.js
+++ b/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls-argument.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-catchfinallyfunctions
+description: >
+  thrower is anonymous built-in function with length of 1 that throws reason.
+info: |
+  Catch Finally Functions
+
+  ...
+  8. Let thrower be equivalent to a function that throws reason.
+  9. Return ? Invoke(promise, "then", « thrower »).
+
+  The "length" property of a Catch Finally function is 1.
+features: [Promise.prototype.finally, Reflect.construct]
+includes: [isConstructor.js]
+flags: [async]
+---*/
+
+Promise.reject(new Test262Error()).finally(function() {});
+Promise.prototype.then = function(thrower) {
+  assert(!isConstructor(thrower));
+  assert.sameValue(thrower.length, 1);
+  assert.sameValue(thrower.name, '');
+  assert.throws(Test262Error, thrower);
+
+  $DONE();
+};

--- a/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls-argument.js
+++ b/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls-argument.js
@@ -17,12 +17,16 @@ includes: [isConstructor.js]
 flags: [async]
 ---*/
 
-Promise.reject(new Test262Error()).finally(function() {});
+Promise.reject(new Test262Error())
+  .finally(function() {})
+  .then($DONE, $DONE);
+
+var then = Promise.prototype.then;
 Promise.prototype.then = function(thrower) {
   assert(!isConstructor(thrower));
   assert.sameValue(thrower.length, 1);
   assert.sameValue(thrower.name, '');
   assert.throws(Test262Error, thrower);
 
-  $DONE();
+  return then.call(this, thrower);
 };

--- a/test/built-ins/Promise/prototype/finally/resolved-observable-then-calls-argument.js
+++ b/test/built-ins/Promise/prototype/finally/resolved-observable-then-calls-argument.js
@@ -19,12 +19,16 @@ flags: [async]
 
 var value = {};
 
-Promise.resolve(value).finally(function() {});
+Promise.resolve(value)
+  .finally(function() {})
+  .then($DONE, $DONE);
+
+var then = Promise.prototype.then;
 Promise.prototype.then = function(valueThunk) {
   assert(!isConstructor(valueThunk));
   assert.sameValue(valueThunk.length, 1);
   assert.sameValue(valueThunk.name, '');
   assert.sameValue(valueThunk(), value);
 
-  $DONE();
+  return then.call(this, valueThunk);
 };

--- a/test/built-ins/Promise/prototype/finally/resolved-observable-then-calls-argument.js
+++ b/test/built-ins/Promise/prototype/finally/resolved-observable-then-calls-argument.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2019 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-thenfinallyfunctions
+description: >
+  valueThunk is anonymous built-in function with length of 1 that returns value.
+info: |
+  Then Finally Functions
+
+  ...
+  8. Let valueThunk be equivalent to a function that returns value.
+  9. Return ? Invoke(promise, "then", « valueThunk »).
+
+  The "length" property of a Then Finally function is 1.
+features: [Promise.prototype.finally, Reflect.construct]
+includes: [isConstructor.js]
+flags: [async]
+---*/
+
+var value = {};
+
+Promise.resolve(value).finally(function() {});
+Promise.prototype.then = function(valueThunk) {
+  assert(!isConstructor(valueThunk));
+  assert.sameValue(valueThunk.length, 1);
+  assert.sameValue(valueThunk.name, '');
+  assert.sameValue(valueThunk(), value);
+
+  $DONE();
+};


### PR DESCRIPTION
JSC bug: [Anonymous built-in functions should have empty string for a name](https://bugs.webkit.org/show_bug.cgi?id=204214).