### PR TITLE
Allow new property such as fractionalSecondDigits present in resolvedOptions result

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-dayPeriod.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-dayPeriod.js
@@ -28,8 +28,8 @@ const expected = [
 
 let actual = Object.getOwnPropertyNames(options);
 
-// Ensure all expected items are in actual and also allow other property
-// implemented in other new proposal.
+// Ensure all expected items are in actual and also allow other properties
+// implemented in new proposals.
 assert(arrayContains(actual, expected));
 for (var i = 1; i < expected.length; i++) {
   // Ensure the order as expected but allow additional new property in between

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-dayPeriod.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-dayPeriod.js
@@ -5,7 +5,7 @@
 esid: sec-intl.datetimeformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
 includes: [compareArray.js]
-features: [Intl.DateTimeFormat-dayPeriod]
+features: [Intl.DateTimeFormat-dayPeriod,Intl.DateTimeFormat-fractionalSecondDigits]
 ---*/
 
 const options = new Intl.DateTimeFormat([], {
@@ -24,6 +24,7 @@ const expected = [
   "dayPeriod",
   "hour",
   "minute",
+  "fractionalSecondDigits",
 ];
 
 assert.compareArray(Object.getOwnPropertyNames(options), expected);

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-dayPeriod.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-dayPeriod.js
@@ -4,8 +4,8 @@
 /*---
 esid: sec-intl.datetimeformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [compareArray.js]
-features: [Intl.DateTimeFormat-dayPeriod,Intl.DateTimeFormat-fractionalSecondDigits]
+includes: [arrayContains.js]
+features: [Intl.DateTimeFormat-dayPeriod]
 ---*/
 
 const options = new Intl.DateTimeFormat([], {
@@ -24,7 +24,14 @@ const expected = [
   "dayPeriod",
   "hour",
   "minute",
-  "fractionalSecondDigits",
 ];
 
-assert.compareArray(Object.getOwnPropertyNames(options), expected);
+let actual = Object.getOwnPropertyNames(options);
+
+// Ensure all expected items are in actual and also allow other property
+// implemented in other new proposal.
+assert(arrayContains(actual, expected));
+for (var i = 1; i < expected.length; i++) {
+  // Ensure the order as expected but allow additional new property in between
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]));
+}

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-fractionalSecondDigits.js
@@ -26,8 +26,8 @@ const expected = [
 
 let actual = Object.getOwnPropertyNames(options);
 
-// Ensure all expected items are in actual and also allow other property
-// implemented in other new proposal.
+// Ensure all expected items are in actual and also allow other properties
+// implemented in new proposals.
 assert(arrayContains(actual, expected));
 for (var i = 1; i < expected.length; i++) {
   // Ensure the order as expected but allow additional new property in between

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-fractionalSecondDigits.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-intl.datetimeformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [compareArray.js]
+includes: [arrayContains.js]
 features: [Intl.DateTimeFormat-fractionalSecondDigits]
 ---*/
 
@@ -24,4 +24,12 @@ const expected = [
   "fractionalSecondDigits",
 ];
 
-assert.compareArray(Object.getOwnPropertyNames(options), expected);
+let actual = Object.getOwnPropertyNames(options);
+
+// Ensure all expected items are in actual and also allow other property
+// implemented in other new proposal.
+assert(arrayContains(actual, expected));
+for (var i = 1; i < expected.length; i++) {
+  // Ensure the order as expected but allow additional new property in between
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]));
+}

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-style.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-style.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-intl.datetimeformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [compareArray.js]
+includes: [arrayContains.js]
 features: [Intl.DateTimeFormat-datetimestyle]
 ---*/
 
@@ -32,4 +32,12 @@ const expected = [
   "timeStyle",
 ];
 
-assert.compareArray(Object.getOwnPropertyNames(options), expected);
+let actual = Object.getOwnPropertyNames(options);
+
+// Ensure all expected items are in actual and also allow other properties
+// implemented in new proposals.
+assert(arrayContains(actual, expected));
+for (var i = 1; i < expected.length; i++) {
+  // Ensure the order as expected but allow additional new property in between
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]));
+}

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order.js
@@ -40,8 +40,8 @@ const expected = [
 
 let actual = Object.getOwnPropertyNames(options);
 
-// Ensure all expected items are in actual and also allow other property
-// implemented in other new proposal.
+// Ensure all expected items are in actual and also allow other properties
+// implemented in new proposals.
 assert(arrayContains(actual, expected));
 for (var i = 1; i < expected.length; i++) {
   // Ensure the order as expected but allow additional new property in between

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order.js
@@ -4,8 +4,7 @@
 /*---
 esid: sec-intl.datetimeformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [compareArray.js]
-features: [Intl.DateTimeFormat-fractionalSecondDigits]
+includes: [arrayContains.js]
 ---*/
 
 const options = new Intl.DateTimeFormat([], {
@@ -37,7 +36,14 @@ const expected = [
   "minute",
   "second",
   "timeZoneName",
-  "fractionalSecondDigits",
 ];
 
-assert.compareArray(Object.getOwnPropertyNames(options), expected);
+let actual = Object.getOwnPropertyNames(options);
+
+// Ensure all expected items are in actual and also allow other property
+// implemented in other new proposal.
+assert(arrayContains(actual, expected));
+for (var i = 1; i < expected.length; i++) {
+  // Ensure the order as expected but allow additional new property in between
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]));
+}

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order.js
@@ -5,6 +5,7 @@
 esid: sec-intl.datetimeformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
 includes: [compareArray.js]
+features: [Intl.DateTimeFormat-fractionalSecondDigits]
 ---*/
 
 const options = new Intl.DateTimeFormat([], {
@@ -36,6 +37,7 @@ const expected = [
   "minute",
   "second",
   "timeZoneName",
+  "fractionalSecondDigits",
 ];
 
 assert.compareArray(Object.getOwnPropertyNames(options), expected);


### PR DESCRIPTION
This fix the conflict with the https://github.com/tc39/ecma402/pull/347 
so the resolvedOptions contains fractionalSecondDigits even it is undefined in the input, except the cases which dateStyle or timeStyle is specified.
close #2591  

