### PR TITLE
verifyProperty: gracefully handle `originalDesc` being `undefined`

### DIFF
--- a/harness/propertyHelper.js
+++ b/harness/propertyHelper.js
@@ -43,6 +43,12 @@ function verifyProperty(obj, name, desc, options) {
 
     // desc and originalDesc are both undefined, problem solved;
     return true;
+  } else {
+    assert.notSameValue(
+      originalDesc,
+      undefined,
+      "obj['" + nameStr + "'] descriptor should not be undefined"
+    );
   }
 
   assert(

--- a/test/harness/verifyProperty-undefined-desc.js
+++ b/test/harness/verifyProperty-undefined-desc.js
@@ -18,6 +18,10 @@ assert.sameValue(
 );
 
 assert.throws(Test262Error, () => {
+  verifyProperty(sample, "foo2", {value: undefined});
+}, "originalDesc is undefined, desc is not undefined");
+
+assert.throws(Test262Error, () => {
   verifyProperty(sample, 'bar', undefined);
 }, "dataDescriptor value is undefined");
 


### PR DESCRIPTION
Output without this change:

```yaml
test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-missing-target-is-proxy.js:
  default: "TypeError: undefined is not an object (evaluating 'originalDesc.enumerable')"
  strict mode: "TypeError: undefined is not an object (evaluating 'originalDesc.enumerable')"
test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-null-target-is-proxy.js:
  default: "TypeError: undefined is not an object (evaluating 'originalDesc.value')"
  strict mode: "TypeError: undefined is not an object (evaluating 'originalDesc.value')"
test/built-ins/Proxy/getOwnPropertyDescriptor/trap-is-undefined-target-is-proxy.js:
  default: "TypeError: undefined is not an object (evaluating 'originalDesc.value')"
  strict mode: "TypeError: undefined is not an object (evaluating 'originalDesc.value')"
```