### PR TITLE
Tests for Function.prototype.{arguments,caller}

### DIFF
--- a/test/annexB/built-ins/Function/prototype/arguments-caller/arguments-call-stack.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/arguments-call-stack.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    The result of func.arguments is based on execution context stack.
+flags: [noStrict]
+---*/
+
+
+
+function f(rec) {
+    if (rec === 'inner') {
+        assert(f.arguments[0] === 'inner')
+    }
+    else if (rec === 'outer') {
+        assert(f.arguments[0] === 'outer')
+        f('inner')
+        assert(f.arguments[0] === 'outer')
+    }
+    else {
+        assert(false)
+    }
+}
+
+function g() {
+    assert(f.arguments === null)
+    f('outer')
+    assert(f.arguments === null)
+}
+
+g()

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/arguments-correct-shape.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/arguments-correct-shape.js
@@ -1,0 +1,72 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    func.arguments evaluates to an object with some defined characteristics.
+flags: [noStrict]
+---*/
+
+
+function f() { return [f, f.arguments, arguments] }
+
+var listFunctions = {
+    'non-strict function defined by a FunctionDeclaration': f
+  , 'non-strict function defined by a FunctionExpression': (function f() { return [f, f.arguments, arguments] })
+  , 'non-strict function constructed using the Function constructor': Function("return [arguments.callee, arguments.callee.arguments, arguments]")
+  , 'non-strict function with a non-simple parameter list': function f(...args) { return [f, f.arguments, arguments] }
+}
+
+
+for (let [key, func] of Object.entries(listFunctions)) {
+
+    let [receiver, argObject, trueArguments] = func('a', 'b')
+
+    assert(typeof argObject === "object" && argObject !== null
+      , `f.arguments must be an object when f is ${key}.`
+    )
+
+    assert(Object.getPrototypeOf(argObject) === Object.prototype
+      , `f.arguments must inherit from Object.prototype when f is ${key}.`
+    )
+
+    assert(argObject.toString() === '[object Arguments]'
+      , `f.arguments.toString() must be "[object Arguments]" when f is ${key}.`
+    )
+
+    assert(argObject !== trueArguments
+      , `f.arguments must be distinct from the arguments binding when f is ${key}.`
+    )
+
+    assert(argObject.length === 2 && argObject[0] === 'a' && argObject[1] === 'b'
+      , `f.arguments must reflect the arguments passed to f when f is ${key}.`
+    )
+
+    assert(argObject[Symbol.iterator] === Array.prototype.values
+      , `f.arguments[Symbol.iterator] must be Array.prototype.values when f is ${key}.`
+    )
+
+    let hasThrown = 0
+    try {
+        assert(trueArguments.callee === receiver)
+    }
+    catch (e) {
+        if (e instanceof Test262Error)
+            throw e
+        hasThrown++
+    }
+
+    try {
+        assert(argObject.callee === receiver
+          , `f.arguments.callee must evaluates to the callee when f is ${key}`
+        )
+    }
+    catch (e) {
+        if (e instanceof Test262Error)
+            throw e
+        hasThrown++
+    }
+
+    assert(hasThrown === 0 || hasThrown === 2
+      , `f.arguments.callee must be poisoned if and only if arguments.callee is poisoned when f is ${key}`
+    )
+}

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/arguments-recreated-original.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/arguments-recreated-original.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    func.arguments evaluates to a new object which is not mapped to the actual arguments.
+flags: [noStrict]
+---*/
+
+
+
+function f(x, y, z) {
+
+    assert(f.arguments !== arguments)
+
+    x = 42
+
+    assert(f.arguments.length === 2)
+    assert(f.arguments[0] === 'a')
+    assert(f.arguments[1] === 'b')
+
+    f.arguments[1] = "pwnd"
+    assert(y === 'b')
+    assert(arguments[1] === 'b')
+
+    assert(f.arguments !== f.arguments)
+
+}
+
+f('a', 'b')

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/caller-call-stack.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/caller-call-stack.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    The result of func.caller is based on execution context stack.
+flags: [noStrict]
+---*/
+
+
+
+function f(rec) {
+    if (rec === 'inner') {
+        assert(f.caller === f)
+    }
+    else if (rec === 'outer') {
+        assert(f.caller === g)
+        f('inner')
+        assert(f.caller === g)
+    }
+    else {
+        assert(false)
+    }
+}
+
+function g() {
+    assert(f.caller === null)
+    f('outer')
+    assert(f.caller === null)
+}
+
+g()

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/caller-censored-async.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/caller-censored-async.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    func.caller evaluates to null for async callers.
+flags: [noStrict, async]
+---*/
+
+function getCaller() { return getCaller.caller }
+
+var listCallers = {
+    'async function': async function () { return getCaller() }
+  , 'async arow function': async _ => getCaller()
+  , 'async generator': async _ => {
+        let f = async function*() { yield getCaller() }
+        let result = await (f().next())
+        return result.value
+    }
+  , 'async arrow function': async _=> getCaller()
+}
+
+;(async function () {
+    for (let [key, func] of Object.entries(listCallers)) {
+        assert((await func()) === null
+          , `f.caller must evaluate to null when the caller is a ${key}`
+        )
+    }
+    print('Test262:AsyncTestComplete')
+})().then(
+    _ => print('Test262:AsyncTestComplete')
+  , _ => print('Test262:AsyncTestFailure: ' + _)
+)

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/caller-censored-sync.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/caller-censored-sync.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    func.caller evaluates to null for censored sync callers.
+flags: [noStrict]
+---*/
+
+function getCaller() { return getCaller.caller }
+
+var listCallers = {
+    'strict function': function () {
+        "use strict"
+        // Beware of PTC!
+        let r = getCaller()
+        return r
+    }
+  , 'generator function': _ => (function*() {
+        yield getCaller()
+    })().next().value
+  , 'built-in function': _ => {
+        let r
+        ;[0].forEach(function g() {
+            r = g.caller
+        })
+        return r
+    }
+}
+
+
+for (let [key, func] of Object.entries(listCallers)) {
+    try {
+        assert(func() === null
+          , `f.caller must evaluate to null when the caller is a ${key}`
+        )
+    }
+    catch (e) {
+        if (e instanceof Test262Error)
+            throw e
+        $ERROR(`f.caller must not throw when the caller is a ${key}. Thrown: ${e}`)
+    }
+}
+

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/caller-cross-realm.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/caller-cross-realm.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    func.caller evaluates to null for cross-realm caller.
+flags: [noStrict]
+---*/
+
+var foreignGetCaller = $262.createRealm().global.Function("return arguments.callee.caller")
+
+assert((function () { return foreignGetCaller() })() === null
+  , `f.caller must evaluate to null when the caller is from another realm`
+)

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/caller-tail-call.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/caller-tail-call.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    Test interactions between .caller and proper tail calls.
+flags: [noStrict]
+---*/
+
+function getCaller() { return getCaller.caller }
+
+var listCallers = {
+    get 'g calls f in apparent tail position in non-strict mode'() {
+        let shouldNotTriggerTailCall = function () {
+            return getCaller()
+        }
+        let wrapper = function() {
+            let r = shouldNotTriggerTailCall()
+            return r
+        }
+        return [ shouldNotTriggerTailCall, wrapper ]
+    }
+  , get 'g calls a strict function that calls f in tail position'() {
+        let willTriggerTailCall = function () {
+            "use strict"
+            return getCaller()
+        }
+        let wrapper = function () {
+            let r = willTriggerTailCall()
+            return r
+        }
+        return [ wrapper, wrapper ]
+    }
+}
+
+for (let [key, [caller, func]] of Object.entries(listCallers)) {
+    let result
+    try {
+        assert(func() === caller
+          , `f.caller must return g when ${key}`
+        )
+    }
+    catch (e) {
+        if (e instanceof Test262Error)
+            throw e
+        $ERROR(`f.caller must not throw when ${key}. Thrown: ${e}`)
+    }
+}

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/caller-uncensored.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/caller-uncensored.js
@@ -1,0 +1,66 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    func.caller evaluates to the caller of func for uncensored callers..
+flags: [noStrict]
+---*/
+
+function getCaller() { return getCaller.caller }
+
+var listCallers = {
+    get 'non-strict function defined by a FunctionDeclaretion'() {
+        function f() { return getCaller() }
+        return [ f, f ]
+    }
+  , get 'non-strict function defined by a FunctionExpression'() {
+        var f = function () { return getCaller() }
+        return [ f, f ]
+    }
+  , get 'non-strict function defined using the Function constructor'() {
+        var f = Function("return getCaller()")
+        return [ f, f ]
+    }
+  , get 'non-strict function with non-simple parameter list'() {
+        function f(...args) { return getCaller() }
+        return [ f, f ]
+    }
+  , get 'non-strict target of bound function'() {
+        function f() { return getCaller() }
+        let bound = f.bind(null)
+        return [ f, bound ]
+    }
+  , get 'non-strict arrow function'() {
+        let f =  _ => getCaller()
+        return [ f, f ]
+    }
+  , get 'non-strict method from object literal'() {
+        let obj = { foo() { return getCaller() } }
+        return [ obj.foo, _ => obj.foo() ]
+    }
+  , get 'non-strict getter from object literal'() {
+        let obj = { get foo() { return getCaller() } }
+        let getFoo = Object.getOwnPropertyDescriptor(obj, 'foo').get
+        return [ getFoo, _ => obj.foo ]
+    }
+  , get 'non-strict proxy target'() {
+        let target = function() { return getCaller() }
+        let proxy = new Proxy(target, { })
+        return [ target, proxy ]
+    }
+  , get 'non-strict proxy handler'() {
+        let applyHandler = function() { return getCaller() }
+        let proxy = new Proxy(function () { }, { apply: applyHandler })
+        return [ applyHandler, proxy ]
+    }
+  , get 'non-strict function using call'() {
+        function f() { return getCaller.call() }
+        return [ f, f ]
+    }
+}
+
+for (let [key, [expectedCaller, func]] of Object.entries(listCallers)) {
+    assert(func() === expectedCaller
+      , `func.caller must evaluate to its caller when the caller is a ${key}`
+    )
+}

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/deletable-accessor-without-setter.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/deletable-accessor-without-setter.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    Function.prototype.arguments and Function.prototype.caller
+    must be deletable accessor properties without setter.
+---*/
+
+for (let property of ['caller', 'arguments']) {
+    var desc = Object.getOwnPropertyDescriptor(Function.prototype, property)
+    assert(desc !== undefined, `Function.prototype.${property} must exist as own property`)
+    assert(desc.configurable === true, `Function.prototype.${property} must be configurable`)
+    assert(desc.enumerable === false, `Function.prototype.${property} must be non-enumerable`)
+    assert(!('value' in desc), `Function.prototype.${property} must be an accessor property`)
+    assert(desc.set === undefined, `Function.prototype.${property} must have no setter`)
+    assert(typeof desc.get === "function", `Function.prototype.${property} must have a getter`)
+    delete desc[property]
+    var newDesc = Object.getOwnPropertyDescriptor(Function.prototype, property)
+    assert(newDesc === undefined, `Function.prototype.${property} must be deletable`)
+}

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/not-own-properties.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/not-own-properties.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    func.arguments and func.caller must not exist as own properties on individual functions.
+flags: [noStrict]
+---*/
+
+function f() {}
+
+var listFunctions = {
+    'non-strict function defined by a FunctionDeclaration': f
+  , 'non-strict function defined by a FunctionExpression': function () { }
+  , 'non-strict function with a non-simple parameter list': function (...args) { }
+  , 'non-strict function constructed using the Function constructor': Function("")
+  , 'non-function': Object.create(Function.prototype)
+  , 'strict function': function f() { "use strict"; }
+  , 'class constructor': class { constructor() { } }
+  , 'implicit class constructor': class { }
+  , 'implicit derived class constructor': class extends (class { }) { }
+  , 'class method': (class { foo() { }}).prototype.foo
+  , 'class static method': (class { static foo() { } }).foo
+  , 'builtin function': [].reduce
+  , 'builtin getter': Object.getOwnPropertyDescriptor(Set.prototype, 'size').get
+  , 'bound function': (function() { }).bind(null)
+  , 'arrow function': _ => _
+  , 'generator function': function* () { yield 42; }
+  , '.next method of generator': (function* () { yield 42; })().next
+  , 'async function': async function() { }
+  , 'async generator function': async function*() { }
+  , 'async arrow function': async _ => _
+  , 'method from object literal': ({ f() { } }).f
+  , 'getter from object literal': Object.getOwnPropertyDescriptor({ get f() { } }, "f").get
+  , 'setter from object literal': Object.getOwnPropertyDescriptor({ set f(v) { } }, "f").set
+  , 'proxy function': new Proxy(function () { }, { })
+}
+
+for (let property of ['caller', 'arguments']) {
+    for (let [key, func] of Object.entries(listFunctions)) {
+        assert(func.hasOwnProperty(property) === false
+          , `func.${property} must not be an own property of a ${key}.`
+        )
+    }
+}

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/receiver-censored.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/receiver-censored.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    func.arguments and func.caller throw a TypeError exception when the receiver is censored.
+flags: [noStrict]
+---*/
+
+var listFunctions = {
+    'non-function': Object.create(Function.prototype)
+  , 'strict function': function f() { "use strict"; }
+  , 'class constructor': class { constructor() { } }
+  , 'implicit class constructor': class { }
+  , 'implicit derived class constructor': class extends (class { }) { }
+  , 'class method': (class { foo() { } }).prototype.foo
+  , 'class static method': (class { static foo() { } }).foo
+  , 'builtin function': [].reduce
+  , 'builtin getter': Object.getOwnPropertyDescriptor(Set.prototype, 'size').get
+  , 'bound function': (function() { }).bind(null)
+  , 'arrow function': _ => _
+  , 'generator function': function* () { yield 42; }
+  , '.next method of generator': (function* () { yield 42; })().next
+  , 'async function': async function() { }
+  , 'async generator function': async function*() { }
+  , 'async arrow function': async _ => _
+  , 'method from object literal': ({ f() { } }).f
+  , 'getter from object literal': Object.getOwnPropertyDescriptor({ get f() { } }, "f").get
+  , 'setter from object literal': Object.getOwnPropertyDescriptor({ set f(v) { } }, "f").set
+  , 'proxy function': new Proxy(function () { }, { })
+}
+
+for (let property of ['caller', 'arguments']) {
+    for (let [key, func] of Object.entries(listFunctions)) {
+        assert.throws(
+            TypeError
+          , _ => func[property]
+          , `func.${property} must throw a TypeError when the receiver is a ${key}.`
+        )
+    }
+}

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/receiver-cross-realm.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/receiver-cross-realm.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+   func.arguments and func.caller throw a TypeError exception when the realm
+    of the receiver and the realm of the getter do not match.
+flags: [noStrict]
+---*/
+
+var crossRealmFunc = $262.createRealm().global.Function("")
+Object.setPrototypeOf(crossRealmFunc, Function.prototype)
+
+for (let property of ['caller', 'arguments']) {
+    assert(property in crossRealmFunc, `func.${property} should exist.`)
+    assert(!crossRealmFunc.hasOwnProperty(property), `func.${property} should not be an own property.`)
+    assert.throws(
+        TypeError
+      , _ => crossRealmFunc[property]
+      , `func.${property} must throw a TypeError when its .${property} getter is from another realm.`
+    )
+}

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/receiver-uncensored.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/receiver-uncensored.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    func.arguments and func.caller returns null when the receiver is a non-strict function
+    defined through FunctionDeclaration, FunctionExpression or the Function constructor,
+    and the receiver is not in the call stack.
+flags: [noStrict]
+---*/
+
+function f() { }
+
+var listFunctions = {
+    'non-strict function defined by a FunctionDeclaration': f
+  , 'non-strict function defined by a FunctionExpression': (function () { })
+  , 'non-strict function with a non-simple parameter list': function (...args) { }
+  , 'non-strict function constructed using the Function constructor': Function("")
+}
+
+
+for (let property of ['caller', 'arguments']) {
+    for (let [key, func] of Object.entries(listFunctions)) {
+        assert(
+            func[property] === null
+          , `f.${property} must evaluate to null when the receiver is a ${key} (when not in the call stack).`
+        )
+    }
+}

