### PR TITLE
Add property order after [[DefineOwnProperty]] tests

### DIFF
--- a/test/built-ins/Object/entries/order-after-define-property.js
+++ b/test/built-ins/Object/entries/order-after-define-property.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.entries
+description: >
+  Property names are returned in ascending chronological order of creation
+  that is unaffected by [[DefineOwnProperty]].
+info: |
+  Object.entries ( O )
+
+  [...]
+  2. Let nameList be ? EnumerableOwnPropertyNames(obj, key+value).
+  3. Return CreateArrayFromList(nameList).
+
+  EnumerableOwnPropertyNames ( O, kind )
+
+  [...]
+  2. Let ownKeys be ? O.[[OwnPropertyKeys]]().
+  [...]
+
+  OrdinaryOwnPropertyKeys ( O )
+
+  [...]
+  3. For each own property key P of O that is a String but is not an array index,
+  in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  [...]
+  5. Return keys.
+features: [arrow-function]
+includes: [compareArray.js]
+---*/
+
+var obj = {};
+obj.a = 1;
+obj.b = 2;
+Object.defineProperty(obj, "a", {writable: false});
+var objKeys = Object.entries(obj).map(e => e[0]);
+assert.compareArray(objKeys, ["a", "b"]);
+
+var fn = () => {};
+fn.a = 1;
+Object.defineProperty(fn, "name", {enumerable: true});
+var fnKeys = Object.entries(fn).map(e => e[0]);
+assert.compareArray(fnKeys, ["name", "a"]);

--- a/test/built-ins/Object/getOwnPropertyDescriptors/order-after-define-property.js
+++ b/test/built-ins/Object/getOwnPropertyDescriptors/order-after-define-property.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.getownpropertydescriptors
+description: >
+  Property names are returned in ascending chronological order of creation
+  that is unaffected by [[DefineOwnProperty]].
+info: |
+  Object.getOwnPropertyDescriptors ( O )
+
+  [...]
+  2. Let ownKeys be ? obj.[[OwnPropertyKeys]]().
+  3. Let descriptors be ! OrdinaryObjectCreate(%Object.prototype%).
+  4. For each element key of ownKeys in List order, do
+    [...]
+    c. If descriptor is not undefined,
+    perform ! CreateDataPropertyOrThrow(descriptors, key, descriptor).
+  5. Return descriptors.
+
+  OrdinaryOwnPropertyKeys ( O )
+
+  [...]
+  3. For each own property key P of O that is a String but is not an array index,
+  in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  4. For each own property key P of O that is a Symbol, in ascending
+  chronological order of property creation, do
+    a. Add P as the last element of keys.
+  5. Return keys.
+features: [Symbol, Reflect]
+includes: [compareArray.js]
+---*/
+
+var obj = {};
+var symA = Symbol("a");
+var symB = Symbol("b");
+obj[symA] = 1;
+obj[symB] = 2;
+Object.defineProperty(obj, symA, {configurable: false});
+var objDescs = Object.getOwnPropertyDescriptors(obj);
+assert.compareArray(Reflect.ownKeys(objDescs), [symA, symB]);
+
+var re = /(?:)/g;
+re.a = 1;
+Object.defineProperty(re, "lastIndex", {value: 2});
+var reDescs = Object.getOwnPropertyDescriptors(re);
+assert.compareArray(Reflect.ownKeys(reDescs), ["lastIndex", "a"]);

--- a/test/built-ins/Object/getOwnPropertyNames/order-after-define-property.js
+++ b/test/built-ins/Object/getOwnPropertyNames/order-after-define-property.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.getownpropertynames
+description: >
+  Property names are returned in ascending chronological order of creation
+  that is unaffected by [[DefineOwnProperty]].
+info: |
+  Object.getOwnPropertyNames ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, String).
+
+  GetOwnPropertyKeys ( O, type )
+
+  1. Let obj be ? ToObject(O).
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+  [...]
+
+  OrdinaryOwnPropertyKeys ( O )
+
+  [...]
+  3. For each own property key P of O that is a String but is not an array index,
+  in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  [...]
+  5. Return keys.
+features: [arrow-function]
+includes: [compareArray.js]
+---*/
+
+var obj = {};
+Object.defineProperty(obj, "a", {
+  get: function() {},
+  set: function(_value) {},
+  enumerable: true,
+  configurable: true,
+})
+obj.b = 2;
+Object.defineProperty(obj, "a", {
+  set: function(_value) {},
+});
+assert.compareArray(Object.getOwnPropertyNames(obj), ["a", "b"]);
+
+var arr = [];
+arr.a = 1;
+Object.defineProperty(arr, "length", {value: 2});
+assert.compareArray(Object.getOwnPropertyNames(arr), ["length", "a"]);

