### PR TITLE
Upstream language tag canonicalisation and Intl.Locale tests from SpiderMonkey

### DIFF
--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -39,7 +39,8 @@ function testWithIntlConstructors(f) {
   var constructors = ["Collator", "NumberFormat", "DateTimeFormat"];
 
   // Optionally supported Intl constructors.
-  ["PluralRules"].forEach(function(constructor) {
+  // NB: Intl.Locale isn't an Intl service constructor!
+  ["PluralRules", "RelativeTimeFormat", "ListFormat", "DisplayNames"].forEach(function(constructor) {
     if (typeof Intl[constructor] === "function") {
       constructors[constructors.length] = constructor;
     }

--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -299,6 +299,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
     duplicateVariant = "(" + alphanum + "{2,8}-)+" + variant + "-(" + alphanum + "{2,8}-)*\\3(?!" + alphanum + ")",
     duplicateVariantRE = new RegExp(duplicateVariant, "i");
 
+  var transformKeyRE = new RegExp("^" + alpha + digit + "$", "i");
 
   /**
    * Verifies that the given string is a well-formed Unicode BCP 47 Locale Identifier
@@ -1255,6 +1256,330 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
     "polytoni": {type: "variant", replacement: "polyton"},
   };
 
+
+  /**
+   * Mappings from Unicode extension subtags to preferred values.
+   *
+   * Spec: http://unicode.org/reports/tr35/#Identifiers
+   * Version: CLDR, version 36.1
+   */
+  var __unicodeMappings = {
+    // property names and values must be in canonical case
+
+    "ca": {
+      "ethiopic-amete-alem": "ethioaa",
+      "islamicc": "islamic-civil",
+    },
+    "kb": {
+      "yes": "true",
+    },
+    "kc": {
+      "yes": "true",
+    },
+    "kh": {
+      "yes": "true",
+    },
+    "kk": {
+      "yes": "true",
+    },
+    "kn": {
+      "yes": "true",
+    },
+    "ks": {
+      "primary": "level1",
+      "tertiary": "level3",
+    },
+    "ms": {
+      "imperial": "uksystem",
+    },
+    "rg": {
+      "cn11": "cnbj",
+      "cn12": "cntj",
+      "cn13": "cnhe",
+      "cn14": "cnsx",
+      "cn15": "cnmn",
+      "cn21": "cnln",
+      "cn22": "cnjl",
+      "cn23": "cnhl",
+      "cn31": "cnsh",
+      "cn32": "cnjs",
+      "cn33": "cnzj",
+      "cn34": "cnah",
+      "cn35": "cnfj",
+      "cn36": "cnjx",
+      "cn37": "cnsd",
+      "cn41": "cnha",
+      "cn42": "cnhb",
+      "cn43": "cnhn",
+      "cn44": "cngd",
+      "cn45": "cngx",
+      "cn46": "cnhi",
+      "cn50": "cncq",
+      "cn51": "cnsc",
+      "cn52": "cngz",
+      "cn53": "cnyn",
+      "cn54": "cnxz",
+      "cn61": "cnsn",
+      "cn62": "cngs",
+      "cn63": "cnqh",
+      "cn64": "cnnx",
+      "cn65": "cnxj",
+      "cz10a": "cz110",
+      "cz10b": "cz111",
+      "cz10c": "cz112",
+      "cz10d": "cz113",
+      "cz10e": "cz114",
+      "cz10f": "cz115",
+      "cz611": "cz663",
+      "cz612": "cz632",
+      "cz613": "cz633",
+      "cz614": "cz634",
+      "cz615": "cz635",
+      "cz621": "cz641",
+      "cz622": "cz642",
+      "cz623": "cz643",
+      "cz624": "cz644",
+      "cz626": "cz646",
+      "cz627": "cz647",
+      "czjc": "cz31",
+      "czjm": "cz64",
+      "czka": "cz41",
+      "czkr": "cz52",
+      "czli": "cz51",
+      "czmo": "cz80",
+      "czol": "cz71",
+      "czpa": "cz53",
+      "czpl": "cz32",
+      "czpr": "cz10",
+      "czst": "cz20",
+      "czus": "cz42",
+      "czvy": "cz63",
+      "czzl": "cz72",
+      "fra": "frges",
+      "frb": "frnaq",
+      "frc": "frara",
+      "frd": "frbfc",
+      "fre": "frbre",
+      "frf": "frcvl",
+      "frg": "frges",
+      "frh": "frcor",
+      "fri": "frbfc",
+      "frj": "fridf",
+      "frk": "frocc",
+      "frl": "frnaq",
+      "frm": "frges",
+      "frn": "frocc",
+      "fro": "frhdf",
+      "frp": "frnor",
+      "frq": "frnor",
+      "frr": "frpdl",
+      "frs": "frhdf",
+      "frt": "frnaq",
+      "fru": "frpac",
+      "frv": "frara",
+      "laxn": "laxs",
+      "lud": "lucl",
+      "lug": "luec",
+      "lul": "luca",
+      "mrnkc": "mr13",
+      "no23": "no50",
+      "nzn": "nzauk",
+      "nzs": "nzcan",
+      "omba": "ombj",
+      "omsh": "omsj",
+      "plds": "pl02",
+      "plkp": "pl04",
+      "pllb": "pl08",
+      "plld": "pl10",
+      "pllu": "pl06",
+      "plma": "pl12",
+      "plmz": "pl14",
+      "plop": "pl16",
+      "plpd": "pl20",
+      "plpk": "pl18",
+      "plpm": "pl22",
+      "plsk": "pl26",
+      "plsl": "pl24",
+      "plwn": "pl28",
+      "plwp": "pl30",
+      "plzp": "pl32",
+      "tteto": "tttob",
+      "ttrcm": "ttmrc",
+      "ttwto": "tttob",
+      "twkhq": "twkhh",
+      "twtnq": "twtnn",
+      "twtpq": "twnwt",
+      "twtxq": "twtxg",
+    },
+    "sd": {
+      "cn11": "cnbj",
+      "cn12": "cntj",
+      "cn13": "cnhe",
+      "cn14": "cnsx",
+      "cn15": "cnmn",
+      "cn21": "cnln",
+      "cn22": "cnjl",
+      "cn23": "cnhl",
+      "cn31": "cnsh",
+      "cn32": "cnjs",
+      "cn33": "cnzj",
+      "cn34": "cnah",
+      "cn35": "cnfj",
+      "cn36": "cnjx",
+      "cn37": "cnsd",
+      "cn41": "cnha",
+      "cn42": "cnhb",
+      "cn43": "cnhn",
+      "cn44": "cngd",
+      "cn45": "cngx",
+      "cn46": "cnhi",
+      "cn50": "cncq",
+      "cn51": "cnsc",
+      "cn52": "cngz",
+      "cn53": "cnyn",
+      "cn54": "cnxz",
+      "cn61": "cnsn",
+      "cn62": "cngs",
+      "cn63": "cnqh",
+      "cn64": "cnnx",
+      "cn65": "cnxj",
+      "cz10a": "cz110",
+      "cz10b": "cz111",
+      "cz10c": "cz112",
+      "cz10d": "cz113",
+      "cz10e": "cz114",
+      "cz10f": "cz115",
+      "cz611": "cz663",
+      "cz612": "cz632",
+      "cz613": "cz633",
+      "cz614": "cz634",
+      "cz615": "cz635",
+      "cz621": "cz641",
+      "cz622": "cz642",
+      "cz623": "cz643",
+      "cz624": "cz644",
+      "cz626": "cz646",
+      "cz627": "cz647",
+      "czjc": "cz31",
+      "czjm": "cz64",
+      "czka": "cz41",
+      "czkr": "cz52",
+      "czli": "cz51",
+      "czmo": "cz80",
+      "czol": "cz71",
+      "czpa": "cz53",
+      "czpl": "cz32",
+      "czpr": "cz10",
+      "czst": "cz20",
+      "czus": "cz42",
+      "czvy": "cz63",
+      "czzl": "cz72",
+      "fra": "frges",
+      "frb": "frnaq",
+      "frc": "frara",
+      "frd": "frbfc",
+      "fre": "frbre",
+      "frf": "frcvl",
+      "frg": "frges",
+      "frh": "frcor",
+      "fri": "frbfc",
+      "frj": "fridf",
+      "frk": "frocc",
+      "frl": "frnaq",
+      "frm": "frges",
+      "frn": "frocc",
+      "fro": "frhdf",
+      "frp": "frnor",
+      "frq": "frnor",
+      "frr": "frpdl",
+      "frs": "frhdf",
+      "frt": "frnaq",
+      "fru": "frpac",
+      "frv": "frara",
+      "laxn": "laxs",
+      "lud": "lucl",
+      "lug": "luec",
+      "lul": "luca",
+      "mrnkc": "mr13",
+      "no23": "no50",
+      "nzn": "nzauk",
+      "nzs": "nzcan",
+      "omba": "ombj",
+      "omsh": "omsj",
+      "plds": "pl02",
+      "plkp": "pl04",
+      "pllb": "pl08",
+      "plld": "pl10",
+      "pllu": "pl06",
+      "plma": "pl12",
+      "plmz": "pl14",
+      "plop": "pl16",
+      "plpd": "pl20",
+      "plpk": "pl18",
+      "plpm": "pl22",
+      "plsk": "pl26",
+      "plsl": "pl24",
+      "plwn": "pl28",
+      "plwp": "pl30",
+      "plzp": "pl32",
+      "tteto": "tttob",
+      "ttrcm": "ttmrc",
+      "ttwto": "tttob",
+      "twkhq": "twkhh",
+      "twtnq": "twtnn",
+      "twtpq": "twnwt",
+      "twtxq": "twtxg",
+    },
+    "tz": {
+      "aqams": "nzakl",
+      "cnckg": "cnsha",
+      "cnhrb": "cnsha",
+      "cnkhg": "cnurc",
+      "cuba": "cuhav",
+      "egypt": "egcai",
+      "eire": "iedub",
+      "est": "utcw05",
+      "gmt0": "gmt",
+      "hongkong": "hkhkg",
+      "hst": "utcw10",
+      "iceland": "isrey",
+      "iran": "irthr",
+      "israel": "jeruslm",
+      "jamaica": "jmkin",
+      "japan": "jptyo",
+      "libya": "lytip",
+      "mst": "utcw07",
+      "navajo": "usden",
+      "poland": "plwaw",
+      "portugal": "ptlis",
+      "prc": "cnsha",
+      "roc": "twtpe",
+      "rok": "krsel",
+      "turkey": "trist",
+      "uct": "utc",
+      "usnavajo": "usden",
+      "zulu": "utc",
+    },
+  };
+
+
+  /**
+   * Mappings from Unicode extension subtags to preferred values.
+   *
+   * Spec: http://unicode.org/reports/tr35/#Identifiers
+   * Version: CLDR, version 36.1
+   */
+  var __transformMappings = {
+    // property names and values must be in canonical case
+
+    "d0": {
+      "name": "charname",
+    },
+    "m0": {
+      "names": "prprname",
+    },
+  };
+
   /**
    * Canonicalizes the given well-formed BCP 47 language tag, including regularized case of subtags.
    *
@@ -1364,7 +1689,80 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
       while (i < subtags.length && subtags[i].length > 1) {
         i++;
       }
-      var extension = subtags.slice(extensionStart, i).join("-");
+
+      var extension;
+      var extensionKey = subtags[extensionStart];
+      if (extensionKey === "u") {
+        var j = extensionStart + 1;
+
+        // skip over leading attributes
+        while (j < i && subtags[j].length > 2) {
+          j++;
+        }
+
+        extension = subtags.slice(extensionStart, j).join("-");
+
+        while (j < i) {
+          var keyStart = j;
+          j++;
+
+          while (j < i && subtags[j].length > 2) {
+            j++;
+          }
+
+          var key = subtags[keyStart];
+          var value = subtags.slice(keyStart + 1, j).join("-");
+
+          if (__unicodeMappings.hasOwnProperty(key)) {
+            var mapping = __unicodeMappings[key];
+            if (mapping.hasOwnProperty(value)) {
+              value = mapping[value];
+            }
+          }
+
+          extension += "-" + key;
+          if (value !== "" && value !== "true") {
+            extension += "-" + value;
+          }
+        }
+      } else if (extensionKey === "t") {
+        var j = extensionStart + 1;
+
+        while (j < i && !transformKeyRE.test(subtags[j])) {
+          j++;
+        }
+
+        extension = "t";
+
+        var transformLanguage = subtags.slice(extensionStart + 1, j).join("-");
+        if (transformLanguage !== "") {
+          extension += "-" + canonicalizeLanguageTag(transformLanguage).toLowerCase();
+        }
+
+        while (j < i) {
+          var keyStart = j;
+          j++;
+
+          while (j < i && subtags[j].length > 2) {
+            j++;
+          }
+
+          var key = subtags[keyStart];
+          var value = subtags.slice(keyStart + 1, j).join("-");
+
+          if (__transformMappings.hasOwnProperty(key)) {
+            var mapping = __transformMappings[key];
+            if (mapping.hasOwnProperty(value)) {
+              value = mapping[value];
+            }
+          }
+
+          extension += "-" + key + "-" + value;
+        }
+      } else {
+        extension = subtags.slice(extensionStart, i).join("-");
+      }
+
       extensions.push(extension);
     }
     extensions.sort();

--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -319,7 +319,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
    * Mappings from complete tags to preferred values.
    *
    * Spec: http://unicode.org/reports/tr35/#Identifiers
-   * Version: CLDR, version 35
+   * Version: CLDR, version 36.1
    */
   var __tagMappings = {
     // property names must be in lower case; values in canonical form
@@ -336,7 +336,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
    * Mappings from language subtags to preferred values.
    *
    * Spec: http://unicode.org/reports/tr35/#Identifiers
-   * Version: CLDR, version 35
+   * Version: CLDR, version 36.1
    */
   var __languageMappings = {
     // property names and values must be in canonical case
@@ -355,6 +355,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
     "arb": "ar",
     "arg": "an",
     "arm": "hy",
+    "asd": "snz",
     "asm": "as",
     "aue": "ktz",
     "ava": "av",
@@ -410,6 +411,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
     "dhd": "mwr",
     "dik": "din",
     "diq": "zza",
+    "dit": "dif",
     "div": "dv",
     "drh": "mn",
     "dut": "nl",
@@ -525,6 +527,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
     "lim": "li",
     "lin": "ln",
     "lit": "lt",
+    "llo": "ngt",
     "lmm": "rmx",
     "ltz": "lb",
     "lub": "lu",
@@ -551,6 +554,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
     "mup": "raj",
     "mwj": "vaj",
     "mya": "my",
+    "myd": "aog",
     "myt": "mry",
     "nad": "xny",
     "nau": "na",
@@ -562,6 +566,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
     "nep": "ne",
     "nld": "nl",
     "nno": "nn",
+    "nns": "nbr",
     "nnx": "ngv",
     "no": "nb",
     "nob": "nb",
@@ -690,14 +695,14 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
     "zsm": "ms",
     "zul": "zu",
     "zyb": "za",
-  }
+  };
 
 
   /**
    * Mappings from region subtags to preferred values.
    *
    * Spec: http://unicode.org/reports/tr35/#Identifiers
-   * Version: CLDR, version 35
+   * Version: CLDR, version 36.1
    */
   var __regionMappings = {
     // property names and values must be in canonical case
@@ -1029,6 +1034,228 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
 
 
   /**
+   * Complex mappings from language subtags to preferred values.
+   *
+   * Spec: http://unicode.org/reports/tr35/#Identifiers
+   * Version: CLDR, version 36.1
+   */
+  var __complexLanguageMappings = {
+    // property names and values must be in canonical case
+
+    "cnr": {language: "sr", region: "ME"},
+    "drw": {language: "fa", region: "AF"},
+    "hbs": {language: "sr", script: "Latn"},
+    "prs": {language: "fa", region: "AF"},
+    "sh": {language: "sr", script: "Latn"},
+    "swc": {language: "sw", region: "CD"},
+    "tnf": {language: "fa", region: "AF"},
+  };
+
+
+  /**
+   * Complex mappings from region subtags to preferred values.
+   *
+   * Spec: http://unicode.org/reports/tr35/#Identifiers
+   * Version: CLDR, version 36.1
+   */
+  var __complexRegionMappings = {
+    // property names and values must be in canonical case
+
+    "172": {
+      default: "RU",
+      "ab": "GE",
+      "az": "AZ",
+      "be": "BY",
+      "crh": "UA",
+      "gag": "MD",
+      "got": "UA",
+      "hy": "AM",
+      "ji": "UA",
+      "ka": "GE",
+      "kaa": "UZ",
+      "kk": "KZ",
+      "ku-Yezi": "GE",
+      "ky": "KG",
+      "os": "GE",
+      "rue": "UA",
+      "sog": "UZ",
+      "tg": "TJ",
+      "tk": "TM",
+      "tkr": "AZ",
+      "tly": "AZ",
+      "ttt": "AZ",
+      "ug-Cyrl": "KZ",
+      "uk": "UA",
+      "und-Armn": "AM",
+      "und-Chrs": "UZ",
+      "und-Geor": "GE",
+      "und-Goth": "UA",
+      "und-Sogd": "UZ",
+      "und-Sogo": "UZ",
+      "und-Yezi": "GE",
+      "uz": "UZ",
+      "xco": "UZ",
+      "xmf": "GE",
+    },
+    "200": {
+      default: "CZ",
+      "sk": "SK",
+    },
+    "530": {
+      default: "CW",
+      "vic": "SX",
+    },
+    "532": {
+      default: "CW",
+      "vic": "SX",
+    },
+    "536": {
+      default: "SA",
+      "akk": "IQ",
+      "ckb": "IQ",
+      "ku-Arab": "IQ",
+      "mis": "IQ",
+      "syr": "IQ",
+      "und-Hatr": "IQ",
+      "und-Syrc": "IQ",
+      "und-Xsux": "IQ",
+    },
+    "582": {
+      default: "FM",
+      "mh": "MH",
+      "pau": "PW",
+    },
+    "810": {
+      default: "RU",
+      "ab": "GE",
+      "az": "AZ",
+      "be": "BY",
+      "crh": "UA",
+      "et": "EE",
+      "gag": "MD",
+      "got": "UA",
+      "hy": "AM",
+      "ji": "UA",
+      "ka": "GE",
+      "kaa": "UZ",
+      "kk": "KZ",
+      "ku-Yezi": "GE",
+      "ky": "KG",
+      "lt": "LT",
+      "ltg": "LV",
+      "lv": "LV",
+      "os": "GE",
+      "rue": "UA",
+      "sgs": "LT",
+      "sog": "UZ",
+      "tg": "TJ",
+      "tk": "TM",
+      "tkr": "AZ",
+      "tly": "AZ",
+      "ttt": "AZ",
+      "ug-Cyrl": "KZ",
+      "uk": "UA",
+      "und-Armn": "AM",
+      "und-Chrs": "UZ",
+      "und-Geor": "GE",
+      "und-Goth": "UA",
+      "und-Sogd": "UZ",
+      "und-Sogo": "UZ",
+      "und-Yezi": "GE",
+      "uz": "UZ",
+      "vro": "EE",
+      "xco": "UZ",
+      "xmf": "GE",
+    },
+    "890": {
+      default: "RS",
+      "bs": "BA",
+      "hr": "HR",
+      "mk": "MK",
+      "sl": "SI",
+    },
+    "AN": {
+      default: "CW",
+      "vic": "SX",
+    },
+    "NT": {
+      default: "SA",
+      "akk": "IQ",
+      "ckb": "IQ",
+      "ku-Arab": "IQ",
+      "mis": "IQ",
+      "syr": "IQ",
+      "und-Hatr": "IQ",
+      "und-Syrc": "IQ",
+      "und-Xsux": "IQ",
+    },
+    "PC": {
+      default: "FM",
+      "mh": "MH",
+      "pau": "PW",
+    },
+    "SU": {
+      default: "RU",
+      "ab": "GE",
+      "az": "AZ",
+      "be": "BY",
+      "crh": "UA",
+      "et": "EE",
+      "gag": "MD",
+      "got": "UA",
+      "hy": "AM",
+      "ji": "UA",
+      "ka": "GE",
+      "kaa": "UZ",
+      "kk": "KZ",
+      "ku-Yezi": "GE",
+      "ky": "KG",
+      "lt": "LT",
+      "ltg": "LV",
+      "lv": "LV",
+      "os": "GE",
+      "rue": "UA",
+      "sgs": "LT",
+      "sog": "UZ",
+      "tg": "TJ",
+      "tk": "TM",
+      "tkr": "AZ",
+      "tly": "AZ",
+      "ttt": "AZ",
+      "ug-Cyrl": "KZ",
+      "uk": "UA",
+      "und-Armn": "AM",
+      "und-Chrs": "UZ",
+      "und-Geor": "GE",
+      "und-Goth": "UA",
+      "und-Sogd": "UZ",
+      "und-Sogo": "UZ",
+      "und-Yezi": "GE",
+      "uz": "UZ",
+      "vro": "EE",
+      "xco": "UZ",
+      "xmf": "GE",
+    },
+  };
+
+
+  /**
+   * Mappings from variant subtags to preferred values.
+   *
+   * Spec: http://unicode.org/reports/tr35/#Identifiers
+   * Version: CLDR, version 36.1
+   */
+  var __variantMappings = {
+    // property names and values must be in canonical case
+
+    "aaland": {type: "region", replacement: "AX"},
+    "arevela": {type: "language", replacement: "hy"},
+    "arevmda": {type: "language", replacement: "hyw"},
+    "heploc": {type: "variant", replacement: "alalc97"},
+    "polytoni": {type: "variant", replacement: "polyton"},
+  };
+
+  /**
    * Canonicalizes the given well-formed BCP 47 language tag, including regularized case of subtags.
    *
    * Spec: ECMAScript Internationalization API Specification, draft, 6.2.3.
@@ -1067,195 +1294,33 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
 
     if (__languageMappings.hasOwnProperty(language)) {
       language = __languageMappings[language];
-    } else {
-      // Language subtags with complex mappings, CLDR 35.
-      switch (language) {
-      case "cnr":
-        language = "sr";
-        if (region === undefined) {
-          region = "ME";
-        }
-        break;
-      case "drw":
-      case "prs":
-      case "tnf":
-        language = "fa";
-        if (region === undefined) {
-          region = "AF";
-        }
-        break;
-      case "hbs":
-      case "sh":
-        language = "sr";
-        if (script === undefined) {
-          script = "Latn";
-        }
-        break;
-      case "swc":
-        language = "sw";
-        if (region === undefined) {
-          region = "CD";
-        }
-        break;
+    } else if (__complexLanguageMappings.hasOwnProperty(language)) {
+      var mapping = __complexLanguageMappings[language];
+
+      language = mapping.language;
+      if (script === undefined && mapping.hasOwnProperty("script")) {
+        script = mapping.script;
+      }
+      if (region === undefined && mapping.hasOwnProperty("region")) {
+        region = mapping.region;
       }
     }
 
     if (region !== undefined) {
       if (__regionMappings.hasOwnProperty(region)) {
         region = __regionMappings[region];
-      } else {
-        // Region subtags with complex mappings, CLDR 35.
-        switch (region) {
-        case "172":
-          if (language === "ab" || language === "ka" || language === "os" ||
-              (language === "und" && script === "Geor") || language === "xmf") {
-            region = "GE";
-          }
-          else if (language === "az" || language === "tkr" || language === "tly" || language === "ttt") {
-            region = "AZ";
-          }
-          else if (language === "be") {
-            region = "BY";
-          }
-          else if (language === "crh" || language === "got" || language === "ji" || language === "rue" ||
-                   language === "uk" || (language === "und" && script === "Goth")) {
-            region = "UA";
-          }
-          else if (language === "gag") {
-            region = "MD";
-          }
-          else if (language === "hy" || (language === "und" && script === "Armn")) {
-            region = "AM";
-          }
-          else if (language === "kaa" || language === "sog" || (language === "und" && script === "Sogd") ||
-                   (language === "und" && script === "Sogo") || language === "uz") {
-            region = "UZ";
-          }
-          else if (language === "kk" || (language === "ug" && script === "Cyrl")) {
-            region = "KZ";
-          }
-          else if (language === "ky") {
-            region = "KG";
-          }
-          else if (language === "tg") {
-            region = "TJ";
-          }
-          else if (language === "tk") {
-            region = "TM";
-          }
-          else {
-            region = "RU";
-          }
-          break;
-        case "200":
-          if (language === "sk") {
-            region = "SK";
-          }
-          else {
-            region = "CZ";
-          }
-          break;
-        case "530":
-        case "532":
-        case "AN":
-          if (language === "vic") {
-            region = "SX";
-          }
-          else {
-            region = "CW";
-          }
-          break;
-        case "536":
-        case "NT":
-          if (language === "akk" || language === "ckb" || (language === "ku" && script === "Arab") ||
-              language === "mis" || language === "syr" || (language === "und" && script === "Xsux") ||
-              (language === "und" && script === "Hatr") || (language === "und" && script === "Syrc")) {
-            region = "IQ";
-          }
-          else {
-            region = "SA";
-          }
-          break;
-        case "582":
-        case "PC":
-          if (language === "mh") {
-            region = "MH";
-          }
-          else if (language === "pau") {
-            region = "PW";
-          }
-          else {
-            region = "FM";
-          }
-          break;
-        case "810":
-        case "SU":
-          if (language === "ab" || language === "ka" || language === "os" || language === "xmf" ||
-              (language === "und" && script === "Geor")) {
-            region = "GE";
-          }
-          else if (language === "az" || language === "tkr" || language === "tly" || language === "ttt") {
-            region = "AZ";
-          }
-          else if (language === "be") {
-            region = "BY";
-          }
-          else if (language === "crh" || language === "got" || language === "ji" || language === "rue" ||
-                   language === "uk" || (language === "und" && script === "Goth")) {
-            region = "UA";
-          }
-          else if (language === "et" || language === "vro") {
-            region = "EE";
-          }
-          else if (language === "gag") {
-            region = "MD";
-          }
-          else if (language === "hy" || (language === "und" && script === "Armn")) {
-            region = "AM";
-          }
-          else if (language === "kaa" || language === "sog" || (language === "und" && script === "Sogd") ||
-                   (language === "und" && script === "Sogo") || language === "uz") {
-            region = "UZ";
-          }
-          else if (language === "kk" || (language === "ug" && script === "Cyrl")) {
-            region = "KZ";
-          }
-          else if (language === "ky") {
-            region = "KG";
-          }
-          else if (language === "lt" || language === "sgs") {
-            region = "LT";
-          }
-          else if (language === "ltg" || language === "lv") {
-            region = "LV";
-          }
-          else if (language === "tg") {
-            region = "TJ";
-          }
-          else if (language === "tk") {
-            region = "TM";
-          }
-          else {
-            region = "RU";
-          }
-          break;
-        case "890":
-          if (language === "bs") {
-            region = "BA";
-          }
-          else if (language === "hr") {
-            region = "HR";
-          }
-          else if (language === "mk") {
-            region = "MK";
-          }
-          else if (language === "sl") {
-            region = "SI";
-          }
-          else {
-            region = "RS";
-          }
-          break;
+      } else if (__complexRegionMappings.hasOwnProperty(region)) {
+        var mapping = __complexRegionMappings[region];
+
+        var mappingKey = language;
+        if (script !== undefined) {
+          mappingKey += "-" + script;
+        }
+
+        if (mapping.hasOwnProperty(mappingKey)) {
+          region = mapping[mappingKey];
+        } else {
+          region = mapping.default;
         }
       }
     }
@@ -1263,8 +1328,31 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
     // handle variants
     var variants = [];
     while (i < subtags.length && subtags[i].length > 1) {
-        variants.push(subtags[i]);
-        i += 1;
+      var variant = subtags[i];
+
+      if (__variantMappings.hasOwnProperty(variant)) {
+        var mapping = __variantMappings[variant];
+        switch (mapping.type) {
+          case "language":
+            language = mapping.replacement;
+            break;
+
+          case "region":
+            region = mapping.replacement;
+            break;
+
+          case "variant":
+            variants.push(mapping.replacement);
+            break;
+
+          default:
+            throw new Error("illegal variant mapping type");
+        }
+      } else {
+        variants.push(variant);
+      }
+
+      i += 1;
     }
     variants.sort();
 

--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -1550,7 +1550,7 @@ function testForUnwantedRegExpChanges(testFunc) {
 
 function isValidNumberingSystem(name) {
 
-  // source: CLDR file common/bcp47/number.xml; version CLDR 32.
+  // source: CLDR file common/bcp47/number.xml; version CLDR 36.1.
   var numberingSystems = [
     "adlm",
     "ahom",
@@ -1566,10 +1566,12 @@ function isValidNumberingSystem(name) {
     "cham",
     "cyrl",
     "deva",
+    "diak",
     "ethi",
     "finance",
     "fullwide",
     "geor",
+    "gong",
     "gonm",
     "grek",
     "greklow",
@@ -1583,9 +1585,11 @@ function isValidNumberingSystem(name) {
     "hantfin",
     "hebr",
     "hmng",
+    "hmnp",
     "java",
     "jpan",
     "jpanfin",
+    "jpanyear",
     "kali",
     "khmr",
     "knda",
@@ -1614,6 +1618,7 @@ function isValidNumberingSystem(name) {
     "olck",
     "orya",
     "osma",
+    "rohg",
     "roman",
     "romanlow",
     "saur",
@@ -1633,6 +1638,7 @@ function isValidNumberingSystem(name) {
     "traditio",
     "vaii",
     "wara",
+    "wcho",
   ];
 
   var excluded = [

--- a/test/intl402/Intl/getCanonicalLocales/complex-language-subtag-replacement.js
+++ b/test/intl402/Intl/getCanonicalLocales/complex-language-subtag-replacement.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Assert non-simple language subtag replacements work as expected.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+  UTS 35, §3.2.1 Canonical Unicode Locale Identifiers
+
+  - Replace aliases in the unicode_language_id and tlang (if any) using the following process:
+    - If the language subtag matches the type attribute of a languageAlias element in
+      Supplemental Data, replace the language subtag with the replacement value.
+      1. If there are additional subtags in the replacement value, add them to the result,
+         but only if there is no corresponding subtag already in the tag.
+
+includes: [testIntl.js]
+---*/
+
+// CLDR contains language mappings where in addition to the language subtag also
+// the script or region subtag is modified, unless they're already present.
+
+const testData = {
+  // "sh" adds "Latn", unless a script subtag is already present.
+  // <languageAlias type="sh" replacement="sr_Latn" reason="legacy"/>
+  "sh": "sr-Latn",
+  "sh-Cyrl": "sr-Cyrl",
+
+  // "cnr" adds "ME", unless a region subtag is already present.
+  // <languageAlias type="cnr" replacement="sr_ME" reason="legacy"/>
+  "cnr": "sr-ME",
+  "cnr-BA": "sr-BA",
+};
+
+for (let [tag, canonical] of Object.entries(testData)) {
+  // Make sure the test data is correct.
+  assert(
+    isCanonicalizedStructurallyValidLanguageTag(canonical),
+    "\"" + canonical + "\" is a canonicalized and structurally valid language tag."
+  );
+
+  let result = Intl.getCanonicalLocales(tag);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], canonical);
+}

--- a/test/intl402/Intl/getCanonicalLocales/complex-region-subtag-replacement.js
+++ b/test/intl402/Intl/getCanonicalLocales/complex-region-subtag-replacement.js
@@ -1,0 +1,108 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Assert non-simple region subtag replacements work as expected.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+  UTS 35, §3.2.1 Canonical Unicode Locale Identifiers
+
+  - Replace aliases in the unicode_language_id and tlang (if any) using the following process:
+    - If the region subtag matches the type attribute of a territoryAlias element in
+      Supplemental Data, replace the language subtag with the replacement value, as follows:
+      1. If there is a single territory in the replacement, use it.
+      2. If there are multiple territories:
+        1. Look up the most likely territory for the base language code (and script, if there is one).
+        2. If that likely territory is in the list, use it.
+        3. Otherwise, use the first territory in the list.
+
+includes: [testIntl.js]
+---*/
+
+// CLDR contains region mappings where the replacement region depends on the
+// likely subtags from the language and script subtags.
+
+const testData = {
+  // For example, the breakup of the Soviet Union ("SU") means that the region of
+  // the Soviet Union ("SU") is replaced by Russia ("RU"), Armenia ("AM"), or
+  // many others -- depending on the specified (or merely likely) language and
+  // script subtags:
+  //
+  // <territoryAlias type="SU" replacement="RU AM AZ BY EE GE KZ KG LV LT MD TJ TM UA UZ" reason="deprecated"/>
+  // <territoryAlias type="810" replacement="RU AM AZ BY EE GE KZ KG LV LT MD TJ TM UA UZ" reason="overlong"/>
+  "ru-SU": "ru-RU",
+  "ru-810": "ru-RU",
+  "en-SU": "en-RU",
+  "en-810": "en-RU",
+  "und-SU": "und-RU",
+  "und-810": "und-RU",
+  "und-Latn-SU": "und-Latn-RU",
+  "und-Latn-810": "und-Latn-RU",
+
+  // Armenia can be the preferred region when the language is "hy" (Armenian) or
+  // the script is "Armn" (Armenian).
+  //
+  // <likelySubtag from="hy" to="hy_Armn_AM"/>
+  // <likelySubtag from="und_Armn" to="hy_Armn_AM"/>
+  "hy-SU": "hy-AM",
+  "hy-810": "hy-AM",
+  "und-Armn-SU": "und-Armn-AM",
+  "und-Armn-810": "und-Armn-AM",
+
+  // <territoryAlias type="CS" replacement="RS ME" reason="deprecated"/>
+  //
+  // The following likely-subtags entries contain "RS" and "ME":
+  //
+  // <likelySubtag from="sr" to="sr_Cyrl_RS"/>
+  // <likelySubtag from="sr_ME" to="sr_Latn_ME"/>
+  // <likelySubtag from="und_RS" to="sr_Cyrl_RS"/>
+  // <likelySubtag from="und_ME" to="sr_Latn_ME"/>
+  //
+  // In this case there is no language/script combination (without a region
+  // subtag) where "ME" is ever chosen, so the replacement is always "RS".
+  "sr-CS": "sr-RS",
+  "sr-Latn-CS": "sr-Latn-RS",
+  "sr-Cyrl-CS": "sr-Cyrl-RS",
+
+  // The existing region in the source locale identifier is ignored when selecting
+  // the likely replacement region. For example take "az-NT", which is Azerbaijani
+  // spoken in the Neutral Zone. The replacement region for "NT" is either
+  // "SA" (Saudi-Arabia) or "IQ" (Iraq), and there is also a likely subtags entry
+  // for "az-IQ". But when only looking at the language subtag in "az-NT", "az" is
+  // always resolved to "az-Latn-AZ", and because "AZ" is not in the list ["SA",
+  // "IQ"], the final replacement region is the default for "NT", namely "SA".
+  // That means "az-NT" will be canonicalised to "az-SA" and not "az-IQ", even
+  // though the latter may be a more sensible candidate based on the actual usage
+  // of the target locales.
+  //
+  // <territoryAlias type="NT" replacement="SA IQ" reason="deprecated"/>
+  // <likelySubtag from="az_IQ" to="az_Arab_IQ"/>
+  // <likelySubtag from="az" to="az_Latn_AZ"/>
+  "az-NT": "az-SA",
+};
+
+for (let [tag, canonical] of Object.entries(testData)) {
+  // Make sure the test data is correct.
+  assert(
+    isCanonicalizedStructurallyValidLanguageTag(canonical),
+    "\"" + canonical + "\" is a canonicalized and structurally valid language tag."
+  );
+
+  let result = Intl.getCanonicalLocales(tag);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], canonical);
+}

--- a/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
+++ b/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
@@ -61,16 +61,12 @@ var testData = [
         canonical: "cs",
     },
     {
-        // ECMA-402 currently requires that variant subtags are not canonicalized.
-        // https://github.com/tc39/ecma402/issues/330
         tag: "hy-arevela",
-        canonical: "hy-arevela",
+        canonical: "hy",
     },
     {
-        // ECMA-402 currently requires that variant subtags are not canonicalized.
-        // https://github.com/tc39/ecma402/issues/330
         tag: "hy-arevmda",
-        canonical: "hy-arevmda",
+        canonical: "hyw",
     },
 ];
 

--- a/test/intl402/Intl/getCanonicalLocales/preferred-variant.js
+++ b/test/intl402/Intl/getCanonicalLocales/preferred-variant.js
@@ -36,12 +36,10 @@ info: |
 includes: [testIntl.js]
 ---*/
 
-// Generated from http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
-// File-Date: 2017-08-15
+// Generated from https://github.com/unicode-org/cldr/blob/master/common/supplemental/supplementalMetadata.xml
+// File-Date: 2020-03-30
 var canonicalizedTags = {
-  // ECMA-402 currently requires that variant subtags are not canonicalized.
-  // https://github.com/tc39/ecma402/issues/330
-  "ja-latn-hepburn-heploc": "ja-Latn-hepburn-heploc",
+  "ja-latn-hepburn-heploc": "ja-Latn-alalc97-hepburn",
 };
 
 // make sure the data above is correct

--- a/test/intl402/Intl/getCanonicalLocales/transformed-ext-canonical.js
+++ b/test/intl402/Intl/getCanonicalLocales/transformed-ext-canonical.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Test canonicalisation within transformed extension subtags.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+includes: [testIntl.js]
+---*/
+
+const testData = {
+  // Variant subtags are alphabetically ordered.
+  "sl-t-sl-rozaj-biske-1994": "sl-t-sl-1994-biske-rozaj",
+
+  // tfield subtags are alphabetically ordered.
+  // (Also tests subtag case normalisation.)
+  "DE-T-M0-DIN-K0-QWERTZ": "de-t-k0-qwertz-m0-din",
+
+  // "true" tvalue subtags aren't removed.
+  // (UTS 35 version 36, §3.2.1 claims otherwise, but tkey must be followed by
+  // tvalue, so that's likely a spec bug in UTS 35.)
+  "en-t-m0-true": "en-t-m0-true",
+
+  // tlang subtags are canonicalised.
+  "en-t-iw": "en-t-he",
+
+  // Deprecated tvalue subtags are replaced by their preferred value.
+  "und-Latn-t-und-hani-m0-names": "und-Latn-t-und-hani-m0-prprname",
+};
+
+for (let [tag, canonical] of Object.entries(testData)) {
+  // Make sure the test data is correct.
+  assert(isCanonicalizedStructurallyValidLanguageTag(canonical),
+         "\"" + canonical + "\" is a canonical and structurally valid language tag.");
+
+  let result = Intl.getCanonicalLocales(tag);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], canonical);
+}

