### PR TITLE
Repair indexOf test that was testing lastIndexOf

### DIFF
--- a/test/built-ins/Array/prototype/indexOf/15.4.4.14-4-4.js
+++ b/test/built-ins/Array/prototype/indexOf/15.4.4.14-4-4.js
@@ -8,7 +8,7 @@ description: >
     'array' with length 0 )
 ---*/
 
-var i = Array.prototype.lastIndexOf.call({
+var i = Array.prototype.indexOf.call({
   length: 0
 }, 1);
 


### PR DESCRIPTION
Looks like a cut-n-paste error; a test in the `indexOf` subtree was actually testing the `lastIndexOf` function. Now pointing where it should.

Fixes #2520.