### PR TITLE
Correct the expectation of zh-Hant for Locale.minimize

### DIFF
--- a/test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js
+++ b/test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js
@@ -34,7 +34,7 @@ var testDataMinimal = {
     // https://unicode-org.atlassian.net/browse/ICU-12345
     "und-CW": "pap-CW",
     "und-US": "en",
-    "zh-Hant": "zh-TW",
+    "zh-Hant": "zh-Hant",
     "zh-Hani": "zh-Hani",
 };
 


### PR DESCRIPTION
It is incorrect to expect the minimize result of "zh-Hant" to be "zh-TW". It should be "zh-Hant". Why?

first, what we have in input for zh-Hant
lang = zh
region = [none]
script = Hant 

Now, look at the AddLikelySubtags algorithm in http://www.unicode.org/reports/tr35/#Likely_Subtags

```
Remove Likely Subtags: Given a locale, remove any fields that Add Likely Subtags would add.
The reverse operation removes fields that would be added by the first operation.
1. First get max = AddLikelySubtags(inputLocale). If an error is signaled, return it.
2. Remove the variants from max.
3. Then for trial in {language, language _ region, language _ script}
3-* If AddLikelySubtags(trial) = max, then return trial + variants.
4. If you do not get a match, return max + variants.
```

after 1 and 2, max = AddLikelySubtags(zh-Hant) = “zh-Hant-TW”
in 3, we loop through the following
A trial = language = zh. AddLikelySubtags(zh) = ”zh-Hans-CN” != max
[and there are “no region code”, so no language _ region for trial]
B. trial = language _ script = zh_Hant AddLikelySubtags(zh-Hant) = ”zh-Hant-TW” == max so we return trial + v which is “zh_Hant”