--- a/test/intl402/Intl/getCanonicalLocales/transformed-ext-invalid.js
+++ b/test/intl402/Intl/getCanonicalLocales/transformed-ext-invalid.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  A RangeError is thrown when a language tag includes an invalid transformed extension subtag.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        ...
+
+includes: [testIntl.js]
+---*/
+
+const invalid = [
+  // empty
+  "en-t",
+  "en-t-a",
+  "en-t-x",
+  "en-t-0",
+
+  // incomplete
+  "en-t-",
+  "en-t-en-",
+  "en-t-0x-",
+
+  // tlang: unicode_language_subtag must be 2-3 or 5-8 characters and mustn't
+  // contain extlang subtags.
+  "en-t-root",
+  "en-t-abcdefghi",
+  "en-t-ar-aao",
+
+  // tlang: unicode_script_subtag must be 4 alphabetical characters, can't
+  // be repeated.
+  "en-t-en-lat0",
+  "en-t-en-latn-latn",
+
+  // tlang: unicode_region_subtag must either be 2 alpha characters or a three
+  // digit code.
+  "en-t-en-0",
+  "en-t-en-00",
+  "en-t-en-0x",
+  "en-t-en-x0",
+  "en-t-en-latn-0",
+  "en-t-en-latn-00",
+  "en-t-en-latn-xyz",
+
+  // tlang: unicode_variant_subtag is either 5-8 alphanum characters or 4
+  // characters starting with a digit.
+  "en-t-en-abcdefghi",
+  "en-t-en-latn-gb-ab",
+  "en-t-en-latn-gb-abc",
+  "en-t-en-latn-gb-abcd",
+  "en-t-en-latn-gb-abcdefghi",
+
+  // tkey must be followed by tvalue.
+  "en-t-d0",
+  "en-t-d0-m0",
+  "en-t-d0-x-private",
+];
+
+for (let tag of invalid) {
+  // Make sure the test data is correct.
+  assert.sameValue(isCanonicalizedStructurallyValidLanguageTag(tag), false,
+                   "\"" + tag + "\" isn't a structurally valid language tag.");
+
+  assert.throws(RangeError, () => Intl.getCanonicalLocales(tag), `${tag}`);
+}

