### PR TITLE
Harness: properly format negative zero

### DIFF
--- a/harness/assert.js
+++ b/harness/assert.js
@@ -96,6 +96,10 @@ assert.throws = function (expectedErrorConstructor, func, message) {
 
 assert._toString = function (value) {
   try {
+    if (value === 0 && 1 / value === -Infinity) {
+      return '-0';
+    }
+
     return String(value);
   } catch (err) {
     if (err.name === 'TypeError') {

--- a/test/harness/assert-samevalue-zeros.js
+++ b/test/harness/assert-samevalue-zeros.js
@@ -18,6 +18,7 @@ try {
       '" was thrown.'
     );
   }
+  assert.notSameValue(err.message.indexOf('-0'), -1);
 }
 
 if (threw === false) {


### PR DESCRIPTION
`test262-runner` output:

```
! NEW FAIL test/built-ins/RegExp/prototype/Symbol.search/set-lastindex-init-samevalue.js (default)
Exception: Test262Error: Expected SameValue(«0», «0») to be true
```

Follow-up of #2539.