### PR TITLE
Fix DST sensitivity in Date/parse/without-utc-offset.js.

### DIFF
--- a/test/built-ins/Date/parse/without-utc-offset.js
+++ b/test/built-ins/Date/parse/without-utc-offset.js
@@ -11,7 +11,7 @@ info: |
   as a UTC time and date-time forms are interpreted as a local time.
 ---*/
 
-const timezoneOffsetMS = new Date().getTimezoneOffset() * 60000;
+const timezoneOffsetMS = new Date(0).getTimezoneOffset() * 60000;
 
 assert.sameValue(Date.parse('1970-01-01T00:00:00'), timezoneOffsetMS);
 assert.sameValue(Date.parse('1970-01-01'), 0);


### PR DESCRIPTION
Addresses https://github.com/tc39/test262/pull/2461#issuecomment-596199997.

(CC @anba)