--- a/test/intl402/Intl/getCanonicalLocales/transformed-ext-valid.js
+++ b/test/intl402/Intl/getCanonicalLocales/transformed-ext-valid.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  No RangeError is thrown when a language tag includes a valid transformed extension subtag.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+includes: [testIntl.js]
+---*/
+
+const valid = [
+  // tlang with unicode_language_subtag.
+  "en-t-en",
+
+  // tlang with unicode_script_subtag.
+  "en-t-en-latn",
+
+  // tlang with unicode_region_subtag.
+  "en-t-en-ca",
+
+  // tlang with unicode_script_subtag and unicode_region_subtag.
+  "en-t-en-latn-ca",
+
+  // tlang with unicode_variant_subtag.
+  "en-t-en-emodeng",
+
+  // tlang with unicode_script_subtag and unicode_variant_subtag.
+  "en-t-en-latn-emodeng",
+
+  // tlang with unicode_script_subtag and unicode_variant_subtag.
+  "en-t-en-ca-emodeng",
+
+  // tlang with unicode_script_subtag, unicode_region_subtag, and unicode_variant_subtag.
+  "en-t-en-latn-ca-emodeng",
+
+  // No tlang. (Must contain at least one tfield.)
+  "en-t-d0-ascii",
+];
+
+const extraFields = [
+  // No extra tfield
+  "",
+
+  // tfield with a tvalue consisting of a single subtag.
+  "-i0-handwrit",
+
+  // tfield with a tvalue consisting of two subtags.
+  "-s0-accents-publish",
+];
+
+for (let tag of valid) {
+  for (let extra of extraFields) {
+    let actualTag = tag + extra;
+
+    // Make sure the test data is correct.
+    assert(isCanonicalizedStructurallyValidLanguageTag(actualTag),
+           "\"" + actualTag + "\" is a canonical and structurally valid language tag.");
+
+    let result = Intl.getCanonicalLocales(actualTag);
+    assert.sameValue(result.length, 1);
+    assert.sameValue(result[0], actualTag);
+  }
+}

