### PR TITLE
Improve GetMethod coverage in String.prototype methods

### DIFF
--- a/test/built-ins/String/prototype/match/cstm-matcher-is-null.js
+++ b/test/built-ins/String/prototype/match/cstm-matcher-is-null.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-string.prototype.match
+description: >
+  If regexp's Symbol.match property is null, no error is thrown.
+info: |
+  String.prototype.match ( regexp )
+
+  [...]
+  2. If regexp is neither undefined nor null, then
+    a. Let matcher be ? GetMethod(regexp, @@match).
+    b. If matcher is not undefined, then
+      [...]
+  [...]
+  5. Return ? Invoke(rx, @@match, « S »).
+
+  GetMethod ( V, P )
+
+  [...]
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+features: [Symbol.match]
+---*/
+
+var regexp = {};
+regexp[Symbol.match] = null;
+regexp.toString = function() { return "\\d"; };
+regexp.valueOf = function() { throw new Test262Error("should not be called"); };
+
+assert.sameValue("abc".match(regexp), null);
+assert.sameValue("ab3c".match(regexp)[0], "3");

--- a/test/built-ins/String/prototype/replace/cstm-replace-is-null.js
+++ b/test/built-ins/String/prototype/replace/cstm-replace-is-null.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-string.prototype.replace
+description: >
+  If searchValue's Symbol.replace property is null, no error is thrown.
+info: |
+  String.prototype.replace ( searchValue, replaceValue )
+
+  [...]
+  2. If searchValue is neither undefined nor null, then
+    a. Let replacer be ? GetMethod(searchValue, @@replace).
+    b. If replacer is not undefined, then
+      [...]
+  [...]
+  12. Return newString.
+
+  GetMethod ( V, P )
+
+  [...]
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+features: [Symbol.replace]
+---*/
+
+var searchValue = {};
+searchValue[Symbol.replace] = null;
+searchValue.toString = function() { return "3"; };
+searchValue.valueOf = function() { throw new Test262Error("should not be called"); };
+
+var replacer = function() { return "<foo>"; };
+assert.sameValue("ab3c".replace(searchValue, replacer), "ab<foo>c");
+assert.sameValue("ab3c".replace(searchValue, "<foo>"), "ab<foo>c");

--- a/test/built-ins/String/prototype/replaceAll/searchValue-replacer-is-null.js
+++ b/test/built-ins/String/prototype/replaceAll/searchValue-replacer-is-null.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-string.prototype.replaceall
+description: >
+  If searchValue's Symbol.replace property is null, no error is thrown.
+info: |
+  String.prototype.replaceAll ( searchValue, replaceValue )
+
+  [...]
+  2. If searchValue is neither undefined nor null, then
+    [...]
+    c. Let replacer be ? GetMethod(searchValue, @@replace).
+    d. If replacer is not undefined, then
+      [...]
+  [...]
+  16. Return result.
+
+  GetMethod ( V, P )
+
+  [...]
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+features: [String.prototype.replaceAll, Symbol.replace]
+---*/
+
+var searchValue = {};
+searchValue[Symbol.replace] = null;
+searchValue.toString = function() { return "2"; };
+searchValue.valueOf = function() { throw new Test262Error("should not be called"); };
+
+var replacer = function() { return "<foo>"; };
+assert.sameValue("a2b2c".replaceAll(searchValue, replacer), "a<foo>b<foo>c");
+assert.sameValue("a2b2c".replaceAll(searchValue, "<foo>"), "a<foo>b<foo>c");

--- a/test/built-ins/String/prototype/replaceAll/searchValue-replacer-method-abrupt.js
+++ b/test/built-ins/String/prototype/replaceAll/searchValue-replacer-method-abrupt.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-string.prototype.replaceall
 description: >
-  Return abrupt completion from GetMethod(searchValeu @@replace)
+  Return abrupt completion from GetMethod(searchValue.@@replace)
 info: |
   String.prototype.replaceAll ( searchValue, replaceValue )
 

--- a/test/built-ins/String/prototype/search/cstm-search-is-null.js
+++ b/test/built-ins/String/prototype/search/cstm-search-is-null.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-string.prototype.search
+description: >
+  If regexp's Symbol.search property is null, no error is thrown.
+info: |
+  String.prototype.search ( regexp )
+
+  [...]
+  2. If regexp is neither undefined nor null, then
+    a. Let searcher be ? GetMethod(regexp, @@search).
+    b. If searcher is not undefined, then
+      [...]
+  [...]
+  5. Return ? Invoke(rx, @@search, « string »).
+
+  GetMethod ( V, P )
+
+  [...]
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+features: [Symbol.search]
+---*/
+
+var regexp = {};
+regexp[Symbol.search] = null;
+regexp.toString = function() { return "\\d"; };
+regexp.valueOf = function() { throw new Test262Error("should not be called"); };
+
+assert.sameValue("abc".search(regexp), -1);
+assert.sameValue("ab3c".search(regexp), 2);

--- a/test/built-ins/String/prototype/split/cstm-split-is-null.js
+++ b/test/built-ins/String/prototype/split/cstm-split-is-null.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-string.prototype.split
+description: >
+  If separator's Symbol.split property is null, no error is thrown.
+info: |
+  String.prototype.split ( separator, limit )
+
+  [...]
+  2. If separator is neither undefined nor null, then
+    a. Let splitter be ? GetMethod(separator, @@split).
+    b. If splitter is not undefined, then
+      [...]
+  [...]
+  17. Return A.
+
+  GetMethod ( V, P )
+
+  [...]
+  2. Let func be ? GetV(V, P).
+  3. If func is either undefined or null, return undefined.
+includes: [compareArray.js]
+features: [Symbol.split]
+---*/
+
+var separator = {};
+separator[Symbol.split] = null;
+separator.toString = function() { return "2"; };
+separator.valueOf = function() { throw new Test262Error("should not be called"); };
+
+assert.compareArray("a2b2c".split(separator), ["a", "b", "c"]);
+assert.compareArray("a2b2c".split(separator, 1), ["a"]);


### PR DESCRIPTION
[`String.prototype.matchAll`](https://tc39.es/ecma262/#sec-string.prototype.matchall) case is covered by [`/test/built-ins/String/prototype/matchAll/regexp-is-undefined-or-null-invokes-matchAll.js`](https://github.com/tc39/test262/blob/master/test/built-ins/String/prototype/matchAll/regexp-is-undefined-or-null-invokes-matchAll.js).