### PR TITLE
Add test for \0 in Unicode patterns

### DIFF
--- a/test/language/literals/regexp/u-null-character-escape.js
+++ b/test/language/literals/regexp/u-null-character-escape.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: prod-CharacterEscape
+description: >
+  Null character escape is permitted in Unicode patterns.
+info: |
+  CharacterEscape[U] ::
+    ControlEscape
+    c ControlLetter
+    0 [lookahead ∉ DecimalDigit]
+    HexEscapeSequence
+    RegExpUnicodeEscapeSequence[?U]
+    IdentityEscape[?U]
+
+  DecimalDigit :: one of
+    0 1 2 3 4 5 6 7 8 9
+---*/
+
+var nullChar = String.fromCharCode(0);
+assert.sameValue(/\0/u.exec(nullChar)[0], nullChar);
+assert(/^\0a$/u.test('\0a'));
+assert.sameValue('\x00②'.match(/\0②/u)[0], '\x00②');
+assert.sameValue('\u0000፬'.search(/\0፬$/u), 0);


### PR DESCRIPTION
JSC bug: [Octal escapes should be max 3 digits and syntax errors in Unicode patterns](https://bugs.webkit.org/show_bug.cgi?id=167067).

When fixing [test/built-ins/RegExp/unicode_restricted_octal_escape.js](https://github.com/tc39/test262/blob/master/test/built-ins/RegExp/unicode_restricted_octal_escape.js) it was quite easy to miss `\0` case and no tests were failing.

//cc @mathiasbynens 