--- a/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-calendar.js
+++ b/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-calendar.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Test Unicode extension subtag canonicalisation for the "ca" extension key.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+  UTS 35, §3.2.1 Canonical Unicode Locale Identifiers
+    Use the bcp47 data to replace keys, types, tfields, and tvalues by their canonical forms.
+    See Section 3.6.4 U Extension Data Files) and Section 3.7.1 T Extension Data Files. The
+    aliases are in the alias attribute value, while the canonical is in the name attribute value.
+includes: [testIntl.js]
+---*/
+
+// <key name="ca" [...] alias="calendar">
+const testData = {
+  // <type name="ethioaa" [...] alias="ethiopic-amete-alem"/>
+  "ethiopic-amete-alem": "ethioaa",
+
+  // <type name="islamic-civil" [...] />
+  // <type name="islamicc" [...] deprecated="true" preferred="islamic-civil" alias="islamic-civil"/>
+  //
+  // "name" and "alias" for "islamic-civil" don't quite match of what's spec'ed in UTS 35, §3.2.1.
+  // Specifically following §3.2.1 to the letter means "islamicc" is the canonical value whereas
+  // "islamic-civil" is an alias value. Assume the definitions in
+  // https://unicode.org/reports/tr35/#Unicode_Locale_Extension_Data_Files overrule UTS 35, §3.2.1.
+  "islamicc": "islamic-civil",
+};
+
+for (let [alias, name] of Object.entries(testData)) {
+  let tag = "und-u-ca-" + alias;
+  let canonical = "und-u-ca-" + name;
+
+  // Make sure the test data is correct.
+  assert.sameValue(isCanonicalizedStructurallyValidLanguageTag(tag), false,
+                   "\"" + tag + "\" isn't a canonical language tag.");
+  assert(isCanonicalizedStructurallyValidLanguageTag(canonical),
+         "\"" + canonical + "\" is a canonical and structurally valid language tag.");
+
+  let result = Intl.getCanonicalLocales(tag);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], canonical);
+}