--- a/test/built-ins/Object/getOwnPropertySymbols/order-after-define-property.js
+++ b/test/built-ins/Object/getOwnPropertySymbols/order-after-define-property.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.getownpropertysymbols
+description: >
+  Property names are returned in ascending chronological order of creation
+  that is unaffected by [[DefineOwnProperty]].
+info: |
+  Object.getOwnPropertySymbols ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, Symbol).
+
+  GetOwnPropertyKeys ( O, type )
+
+  1. Let obj be ? ToObject(O).
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+  [...]
+
+  OrdinaryOwnPropertyKeys ( O )
+
+  [...]
+  4. For each own property key P of O that is a Symbol, in ascending
+  chronological order of property creation, do
+    a. Add P as the last element of keys.
+  5. Return keys.
+features: [Symbol]
+includes: [compareArray.js]
+---*/
+
+var symA = Symbol("a");
+var symB = Symbol("b");
+
+var obj = {};
+obj[symA] = 1;
+obj[symB] = 2;
+Object.defineProperty(obj, symA, {
+  get: function() {},
+});
+assert.compareArray(Object.getOwnPropertySymbols(obj), [symA, symB]);
+
+var arr = [];
+arr[symA] = 1;
+arr[symB] = 2;
+Object.defineProperty(arr, symA, {writable: false});
+assert.compareArray(Object.getOwnPropertySymbols(arr), [symA, symB]);

--- a/test/built-ins/Object/keys/order-after-define-property.js
+++ b/test/built-ins/Object/keys/order-after-define-property.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.keys
+description: >
+  Property names are returned in ascending chronological order of creation
+  that is unaffected by [[DefineOwnProperty]].
+info: |
+  Object.keys ( O )
+
+  [...]
+  2. Let nameList be ? EnumerableOwnPropertyNames(obj, key).
+  3. Return CreateArrayFromList(nameList).
+
+  EnumerableOwnPropertyNames ( O, kind )
+
+  [...]
+  2. Let ownKeys be ? O.[[OwnPropertyKeys]]().
+  [...]
+
+  OrdinaryOwnPropertyKeys ( O )
+
+  [...]
+  3. For each own property key P of O that is a String but is not an array index,
+  in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  [...]
+  5. Return keys.
+features: [Proxy]
+includes: [compareArray.js]
+---*/
+
+var obj = {};
+Object.defineProperty(obj, "a", {
+  get: function() {},
+  set: function(_value) {},
+  enumerable: true,
+  configurable: true,
+});
+obj.b = 2;
+Object.defineProperty(obj, "a", {value: 1});
+assert.compareArray(Object.keys(obj), ["a", "b"]);
+
+var fn = () => {};
+fn.a = 1;
+Object.defineProperty(fn, "length", {enumerable: true});
+assert.compareArray(Object.keys(fn), ["length", "a"]);

