### PR TITLE
Improve coverage of RegExp.prototype[@@replace] with named groups

### DIFF
--- a/test/built-ins/RegExp/prototype/Symbol.replace/named-groups-fn.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/named-groups-fn.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-regexp.prototype-@@replace
+description: >
+  "groups" value is passed as last argument of replacer unless it is undefined.
+info: |
+  RegExp.prototype [ @@replace ] ( string, replaceValue )
+
+  [...]
+  14. For each result in results, do
+    [...]
+    j. Let namedCaptures be ? Get(result, "groups").
+    k. If functionalReplace is true, then
+      [...]
+      iv. If namedCaptures is not undefined, then
+        1. Append namedCaptures as the last element of replacerArgs.
+      v. Let replValue be ? Call(replaceValue, undefined, replacerArgs).
+features: [Symbol.replace, regexp-named-groups]
+---*/
+
+var matchGroups;
+var re = /./;
+re.exec = function() {
+  return {
+    length: 1,
+    0: "a",
+    index: 0,
+    groups: matchGroups,
+  };
+};
+
+var replacerCalls = 0;
+var replacerLastArg;
+var replacer = function() {
+  replacerCalls++;
+  replacerLastArg = arguments[arguments.length - 1];
+};
+
+matchGroups = null;
+re[Symbol.replace]("a", replacer);
+assert.sameValue(replacerCalls, 1);
+assert.sameValue(replacerLastArg, matchGroups);
+
+matchGroups = undefined;
+re[Symbol.replace]("a", replacer);
+assert.sameValue(replacerCalls, 2);
+assert.sameValue(replacerLastArg, "a");
+
+matchGroups = 10;
+re[Symbol.replace]("a", replacer);
+assert.sameValue(replacerCalls, 3);
+assert.sameValue(replacerLastArg, matchGroups);
+
+matchGroups = {};
+re[Symbol.replace]("a", replacer);
+assert.sameValue(replacerCalls, 4);
+assert.sameValue(replacerLastArg, matchGroups);

--- a/test/built-ins/RegExp/prototype/Symbol.replace/named-groups.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/named-groups.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-getsubstitution
+description: >
+  RegExp.prototype[Symbol.replace] works with named capture references as expected.
+  (string replacement)
+info: |
+  GetSubstitution ( matched, str, position, captures, namedCaptures, replacement )
+
+  Table: Replacement Text Symbol Substitutions
+
+  Unicode Characters: $<
+  Replacement text:
+    1. If namedCaptures is undefined, the replacement text is the literal string $<.
+    2. Else,
+      a. Assert: Type(namedCaptures) is Object.
+      b. Scan until the next > U+003E (GREATER-THAN SIGN).
+      c. If none is found, the replacement text is the String "$<".
+      d. Else,
+        i. Let groupName be the enclosed substring.
+        ii. Let capture be ? Get(namedCaptures, groupName).
+        iii. If capture is undefined, replace the text through > with the empty String.
+        iv. Otherwise, replace the text through > with ? ToString(capture).
+features: [Symbol.replace, regexp-named-groups]
+---*/
+
+assert.sameValue(/b/u[Symbol.replace]("abc", "$&$<food"), "ab$<foodc");
+assert.sameValue(/./g[Symbol.replace]("ab", "c$<foo>d"), "c$<foo>dc$<foo>d");
+assert.sameValue(/(b)./[Symbol.replace]("abc", "$<foo>$1"), "a$<foo>b");
+
+assert.sameValue(/(?<foo>.)(?<bar>.)/[Symbol.replace]("abc", "$<bar>$<foo>"), "bac");
+assert.sameValue(/(?<foo>.)(?<bar>.)/gu[Symbol.replace]("abc", "$2$<foo>$1"), "baac");
+assert.sameValue(/(?<foo>b)/u[Symbol.replace]("abc", "c$<bar>d"), "acdc");
+assert.sameValue(/(?<foo>.)/g[Symbol.replace]("abc", "$<$1>"), "");
+assert.sameValue(/(?<foo>b)/[Symbol.replace]("abc", "$<>"), "ac");
+assert.sameValue(/(?<foo>.)(?<bar>.)/g[Symbol.replace]("abc", "$2$1"), "bac");
+assert.sameValue(/(?<foo>b)/u[Symbol.replace]("abc", "$<foo"), "a$<fooc");
+assert.sameValue(/(?<foo>.)/gu[Symbol.replace]("abc", "$<bar>"), "");
+assert.sameValue(/(?<foo>b)/[Symbol.replace]("abc", "$$<foo>$&"), "a$<foo>bc");
+
+assert.sameValue(/(?<𝒜>b)/u[Symbol.replace]("abc", "d$<𝒜>$`"), "adbac");
+assert.sameValue(/(?<$𐒤>b)/gu[Symbol.replace]("abc", "$'$<$𐒤>d"), "acbdc");

--- a/test/built-ins/RegExp/prototype/Symbol.replace/result-coerce-groups-prop.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/result-coerce-groups-prop.js
@@ -58,6 +58,7 @@ var coercibleValue = {
         throw new Test262Error('This method should not be invoked.');
       },
     },
+    bar: null,
   },
 };
 
@@ -66,3 +67,4 @@ r.exec = function() {
 };
 
 assert.sameValue(r[Symbol.replace]('ab', '[$<foo>]'), '[toString value]b');
+assert.sameValue(r[Symbol.replace]('ab', '[$<bar>]'), '[null]b');


### PR DESCRIPTION
While we have a bit more extensive coverage for named capture groups with `String.prototype.replace` in [`/test/built-ins/RegExp/named-groups`](https://github.com/tc39/test262/tree/master/test/built-ins/RegExp/named-groups), JSC has `RegExp.prototype[@@replace]` as slow path for RegExp subclasses and it lacked named groups support until [recently](https://trac.webkit.org/changeset/254195). Please also see [engine262 coverage report](https://coveralls.io/builds/29870435/source?filename=src/runtime-semantics/GetSubstitution.mjs).

JSC bug: [RegExp.prototype[Symbol.replace] does not support named capture groups](https://bugs.webkit.org/show_bug.cgi?id=205783).
Follow-up of #2481.
//cc @mathiasbynens