### PR TITLE
Test unicode escapes without Hex4Digits in strings

### DIFF
--- a/test/language/expressions/template-literal/unicode-escape-no-hex-err.js
+++ b/test/language/expressions/template-literal/unicode-escape-no-hex-err.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-Template
+description: >
+  \u is at the end of string, Hex4Digits is required.
+info: |
+  Template ::
+    NoSubstitutionTemplate
+    TemplateHead
+
+  NoSubstitutionTemplate ::
+    ` TemplateCharacters_opt `
+
+  TemplateCharacters ::
+    TemplateCharacter TemplateCharacters_opt
+
+  TemplateCharacter ::
+    $ [lookahead ≠ {]
+    \ EscapeSequence
+    \ NotEscapeSequence
+    LineContinuation
+    LineTerminatorSequence
+    SourceCharacter but not one of ` or \ or $ or LineTerminator
+
+  EscapeSequence ::
+    CharacterEscapeSequence
+    0 [lookahead ∉ DecimalDigit]
+    HexEscapeSequence
+    UnicodeEscapeSequence
+
+  UnicodeEscapeSequence ::
+    u Hex4Digits
+    u{ CodePoint }
+
+  Hex4Digits ::
+    HexDigit HexDigit HexDigit HexDigit
+
+  HexDigit :: one of
+    0 1 2 3 4 5 6 7 8 9 a b c d e f A B C D E F
+
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+`\u`

--- a/test/language/literals/string/unicode-escape-no-hex-err-double.js
+++ b/test/language/literals/string/unicode-escape-no-hex-err-double.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-StringLiteral
+description: >
+  \u is at the end of string, Hex4Digits is required.
+info: |
+  StringLiteral ::
+    " DoubleStringCharacters_opt "
+    ' SingleStringCharacters_opt '
+
+  DoubleStringCharacters ::
+    DoubleStringCharacter DoubleStringCharacters_opt
+
+  DoubleStringCharacter ::
+    SourceCharacter but not one of " or \ or LineTerminator
+    <LS>
+    <PS>
+    \ EscapeSequence
+    LineContinuation
+
+  EscapeSequence ::
+    CharacterEscapeSequence
+    0 [lookahead ∉ DecimalDigit]
+    HexEscapeSequence
+    UnicodeEscapeSequence
+
+  UnicodeEscapeSequence ::
+    u Hex4Digits
+    u{ CodePoint }
+
+  Hex4Digits ::
+    HexDigit HexDigit HexDigit HexDigit
+
+  HexDigit :: one of
+    0 1 2 3 4 5 6 7 8 9 a b c d e f A B C D E F
+
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+"\u"

--- a/test/language/literals/string/unicode-escape-no-hex-err-single.js
+++ b/test/language/literals/string/unicode-escape-no-hex-err-single.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-StringLiteral
+description: >
+  \u is at the end of string, Hex4Digits is required.
+info: |
+  StringLiteral ::
+    " DoubleStringCharacters_opt "
+    ' SingleStringCharacters_opt '
+
+  SingleStringCharacters ::
+    SingleStringCharacter SingleStringCharacters_opt
+
+  SingleStringCharacter ::
+    SourceCharacter but not one of ' or \ or LineTerminator
+    <LS>
+    <PS>
+    \ EscapeSequence
+    LineContinuation
+
+  EscapeSequence ::
+    CharacterEscapeSequence
+    0 [lookahead ∉ DecimalDigit]
+    HexEscapeSequence
+    UnicodeEscapeSequence
+
+  UnicodeEscapeSequence ::
+    u Hex4Digits
+    u{ CodePoint }
+
+  Hex4Digits ::
+    HexDigit HexDigit HexDigit HexDigit
+
+  HexDigit :: one of
+    0 1 2 3 4 5 6 7 8 9 a b c d e f A B C D E F
+
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+'\u'


### PR DESCRIPTION
JSC bug: ['\u' should throw an early SyntaxError exception, but instead evaluates to 'u'](https://bugs.webkit.org/show_bug.cgi?id=198790).
//cc @mathiasbynens