--- a/test/built-ins/Object/values/order-after-define-property.js
+++ b/test/built-ins/Object/values/order-after-define-property.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.values
+description: >
+  Property names are returned in ascending chronological order of creation
+  that is unaffected by [[DefineOwnProperty]].
+info: |
+  Object.values ( O )
+
+  [...]
+  2. Let nameList be ? EnumerableOwnPropertyNames(obj, value).
+  3. Return CreateArrayFromList(nameList).
+
+  EnumerableOwnPropertyNames ( O, kind )
+
+  [...]
+  2. Let ownKeys be ? O.[[OwnPropertyKeys]]().
+  [...]
+
+  OrdinaryOwnPropertyKeys ( O )
+
+  [...]
+  3. For each own property key P of O that is a String but is not an array index,
+  in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  [...]
+  5. Return keys.
+includes: [compareArray.js]
+---*/
+
+var obj = {};
+Object.defineProperty(obj, "a", {
+  get: function() {},
+  enumerable: true,
+  configurable: true,
+});
+obj.b = "b";
+Object.defineProperty(obj, "a", {
+  get: function() {
+    return "a";
+  },
+});
+assert.compareArray(Object.values(obj), ["a", "b"]);
+
+var proxy = new Proxy({}, {});
+Object.defineProperty(proxy, "a", {
+  get: function() {},
+  enumerable: true,
+  configurable: true,
+});
+proxy.b = "b";
+Object.defineProperty(proxy, "a", {value: "a"});
+assert.compareArray(Object.values(proxy), ["a", "b"]);

--- a/test/built-ins/Reflect/ownKeys/order-after-define-property.js
+++ b/test/built-ins/Reflect/ownKeys/order-after-define-property.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-reflect.ownkeys
+description: >
+  Property names are returned in ascending chronological order of creation
+  that is unaffected by [[DefineOwnProperty]].
+info: |
+  Reflect.ownKeys ( target )
+
+  [...]
+  2. Let keys be ? target.[[OwnPropertyKeys]]().
+  3. Return CreateArrayFromList(keys).
+
+  OrdinaryOwnPropertyKeys ( O )
+
+  [...]
+  4. For each own property key P of O that is a Symbol, in ascending
+  chronological order of property creation, do
+    a. Add P as the last element of keys.
+  5. Return keys.
+
+  [[OwnPropertyKeys]] ( )
+
+  [...]
+  7. For each own property key P of O such that Type(P) is String and P is not
+  an array index, in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  [...]
+  9. Return keys.
+features: [Symbol, Reflect]
+includes: [compareArray.js]
+---*/
+
+var obj = {};
+var symA = Symbol("a");
+var symB = Symbol("b");
+obj[symA] = 1;
+obj[symB] = 2;
+Object.defineProperty(obj, symA, {configurable: false});
+assert.compareArray(Reflect.ownKeys(obj), [symA, symB]);
+
+var str = new String("");
+str.a = 1;
+str.b = 2;
+Object.defineProperty(str, "a", {
+  get: function() {},
+});
+assert.compareArray(Reflect.ownKeys(str), ["length", "a", "b"]);

--- a/test/language/statements/for-in/order-after-define-property.js
+++ b/test/language/statements/for-in/order-after-define-property.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-enumerate-object-properties
+description: >
+  Property names are returned in ascending chronological order of creation
+  that is unaffected by [[DefineOwnProperty]].
+info: |
+  EnumerateObjectProperties ( O )
+
+  EnumerateObjectProperties must obtain the own property keys of the target object
+  by calling its [[OwnPropertyKeys]] internal method. Property attributes of the
+  target object must be obtained by calling its [[GetOwnProperty]] internal method.
+
+  OrdinaryOwnPropertyKeys ( O )
+
+  [...]
+  3. For each own property key P of O that is a String but is not an array index,
+  in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  [...]
+  5. Return keys.
+includes: [compareArray.js]
+---*/
+
+var obj = {};
+obj.a = 1;
+obj.b = 2;
+Object.defineProperty(obj, "a", {value: 11});
+var objKeys = [];
+for (var objKey in obj) {
+  objKeys.push(objKey);
+}
+assert.compareArray(objKeys, ["a", "b"]);
+
+var arr = [];
+Object.defineProperty(arr, "a", {
+  get: function() {},
+  enumerable: true,
+  configurable: true,
+})
+arr.b = 2;
+Object.defineProperty(arr, "a", {
+  get: function() {},
+});
+var arrKeys = [];
+for (var arrKey in arr) {
+  arrKeys.push(arrKey);
+}
+assert.compareArray(arrKeys, ["a", "b"]);


### PR DESCRIPTION
JSC bug: [Redefining a property should not change its insertion index](https://bugs.webkit.org/show_bug.cgi?id=142933).