### PR TITLE
Fixed wrong `esid` and `features` in a Promise.all test

### DIFF
--- a/test/built-ins/Promise/all/invoke-resolve-get-once-no-calls.js
+++ b/test/built-ins/Promise/all/invoke-resolve-get-once-no-calls.js
@@ -4,7 +4,7 @@
 /*---
 description: >
   Gets constructor's `resolve` method once from zero to many invocations.
-esid: sec-promise.allsettled
+esid: sec-promise.all
 info: |
   Runtime Semantics: PerformPromiseAll
 
@@ -14,7 +14,7 @@ info: |
   1. Repeat,
     ...
     1. Let nextPromise be ? Call(promiseResolve, constructor, &laquo; nextValue &raquo;).
-features: [Promise.allSettled]
+features: [Promise.all]
 ---*/
 
 var resolve = Promise.resolve;


### PR DESCRIPTION
I found a minor bug in `esid` and `features` of the test
`test/built-ins/Promise/all/invoke-resolve-get-once-no-calls.js`.
I revised the `esid` and `features` to use `Promise.all` instead of `Promise.allSettled`.