### PR TITLE
Add coverage for astral ID_Start and ID_Continue in identifiers

### DIFF
--- a/test/built-ins/RegExp/match-indices/indices-array-unicode-property-names.js
+++ b/test/built-ins/RegExp/match-indices/indices-array-unicode-property-names.js
@@ -14,7 +14,7 @@ assert.compareArray([1, 2], /(?<π>a)/u.exec("bab").indices.groups.\u03C0);
 assert.compareArray([1, 2], /(?<\u{03C0}>a)/u.exec("bab").indices.groups.\u03C0);
 assert.compareArray([1, 2], /(?<$>a)/u.exec("bab").indices.groups.$);
 assert.compareArray([1, 2], /(?<_>a)/u.exec("bab").indices.groups._);
-assert.compareArray([1, 2], /(?<$𐒤>a)/u.exec("bab").indices.groups.$𐒤);
+assert.compareArray([1, 2], /(?<$𐒤>a)/u.exec("bab").indices.groups["$𐒤"]);
 assert.compareArray([1, 2], /(?<_\u200C>a)/u.exec("bab").indices.groups._\u200C);
 assert.compareArray([1, 2], /(?<_\u200D>a)/u.exec("bab").indices.groups._\u200D);
 assert.compareArray([1, 2], /(?<ಠ_ಠ>a)/u.exec("bab").indices.groups.ಠ_ಠ);

--- a/test/built-ins/RegExp/named-groups/unicode-property-names.js
+++ b/test/built-ins/RegExp/named-groups/unicode-property-names.js
@@ -13,7 +13,7 @@ assert.sameValue("a", /(?<π>a)/u.exec("bab").groups.\u03C0);
 assert.sameValue("a", /(?<\u{03C0}>a)/u.exec("bab").groups.\u03C0);
 assert.sameValue("a", /(?<$>a)/u.exec("bab").groups.$);
 assert.sameValue("a", /(?<_>a)/u.exec("bab").groups._);
-assert.sameValue("a", /(?<$𐒤>a)/u.exec("bab").groups.$𐒤);
+assert.sameValue("a", /(?<$𐒤>a)/u.exec("bab").groups["$𐒤"]);
 assert.sameValue("a", /(?<_\u200C>a)/u.exec("bab").groups._\u200C);
 assert.sameValue("a", /(?<_\u200D>a)/u.exec("bab").groups._\u200D);
 assert.sameValue("a", /(?<ಠ_ಠ>a)/u.exec("bab").groups.ಠ_ಠ);

--- a/test/language/identifiers/other_id_continue-astral.js
+++ b/test/language/identifiers/other_id_continue-astral.js
@@ -3,9 +3,9 @@
 
 /*---
 esid: sec-names-and-keywords
-description: Test grandfathered astral characters of ID_Continue.
+description: Test astral characters of ID_Continue.
 info: |
-  Grandfathered astral characters (Other_ID_Continue)
+  Astral characters (Other_ID_Continue)
 ---*/
 
 // Other_ID_Continue (Unicode 4.1)

--- a/test/language/identifiers/other_id_continue-astral.js
+++ b/test/language/identifiers/other_id_continue-astral.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-names-and-keywords
+description: Test grandfathered astral characters of ID_Continue.
+info: |
+  Grandfathered astral characters (Other_ID_Continue)
+---*/
+
+// Other_ID_Continue (Unicode 4.1)
+var a𐒤; // U+104A4
+var a𐨏; // U+10A0F
+
+// Other_ID_Continue (Unicode 5.2)
+var a𑂺; // U+110BA
+var a𑂸; // U+110B8
+
+// Other_ID_Continue (Unicode 6.3)
+var a𑄁; // U+11101
+var a𑁪; // U+1106A
+
+// Other_ID_Continue (Unicode 7.0)
+var a𑖿; // U+115BF
+var a𑌁; // U+11301
+
+// Other_ID_Continue (Unicode 8.0)
+var a𝨅; // U+1DA05
+var a𑜪; // U+1172A
+
+// Other_ID_Continue (Unicode 9.0)
+var a𑱗; // U+11C57
+var a𑲟; // U+11C9F
+
+// Other_ID_Continue (Unicode 10.0)
+var a𑨹; // U+11A39
+var a𑵁; // U+11D41
+
+// Other_ID_Continue (Unicode 11.0)
+var a𐴱; // U+10D31
+var a𐽍; // U+10F4D
+
+// Other_ID_Continue (Unicode 12.0)
+var a𞄵; // U+1E135
+var a𞅃; // U+1E143

--- a/test/language/identifiers/other_id_start-astral.js
+++ b/test/language/identifiers/other_id_start-astral.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-names-and-keywords
+description: Test grandfathered astral characters of ID_Start.
+info: |
+  Grandfathered astral characters (Other_ID_Start)
+---*/
+
+// Other_ID_Start (Unicode 4.1)
+var 𐨪; // U+10A2A
+var 𐅫; // U+1016B
+
+// Other_ID_Start (Unicode 5.2)
+var 𓁬; // U+1306C
+var 𒅹; // U+12179
+
+// Other_ID_Start (Unicode 6.3)
+var 𖼟; // U+16F1F
+var 𑄥; // U+11125
+
+// Other_ID_Start (Unicode 7.0)
+var 𞠄; // U+1E804
+var 𞢗; // U+1E897
+
+// Other_ID_Start (Unicode 8.0)
+var 𒓇; // U+124C7
+var 𐳢; // U+10CE2
+
+// Other_ID_Start (Unicode 9.0)
+var 𘋁; // U+182C1
+var 𗌹; // U+17339
+
+// Other_ID_Start (Unicode 10.0)
+var 𛋐; // U+1B2D0
+var 𛂑; // U+1B091
+
+// Other_ID_Start (Unicode 11.0)
+var 𘟮; // U+187EE
+var 𐴁; // U+10D01
+
+// Other_ID_Start (Unicode 12.0)
+var 𞋧; // U+1E2E7
+var 𖽆; // U+16F46

--- a/test/language/identifiers/other_id_start-astral.js
+++ b/test/language/identifiers/other_id_start-astral.js
@@ -3,9 +3,9 @@
 
 /*---
 esid: sec-names-and-keywords
-description: Test grandfathered astral characters of ID_Start.
+description: Test astral characters of ID_Start.
 info: |
-  Grandfathered astral characters (Other_ID_Start)
+  Astral characters (Other_ID_Start)
 ---*/
 
 // Other_ID_Start (Unicode 4.1)


### PR DESCRIPTION
While the test is correct as-is, it requires good unicode support in [`IdentifierPart`](https://tc39.es/ecma262/#prod-IdentifierPart) to work.

With this change, it would be possible to add surrogate pair support to [`RegExpIdentifierPart`](https://tc39.es/ecma262/#prod-RegExpIdentifierPart) and pass the test before [updating Unicode version in JSC](https://bugs.webkit.org/show_bug.cgi?id=79353).

//cc @mathiasbynens