### PR TITLE
CreateDynamicFunction: test Realm of "prototype" object

### DIFF
--- a/test/built-ins/AsyncGeneratorFunction/proto-from-ctor-realm-prototype.js
+++ b/test/built-ins/AsyncGeneratorFunction/proto-from-ctor-realm-prototype.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-createdynamicfunction
+description: >
+  While default [[Prototype]] value derives from realm of the newTarget,
+  "prototype" object inherits from %Object.prototype% of constructor's realm.
+info: |
+  AsyncGeneratorFunction ( p1, p2, … , pn, body )
+
+  [...]
+  3. Return ? CreateDynamicFunction(C, NewTarget, asyncGenerator, args).
+
+  CreateDynamicFunction ( constructor, newTarget, kind, args )
+
+  [...]
+  18. Let proto be ? GetPrototypeFromConstructor(newTarget, fallbackProto).
+  19. Let realmF be the current Realm Record.
+  20. Let scope be realmF.[[GlobalEnv]].
+  21. Let F be ! OrdinaryFunctionCreate(proto, parameters, body, non-lexical-this, scope).
+  [...]
+  24. Else if kind is asyncGenerator, then
+    a. Let prototype be OrdinaryObjectCreate(%AsyncGenerator.prototype%).
+    b. Perform DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]:
+    prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
+  [...]
+  30. Return F.
+features: [async-iteration, cross-realm, Reflect]
+---*/
+
+var realmA = $262.createRealm().global;
+realmA.calls = 0;
+var aAsyncGeneratorFunction = realmA.eval("(async function* () {})").constructor;
+var aAsyncGeneratorPrototype = Object.getPrototypeOf(
+  realmA.eval("(async function* () {})").prototype
+);
+
+var realmB = $262.createRealm().global;
+var bAsyncGeneratorFunction = realmB.eval("(async function* () {})").constructor;
+var newTarget = new realmB.Function();
+newTarget.prototype = null;
+
+var fn = Reflect.construct(aAsyncGeneratorFunction, ["calls += 1;"], newTarget);
+assert.sameValue(Object.getPrototypeOf(fn), bAsyncGeneratorFunction.prototype);
+assert.sameValue(Object.getPrototypeOf(fn.prototype), aAsyncGeneratorPrototype);
+
+var gen = fn();
+assert(gen instanceof realmA.Object);
+gen.next();
+assert.sameValue(realmA.calls, 1);

--- a/test/built-ins/Function/proto-from-ctor-realm-prototype.js
+++ b/test/built-ins/Function/proto-from-ctor-realm-prototype.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-createdynamicfunction
+description: >
+  While default [[Prototype]] value derives from realm of the newTarget,
+  "prototype" object inherits from %Object.prototype% of constructor's realm.
+info: |
+  Function ( p1, p2, … , pn, body )
+
+  [...]
+  3. Return ? CreateDynamicFunction(C, NewTarget, normal, args).
+
+  CreateDynamicFunction ( constructor, newTarget, kind, args )
+
+  [...]
+  18. Let proto be ? GetPrototypeFromConstructor(newTarget, fallbackProto).
+  19. Let realmF be the current Realm Record.
+  20. Let scope be realmF.[[GlobalEnv]].
+  21. Let F be ! OrdinaryFunctionCreate(proto, parameters, body, non-lexical-this, scope).
+  [...]
+  25. Else if kind is normal, perform MakeConstructor(F).
+  [...]
+  30. Return F.
+
+  MakeConstructor ( F [ , writablePrototype [ , prototype ] ] )
+
+  [...]
+  7. If prototype is not present, then
+    a. Set prototype to OrdinaryObjectCreate(%Object.prototype%).
+    [...]
+  8. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor {[[Value]]: prototype,
+  [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: false }).
+features: [cross-realm, Reflect]
+---*/
+
+var realmA = $262.createRealm().global;
+realmA.calls = 0;
+
+var realmB = $262.createRealm().global;
+var newTarget = new realmB.Function();
+newTarget.prototype = null;
+
+var fn = Reflect.construct(realmA.Function, ["calls += 1;"], newTarget);
+assert.sameValue(Object.getPrototypeOf(fn), realmB.Function.prototype);
+assert.sameValue(Object.getPrototypeOf(fn.prototype), realmA.Object.prototype);
+
+assert(new fn() instanceof realmA.Object);
+assert.sameValue(realmA.calls, 1);

--- a/test/built-ins/GeneratorFunction/proto-from-ctor-realm-prototype.js
+++ b/test/built-ins/GeneratorFunction/proto-from-ctor-realm-prototype.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-createdynamicfunction
+description: >
+  While default [[Prototype]] value derives from realm of the newTarget,
+  "prototype" object inherits from %Object.prototype% of constructor's realm.
+info: |
+  GeneratorFunction ( p1, p2, … , pn, body )
+
+  [...]
+  3. Return ? CreateDynamicFunction(C, NewTarget, generator, args).
+
+  CreateDynamicFunction ( constructor, newTarget, kind, args )
+
+  [...]
+  18. Let proto be ? GetPrototypeFromConstructor(newTarget, fallbackProto).
+  19. Let realmF be the current Realm Record.
+  20. Let scope be realmF.[[GlobalEnv]].
+  21. Let F be ! OrdinaryFunctionCreate(proto, parameters, body, non-lexical-this, scope).
+  [...]
+  23. If kind is generator, then
+    a. Let prototype be OrdinaryObjectCreate(%Generator.prototype%).
+    b. Perform DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype,
+    [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
+  [...]
+  30. Return F.
+features: [generators, cross-realm, Reflect]
+---*/
+
+var realmA = $262.createRealm().global;
+realmA.calls = 0;
+var aGeneratorFunction = realmA.eval("(function* () {})").constructor;
+var aGeneratorPrototype = Object.getPrototypeOf(
+  realmA.eval("(function* () {})").prototype
+);
+
+var realmB = $262.createRealm().global;
+var bGeneratorFunction = realmB.eval("(function* () {})").constructor;
+var newTarget = new realmB.Function();
+newTarget.prototype = null;
+
+var fn = Reflect.construct(aGeneratorFunction, ["calls += 1;"], newTarget);
+assert.sameValue(Object.getPrototypeOf(fn), bGeneratorFunction.prototype);
+assert.sameValue(Object.getPrototypeOf(fn.prototype), aGeneratorPrototype);
+
+var gen = fn();
+assert(gen instanceof realmA.Object);
+gen.next();
+assert.sameValue(realmA.calls, 1);


### PR DESCRIPTION
JSC bug: [InternalFunction::createSubclassStructure should use newTarget's globalObject](https://bugs.webkit.org/show_bug.cgi?id=202599).
Follow-up of #2342.