### PR TITLE
Make GetFunctionRealm tests useful

### DIFF
--- a/test/built-ins/Function/prototype/bind/get-fn-realm.js
+++ b/test/built-ins/Function/prototype/bind/get-fn-realm.js
@@ -3,23 +3,53 @@
 /*---
 esid: sec-getfunctionrealm
 description: >
-    The realm of a bound function exotic object is the realm of its target
-    function
+  The realm of a bound function exotic object is the realm of its target function.
 info: |
-    7.3.22 GetFunctionRealm ( obj )
+  Date ( )
 
+  [...]
+  3. If NewTarget is undefined, then
     [...]
-    2. If obj has a [[Realm]] internal slot, then
-       a. Return obj.[[Realm]].
-    3. If obj is a Bound Function exotic object, then
-       a. Let target be obj.[[BoundTargetFunction]].
-       b. Return ? GetFunctionRealm(target).
-features: [cross-realm]
+  4. Else,
+    a. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%Date.prototype%", « [[DateValue]] »).
+    [...]
+    c. Return O.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  [...]
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return OrdinaryObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  [...]
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+
+  GetFunctionRealm ( obj )
+
+  [...]
+  2. If obj has a [[Realm]] internal slot, then
+    a. Return obj.[[Realm]].
+  3. If obj is a bound function exotic object, then
+    a. Let target be obj.[[BoundTargetFunction]].
+    b. Return ? GetFunctionRealm(target).
+features: [cross-realm, Reflect]
 ---*/
 
-var other = $262.createRealm().global;
-var C = new other.Function();
-C.prototype = null;
-var B = C.bind();
+var realm1 = $262.createRealm().global;
+var realm2 = $262.createRealm().global;
+var realm3 = $262.createRealm().global;
 
-assert.sameValue(Object.getPrototypeOf(new B()), other.Object.prototype);
+var newTarget = new realm1.Function();
+newTarget.prototype = "str";
+
+var boundNewTarget = realm2.Function.prototype.bind.call(newTarget);
+var date = Reflect.construct(realm3.Date, [], boundNewTarget);
+
+assert(date instanceof realm1.Date);
+assert.sameValue(Object.getPrototypeOf(date), realm1.Date.prototype);

--- a/test/built-ins/Proxy/get-fn-realm-recursive.js
+++ b/test/built-ins/Proxy/get-fn-realm-recursive.js
@@ -3,25 +3,55 @@
 /*---
 esid: sec-getfunctionrealm
 description: >
-    The realm of a proxy exotic object is the realm of its target function.
-    GetFunctionRealm is called recursively.
+  The realm of a Proxy exotic object is the realm of its target function.
+  GetFunctionRealm is called recursively.
 info: |
-    7.3.22 GetFunctionRealm ( obj )
+  Boolean ( value )
 
+  [...]
+  3. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%Boolean.prototype%", « [[BooleanData]] »).
+  [...]
+  5. Return O.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  [...]
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return OrdinaryObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  [...]
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+
+  GetFunctionRealm ( obj )
+
+  [...]
+  2. If obj has a [[Realm]] internal slot, then
+    a. Return obj.[[Realm]].
+  [...]
+  4. If obj is a Proxy exotic object, then
     [...]
-    2. If obj has a [[Realm]] internal slot, then
-       a. Return obj.[[Realm]].
-    [...]
-    4. If obj is a Proxy exotic object, then
-       a. If obj.[[ProxyHandler]] is null, throw a TypeError exception.
-       b. Let proxyTarget be obj.[[ProxyTarget]].
-       c. Return ? GetFunctionRealm(proxyTarget).
-features: [cross-realm, Proxy]
+    b. Let proxyTarget be obj.[[ProxyTarget]].
+    c. Return ? GetFunctionRealm(proxyTarget).
+features: [cross-realm, Reflect, Proxy]
 ---*/
 
-var other = $262.createRealm().global;
-var C = new other.Function();
-C.prototype = null;
-var P = new Proxy(new Proxy(C, {}), {});
+var realm1 = $262.createRealm().global;
+var realm2 = $262.createRealm().global;
+var realm3 = $262.createRealm().global;
+var realm4 = $262.createRealm().global;
 
-assert.sameValue(Object.getPrototypeOf(new P()), other.Object.prototype);
+var newTarget = new realm1.Function();
+newTarget.prototype = null;
+
+var newTargetProxy = new realm2.Proxy(newTarget, {});
+var newTargetProxyProxy = new realm3.Proxy(newTargetProxy, {});
+var boolean = Reflect.construct(realm4.Boolean, [], newTargetProxyProxy);
+
+assert(boolean instanceof realm1.Boolean);
+assert.sameValue(Object.getPrototypeOf(boolean), realm1.Boolean.prototype);

--- a/test/built-ins/Proxy/get-fn-realm.js
+++ b/test/built-ins/Proxy/get-fn-realm.js
@@ -3,24 +3,51 @@
 /*---
 esid: sec-getfunctionrealm
 description: >
-    The realm of a proxy exotic object is the realm of its target function
+  The realm of a Proxy exotic object is the realm of its target function.
 info: |
-    7.3.22 GetFunctionRealm ( obj )
+  Array ( )
 
+  [...]
+  4. Let proto be ? GetPrototypeFromConstructor(newTarget, "%Array.prototype%").
+  5. Return ! ArrayCreate(0, proto).
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  [...]
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return OrdinaryObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  [...]
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+
+  GetFunctionRealm ( obj )
+
+  [...]
+  2. If obj has a [[Realm]] internal slot, then
+    a. Return obj.[[Realm]].
+  [...]
+  4. If obj is a Proxy exotic object, then
     [...]
-    2. If obj has a [[Realm]] internal slot, then
-       a. Return obj.[[Realm]].
-    [...]
-    4. If obj is a Proxy exotic object, then
-       a. If obj.[[ProxyHandler]] is null, throw a TypeError exception.
-       b. Let proxyTarget be obj.[[ProxyTarget]].
-       c. Return ? GetFunctionRealm(proxyTarget).
-features: [cross-realm, Proxy]
+    b. Let proxyTarget be obj.[[ProxyTarget]].
+    c. Return ? GetFunctionRealm(proxyTarget).
+features: [cross-realm, Reflect, Proxy]
 ---*/
 
-var other = $262.createRealm().global;
-var C = new other.Function();
-C.prototype = null;
-var P = new Proxy(C, {});
+var realm1 = $262.createRealm().global;
+var realm2 = $262.createRealm().global;
+var realm3 = $262.createRealm().global;
 
-assert.sameValue(Object.getPrototypeOf(new P()), other.Object.prototype);
+var newTarget = new realm1.Function();
+newTarget.prototype = false;
+
+var newTargetProxy = new realm2.Proxy(newTarget, {});
+var array = Reflect.construct(realm3.Array, [], newTargetProxy);
+
+assert(array instanceof realm1.Array);
+assert.sameValue(Object.getPrototypeOf(array), realm1.Array.prototype);


### PR DESCRIPTION
JSC bug: [InternalFunction::createSubclassStructure should use newTarget's globalObject](https://bugs.webkit.org/show_bug.cgi?id=202599).
Follow-up of #2155.