### PR TITLE
Add a test for Unicode key-type pairs being canonicalized by Intl.Locale when passed in options

### DIFF
--- a/test/intl402/Locale/constructor-options-canonicalized.js
+++ b/test/intl402/Locale/constructor-options-canonicalized.js
@@ -1,0 +1,69 @@
+// Copyright 2020 Mozilla Corporation. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-resolvelocale
+description: >
+    Values provided as properties of the options-argument to the Locale
+    constructor are converted to canonical form.
+info: |
+    ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )
+
+    ...
+    9.i.iii.1. Let optionsValue be the string optionsValue after performing the algorithm steps to transform Unicode extension values to canonical syntax per Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers, treating key as ukey and optionsValue as uvalue productions.
+    9.i.iii.2. Let optionsValue be the string optionsValue after performing the algorithm steps to replace Unicode extension values with their canonical form per Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers, treating key as ukey and optionsValue as uvalue productions.
+    ...
+
+features: [Intl.Locale]
+---*/
+
+const keyValueTests = [
+  {
+    key: "ca",
+    option: "calendar",
+    tests: [
+      ["islamicc", "islamic-civil"],
+      ["ethiopic-amete-alem", "ethioaa"],
+    ],
+  },
+];
+
+for (const { key, option, tests } of keyValueTests) {
+  for (const [noncanonical, canonical] of tests) {
+    let canonicalInLocale =
+      new Intl.Locale(`en-u-${key}-${canonical}`);
+
+    assert.sameValue(
+      canonicalInLocale[option],
+      canonical,
+      `new Intl.Locale("en-u-${key}-${canonical}").${option} returns ${canonical}`
+    );
+
+    let canonicalInOption =
+      new Intl.Locale(`en`, { [option]: canonical });
+
+    assert.sameValue(
+      canonicalInOption[option],
+      canonical,
+      `new Intl.Locale("en", { ${option}: "${canonical}" }).${option} returns ${canonical}`
+    );
+
+    let noncanonicalInLocale =
+      new Intl.Locale(`en-u-${key}-${noncanonical}`);
+
+    assert.sameValue(
+      noncanonicalInLocale[option],
+      canonical,
+      `new Intl.Locale("en-u-${key}-${noncanonical}").${option} returns ${canonical}`
+    );
+
+    let noncanonicalInOption =
+      new Intl.Locale(`en`, { [option]: noncanonical });
+
+    assert.sameValue(
+      noncanonicalInOption[option],
+      canonical,
+      `new Intl.Locale("en", { ${option}: "${noncanonical}" }).${option} returns ${canonical}`
+    );
+  }
+}


### PR DESCRIPTION
This adds a test for https://github.com/tc39/ecma402/issues/413 for the "calendar" part of it.  I can't readily find a `nu`/`numberingSystem` that has an alias, so there doesn't seem to be a way to test that aspect of the change.  If one ever manifests, it ought be easy to slot it into this test.

This test as written depends upon particular TR35 canonicalization, which the base-most Intl spec doesn't technically guarantee.  If that isn't acceptable, we could more minimally test that `new Intl.Locale("en-u-ca-islamicc").calendar === new Intl.Locale("en", { calendar: "islamicc" })` to detect dissimilar canonicalization actions being taken, even if we aren't requiring an exact result.