### PR TITLE
Test Array methods with "length" of MAX_SAFE_INTEGER

### DIFF
--- a/test/built-ins/Array/prototype/concat/arg-length-exceeding-integer-limit.js
+++ b/test/built-ins/Array/prototype/concat/arg-length-exceeding-integer-limit.js
@@ -16,12 +16,6 @@ info: |
       ii. Let len be ? LengthOfArrayLike(E).
       iii. If n + len > 2^53 - 1, throw a TypeError exception.
     [...]
-
-  CreateDataPropertyOrThrow ( O, P, V )
-
-  [...]
-  3. Let success be ? CreateDataProperty(O, P, V).
-  4. If success is false, throw a TypeError exception.
 features: [Symbol.isConcatSpreadable, Proxy]
 ---*/
 

--- a/test/built-ins/Array/prototype/concat/arg-length-near-integer-limit.js
+++ b/test/built-ins/Array/prototype/concat/arg-length-near-integer-limit.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.concat
+description: >
+  Elements are copied from a spreadable array-like object
+  whose "length" property is near the integer limit.
+info: |
+  Array.prototype.concat ( ...arguments )
+
+  [...]
+  5. Repeat, while items is not empty
+    [...]
+    c. If spreadable is true, then
+      [...]
+      ii. Let len be ? LengthOfArrayLike(E).
+      iii. If n + len > 2^53 - 1, throw a TypeError exception.
+      iv. Repeat, while k < len
+        [...]
+        3. If exists is true, then
+          a. Let subElement be ? Get(E, P).
+    [...]
+features: [Symbol.isConcatSpreadable]
+---*/
+
+var spreadable = {
+  length: Number.MAX_SAFE_INTEGER,
+  get 0() {
+    throw new Test262Error();
+  },
+};
+spreadable[Symbol.isConcatSpreadable] = true;
+
+assert.throws(Test262Error, function() {
+  [].concat(spreadable);
+});

--- a/test/built-ins/Array/prototype/copyWithin/length-near-integer-limit.js
+++ b/test/built-ins/Array/prototype/copyWithin/length-near-integer-limit.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.copywithin
+description: >
+  Elements are copied and deleted in an array-like object
+  whose "length" property is near the integer limit.
+info: |
+  Array.prototype.copyWithin ( target, start [ , end ] )
+
+  1. Let O be ? ToObject(this value).
+  2. Let len be ? LengthOfArrayLike(O).
+  [...]
+  9. Let count be min(final - from, len - to).
+  [...]
+  12. Repeat, while count > 0
+    [...]
+    d. If fromPresent is true, then
+      i. Let fromVal be ? Get(O, fromKey).
+      ii. Perform ? Set(O, toKey, fromVal, true).
+    e. Else,
+      i. Assert: fromPresent is false.
+      ii. Perform ? DeletePropertyOrThrow(O, toKey).
+    [...]
+---*/
+
+var startIndex = Number.MAX_SAFE_INTEGER - 3;
+var arrayLike = {
+  0: 0,
+  1: 1,
+  2: 2,
+  length: Number.MAX_SAFE_INTEGER,
+};
+
+arrayLike[startIndex] = -3;
+arrayLike[startIndex + 2] = -1;
+
+Array.prototype.copyWithin.call(arrayLike, 0, startIndex, startIndex + 3);
+
+assert.sameValue(arrayLike[0], -3);
+assert.sameValue(1 in arrayLike, false);
+assert.sameValue(arrayLike[2], -1);

--- a/test/built-ins/Array/prototype/fill/length-near-integer-limit.js
+++ b/test/built-ins/Array/prototype/fill/length-near-integer-limit.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.fill
+description: >
+  Elements are filled in an array-like object
+  whose "length" property is near the integer limit.
+info: |
+  Array.prototype.fill ( value [ , start [ , end ] ] )
+
+  1. Let O be ? ToObject(this value).
+  2. Let len be ? LengthOfArrayLike(O).
+  [...]
+  7. Repeat, while k < final
+    a. Let Pk be ! ToString(k).
+    b. Perform ? Set(O, Pk, value, true).
+    [...]
+---*/
+
+var value = {};
+var startIndex = Number.MAX_SAFE_INTEGER - 3;
+var arrayLike = {
+  length: Number.MAX_SAFE_INTEGER,
+};
+
+Array.prototype.fill.call(arrayLike, value, startIndex, startIndex + 3);
+
+assert.sameValue(arrayLike[startIndex], value);
+assert.sameValue(arrayLike[startIndex + 1], value);
+assert.sameValue(arrayLike[startIndex + 2], value);

