### PR TITLE
Test AsyncFromSyncIterator methods with `undefined` values

### DIFF
--- a/src/async-generators/yield-star-sync-return.case
+++ b/src/async-generators/yield-star-sync-return.case
@@ -157,14 +157,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/src/async-generators/yield-star-sync-throw.case
+++ b/src/async-generators/yield-star-sync-throw.case
@@ -160,14 +160,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/expressions/async-generator/named-yield-star-sync-return.js
+++ b/test/language/expressions/async-generator/named-yield-star-sync-return.js
@@ -170,14 +170,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/expressions/async-generator/named-yield-star-sync-throw.js
+++ b/test/language/expressions/async-generator/named-yield-star-sync-throw.js
@@ -173,14 +173,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/expressions/async-generator/yield-star-sync-return.js
+++ b/test/language/expressions/async-generator/yield-star-sync-return.js
@@ -170,14 +170,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/expressions/async-generator/yield-star-sync-throw.js
+++ b/test/language/expressions/async-generator/yield-star-sync-throw.js
@@ -173,14 +173,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/expressions/class/async-gen-method-static/yield-star-sync-return.js
+++ b/test/language/expressions/class/async-gen-method-static/yield-star-sync-return.js
@@ -177,14 +177,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/expressions/class/async-gen-method-static/yield-star-sync-throw.js
+++ b/test/language/expressions/class/async-gen-method-static/yield-star-sync-throw.js
@@ -180,14 +180,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/expressions/class/async-gen-method/yield-star-sync-return.js
+++ b/test/language/expressions/class/async-gen-method/yield-star-sync-return.js
@@ -177,14 +177,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/expressions/class/async-gen-method/yield-star-sync-throw.js
+++ b/test/language/expressions/class/async-gen-method/yield-star-sync-throw.js
@@ -180,14 +180,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-sync-return.js
+++ b/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-sync-return.js
@@ -182,14 +182,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-sync-throw.js
+++ b/test/language/expressions/class/elements/async-gen-private-method-static/yield-star-sync-throw.js
@@ -185,14 +185,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/expressions/class/elements/async-gen-private-method/yield-star-sync-return.js
+++ b/test/language/expressions/class/elements/async-gen-private-method/yield-star-sync-return.js
@@ -185,14 +185,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/expressions/class/elements/async-gen-private-method/yield-star-sync-throw.js
+++ b/test/language/expressions/class/elements/async-gen-private-method/yield-star-sync-throw.js
@@ -188,14 +188,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/expressions/object/method-definition/async-gen-yield-star-sync-return.js
+++ b/test/language/expressions/object/method-definition/async-gen-yield-star-sync-return.js
@@ -170,14 +170,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/expressions/object/method-definition/async-gen-yield-star-sync-throw.js
+++ b/test/language/expressions/object/method-definition/async-gen-yield-star-sync-throw.js
@@ -173,14 +173,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/statements/async-generator/yield-star-sync-return.js
+++ b/test/language/statements/async-generator/yield-star-sync-return.js
@@ -170,14 +170,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/statements/async-generator/yield-star-sync-throw.js
+++ b/test/language/statements/async-generator/yield-star-sync-throw.js
@@ -173,14 +173,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/statements/class/async-gen-method-static/yield-star-sync-return.js
+++ b/test/language/statements/class/async-gen-method-static/yield-star-sync-return.js
@@ -177,14 +177,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/statements/class/async-gen-method-static/yield-star-sync-throw.js
+++ b/test/language/statements/class/async-gen-method-static/yield-star-sync-throw.js
@@ -180,14 +180,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/statements/class/async-gen-method/yield-star-sync-return.js
+++ b/test/language/statements/class/async-gen-method/yield-star-sync-return.js
@@ -177,14 +177,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/statements/class/async-gen-method/yield-star-sync-throw.js
+++ b/test/language/statements/class/async-gen-method/yield-star-sync-throw.js
@@ -180,14 +180,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/statements/class/elements/async-gen-private-method-static/yield-star-sync-return.js
+++ b/test/language/statements/class/elements/async-gen-private-method-static/yield-star-sync-return.js
@@ -182,14 +182,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/statements/class/elements/async-gen-private-method-static/yield-star-sync-throw.js
+++ b/test/language/statements/class/elements/async-gen-private-method-static/yield-star-sync-throw.js
@@ -185,14 +185,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");

--- a/test/language/statements/class/elements/async-gen-private-method/yield-star-sync-return.js
+++ b/test/language/statements/class/elements/async-gen-private-method/yield-star-sync-return.js
@@ -185,14 +185,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.return("return-arg-2").then(v => {
+    iter.return().then(v => {
       assert.sameValue(log[6].name, "get return");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get return thisValue");
 
       assert.sameValue(log[7].name, "call return");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "get return thisValue");
       assert.sameValue(log[7].args.length, 1, "return args.length");
-      assert.sameValue(log[7].args[0], "return-arg-2", "return args[0]");
+      assert.sameValue(log[7].args[0], undefined, "return args[0]");
 
       assert.sameValue(log[8].name, "get return done (2)");
       assert.sameValue(log[8].thisValue.name, "return-result-2", "get return done thisValue");

--- a/test/language/statements/class/elements/async-gen-private-method/yield-star-sync-throw.js
+++ b/test/language/statements/class/elements/async-gen-private-method/yield-star-sync-throw.js
@@ -188,14 +188,14 @@ iter.next().then(v => {
 
     assert.sameValue(log.length, 6, "log.length");
 
-    iter.throw("throw-arg-2").then(v => {
+    iter.throw().then(v => {
       assert.sameValue(log[6].name, "get throw");
       assert.sameValue(log[6].thisValue.name, "syncIterator", "get throw thisValue");
 
       assert.sameValue(log[7].name, "call throw");
       assert.sameValue(log[7].thisValue.name, "syncIterator", "throw thisValue");
       assert.sameValue(log[7].args.length, 1, "throw args.length");
-      assert.sameValue(log[7].args[0], "throw-arg-2", "throw args[0]");
+      assert.sameValue(log[7].args[0], undefined, "throw args[0]");
 
       assert.sameValue(log[8].name, "get throw done (2)");
       assert.sameValue(log[8].thisValue.name, "throw-result-2", "get throw done thisValue");


### PR DESCRIPTION
I've modified existing templates instead of adding new test files because string as `throw`/`return` argument is already covered a few lines above, and by testing `undefined` case we make sure that "is present" check of https://github.com/tc39/ecma262/pull/1776 is implemented correctly. This PR also aligns `throw` and `return` templates with `next`, which already covers `undefined` case.

Follow-up of #2571.
JSC bug: [AsyncFromSyncIterator methods should not pass absent values](https://bugs.webkit.org/show_bug.cgi?id=211147).