### PR TITLE
Define Test262Error.prototype.name

### DIFF
--- a/harness/sta.js
+++ b/harness/sta.js
@@ -14,6 +14,7 @@ function Test262Error(message) {
   this.message = message || "";
 }
 
+Test262Error.prototype.name = "Test262Error";
 Test262Error.prototype.toString = function () {
   return "Test262Error: " + this.message;
 };

--- a/test/harness/sta.js
+++ b/test/harness/sta.js
@@ -9,6 +9,7 @@ description: >
 ---*/
 
 assert(typeof Test262Error === "function");
+assert.sameValue(Test262Error.prototype.name, "Test262Error");
 assert(typeof Test262Error.prototype.toString === "function");
 assert(typeof $ERROR === "function");
 assert(typeof $DONOTEVALUATE === "function");


### PR DESCRIPTION
Please consider current output of a failing `async` test:

```yaml
test/built-ins/AsyncFromSyncIteratorPrototype/next/absent-value-not-passed.js:
  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«1», «0») to be true'
  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«1», «0») to be true'
```

<br>`Test262Error` is duplicated because `Test262Error` does not implement `Error` interface `$DONE` expects it to:

```js
function $DONE(error) {
  if (error) {
    if(typeof error === 'object' && error !== null && 'name' in error) { // Test262Error has no "name"
      __consolePrintHandle__('Test262:AsyncTestFailure:' + error.name + ': ' + error.message);
    } else {
      __consolePrintHandle__('Test262:AsyncTestFailure:Test262Error: ' + error);
    }
  } else {
    __consolePrintHandle__('Test262:AsyncTestComplete');
  }
}
```

<br> and gets converted to string.