--- a/test/built-ins/Array/prototype/indexOf/length-near-integer-limit.js
+++ b/test/built-ins/Array/prototype/indexOf/length-near-integer-limit.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.indexof
+description: >
+  Elements are found in an array-like object
+  whose "length" property is near the integer limit.
+info: |
+  Array.prototype.indexOf ( searchElement [ , fromIndex ] )
+
+  1. Let O be ? ToObject(this value).
+  2. Let len be ? LengthOfArrayLike(O).
+  [...]
+  9. Repeat, while k < len
+    a. Let kPresent be ? HasProperty(O, ! ToString(k)).
+    b. If kPresent is true, then
+      i. Let elementK be ? Get(O, ! ToString(k)).
+      ii. Let same be the result of performing Strict Equality Comparison searchElement === elementK.
+      iii. If same is true, return k.
+    [...]
+---*/
+
+var el = {};
+var elIndex = Number.MAX_SAFE_INTEGER - 1;
+var fromIndex = Number.MAX_SAFE_INTEGER - 3;
+var arrayLike = {
+  length: Number.MAX_SAFE_INTEGER,
+};
+
+arrayLike[elIndex] = el;
+
+var res = Array.prototype.indexOf.call(arrayLike, el, fromIndex);
+
+assert.sameValue(res, elIndex);

--- a/test/built-ins/Array/prototype/lastIndexOf/length-near-integer-limit.js
+++ b/test/built-ins/Array/prototype/lastIndexOf/length-near-integer-limit.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.lastindexof
+description: >
+  Elements are found in an array-like object
+  whose "length" property is near the integer limit.
+info: |
+  Array.prototype.lastIndexOf ( searchElement [ , fromIndex ] )
+
+  1. Let O be ? ToObject(this value).
+  2. Let len be ? LengthOfArrayLike(O).
+  [...]
+  7. Repeat, while k ≥ 0
+    a. Let kPresent be ? HasProperty(O, ! ToString(k)).
+    b. If kPresent is true, then
+      i. Let elementK be ? Get(O, ! ToString(k)).
+      ii. Let same be the result of performing Strict Equality Comparison searchElement === elementK.
+      iii. If same is true, return k.
+    [...]
+---*/
+
+var el = {};
+var elIndex = Number.MAX_SAFE_INTEGER - 3;
+var fromIndex = Number.MAX_SAFE_INTEGER - 1;
+var arrayLike = {
+  length: Number.MAX_SAFE_INTEGER,
+};
+
+arrayLike[elIndex] = el;
+
+var res = Array.prototype.lastIndexOf.call(arrayLike, el, fromIndex);
+
+assert.sameValue(res, elIndex);

--- a/test/built-ins/Array/prototype/reduceRight/length-near-integer-limit.js
+++ b/test/built-ins/Array/prototype/reduceRight/length-near-integer-limit.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.reduceright
+description: >
+  Elements are processed in an array-like object
+  whose "length" property is near the integer limit.
+info: |
+  Array.prototype.reduceRight ( callbackfn [ , initialValue ] )
+
+  1. Let O be ? ToObject(this value).
+  2. Let len be ? LengthOfArrayLike(O).
+  [...]
+  9. Repeat, while k ≥ 0
+    a. Let Pk be ! ToString(k).
+    b. Let kPresent be ? HasProperty(O, Pk).
+    c. If kPresent is true, then
+      i. Let kValue be ? Get(O, Pk).
+      ii. Set accumulator to ? Call(callbackfn, undefined, « accumulator, kValue, k, O »).
+    [...]
+includes: [compareArray.js]
+---*/
+
+var arrayLike = {
+  length: Number.MAX_SAFE_INTEGER,
+};
+
+arrayLike[Number.MAX_SAFE_INTEGER - 1] = 1;
+arrayLike[Number.MAX_SAFE_INTEGER - 3] = 3;
+
+var accumulator = function(acc, el, index) {
+  acc.push([el, index]);
+
+  if (el === 3) {
+    throw acc;
+  }
+
+  return acc;
+};
+
+try {
+  Array.prototype.reduceRight.call(arrayLike, accumulator, []);
+  throw new Test262Error("should not be called");
+} catch (acc) {
+  assert.sameValue(acc.length, 2);
+  assert.compareArray(acc[0], [1, Number.MAX_SAFE_INTEGER - 1]);
+  assert.compareArray(acc[1], [3, Number.MAX_SAFE_INTEGER - 3]);
+}


### PR DESCRIPTION
JSC implements `Array.prototype.{copyWithin,fill,reduceRight}` methods in JavaScript.