### PR TITLE
Adding test cases to verify 'numberingSystem' and 'calendar' lower casing

### DIFF
--- a/test/intl402/DateTimeFormat/casing-numbering-system-calendar-options.js
+++ b/test/intl402/DateTimeFormat/casing-numbering-system-calendar-options.js
@@ -1,0 +1,43 @@
+// Copyright 2020 Google Inc, Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-initializedatetimeformat
+description: >
+    Tests that the options numberingSystem and calendar are mapped
+    to lower case properly.
+author: Caio Lima
+---*/
+
+let defaultLocale = new Intl.DateTimeFormat().resolvedOptions().locale;
+
+let supportedNumberingSystems = ["latn", "arab"].filter(nu =>
+  new Intl.DateTimeFormat(defaultLocale + "-u-nu-" + nu)
+    .resolvedOptions().numberingSystem === nu
+);
+
+if (supportedNumberingSystems.includes("latn")) {
+  let dateTimeFormat = new Intl.DateTimeFormat(defaultLocale + "-u-nu-lATn");
+  assert.sameValue(dateTimeFormat.resolvedOptions().numberingSystem, "latn", "Numbering system option should be in lower case");
+}
+
+if (supportedNumberingSystems.includes("arab")) {
+  let dateTimeFormat = new Intl.DateTimeFormat(defaultLocale + "-u-nu-Arab");
+  assert.sameValue(dateTimeFormat.resolvedOptions().numberingSystem, "arab", "Numbering system option should be in lower case");
+}
+
+let supportedCalendars = ["gregory", "chinese"].filter(ca =>
+  new Intl.DateTimeFormat(defaultLocale + "-u-ca-" + ca)
+    .resolvedOptions().calendar === ca
+);
+
+if (supportedCalendars.includes("gregory")) {
+  let dateTimeFormat = new Intl.DateTimeFormat(defaultLocale + "-u-ca-Gregory");
+  assert.sameValue(dateTimeFormat.resolvedOptions().calendar, "gregory", "Calendar option should be in lower case");
+}
+
+if (supportedCalendars.includes("chinese")) {
+  let dateTimeFormat = new Intl.DateTimeFormat(defaultLocale + "-u-ca-CHINESE");
+  assert.sameValue(dateTimeFormat.resolvedOptions().calendar, "chinese", "Calendar option should be in lower case");
+}
+

--- a/test/intl402/NumberFormat/casing-numbering-system-options.js
+++ b/test/intl402/NumberFormat/casing-numbering-system-options.js
@@ -1,0 +1,26 @@
+// Copyright 2020 Google Inc, Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-initializenumberformat
+description: >
+    Tests that the options numberingSystem are mapped to lower case.
+author: Caio Lima
+---*/
+
+let defaultLocale = new Intl.NumberFormat().resolvedOptions().locale;
+
+let supportedNumberingSystems = ["latn", "arab"].filter(nu =>
+  new Intl.NumberFormat(defaultLocale + "-u-nu-" + nu)
+    .resolvedOptions().numberingSystem === nu
+);
+
+if (supportedNumberingSystems.includes("latn")) {
+  let numberFormat = new Intl.NumberFormat(defaultLocale + "-u-nu-lATn");
+  assert.sameValue(numberFormat.resolvedOptions().numberingSystem, "latn", "Numbering system option should be in lower case");
+}
+
+if (supportedNumberingSystems.includes("arab")) {
+  let numberFormat = new Intl.NumberFormat(defaultLocale + "-u-nu-Arab");
+  assert.sameValue(numberFormat.resolvedOptions().numberingSystem, "arab", "Numbering system option should be in lower case");
+}


### PR DESCRIPTION
According to [PR #175](https://github.com/tc39/ecma402/pull/175) on ECMA402, `numberingSystem` and `calendar` options should always be transformed to lower case. We are tests to cover this part of spec.