### PR TITLE
Add RegExp.prototype[@@search] SameValue tests

### DIFF
--- a/test/built-ins/RegExp/prototype/Symbol.search/set-lastindex-init-samevalue.js
+++ b/test/built-ins/RegExp/prototype/Symbol.search/set-lastindex-init-samevalue.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-regexp.prototype-@@search
+description: >
+  `previousLastIndex` value is compared using SameValue. 
+info: |
+  RegExp.prototype [ @@search ] ( string )
+
+  [...]
+  4. Let previousLastIndex be ? Get(rx, "lastIndex").
+  5. If SameValue(previousLastIndex, 0) is false, then
+    a. Perform ? Set(rx, "lastIndex", 0, true).
+  6. Let result be ? RegExpExec(rx, S).
+  [...]
+features: [Symbol.search]
+---*/
+
+var re = /(?:)/;
+var execLastIndex;
+
+re.lastIndex = -0;
+re.exec = function() {
+  execLastIndex = re.lastIndex;
+  return null;
+};
+
+assert.sameValue(re[Symbol.search](""), -1);
+assert.sameValue(execLastIndex, 0);

--- a/test/built-ins/RegExp/prototype/Symbol.search/set-lastindex-restore-samevalue.js
+++ b/test/built-ins/RegExp/prototype/Symbol.search/set-lastindex-restore-samevalue.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-regexp.prototype-@@search
+description: >
+  `currentLastIndex` value is compared using SameValue. 
+info: |
+  RegExp.prototype [ @@search ] ( string )
+
+  [...]
+  6. Let result be ? RegExpExec(rx, S).
+  7. Let currentLastIndex be ? Get(rx, "lastIndex").
+  8. If SameValue(currentLastIndex, previousLastIndex) is false, then
+  	a. Perform ? Set(rx, "lastIndex", previousLastIndex, true).
+  [...]
+features: [Symbol.search]
+---*/
+
+var re = /(?:)/;
+re.exec = function() {
+  re.lastIndex = -0;
+  return null;
+};
+
+assert.sameValue(re[Symbol.search](""), -1);
+assert.sameValue(re.lastIndex, 0);


### PR DESCRIPTION
JSC bug: [Add op_same_value bytecode, intrinsic, JIT supports](https://bugs.webkit.org/show_bug.cgi?id=173226).