### PR TITLE
Improve malformed RegExp named groups coverage

### DIFF
--- a/test/annexB/built-ins/RegExp/named-groups/non-unicode-malformed-lookbehind.js
+++ b/test/annexB/built-ins/RegExp/named-groups/non-unicode-malformed-lookbehind.js
@@ -1,0 +1,15 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-GroupSpecifier
+description: >
+  \k is parsed as IdentityEscape as look-behind assertion is not a GroupName.
+features: [regexp-named-groups, regexp-lookbehind]
+---*/
+
+assert(/\k<a>(?<=>)a/.test("k<a>a"));
+assert(/(?<=>)\k<a>/.test(">k<a>"));
+
+assert(/\k<a>(?<!a)a/.test("k<a>a"));
+assert(/(?<!a>)\k<a>/.test("k<a>"));

--- a/test/annexB/built-ins/RegExp/named-groups/non-unicode-malformed.js
+++ b/test/annexB/built-ins/RegExp/named-groups/non-unicode-malformed.js
@@ -6,7 +6,7 @@ description: >
   Named groups in Unicode RegExps have some syntax errors and some
   compatibility escape fallback behavior.
 esid: prod-GroupSpecifier
-features: [regexp-named-groups, regexp-lookbehind]
+features: [regexp-named-groups]
 includes: [compareArray.js]
 ---*/
 
@@ -17,11 +17,9 @@ assert(/\k/.test("k"));
 
 assert(/(?<a>\a)/.test("a"));
 
-assert(compareArray(["k<a>"], "xxxk<a>xxx".match(/\k<a>/)));
-assert(compareArray(["k<a"], "xxxk<a>xxx".match(/\k<a/)));
+assert.compareArray(["k<a>"], "xxxk<a>xxx".match(/\k<a>/));
+assert.compareArray(["k<a"], "xxxk<a>xxx".match(/\k<a/));
 
-// A couple of corner cases around '\k' as named back-references vs. identity
-// escapes.
-assert(/\k<a>(?<=>)a/.test("k<a>a"));
-assert(/\k<a>(?<!a)a/.test("k<a>a"));
 assert(/\k<a>(<a>x)/.test("k<a><a>x"));
+assert(/\k<a>\1/.test("k<a>\x01"));
+assert(/\1(b)\k<a>/.test("bk<a>"));


### PR DESCRIPTION
This change:
a) Moves named references with look-behind tests to separate file, allowing engines without look-behind assertions support (JSC) to run them.
b) Adds a few tests with both malformed named and **numeric** references, as they both require reparsing and may interfere with each other.

JSC bug: [Invalid numeric and named references should be early syntax errors](https://bugs.webkit.org/show_bug.cgi?id=178175).
//cc @mathiasbynens