--- a/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-col-strength.js
+++ b/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-col-strength.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Test Unicode extension subtag canonicalisation for the "ks" extension key.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+  UTS 35, §3.2.1 Canonical Unicode Locale Identifiers
+    Use the bcp47 data to replace keys, types, tfields, and tvalues by their canonical forms.
+    See Section 3.6.4 U Extension Data Files) and Section 3.7.1 T Extension Data Files. The
+    aliases are in the alias attribute value, while the canonical is in the name attribute value.
+includes: [testIntl.js]
+---*/
+
+// <key name="ks" [...] alias="colStrength">/
+const testData = {
+  // <type name="level1" [...] alias="primary"/>
+  "primary": "level1",
+
+  // "secondary" doesn't match |uvalue|, so we can skip it.
+  // <type name="level2" [...] alias="secondary"/>
+  // "secondary": "level2",
+
+  // <type name="level3" [...] alias="tertiary"/>
+  "tertiary": "level3",
+
+  // Neither "quaternary" nor "quarternary" match |uvalue|, so we can skip them.
+  // <type name="level4" [...] alias="quaternary quarternary"/>
+  // "quaternary": "level4",
+  // "quarternary": "level4",
+
+  // "identical" doesn't match |uvalue|, so we can skip it.
+  // <type name="identic" [...] alias="identical"/>
+  // "identical": "identic",
+};
+
+for (let [alias, name] of Object.entries(testData)) {
+  let tag = "und-u-ks-" + alias;
+  let canonical = "und-u-ks-" + name;
+
+  // Make sure the test data is correct.
+  assert.sameValue(isCanonicalizedStructurallyValidLanguageTag(tag), false,
+                   "\"" + tag + "\" isn't a canonical language tag.");
+  assert(isCanonicalizedStructurallyValidLanguageTag(canonical),
+         "\"" + canonical + "\" is a canonical and structurally valid language tag.");
+
+  let result = Intl.getCanonicalLocales(tag);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], canonical);
+}

--- a/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-measurement-system.js
+++ b/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-measurement-system.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Test Unicode extension subtag canonicalisation for the "ms" extension key.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+  UTS 35, §3.2.1 Canonical Unicode Locale Identifiers
+    Use the bcp47 data to replace keys, types, tfields, and tvalues by their canonical forms.
+    See Section 3.6.4 U Extension Data Files) and Section 3.7.1 T Extension Data Files. The
+    aliases are in the alias attribute value, while the canonical is in the name attribute value.
+includes: [testIntl.js]
+---*/
+
+// <key name="ms" [...] alias="measure" since="28">
+const testData = {
+  // <type name="uksystem" [...] alias="imperial" since="28" />
+  "imperial": "uksystem",
+};
+
+for (let [alias, name] of Object.entries(testData)) {
+  let tag = "und-u-ms-" + alias;
+  let canonical = "und-u-ms-" + name;
+
+  // Make sure the test data is correct.
+  assert.sameValue(isCanonicalizedStructurallyValidLanguageTag(tag), false,
+                   "\"" + tag + "\" isn't a canonical language tag.");
+  assert(isCanonicalizedStructurallyValidLanguageTag(canonical),
+         "\"" + canonical + "\" is a canonical and structurally valid language tag.");
+
+  let result = Intl.getCanonicalLocales(tag);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], canonical);
+}

--- a/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-region.js
+++ b/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-region.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Test Unicode extension subtag canonicalisation for the "rg" extension key.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+  UTS 35, §3.2.1 Canonical Unicode Locale Identifiers
+    Use the bcp47 data to replace keys, types, tfields, and tvalues by their canonical forms.
+    See Section 3.6.4 U Extension Data Files) and Section 3.7.1 T Extension Data Files. The
+    aliases are in the alias attribute value, while the canonical is in the name attribute value.
+
+    Replace aliases in special key values:
+      If there is an 'sd' or 'rg' key, replace any subdivision alias in its value in the same way,
+      using subdivisionAlias data.
+includes: [testIntl.js]
+---*/
+
+const testData = {
+  // <subdivisionAlias type="no23" replacement="no50" reason="deprecated"/>
+  "no23": "no50",
+
+  // <subdivisionAlias type="cn11" replacement="cnbj" reason="deprecated"/>
+  "cn11": "cnbj",
+
+  // <subdivisionAlias type="cz10a" replacement="cz110" reason="deprecated"/>
+  "cz10a": "cz110",
+
+  // <subdivisionAlias type="fra" replacement="frges" reason="deprecated"/>
+  "fra": "frges",
+
+  // <subdivisionAlias type="frg" replacement="frges" reason="deprecated"/>
+  "frg": "frges",
+
+  // <subdivisionAlias type="lud" replacement="lucl ludi lurd luvd luwi" reason="deprecated"/>
+  "lud": "lucl",
+};
+
+for (let [alias, name] of Object.entries(testData)) {
+  let tag = "und-u-rg-" + alias;
+  let canonical = "und-u-rg-" + name;
+
+  // Make sure the test data is correct.
+  assert.sameValue(isCanonicalizedStructurallyValidLanguageTag(tag), false,
+                   "\"" + tag + "\" isn't a canonical language tag.");
+  assert(isCanonicalizedStructurallyValidLanguageTag(canonical),
+         "\"" + canonical + "\" is a canonical and structurally valid language tag.");
+
+  let result = Intl.getCanonicalLocales(tag);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], canonical);
+}

--- a/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-subdivision.js
+++ b/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-subdivision.js
@@ -1,0 +1,72 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Test Unicode extension subtag canonicalisation for the "sd" extension key.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+  UTS 35, §3.2.1 Canonical Unicode Locale Identifiers
+    Use the bcp47 data to replace keys, types, tfields, and tvalues by their canonical forms.
+    See Section 3.6.4 U Extension Data Files) and Section 3.7.1 T Extension Data Files. The
+    aliases are in the alias attribute value, while the canonical is in the name attribute value.
+
+    Replace aliases in special key values:
+      If there is an 'sd' or 'rg' key, replace any subdivision alias in its value in the same way,
+      using subdivisionAlias data.
+includes: [testIntl.js]
+---*/
+
+const testData = {
+  // <subdivisionAlias type="no23" replacement="no50" reason="deprecated"/>
+  "no23": "no50",
+
+  // <subdivisionAlias type="cn11" replacement="cnbj" reason="deprecated"/>
+  "cn11": "cnbj",
+
+  // <subdivisionAlias type="cz10a" replacement="cz110" reason="deprecated"/>
+  "cz10a": "cz110",
+
+  // <subdivisionAlias type="fra" replacement="frges" reason="deprecated"/>
+  "fra": "frges",
+
+  // <subdivisionAlias type="frg" replacement="frges" reason="deprecated"/>
+  "frg": "frges",
+
+  // <subdivisionAlias type="lud" replacement="lucl ludi lurd luvd luwi" reason="deprecated"/>
+  "lud": "lucl",
+};
+
+for (let [alias, name] of Object.entries(testData)) {
+  // Subdivision codes should always have a matching region subtag. This
+  // shouldn't actually matter for canonicalisation, but let's not push our
+  // luck and instead keep the language tag 'valid' per UTS 35, §3.6.5.
+  let region = name.substring(0, 2).toUpperCase();
+
+  let tag = `und-${region}-u-sd-${alias}`;
+  let canonical = `und-${region}-u-sd-${name}`;
+
+  // Make sure the test data is correct.
+  assert.sameValue(isCanonicalizedStructurallyValidLanguageTag(tag), false,
+                   "\"" + tag + "\" isn't a canonical language tag.");
+  assert(isCanonicalizedStructurallyValidLanguageTag(canonical),
+         "\"" + canonical + "\" is a canonical and structurally valid language tag.");
+
+  let result = Intl.getCanonicalLocales(tag);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], canonical);
+}

--- a/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-timezone.js
+++ b/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-timezone.js
@@ -1,0 +1,72 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Test Unicode extension subtag canonicalisation for the "tz" extension key.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+  UTS 35, §3.2.1 Canonical Unicode Locale Identifiers
+    Use the bcp47 data to replace keys, types, tfields, and tvalues by their canonical forms.
+    See Section 3.6.4 U Extension Data Files) and Section 3.7.1 T Extension Data Files. The
+    aliases are in the alias attribute value, while the canonical is in the name attribute value.
+includes: [testIntl.js]
+---*/
+
+// <key name="tz" [...] alias="timezone">
+const testData = {
+  // Similar to the "ca" extension key, assume "preferred" holds the canonical
+  // value and "name" the alias value.
+
+  // <type name="cnckg" [...] deprecated="true" preferred="cnsha"/>
+  "cnckg": "cnsha",
+
+  // NB: "Eire" matches the |uvalue| production.
+  // <type name="iedub" [...] alias="Europe/Dublin Eire"/>
+  "eire": "iedub",
+
+  // NB: "EST" matches the |uvalue| production.
+  // <type name="utcw05" [...] alias="Etc/GMT+5 EST"/>
+  "est": "utcw05",
+
+  // NB: "GMT0" matches the |uvalue| production.
+  // <type name="gmt" [...] alias="Etc/GMT Etc/GMT+0 Etc/GMT-0 Etc/GMT0 Etc/Greenwich GMT GMT+0 GMT-0 GMT0 Greenwich"/>
+  "gmt0": "gmt",
+
+  // NB: "UCT" matches the |uvalue| production.
+  // <type name="utc" [...] alias="Etc/UTC Etc/UCT Etc/Universal Etc/Zulu UCT UTC Universal Zulu"/>
+  "uct": "utc",
+
+  // NB: "Zulu" matches the |uvalue| production.
+  // <type name="utc" [...] alias="Etc/UTC Etc/UCT Etc/Universal Etc/Zulu UCT UTC Universal Zulu"/>
+  "zulu": "utc",
+};
+
+for (let [alias, name] of Object.entries(testData)) {
+  let tag = "und-u-tz-" + alias;
+  let canonical = "und-u-tz-" + name;
+
+  // Make sure the test data is correct.
+  assert.sameValue(isCanonicalizedStructurallyValidLanguageTag(tag), false,
+                   "\"" + tag + "\" isn't a canonical language tag.");
+  assert(isCanonicalizedStructurallyValidLanguageTag(canonical),
+         "\"" + canonical + "\" is a canonical and structurally valid language tag.");
+
+  let result = Intl.getCanonicalLocales(tag);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], canonical);
+}

--- a/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-yes-to-true.js
+++ b/test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-yes-to-true.js
@@ -1,0 +1,86 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  "kb", "kc", "kh", "kk", and "kn" Unicode extension keys canonicalise "yes" to "true".
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+  UTS 35, §3.2.1 Canonical Unicode Locale Identifiers
+    Use the bcp47 data to replace keys, types, tfields, and tvalues by their canonical forms.
+    See Section 3.6.4 U Extension Data Files) and Section 3.7.1 T Extension Data Files. The
+    aliases are in the alias attribute value, while the canonical is in the name attribute value.
+
+  UTS 35, §3.2.1 Canonical Unicode Locale Identifiers
+    Any type or tfield value "true" is removed.
+includes: [testIntl.js]
+---*/
+
+const unicodeKeys = [
+  // <key name="kb" [...] alias="colBackwards">
+  //   <type name="true" [...] alias="yes"/>
+  "kb",
+
+  // <key name="kc" [...] alias="colCaseLevel">
+  //   <type name="true" [...] alias="yes"/>
+  "kc",
+
+  // <key name="kh" [...] alias="colBackwards">
+  //   <type name="true" [...] alias="yes"/>
+  "kh",
+
+  // <key name="kh" [...] alias="colHiraganaQuaternary">
+  //   <type name="true" [...] alias="yes"/>
+  "kk",
+
+  // <key name="kn" [...] alias="colNumeric">
+  //   <type name="true" [...] alias="yes"/>
+  "kn",
+];
+
+for (let key of unicodeKeys) {
+  let tag = `und-u-${key}-yes`;
+  let canonical = `und-u-${key}`;
+
+  // Make sure the test data is correct.
+  assert.sameValue(isCanonicalizedStructurallyValidLanguageTag(tag), false,
+                   "\"" + tag + "\" isn't a canonical language tag.");
+  assert(isCanonicalizedStructurallyValidLanguageTag(canonical),
+         "\"" + canonical + "\" is a canonical and structurally valid language tag.");
+
+  let result = Intl.getCanonicalLocales(tag);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], canonical);
+}
+
+// Test some other Unicode extension keys which don't contain an alias entry to
+// canonicalise "yes" to "true".
+const otherUnicodeKeys = [
+  "ka", "kf", "kr", "ks", "kv",
+];
+
+for (let key of otherUnicodeKeys) {
+  let tag = `und-u-${key}-yes`;
+
+  // Make sure the test data is correct.
+  assert(isCanonicalizedStructurallyValidLanguageTag(tag),
+         "\"" + tag + "\" is a canonical and structurally valid language tag.");
+
+  let result = Intl.getCanonicalLocales(tag);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], tag);
+}

