### PR TITLE
Improve an error message in assert.throws().

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -84,7 +84,7 @@ assert.throws = function (expectedErrorConstructor, func, message) {
       message += 'Thrown value was not an object!';
       $ERROR(message);
     } else if (thrown.constructor !== expectedErrorConstructor) {
-      message += 'Expected a ' + expectedErrorConstructor.name + ' but got a ' + thrown.constructor.name;
+      message += 'Expected a ' + expectedErrorConstructor.name + ' but got a ' + thrown.constructor.name + ' (' + thrown.message + ')';
       $ERROR(message);
     }
     return;


### PR DESCRIPTION
A message like "Expected a TypeError but got a RangeError" is not
necessarily helpful to find the actual bug. Adding the message will
usually help more.