### PR TITLE
Correct pull/1669 for pl

### DIFF
--- a/test/intl402/RelativeTimeFormat/prototype/format/pl-pl-style-long.js
+++ b/test/intl402/RelativeTimeFormat/prototype/format/pl-pl-style-long.js
@@ -56,7 +56,7 @@ const rtf = new Intl.RelativeTimeFormat("pl-PL", {
 assert.sameValue(typeof rtf.format, "function", "format should be supported");
 
 for (const [unitArgument, expected] of Object.entries(units)) {
-  assert.sameValue(rtf.format(1000, unitArgument), `za 1\u00a0000 ${expected.many}`);
+  assert.sameValue(rtf.format(1000, unitArgument), `za 1000 ${expected.many}`);
   assert.sameValue(rtf.format(10, unitArgument), `za 10 ${expected.many}`);
   assert.sameValue(rtf.format(2, unitArgument), `za 2 ${expected.few}`);
   assert.sameValue(rtf.format(1, unitArgument), `za 1 ${expected.one}`);
@@ -65,5 +65,5 @@ for (const [unitArgument, expected] of Object.entries(units)) {
   assert.sameValue(rtf.format(-1, unitArgument), `1 ${expected.one} temu`);
   assert.sameValue(rtf.format(-2, unitArgument), `2 ${expected.few} temu`);
   assert.sameValue(rtf.format(-10, unitArgument), `10 ${expected.many} temu`);
-  assert.sameValue(rtf.format(-1000, unitArgument), `1\u00a0000 ${expected.many} temu`);
+  assert.sameValue(rtf.format(-1000, unitArgument), `1000 ${expected.many} temu`);
 }

--- a/test/intl402/RelativeTimeFormat/prototype/format/pl-pl-style-narrow.js
+++ b/test/intl402/RelativeTimeFormat/prototype/format/pl-pl-style-narrow.js
@@ -47,7 +47,7 @@ const rtf = new Intl.RelativeTimeFormat("pl-PL", {
 assert.sameValue(typeof rtf.format, "function", "format should be supported");
 
 for (const [unitArgument, expected] of Object.entries(units)) {
-  assert.sameValue(rtf.format(1000, unitArgument), `za 1\u00a0000 ${expected.many}`);
+  assert.sameValue(rtf.format(1000, unitArgument), `za 1000 ${expected.many}`);
   assert.sameValue(rtf.format(10, unitArgument), `za 10 ${expected.many}`);
   assert.sameValue(rtf.format(2, unitArgument), `za 2 ${expected.few}`);
   assert.sameValue(rtf.format(1, unitArgument), `za 1 ${expected.one}`);
@@ -56,5 +56,5 @@ for (const [unitArgument, expected] of Object.entries(units)) {
   assert.sameValue(rtf.format(-1, unitArgument), `1 ${expected.one} temu`);
   assert.sameValue(rtf.format(-2, unitArgument), `2 ${expected.few} temu`);
   assert.sameValue(rtf.format(-10, unitArgument), `10 ${expected.many} temu`);
-  assert.sameValue(rtf.format(-1000, unitArgument), `1\u00a0000 ${expected.many} temu`);
+  assert.sameValue(rtf.format(-1000, unitArgument), `1000 ${expected.many} temu`);
 }

--- a/test/intl402/RelativeTimeFormat/prototype/format/pl-pl-style-short.js
+++ b/test/intl402/RelativeTimeFormat/prototype/format/pl-pl-style-short.js
@@ -47,7 +47,7 @@ const rtf = new Intl.RelativeTimeFormat("pl-PL", {
 assert.sameValue(typeof rtf.format, "function", "format should be supported");
 
 for (const [unitArgument, expected] of Object.entries(units)) {
-  assert.sameValue(rtf.format(1000, unitArgument), `za 1\u00a0000 ${expected.many}`);
+  assert.sameValue(rtf.format(1000, unitArgument), `za 1000 ${expected.many}`);
   assert.sameValue(rtf.format(10, unitArgument), `za 10 ${expected.many}`);
   assert.sameValue(rtf.format(2, unitArgument), `za 2 ${expected.few}`);
   assert.sameValue(rtf.format(1, unitArgument), `za 1 ${expected.one}`);
@@ -56,5 +56,5 @@ for (const [unitArgument, expected] of Object.entries(units)) {
   assert.sameValue(rtf.format(-1, unitArgument), `1 ${expected.one} temu`);
   assert.sameValue(rtf.format(-2, unitArgument), `2 ${expected.few} temu`);
   assert.sameValue(rtf.format(-10, unitArgument), `10 ${expected.many} temu`);
-  assert.sameValue(rtf.format(-1000, unitArgument), `1\u00a0000 ${expected.many} temu`);
+  assert.sameValue(rtf.format(-1000, unitArgument), `1000 ${expected.many} temu`);
 }

--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-long.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-long.js
@@ -74,9 +74,7 @@ assert.sameValue(typeof rtf.formatToParts, "function", "formatToParts should be 
 for (const [unitArgument, expected] of Object.entries(units)) {
   verifyFormatParts(rtf.formatToParts(1000, unitArgument), [
     { "type": "literal", "value": "za " },
-    { "type": "integer", "value": "1", "unit": unitArgument },
-    { "type": "group", "value": "\u00a0", "unit": unitArgument },
-    { "type": "integer", "value": "000", "unit": unitArgument },
+    { "type": "integer", "value": "1000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many}` },
   ], `formatToParts(1000, ${unitArgument})`);
 
@@ -125,9 +123,7 @@ for (const [unitArgument, expected] of Object.entries(units)) {
   ], `formatToParts(-10, ${unitArgument})`);
 
   verifyFormatParts(rtf.formatToParts(-1000, unitArgument), [
-    { "type": "integer", "value": "1", "unit": unitArgument },
-    { "type": "group", "value": "\u00a0", "unit": unitArgument },
-    { "type": "integer", "value": "000", "unit": unitArgument },
+    { "type": "integer", "value": "1000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many} temu` },
   ], `formatToParts(-1000, ${unitArgument})`);
 

--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-narrow.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-narrow.js
@@ -63,9 +63,7 @@ assert.sameValue(typeof rtf.formatToParts, "function", "formatToParts should be 
 for (const [unitArgument, expected] of Object.entries(units)) {
   verifyFormatParts(rtf.formatToParts(1000, unitArgument), [
     { "type": "literal", "value": "za " },
-    { "type": "integer", "value": "1", "unit": unitArgument },
-    { "type": "group", "value": "\u00a0", "unit": unitArgument },
-    { "type": "integer", "value": "000", "unit": unitArgument },
+    { "type": "integer", "value": "1000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many}` },
   ], `formatToParts(1000, ${unitArgument})`);
 
@@ -114,9 +112,7 @@ for (const [unitArgument, expected] of Object.entries(units)) {
   ], `formatToParts(-10, ${unitArgument})`);
 
   verifyFormatParts(rtf.formatToParts(-1000, unitArgument), [
-    { "type": "integer", "value": "1", "unit": unitArgument },
-    { "type": "group", "value": "\u00a0", "unit": unitArgument },
-    { "type": "integer", "value": "000", "unit": unitArgument },
+    { "type": "integer", "value": "1000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many} temu` },
   ], `formatToParts(-1000, ${unitArgument})`);
 

--- a/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-short.js
+++ b/test/intl402/RelativeTimeFormat/prototype/formatToParts/pl-pl-style-short.js
@@ -63,9 +63,7 @@ assert.sameValue(typeof rtf.formatToParts, "function", "formatToParts should be 
 for (const [unitArgument, expected] of Object.entries(units)) {
   verifyFormatParts(rtf.formatToParts(1000, unitArgument), [
     { "type": "literal", "value": "za " },
-    { "type": "integer", "value": "1", "unit": unitArgument },
-    { "type": "group", "value": "\u00a0", "unit": unitArgument },
-    { "type": "integer", "value": "000", "unit": unitArgument },
+    { "type": "integer", "value": "1000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many}` },
   ], `formatToParts(1000, ${unitArgument})`);
 
@@ -114,9 +112,7 @@ for (const [unitArgument, expected] of Object.entries(units)) {
   ], `formatToParts(-10, ${unitArgument})`);
 
   verifyFormatParts(rtf.formatToParts(-1000, unitArgument), [
-    { "type": "integer", "value": "1", "unit": unitArgument },
-    { "type": "group", "value": "\u00a0", "unit": unitArgument },
-    { "type": "integer", "value": "000", "unit": unitArgument },
+    { "type": "integer", "value": "1000", "unit": unitArgument },
     { "type": "literal", "value": ` ${expected.many} temu` },
   ], `formatToParts(-1000, ${unitArgument})`);
 


### PR DESCRIPTION
Correct tests landed in https://github.com/tc39/test262/pull/1669
to close https://github.com/tc39/test262/issues/2589

pl locale has minimumGroupingDigits{"2"}  and should not place \u00a0 if there are only 4 digits (since  minimumGroupingDigits{"2"}   means it require at least 2 digits on the left of the grouping separator)
@Ms2ger @leobalter @rkirsling 