--- a/test/annexB/built-ins/Function/prototype/arguments-caller/setting-strict-mode.js
+++ b/test/annexB/built-ins/Function/prototype/arguments-caller/setting-strict-mode.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2020 Claude Pache. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    func.arguments = 42 and func.caller = 42 must throw a TypeError in strict mode.
+flags: [noStrict]
+---*/
+
+function f() {}
+
+var listFunctions = {
+    'non-strict function defined by a FunctionDeclaration': f
+  , 'non-strict function defined by a FunctionExpression': (function () { })
+  , 'non-strict function with a non-simple parameter list': function (...args) { }
+  , 'non-strict function constructed using the Function constructor': Function("")
+  , 'non-function': Object.create(Function.prototype)
+  , 'strict function': function f() { "use strict"; }
+  , 'class constructor': class { constructor() { } }
+  , 'implicit class constructor': class { }
+  , 'implicit derived class constructor': class extends (class { }) { }
+  , 'class method': (class { foo() { } }).prototype.foo
+  , 'class static method': (class { static foo() { } }).foo
+  , 'builtin function': [].reduce
+  , 'builtin getter': Object.getOwnPropertyDescriptor(Set.prototype, 'size').get
+  , 'bound function': (function() { }).bind(null)
+  , 'arrow function': _ => _
+  , 'generator function': function* () { yield 42; }
+  , '.next method of generator': (function* () { yield 42; })().next
+  , 'async function': async function() { }
+  , 'async generator function': async function*() { }
+  , 'async arrow function': async _ => _
+  , 'method from object literal': ({ f() { } }).f
+  , 'getter from object literal': Object.getOwnPropertyDescriptor({ get f() { } }, "f").get
+  , 'setter from object literal': Object.getOwnPropertyDescriptor({ set f(v) { } }, "f").set
+  , 'proxy function': new Proxy(function () { }, { })
+}
+
+for (let property of ['caller', 'arguments']) {
+    for (let [key, func] of Object.entries(listFunctions)) {
+        assert.throws(
+            TypeError
+          , function() { "use strict"; func[property] = 42; }
+          , `f.${property} = 42 must throw a TypeError in strict mode when the receiver is a ${key}.`
+        )
+
+    }
+}


