### PR TITLE
`Atomics.store` now normalizes -0 to +0

### DIFF
--- a/test/built-ins/Atomics/store/expected-return-value-negative-zero.js
+++ b/test/built-ins/Atomics/store/expected-return-value-negative-zero.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Jordan Harband. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.store
+description: >
+  Atomics.store calls ToInteger, which normalizes -0 to +0
+features: [Atomics, SharedArrayBuffer, TypedArray]
+---*/
+
+const i32a = new Int32Array(
+  new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4)
+);
+
+assert.ok(
+  Object.is(
+    Atomics.store(i32a, 0, -0),
+    +0
+  ),
+  'Atomics.store(i32a, 0, -0) normalizes -0 to +0'
+);
+assert.sameValue(
+  i32a[0],
+  +0,
+  'The value of i32a[0] is normalized to +0'
+);


### PR DESCRIPTION
Per https://github.com/tc39/ecma262/pull/1827