--- a/test/intl402/Intl/getCanonicalLocales/unicode-ext-key-with-digit.js
+++ b/test/intl402/Intl/getCanonicalLocales/unicode-ext-key-with-digit.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.getcanonicallocales
+description: >
+  Test Unicode extension subtags where the ukey subtag contains a digit.
+info: |
+  8.2.1 Intl.getCanonicalLocales (locales)
+    1. Let ll be ? CanonicalizeLocaleList(locales).
+    2. Return CreateArrayFromList(ll).
+
+  9.2.1 CanonicalizeLocaleList (locales)
+    ...
+    7. Repeat, while k < len
+      ...
+      c. If kPresent is true, then
+        ...
+        v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+        vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+        ...
+
+includes: [testIntl.js]
+---*/
+
+// Unicode locale extension sequences don't allow keys with a digit as their
+// second character.
+const invalidCases = [
+  "en-u-c0",
+  "en-u-00",
+];
+
+// The first character is allowed to be a digit.
+const validCases = [
+  "en-u-0c",
+];
+
+for (let invalid of invalidCases) {
+  // Make sure the test data is correct.
+  assert.sameValue(isCanonicalizedStructurallyValidLanguageTag(invalid), false,
+                   "\"" + invalid + "\" isn't a structurally valid language tag.");
+
+  assert.throws(RangeError, () => Intl.getCanonicalLocales(invalid));
+}
+
+for (let valid of validCases) {
+  // Make sure the test data is correct.
+  assert(isCanonicalizedStructurallyValidLanguageTag(valid),
+         "\"" + valid + "\" is a canonical and structurally valid language tag.");
+
+  let result = Intl.getCanonicalLocales(valid);
+  assert.sameValue(result.length, 1);
+  assert.sameValue(result[0], valid);
+}

--- a/test/intl402/Locale/constructor-apply-options-canonicalizes-twice.js
+++ b/test/intl402/Locale/constructor-apply-options-canonicalizes-twice.js
@@ -1,0 +1,26 @@
+// Copyright 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-apply-options-to-tag
+description: >
+    ApplyOptionsToTag canonicalises the language tag two times.
+info: |
+    10.1.1 ApplyOptionsToTag( tag, options )
+
+    ...
+    9. Set tag to CanonicalizeUnicodeLocaleId(tag).
+    10. If language is not undefined,
+        ...
+        b. Set tag to tag with the substring corresponding to the unicode_language_subtag
+           production of the unicode_language_id replaced by the string language.
+    ...
+    13. Return CanonicalizeUnicodeLocaleId(tag).
+features: [Intl.Locale]
+---*/
+
+// ApplyOptionsToTag canonicalises the locale identifier before applying the
+// options. That means "und-Armn-SU" is first canonicalised to "und-Armn-AM",
+// then the language is changed to "ru". If "ru" were applied first, the result
+// would be "ru-Armn-RU" instead.
+assert.sameValue(new Intl.Locale("und-Armn-SU", {language: "ru"}).toString(), "ru-Armn-AM");

--- a/test/intl402/Locale/constructor-non-iana-canon.js
+++ b/test/intl402/Locale/constructor-non-iana-canon.js
@@ -79,18 +79,13 @@ var testData = [
         maximized: "cs-Latn-CZ",
     },
     {
-        // ECMA-402 currently requires that variant subtags are not canonicalized.
-        // https://github.com/tc39/ecma402/issues/330
         tag: "hy-arevela",
-        canonical: "hy-arevela",
-        maximized: "hy-Armn-AM-arevela",
+        canonical: "hy",
+        maximized: "hy-Armn-AM",
     },
     {
-        // ECMA-402 currently requires that variant subtags are not canonicalized.
-        // https://github.com/tc39/ecma402/issues/330
         tag: "hy-arevmda",
-        canonical: "hy-arevmda",
-        maximized: "hy-Armn-AM-arevmda",
+        canonical: "hyw",
     },
 ];
 

