### PR TITLE
Fix #2605; make safe-integer.js call isSafeInteger

### DIFF
--- a/test/built-ins/Number/isSafeInteger/safe-integers.js
+++ b/test/built-ins/Number/isSafeInteger/safe-integers.js
@@ -15,9 +15,9 @@ info: |
   [...]
 ---*/
 
-assert.sameValue(Number.isInteger(1), true, "1");
-assert.sameValue(Number.isInteger(-0), true, "-0");
-assert.sameValue(Number.isInteger(0), true, "0");
-assert.sameValue(Number.isInteger(-1), true, "-1");
-assert.sameValue(Number.isInteger(9007199254740991), true, "9007199254740991");
-assert.sameValue(Number.isInteger(-9007199254740991), true, "-9007199254740991");
+assert.sameValue(Number.isSafeInteger(1), true, "1");
+assert.sameValue(Number.isSafeInteger(-0), true, "-0");
+assert.sameValue(Number.isSafeInteger(0), true, "0");
+assert.sameValue(Number.isSafeInteger(-1), true, "-1");
+assert.sameValue(Number.isSafeInteger(9007199254740991), true, "9007199254740991");
+assert.sameValue(Number.isSafeInteger(-9007199254740991), true, "-9007199254740991");


### PR DESCRIPTION
The folder and file name implies it should be using isSafeInteger rather
than isInteger which it was using.