### PR DESCRIPTION
Early test coverage for the stage 1 [Legacy reflection features for functions in JavaScript](https://github.com/claudepache/es-legacy-function-reflection) proposal (standardisation of Function.prototype.arguments and Function.prototype.caller) in its current state.

Moreover, there are some existing tests that are expected to fail with the proposal, because `f.caller = 42` do no longer throw in non-strict mode when `f` is censored  (list copied from claudepache/es-legacy-function-reflection#11):

```
test262/built-ins/Function/prototype/bind/15.3.4.5-20-3.js
test262/built-ins/Function/prototype/bind/BoundFunction_restricted-properties.js
test262/built-ins/GeneratorFunction/instance-restricted-properties.js
test262/language/statements/function/13.2-22-s.js
test262/language/statements/function/13.2-6-s.js
test262/language/statements/function/13.2-30-s.js
test262/language/statements/function/13.2-10-s.js
test262/language/statements/class/restricted-properties.js
test262/language/statements/class/definition/methods-restricted-properties.js
test262/language/statements/generators/restricted-properties.js
test262/language/expressions/arrow-function/ArrowFunction_restricted-properties.js
test262/language/expressions/class/restricted-properties.js
```

Those tests will be superseded by the following ones that covers the new semantics:

```
test262/annexB/built-ins/Function/prototype/
    deletable-accessor-without-setter
    not-own-properties
    setting-strict-mode
```