--- a/test/intl402/Locale/extensions-grandfathered.js
+++ b/test/intl402/Locale/extensions-grandfathered.js
@@ -22,6 +22,18 @@ features: [Intl.Locale]
 ---*/
 
 const testData = [
+    // Regular grandfathered without modern replacement.
+    {
+        tag: "cel-gaulish",
+        options: {
+            language: "fr",
+            script: "Cyrl",
+            region: "FR",
+            numberingSystem: "latn",
+        },
+        canonical: "fr-Cyrl-FR-u-nu-latn-x-cel-gaulish",
+    },
+
     // Regular grandfathered with modern replacement.
     {
         tag: "art-lojban",

--- a/test/intl402/Locale/getters-grandfathered.js
+++ b/test/intl402/Locale/getters-grandfathered.js
@@ -26,6 +26,13 @@ features: [Intl.Locale]
 ---*/
 
 // Regular grandfathered language tag.
+var loc = new Intl.Locale("cel-gaulish");
+assert.sameValue(loc.baseName, "xtg");
+assert.sameValue(loc.language, "xtg");
+assert.sameValue(loc.script, undefined);
+assert.sameValue(loc.region, undefined);
+
+// Regular grandfathered language tag.
 assert.throws(RangeError, () => new Intl.Locale("zh-min"));
 
 assert.throws(RangeError, () => new Intl.Locale("i-default"));

--- a/test/intl402/Locale/likely-subtags-grandfathered.js
+++ b/test/intl402/Locale/likely-subtags-grandfathered.js
@@ -67,6 +67,10 @@ const regularGrandfathered = [
         maximized: "jbo-Latn-001",
     },
     {
+        tag: "cel-gaulish",
+        canonical: "xtg-x-cel-gaulish",
+    },
+    {
         tag: "zh-guoyu",
         canonical: "zh",
         maximized: "zh-Hans-CN",

--- a/test/intl402/Locale/likely-subtags.js
+++ b/test/intl402/Locale/likely-subtags.js
@@ -37,6 +37,10 @@ const testDataMaximal = {
     "und-419": "es-Latn-419",
     "und-150": "ru-Cyrl-RU",
     "und-AT": "de-Latn-AT",
+    "und-Cyrl-RO": "bg-Cyrl-RO",
+
+    // Undefined primary language not required to change in all cases.
+    "und-AQ": "und-Latn-AQ",
 };
 
 const testDataMinimal = {
@@ -62,6 +66,8 @@ const testDataMinimal = {
     "es-Latn-419": "es-419",
     "ru-Cyrl-RU": "ru",
     "de-Latn-AT": "de-AT",
+    "bg-Cyrl-RO": "bg-RO",
+    "und-Latn-AQ": "und-AQ",
 };
 
 // Add variants, extensions, and privateuse subtags and ensure they don't

--- a/test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js
+++ b/test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js
@@ -1,0 +1,49 @@
+// Copyright 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.minimize
+description: >
+    The "Remove Likely Subtags" algorithm adds likely subtags before processing the locale.
+info: |
+    Intl.Locale.prototype.minimize ()
+    3. Let minimal be the result of the Remove Likely Subtags algorithm applied to loc.[[Locale]].
+       If an error is signaled, set minimal to loc.[[Locale]].
+
+    UTS 35, §4.3 Likely Subtags
+    Remove Likely Subtags
+
+    1. First get max = AddLikelySubtags(inputLocale). If an error is signaled, return it.
+    2. ...
+features: [Intl.Locale]
+---*/
+
+var testDataMinimal = {
+    // Undefined primary language.
+    "und": "en",
+    "und-Thai": "th",
+    "und-419": "es-419",
+    "und-150": "ru",
+    "und-AT": "de-AT",
+
+    // https://unicode-org.atlassian.net/browse/ICU-13786
+    "aae-Latn-IT": "aae-Latn-IT",
+    "aae-Thai-CO": "aae-Thai-CO",
+
+    // https://unicode-org.atlassian.net/browse/ICU-10220
+    // https://unicode-org.atlassian.net/browse/ICU-12345
+    "und-CW": "pap-CW",
+    "und-US": "en",
+    "zh-Hant": "zh-TW",
+    "zh-Hani": "zh-Hani",
+};
+
+for (const [tag, minimal] of Object.entries(testDataMinimal)) {
+    // Assert the |minimal| tag is indeed minimal.
+    assert.sameValue(new Intl.Locale(minimal).minimize().toString(), minimal,
+                     `"${minimal}" should be minimal`);
+
+    // Assert RemoveLikelySubtags(tag) returns |minimal|.
+    assert.sameValue(new Intl.Locale(tag).minimize().toString(), minimal,
+                     `"${tag}".minimize() should be "${minimal}"`);
+}

--- a/tools/misc/make_intl_data.py
+++ b/tools/misc/make_intl_data.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Mozilla Corporation. All rights reserved.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Original file:
+# https://hg.mozilla.org/mozilla-central/file/tip/js/src/builtin/intl/make_intl_data.py
+
+""" Usage:
+    make_intl_data.py langtags [cldr_core.zip]
+
+
+    Target "langtags":
+    This script extracts information about 1) mappings between deprecated and
+    current Unicode BCP 47 locale identifiers, and 2) deprecated and current
+    BCP 47 Unicode extension value from CLDR.
+"""
+
+from __future__ import print_function
+import os
+import re
+import io
+import sys
+from contextlib import closing
+from functools import partial
+from operator import itemgetter
+from zipfile import ZipFile
+
+if sys.version_info.major == 2:
+    from urllib2 import urlopen
+else:
+    from urllib.request import urlopen
+
+
+def read_supplemental_data(core_file):
+    """ Reads CLDR Supplemental Data and extracts information for Intl.js.
+
+        Information extracted:
+        - grandfatheredMappings: mappings from grandfathered tags to preferred
+          complete language tags
+        - languageMappings: mappings from language subtags to preferred subtags
+        - complexLanguageMappings: mappings from language subtags with complex rules
+        - regionMappings: mappings from region subtags to preferred subtags
+        - complexRegionMappings: mappings from region subtags with complex rules
+        - variantMappings: mappings from variant subtags to preferred subtags
+        Returns these mappings as dictionaries.
+    """
+    import xml.etree.ElementTree as ET
+
+    # From Unicode BCP 47 locale identifier <https://unicode.org/reports/tr35/>.
+    re_unicode_language_id = re.compile(
+        r"""
+        ^
+        # unicode_language_id = unicode_language_subtag
+        #     unicode_language_subtag = alpha{2,3} | alpha{5,8}
+        (?P<language>[a-z]{2,3}|[a-z]{5,8})
+
+        # (sep unicode_script_subtag)?
+        #     unicode_script_subtag = alpha{4}
+        (?:-(?P<script>[a-z]{4}))?
+
+        # (sep unicode_region_subtag)?
+        #     unicode_region_subtag = (alpha{2} | digit{3})
+        (?:-(?P<region>([a-z]{2}|[0-9]{3})))?
+
+        # (sep unicode_variant_subtag)*
+        #     unicode_variant_subtag = (alphanum{5,8} | digit alphanum{3})
+        (?P<variants>(-([a-z0-9]{5,8}|[0-9][a-z0-9]{3}))+)?
+        $
+        """, re.IGNORECASE | re.VERBOSE)
+
+    re_unicode_language_subtag = re.compile(
+        r"""
+        ^
+        # unicode_language_subtag = alpha{2,3} | alpha{5,8}
+        ([a-z]{2,3}|[a-z]{5,8})
+        $
+        """, re.IGNORECASE | re.VERBOSE)
+
+    re_unicode_region_subtag = re.compile(
+        r"""
+        ^
+        # unicode_region_subtag = (alpha{2} | digit{3})
+        ([a-z]{2}|[0-9]{3})
+        $
+        """, re.IGNORECASE | re.VERBOSE)
+
+    re_unicode_variant_subtag = re.compile(
+        r"""
+        ^
+        # unicode_variant_subtag = (alphanum{5,8} | digit alphanum{3})
+        ([a-z0-9]{5,8}|(?:[0-9][a-z0-9]{3}))
+        $
+        """, re.IGNORECASE | re.VERBOSE)
+
+    # The fixed list of BCP 47 grandfathered language tags.
+    grandfathered_tags = (
+        "art-lojban",
+        "cel-gaulish",
+        "en-GB-oed",
+        "i-ami",
+        "i-bnn",
+        "i-default",
+        "i-enochian",
+        "i-hak",
+        "i-klingon",
+        "i-lux",
+        "i-mingo",
+        "i-navajo",
+        "i-pwn",
+        "i-tao",
+        "i-tay",
+        "i-tsu",
+        "no-bok",
+        "no-nyn",
+        "sgn-BE-FR",
+        "sgn-BE-NL",
+        "sgn-CH-DE",
+        "zh-guoyu",
+        "zh-hakka",
+        "zh-min",
+        "zh-min-nan",
+        "zh-xiang",
+    )
+
+    # The list of grandfathered tags which are valid Unicode BCP 47 locale identifiers.
+    unicode_bcp47_grandfathered_tags = {tag for tag in grandfathered_tags
+                                        if re_unicode_language_id.match(tag)}
+
+    # Dictionary of simple language subtag mappings, e.g. "in" -> "id".
+    language_mappings = {}
+
+    # Dictionary of complex language subtag mappings, modifying more than one
+    # subtag, e.g. "sh" -> ("sr", "Latn", None) and "cnr" -> ("sr", None, "ME").
+    complex_language_mappings = {}
+
+    # Dictionary of simple region subtag mappings, e.g. "DD" -> "DE".
+    region_mappings = {}
+
+    # Dictionary of complex region subtag mappings, containing more than one
+    # replacement, e.g. "SU" -> ("RU", ["AM", "AZ", "BY", ...]).
+    complex_region_mappings = {}
+
+    # Dictionary of aliased variant subtags to a tuple of preferred replacement
+    # type and replacement, e.g. "arevela" -> ("language", "hy") or
+    # "aaland" -> ("region", "AX") or "heploc" -> ("variant", "alalc97").
+    variant_mappings = {}
+
+    # Dictionary of grandfathered mappings to preferred values.
+    grandfathered_mappings = {}
+
+    # CLDR uses "_" as the separator for some elements. Replace it with "-".
+    def bcp47_id(cldr_id):
+        return cldr_id.replace("_", "-")
+
+    # CLDR uses the canonical case for most entries, but there are some
+    # exceptions, like:
+    #   <languageAlias type="drw" replacement="fa_af" reason="deprecated"/>
+    # Therefore canonicalize all tags to be on the safe side.
+    def bcp47_canonical(language, script, region):
+        # Canonical case for language subtags is lower case.
+        # Canonical case for script subtags is title case.
+        # Canonical case for region subtags is upper case.
+        return (language.lower() if language else None,
+                script.title() if script else None,
+                region.upper() if region else None)
+
+    tree = ET.parse(core_file.open("common/supplemental/supplementalMetadata.xml"))
+
+    for language_alias in tree.iterfind(".//languageAlias"):
+        type = bcp47_id(language_alias.get("type"))
+        replacement = bcp47_id(language_alias.get("replacement"))
+
+        # Handle grandfathered mappings first.
+        if type in unicode_bcp47_grandfathered_tags:
+            grandfathered_mappings[type] = replacement
+            continue
+
+        # We're only interested in language subtag matches, so ignore any
+        # entries which have additional subtags.
+        if re_unicode_language_subtag.match(type) is None:
+            continue
+
+        assert type.islower()
+
+        if re_unicode_language_subtag.match(replacement) is not None:
+            # Canonical case for language subtags is lower-case.
+            language_mappings[type] = replacement.lower()
+        else:
+            replacement_match = re_unicode_language_id.match(replacement)
+            assert replacement_match is not None, (
+                   "{} invalid Unicode BCP 47 locale identifier".format(replacement))
+            assert replacement_match.group("variants") is None, (
+                   "{}: unexpected variant subtags in {}".format(type, replacement))
+
+            complex_language_mappings[type] = bcp47_canonical(replacement_match.group("language"),
+                                                              replacement_match.group("script"),
+                                                              replacement_match.group("region"))
+
+    for territory_alias in tree.iterfind(".//territoryAlias"):
+        type = territory_alias.get("type")
+        replacement = territory_alias.get("replacement")
+
+        # We're only interested in region subtag matches, so ignore any entries
+        # which contain legacy formats, e.g. three letter region codes.
+        if re_unicode_region_subtag.match(type) is None:
+            continue
+
+        assert type.isupper() or type.isdigit()
+
+        if re_unicode_region_subtag.match(replacement) is not None:
+            # Canonical case for region subtags is upper-case.
+            region_mappings[type] = replacement.upper()
+        else:
+            # Canonical case for region subtags is upper-case.
+            replacements = [r.upper() for r in replacement.split(" ")]
+            assert all(
+                re_unicode_region_subtag.match(loc) is not None for loc in replacements
+            ), "{} invalid region subtags".format(replacement)
+            complex_region_mappings[type] = replacements
+
+    for variant_alias in tree.iterfind(".//variantAlias"):
+        type = variant_alias.get("type")
+        replacement = variant_alias.get("replacement")
+
+        assert re_unicode_variant_subtag.match(type) is not None, (
+               "{} invalid variant subtag".format(type))
+
+        # Normalize the case, because some variants are in upper case.
+        type = type.lower()
+
+        # The replacement can be a language, a region, or a variant subtag.
+        # Language and region subtags are case normalized, variant subtags can
+        # be in any case.
+
+        if re_unicode_language_subtag.match(replacement) is not None and replacement.islower():
+            variant_mappings[type] = ("language", replacement)
+
+        elif re_unicode_region_subtag.match(replacement) is not None:
+            assert replacement.isupper() or replacement.isdigit(), (
+                   "{} invalid variant subtag replacement".format(replacement))
+            variant_mappings[type] = ("region", replacement)
+
+        else:
+            assert re_unicode_variant_subtag.match(replacement) is not None, (
+                   "{} invalid variant subtag replacement".format(replacement))
+            variant_mappings[type] = ("variant", replacement.lower())
+
+    tree = ET.parse(core_file.open("common/supplemental/likelySubtags.xml"))
+
+    likely_subtags = {}
+
+    for likely_subtag in tree.iterfind(".//likelySubtag"):
+        from_tag = bcp47_id(likely_subtag.get("from"))
+        from_match = re_unicode_language_id.match(from_tag)
+        assert from_match is not None, (
+               "{} invalid Unicode BCP 47 locale identifier".format(from_tag))
+        assert from_match.group("variants") is None, (
+               "unexpected variant subtags in {}".format(from_tag))
+
+        to_tag = bcp47_id(likely_subtag.get("to"))
+        to_match = re_unicode_language_id.match(to_tag)
+        assert to_match is not None, (
+               "{} invalid Unicode BCP 47 locale identifier".format(to_tag))
+        assert to_match.group("variants") is None, (
+               "unexpected variant subtags in {}".format(to_tag))
+
+        from_canonical = bcp47_canonical(from_match.group("language"),
+                                         from_match.group("script"),
+                                         from_match.group("region"))
+
+        to_canonical = bcp47_canonical(to_match.group("language"),
+                                       to_match.group("script"),
+                                       to_match.group("region"))
+
+        likely_subtags[from_canonical] = to_canonical
+
+    complex_region_mappings_final = {}
+
+    for (deprecated_region, replacements) in complex_region_mappings.items():
+        # Find all likely subtag entries which don't already contain a region
+        # subtag and whose target region is in the list of replacement regions.
+        region_likely_subtags = [(from_language, from_script, to_region)
+                                 for ((from_language, from_script, from_region),
+                                      (_, _, to_region)) in likely_subtags.items()
+                                 if from_region is None and to_region in replacements]
+
+        # The first replacement entry is the default region.
+        default = replacements[0]
+
+        # Find all likely subtag entries whose region matches the default region.
+        default_replacements = {(language, script)
+                                for (language, script, region) in region_likely_subtags
+                                if region == default}
+
+        # And finally find those entries which don't use the default region.
+        # These are the entries we're actually interested in, because those need
+        # to be handled specially when selecting the correct preferred region.
+        non_default_replacements = [(language, script, region)
+                                    for (language, script, region) in region_likely_subtags
+                                    if (language, script) not in default_replacements]
+
+        # If there are no non-default replacements, we can handle the region as
+        # part of the simple region mapping.
+        if non_default_replacements:
+            complex_region_mappings_final[deprecated_region] = (default, non_default_replacements)
+        else:
+            region_mappings[deprecated_region] = default
+
+    return {"grandfatheredMappings": grandfathered_mappings,
+            "languageMappings": language_mappings,
+            "complexLanguageMappings": complex_language_mappings,
+            "regionMappings": region_mappings,
+            "complexRegionMappings": complex_region_mappings_final,
+            "variantMappings": variant_mappings,
+            }
+
+
+def read_unicode_extensions(core_file):
+    import xml.etree.ElementTree as ET
+
+    # Match all xml-files in the BCP 47 directory.
+    bcp_file_re = re.compile(r"^common/bcp47/.+\.xml$")
+
+    # https://www.unicode.org/reports/tr35/#Unicode_locale_identifier
+    #
+    # type = alphanum{3,8} (sep alphanum{3,8})* ;
+    type_re = re.compile(r"^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$")
+
+    # Mapping from Unicode extension types to dict of deprecated to
+    # preferred values.
+    mapping = {
+        # Unicode BCP 47 U Extension
+        "u": {},
+
+        # Unicode BCP 47 T Extension
+        "t": {},
+    }
+
+    def read_bcp47_file(file):
+        tree = ET.parse(file)
+        for keyword in tree.iterfind(".//keyword/key"):
+            extension = keyword.get("extension", "u")
+            assert extension == "u" or extension == "t", (
+                   "unknown extension type: {}".format(extension))
+
+            extension_name = keyword.get("name")
+
+            for type in keyword.iterfind("type"):
+                # <https://unicode.org/reports/tr35/#Unicode_Locale_Extension_Data_Files>:
+                #
+                # The key or type name used by Unicode locale extension with 'u' extension
+                # syntax or the 't' extensions syntax. When alias below is absent, this name
+                # can be also used with the old style "@key=type" syntax.
+                name = type.get("name")
+
+                # Ignore the special name:
+                # - <https://unicode.org/reports/tr35/#CODEPOINTS>
+                # - <https://unicode.org/reports/tr35/#REORDER_CODE>
+                # - <https://unicode.org/reports/tr35/#RG_KEY_VALUE>
+                # - <https://unicode.org/reports/tr35/#SUBDIVISION_CODE>
+                # - <https://unicode.org/reports/tr35/#PRIVATE_USE>
+                if name in ("CODEPOINTS", "REORDER_CODE", "RG_KEY_VALUE", "SUBDIVISION_CODE",
+                            "PRIVATE_USE"):
+                    continue
+
+                # All other names should match the 'type' production.
+                assert type_re.match(name) is not None, (
+                       "{} matches the 'type' production".format(name))
+
+                # <https://unicode.org/reports/tr35/#Unicode_Locale_Extension_Data_Files>:
+                #
+                # The preferred value of the deprecated key, type or attribute element.
+                # When a key, type or attribute element is deprecated, this attribute is
+                # used for specifying a new canonical form if available.
+                preferred = type.get("preferred")
+
+                # <https://unicode.org/reports/tr35/#Unicode_Locale_Extension_Data_Files>:
+                #
+                # The BCP 47 form is the canonical form, and recommended. Other aliases are
+                # included only for backwards compatibility.
+                alias = type.get("alias")
+
+                # <https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers>
+                #
+                # Use the bcp47 data to replace keys, types, tfields, and tvalues by their
+                # canonical forms. See Section 3.6.4 U Extension Data Files) and Section
+                # 3.7.1 T Extension Data Files. The aliases are in the alias attribute
+                # value, while the canonical is in the name attribute value.
+
+                # 'preferred' contains the new preferred name, 'alias' the compatibility
+                # name, but then there's this entry where 'preferred' and 'alias' are the
+                # same. So which one to choose? Assume 'preferred' is the actual canonical
+                # name.
+                #
+                # <type name="islamicc"
+                #       description="Civil (algorithmic) Arabic calendar"
+                #       deprecated="true"
+                #       preferred="islamic-civil"
+                #       alias="islamic-civil"/>
+
+                if preferred is not None:
+                    assert type_re.match(preferred), preferred
+                    mapping[extension].setdefault(extension_name, {})[name] = preferred
+
+                if alias is not None:
+                    for alias_name in alias.lower().split(" "):
+                        # Ignore alias entries which don't match the 'type' production.
+                        if type_re.match(alias_name) is None:
+                            continue
+
+                        # See comment above when 'alias' and 'preferred' are both present.
+                        if (preferred is not None and
+                            name in mapping[extension][extension_name]):
+                            continue
+
+                        # Skip over entries where 'name' and 'alias' are equal.
+                        #
+                        # <type name="pst8pdt"
+                        #       description="POSIX style time zone for US Pacific Time"
+                        #       alias="PST8PDT"
+                        #       since="1.8"/>
+                        if name == alias_name:
+                            continue
+
+                        mapping[extension].setdefault(extension_name, {})[alias_name] = name
+
+    def read_supplemental_metadata(file):
+        # Find subdivision and region replacements.
+        #
+        # <https://www.unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers>
+        #
+        # Replace aliases in special key values:
+        #   - If there is an 'sd' or 'rg' key, replace any subdivision alias
+        #     in its value in the same way, using subdivisionAlias data.
+        tree = ET.parse(file)
+        for alias in tree.iterfind(".//subdivisionAlias"):
+            type = alias.get("type")
+            assert type_re.match(type) is not None, (
+                   "{} matches the 'type' production".format(type))
+
+            # Take the first replacement when multiple ones are present.
+            replacement = alias.get("replacement").split(" ")[0].lower()
+
+            # Skip over invalid replacements.
+            #
+            # <subdivisionAlias type="fi01" replacement="AX" reason="overlong"/>
+            #
+            # It's not entirely clear to me if CLDR actually wants to use
+            # "axzzzz" as the replacement for this case.
+            if type_re.match(replacement) is None:
+                continue
+
+            # 'subdivisionAlias' applies to 'rg' and 'sd' keys.
+            mapping["u"].setdefault("rg", {})[type] = replacement
+            mapping["u"].setdefault("sd", {})[type] = replacement
+
+    for name in core_file.namelist():
+        if bcp_file_re.match(name):
+            read_bcp47_file(core_file.open(name))
+
+    read_supplemental_metadata(core_file.open("common/supplemental/supplementalMetadata.xml"))
+
+    return {
+        "unicodeMappings": mapping["u"],
+        "transformMappings": mapping["t"],
+    }
+
+
+def write_simple_mappings(println, name, mappings):
+    println(u"var {} = {{".format(name))
+
+    for (key, value) in sorted(mappings.items(), key=itemgetter(0)):
+        println(u"""  "{}": "{}",""".format(key, value))
+
+    println(u"};")
+
+
+def write_complex_language_mappings(println, mappings):
+    println(u"var __complexLanguageMappings = {")
+
+    def maybe_subtag(name, subtag):
+        if subtag is None:
+            return u""
+        return u""", {}: "{}\"""".format(name, subtag)
+
+    for (deprecated_language, (language, script, region)) in (
+        sorted(mappings.items(), key=itemgetter(0))
+    ):
+        println(u"""  "{}": {{language: "{}"{}{}}},""".format(deprecated_language, language,
+                                                              maybe_subtag("script", script),
+                                                              maybe_subtag("region", region)))
+
+    println(u"};")
+
+
+def write_complex_region_mappings(println, mappings):
+    println(u"var __complexRegionMappings = {")
+
+    def maybe_subtag(name, subtag):
+        if subtag is None:
+            return u""
+        return u"""{}: "{}", """.format(name, subtag)
+
+    for (deprecated_region, (default, non_default_replacements)) in (
+        sorted(mappings.items(), key=itemgetter(0))
+    ):
+        println(u"""  "{}": {{""".format(deprecated_region))
+        println(u"""    default: "{}",""".format(default))
+
+        for (language, script, region) in sorted(non_default_replacements, key=itemgetter(0, 1)):
+            mapping_key = language
+            if script is not None:
+                mapping_key += "-" + script
+
+            println(u"""    "{}": "{}",""".format(mapping_key, region))
+
+        println(u"  },")
+
+    println(u"};")
+
+
+def write_variant_mappings(println, mappings):
+    println(u"var __variantMappings = {")
+
+    for (deprecated_variant, (type, replacement)) in sorted(mappings.items(), key=itemgetter(0)):
+        println(u"""  "{}": {{type: "{}", replacement: "{}"}},""".format(deprecated_variant, type,
+                                                                         replacement))
+
+    println(u"};")
+
+
+def write_unicode_extension_mappings(println, mapping, extension):
+    println(u"var __{}Mappings = {{".format(extension))
+
+    for (key, replacements) in sorted(mapping.items(), key=itemgetter(0)):
+        println(u"""  "{}": {{""".format(key))
+
+        for (type, replacement) in sorted(replacements.items(), key=itemgetter(0)):
+            println(u"""    "{}": "{}",""".format(type, replacement))
+        println(u"  },")
+
+    println(u"};")
+
+
+def write_cldr_language_tag_data(println, data, url):
+    language_mappings = data["languageMappings"]
+    complex_language_mappings = data["complexLanguageMappings"]
+    region_mappings = data["regionMappings"]
+    complex_region_mappings = data["complexRegionMappings"]
+    variant_mappings = data["variantMappings"]
+    unicode_mappings = data["unicodeMappings"]
+    transform_mappings = data["transformMappings"]
+
+    write_simple_mappings(println, "__languageMappings", language_mappings)
+    write_simple_mappings(println, "__regionMappings", region_mappings)
+
+    write_complex_language_mappings(println, complex_language_mappings)
+    write_complex_region_mappings(println, complex_region_mappings)
+
+    write_variant_mappings(println, variant_mappings)
+
+    write_unicode_extension_mappings(println, unicode_mappings, "unicode")
+    write_unicode_extension_mappings(println, transform_mappings, "transform")
+
+
+def update_cldr_lang_tags(args):
+    """ Generate the language tag mapping objects. """
+    version = args.version
+    url = args.url
+    out = args.out
+    filename = args.file
+
+    url = url.replace("<VERSION>", version)
+
+    print("Arguments:")
+    print("\tCLDR version: %s" % version)
+    print("\tDownload url: %s" % url)
+    if filename is not None:
+        print("\tLocal CLDR core.zip file: %s" % filename)
+    print("\tOutput file: %s" % out)
+    print("")
+
+    data = {
+        "version": version,
+    }
+
+    def read_files(cldr_file):
+        with ZipFile(cldr_file) as zip_file:
+            data.update(read_supplemental_data(zip_file))
+            data.update(read_unicode_extensions(zip_file))
+
+    print("Processing CLDR data...")
+    if filename is not None:
+        print("Always make sure you have the newest CLDR core.zip!")
+        with open(filename, "rb") as cldr_file:
+            read_files(cldr_file)
+    else:
+        print("Downloading CLDR core.zip...")
+        with closing(urlopen(url)) as cldr_file:
+            cldr_data = io.BytesIO(cldr_file.read())
+            read_files(cldr_data)
+
+    print("Writing Intl data...")
+    if out == "stdout":
+        out = sys.stdout.fileno()
+    with io.open(out, mode="w", encoding="utf-8", newline="") as f:
+        println = partial(print, file=f)
+
+        write_cldr_language_tag_data(println, data, url)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    def ensure_https(v):
+        if not v.startswith("https:"):
+            raise argparse.ArgumentTypeError("URL protocol must be https: " % v)
+        return v
+
+    parser = argparse.ArgumentParser(description="Update CLDR language tags data.")
+
+    parser.add_argument("--version",
+                        metavar="VERSION",
+                        required=True,
+                        help="CLDR version number")
+    parser.add_argument("--url",
+                        metavar="URL",
+                        default="https://unicode.org/Public/cldr/<VERSION>/core.zip",
+                        type=ensure_https,
+                        help="Download url CLDR data (default: %(default)s)")
+    parser.add_argument("--out",
+                        default="stdout",
+                        help="Output file (default: %(default)s)")
+    parser.add_argument("file",
+                        nargs="?",
+                        help="Local cldr-core.zip file, if omitted uses <URL>")
+    parser.set_defaults(func=update_cldr_lang_tags)
+
+    args = parser.parse_args()
+    args.func(args)


### PR DESCRIPTION
5663696:
- Updates the list of Intl service constructors to ensure existing tests are also run with RelativeTimeFormat, ListFormat, and DisplayNames.

f2fc3af:
- Updates the list of numbering systems to match current CLDR.

15db7f1:
- Python script used for the next two commits.

79524bf and 32fd063:
- Update the language tag canonicalisation to match UTS 35.

2a7c9f8:
- Variant subtags need to be canonicalised (again).

2e32d50:
- Using UTS 35 means "cel-gaulish" can now be canonicalised consistently across implementations, so we can revert #2054.

cce81ab:
- Additional canonicalisation and Intl.Locale tests from SpiderMonkey.
