### PR TITLE
Partly revert "Simplify alphanum regex in testIntl.js"

### DIFF
--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -272,10 +272,10 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
    *
    * Spec: https://unicode.org/reports/tr35/#Unicode_locale_identifier
    */
-  var alpha = "[A-Za-z]",
+  var alpha = "[a-z]",
     digit = "[0-9]",
-    alphanum = "[A-Za-z0-9]",
-    variant = "(" + alphanum + "{5,8}|(?:" + digit + alphanum + "{3}))",
+    alphanum = "(" + alpha + "|" + digit + ")",
+    variant = "(" + alphanum + "{5,8}|(" + digit + alphanum + "{3}))",
     region = "(" + alpha + "{2}|" + digit + "{3})",
     script = "(" + alpha + "{4})",
     language = "(" + alpha + "{2,3}|" + alpha + "{5,8})",
@@ -292,14 +292,14 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
     extension = "(" + unicode_locale_extensions + "|" + transformed_extensions + "|" + other_extensions + ")",
     locale_id = language + "(-" + script + ")?(-" + region + ")?(-" + variant + ")*(-" + extension + ")*(-" + privateuse + ")?",
     languageTag = "^(" + locale_id + ")$",
-    languageTagRE = new RegExp(languageTag);
+    languageTagRE = new RegExp(languageTag, "i");
 
   var duplicateSingleton = "-" + singleton + "-(.*-)?\\1(?!" + alphanum + ")",
-    duplicateSingletonRE = new RegExp(duplicateSingleton),
-    duplicateVariant = "(" + alphanum + "{2,8}-)+" + variant + "-(" + alphanum + "{2,8}-)*\\2(?!" + alphanum + ")",
-    duplicateVariantRE = new RegExp(duplicateVariant);
+    duplicateSingletonRE = new RegExp(duplicateSingleton, "i"),
+    duplicateVariant = "(" + alphanum + "{2,8}-)+" + variant + "-(" + alphanum + "{2,8}-)*\\3(?!" + alphanum + ")",
+    duplicateVariantRE = new RegExp(duplicateVariant, "i");
 
-  var transformKeyRE = new RegExp("^" + alpha + digit + "$");
+  var transformKeyRE = new RegExp("^" + alpha + digit + "$", "i");
 
   /**
    * Verifies that the given string is a well-formed Unicode BCP 47 Locale Identifier

--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -274,7 +274,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
    */
   var alpha = "[a-z]",
     digit = "[0-9]",
-    alphanum = "(" + alpha + "|" + digit + ")",
+    alphanum = "(?:" + alpha + "|" + digit + ")",
     variant = "(" + alphanum + "{5,8}|(?:" + digit + alphanum + "{3}))",
     region = "(" + alpha + "{2}|" + digit + "{3})",
     script = "(" + alpha + "{4})",

--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -274,7 +274,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
    */
   var alpha = "[a-z]",
     digit = "[0-9]",
-    alphanum = "(?:" + alpha + "|" + digit + ")",
+    alphanum = "[a-z0-9]",
     variant = "(" + alphanum + "{5,8}|(?:" + digit + alphanum + "{3}))",
     region = "(" + alpha + "{2}|" + digit + "{3})",
     script = "(" + alpha + "{4})",

--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -275,7 +275,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
   var alpha = "[a-z]",
     digit = "[0-9]",
     alphanum = "(" + alpha + "|" + digit + ")",
-    variant = "(" + alphanum + "{5,8}|(" + digit + alphanum + "{3}))",
+    variant = "(" + alphanum + "{5,8}|(?:" + digit + alphanum + "{3}))",
     region = "(" + alpha + "{2}|" + digit + "{3})",
     script = "(" + alpha + "{4})",
     language = "(" + alpha + "{2,3}|" + alpha + "{5,8})",
@@ -296,7 +296,7 @@ function isCanonicalizedStructurallyValidLanguageTag(locale) {
 
   var duplicateSingleton = "-" + singleton + "-(.*-)?\\1(?!" + alphanum + ")",
     duplicateSingletonRE = new RegExp(duplicateSingleton, "i"),
-    duplicateVariant = "(" + alphanum + "{2,8}-)+" + variant + "-(" + alphanum + "{2,8}-)*\\3(?!" + alphanum + ")",
+    duplicateVariant = "(" + alphanum + "{2,8}-)+" + variant + "-(" + alphanum + "{2,8}-)*\\2(?!" + alphanum + ")",
     duplicateVariantRE = new RegExp(duplicateVariant, "i");
 
   var transformKeyRE = new RegExp("^" + alpha + digit + "$", "i");


### PR DESCRIPTION
This PR reverts `i` flag change per https://github.com/tc39/test262/pull/2581#issuecomment-619856574, but keeps unnecessary capture group removal since JSC currently [fails to match it correctly](https://bugs.webkit.org/show_bug.cgi?id=210576).

_cc_ @anba @rkirsling