### PR TITLE
Fix typo from optional chaining test

### DIFF
--- a/test/language/expressions/optional-chaining/call-expression.js
+++ b/test/language/expressions/optional-chaining/call-expression.js
@@ -22,7 +22,7 @@ const obj = {
 }
 assert.sameValue(33, fn()?.a);
 assert.sameValue(undefined, fn()?.b);
-assert.sameValue(44, obj.fn());
+assert.sameValue(44, obj?.fn());
 
 // CallExpression SuperCall
 class A {}


### PR DESCRIPTION
### Changes
- Add missing `?` in unit test
It requires the question mark as it is part of the "optional chaining operator" `?.`