### PR TITLE
Correct value to canonicalized locale

### DIFF
--- a/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
+++ b/test/intl402/Intl/getCanonicalLocales/non-iana-canon.js
@@ -23,6 +23,7 @@ var testData = [
     },
     {
         tag: "uz-UZ-cyrillic",
+        canonical: "uz-Latn-UZ-cyrillic",
     },
     {
         tag: "posix",

--- a/test/intl402/Locale/constructor-non-iana-canon.js
+++ b/test/intl402/Locale/constructor-non-iana-canon.js
@@ -32,6 +32,7 @@ var testData = [
     },
     {
         tag: "uz-UZ-cyrillic",
+        canonical: "uz-Latn-UZ-cyrillic",
         maximized: "uz-Latn-UZ-cyrillic",
         minimized: "uz-cyrillic",
     },

--- a/test/intl402/Segmenter/constructor/supportedLocalesOf/locales-specific.js
+++ b/test/intl402/Segmenter/constructor/supportedLocalesOf/locales-specific.js
@@ -19,4 +19,6 @@ assert.sameValue(typeof Intl.Segmenter.supportedLocalesOf, "function",
 assert.compareArray(Intl.Segmenter.supportedLocalesOf("sr"), ["sr"]);
 
 const multiLocale = ["sr-Thai-RS", "de", "zh-CN"];
-assert.compareArray(Intl.Segmenter.supportedLocalesOf(multiLocale), multiLocale);
+const multiCanonLocale = ["sr-Thai-RS", "de", "zh-Hans-CN"];
+
+assert.compareArray(Intl.Segmenter.supportedLocalesOf(multiLocale), multiCanonLocale);

--- a/test/intl402/supportedLocalesOf-unicode-extensions-ignored.js
+++ b/test/intl402/supportedLocalesOf-unicode-extensions-ignored.js
@@ -28,8 +28,8 @@ testWithIntlConstructors(function (Constructor) {
             if (supported1.length === 1) {
                 assert.sameValue(supported2.length, 1, "#1.1: Presence of Unicode locale extension sequence affects whether locale " + locale + " is considered supported with matcher " + matcher + ".");
                 assert.sameValue(supported3.length, 1, "#1.2: Presence of Unicode locale extension sequence affects whether locale " + locale + " is considered supported with matcher " + matcher + ".");
-                assert.sameValue(supported2[0], locale + validExtension, "#2.1: Unicode locale extension sequence is not correctly returned for locale " + locale + " with matcher " + matcher + ".");
-                assert.sameValue(supported3[0], locale + invalidExtension, "#2.2: Unicode locale extension sequence is not correctly returned for locale " + locale + " with matcher " + matcher + ".");
+                assert.sameValue(supported2[0], supported1[0] + validExtension, "#2.1: Unicode locale extension sequence is not correctly returned for locale " + locale + " with matcher " + matcher + ".");
+                assert.sameValue(supported3[0], supported1[0] + invalidExtension, "#2.2: Unicode locale extension sequence is not correctly returned for locale " + locale + " with matcher " + matcher + ".");
             } else {
                 assert.sameValue(supported2.length, 0, "#3.1: Presence of Unicode locale extension sequence affects whether locale " + locale + " is considered supported with matcher " + matcher + ".");
                 assert.sameValue(supported3.length, 0, "#3.2: Presence of Unicode locale extension sequence affects whether locale " + locale + " is considered supported with matcher " + matcher + ".");


### PR DESCRIPTION
(new Intl.Locale("uz-UZ-cyrillic")).toString*) should return "uz-Latn-UZ-cyrillic" not "uz-UZ-cyrillic" because according to
https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid
"2.  Let localeId be the string localeId after performing the algorithm to transform it to canonical form. (The result is a Unicode BCP 47 locale identifier, in both canonical syntax and canonical form.)"

And https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers stated
* Replace aliases in the unicode_language_id and tlang (if any) using the following process:
** If the language subtag matches the type attribute of a languageAlias element in Supplemental Data, replace the language subtag with the replacement value.
*** If there are additional subtags in the replacement value, add them to the result, but only if there is no corresponding subtag already in the tag.

and in https://github.com/unicode-org/cldr/blob/master/common/supplemental/supplementalMetadata.xml
    		<languageAlias type="uz_UZ" replacement="uz_Latn_UZ" reason="legacy"/>
so uz_UZ will be replaced as uz_Latn_UZ during the 

"6.2.3 CanonicalizeUnicodeLocaleId ( locale )"