### PR TITLE
Test Proxy.revocable with revoked target and handler

### DIFF
--- a/test/built-ins/Proxy/revocable/handler-is-revoked-proxy.js
+++ b/test/built-ins/Proxy/revocable/handler-is-revoked-proxy.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxycreate
+description: >
+  A Proxy is created with its [[ProxyHandler]] as revoked Proxy.
+info: |
+  ProxyCreate ( target, handler )
+
+  [...]
+  3. Let P be ! MakeBasicObject(« [[ProxyHandler]], [[ProxyTarget]] »).
+  [...]
+  7. Set P.[[ProxyHandler]] to handler.
+  8. Return P.
+features: [Proxy]
+---*/
+
+var revocableHandler = Proxy.revocable({}, {});
+revocableHandler.revoke();
+
+var revocable = Proxy.revocable({}, revocableHandler.proxy);
+assert.sameValue(typeof revocable.proxy, "object");

--- a/test/built-ins/Proxy/revocable/target-is-revoked-function-proxy.js
+++ b/test/built-ins/Proxy/revocable/target-is-revoked-function-proxy.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxycreate
+description: >
+  A Proxy is created with its [[ProxyTarget]] as revoked function Proxy.
+info: |
+  ProxyCreate ( target, handler )
+
+  [...]
+  3. Let P be ! MakeBasicObject(« [[ProxyHandler]], [[ProxyTarget]] »).
+  [...]
+  6. Set P.[[ProxyTarget]] to target.
+  [...]
+  8. Return P.
+features: [Proxy]
+---*/
+
+var revocableTarget = Proxy.revocable(function() {}, {});
+revocableTarget.revoke();
+
+var revocable = Proxy.revocable(revocableTarget.proxy, {});
+assert.sameValue(typeof revocable.proxy, "function");

--- a/test/built-ins/Proxy/revocable/target-is-revoked-proxy.js
+++ b/test/built-ins/Proxy/revocable/target-is-revoked-proxy.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-proxycreate
+description: >
+  A Proxy is created with its [[ProxyTarget]] as revoked Proxy.
+info: |
+  ProxyCreate ( target, handler )
+
+  [...]
+  3. Let P be ! MakeBasicObject(« [[ProxyHandler]], [[ProxyTarget]] »).
+  [...]
+  6. Set P.[[ProxyTarget]] to target.
+  [...]
+  8. Return P.
+features: [Proxy]
+---*/
+
+var revocableTarget = Proxy.revocable({}, {});
+revocableTarget.revoke();
+
+var revocable = Proxy.revocable(revocableTarget.proxy, {});
+assert.sameValue(typeof revocable.proxy, "object");


### PR DESCRIPTION
Since runtimes are not required to implement abstract ops as they are specified, revoked Proxy checks of [`ProxyCreate`](https://tc39.es/ecma262/#sec-proxycreate) may be inlined in [`Proxy.revocable`](https://tc39.es/ecma262/#sec-proxy.revocable).

Follow-up of #2548
Ref. tc39/ecma262#1814