### PR TITLE
Correctly tag AggregateError proto-from-ctor-realm test

### DIFF
--- a/test/built-ins/NativeErrors/AggregateError/proto-from-ctor-realm.js
+++ b/test/built-ins/NativeErrors/AggregateError/proto-from-ctor-realm.js
@@ -26,7 +26,7 @@ info: |
     a. Let realm be ? GetFunctionRealm(constructor).
     b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
   5. Return proto.
-features: [cross-realm, Reflect, Symbol]
+features: [AggregateError, cross-realm, Reflect, Symbol]
 ---*/
 
 var other = $262.createRealm().global;


### PR DESCRIPTION
It'd be nice to have a CI hook that enforces presence of feature tags for all tests in a built-in directory.