### PR TITLE
Fix invalid YAML from #2470 and #2474.

### DIFF
--- a/test/built-ins/TypedArray/prototype/fill/coerced-end-detach.js
+++ b/test/built-ins/TypedArray/prototype/fill/coerced-end-detach.js
@@ -2,8 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%typedarray%.prototype.fill
-description: Security Throws a TypeError if end coercion detaches 
-  the buffer
+description: >
+  Security Throws a TypeError if end coercion detaches the buffer
 info: |
   22.2.3.8 %TypedArray%.prototype.fill (value [ , start [ , end ] ] )
 

--- a/test/built-ins/TypedArray/prototype/fill/coerced-start-detach.js
+++ b/test/built-ins/TypedArray/prototype/fill/coerced-start-detach.js
@@ -2,8 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%typedarray%.prototype.fill
-description: Security Throws a TypeError if start coercion detaches 
-  the buffer
+description: >
+  Security Throws a TypeError if start coercion detaches the buffer
 info: |
   22.2.3.8 %TypedArray%.prototype.fill (value [ , start [ , end ] ] )
 

--- a/test/built-ins/TypedArray/prototype/fill/coerced-value-detach.js
+++ b/test/built-ins/TypedArray/prototype/fill/coerced-value-detach.js
@@ -2,8 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%typedarray%.prototype.fill
-description: Security Throws a TypeError if value coercion detaches 
-  the buffer
+description: >
+  Security Throws a TypeError if value coercion detaches the buffer
 info: |
   22.2.3.8 %TypedArray%.prototype.fill (value [ , start [ , end ] ] )
 

--- a/test/built-ins/TypedArray/prototype/sort/detached-buffer-comparefn-coerce.js
+++ b/test/built-ins/TypedArray/prototype/sort/detached-buffer-comparefn-coerce.js
@@ -2,8 +2,9 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%typedarray%.prototype.sort
-description: SECURITY Throws a TypeError if coercion of the comparefn
-  return value detaches the object buffer
+description: >
+  SECURITY Throws a TypeError if coercion of the comparefn return value
+  detaches the object buffer
 info: |
   22.2.3.26 %TypedArray%.prototype.sort ( comparefn )
 


### PR DESCRIPTION
The tests added in PRs #2470 and #2474 have invalid YAML (according to perl5/YAML/Loader.pm), which prevents JSC from importing the latest changes.