### PR TITLE
Add missing tests for export-star-as-ns-from-module

### DIFF
--- a/test/language/module-code/eval-rqstd-once.js
+++ b/test/language/module-code/eval-rqstd-once.js
@@ -24,6 +24,7 @@ export {} from './eval-rqstd-once_FIXTURE.js';
 import dflt2, {} from './eval-rqstd-once_FIXTURE.js';
 export * from './eval-rqstd-once_FIXTURE.js';
 export * as ns2 from './eval-rqstd-once_FIXTURE.js';
+export * as class from './eval-rqstd-once_FIXTURE.js';
 import dflt3, * as ns3 from './eval-rqstd-once_FIXTURE.js';
 export default null;
 

--- a/test/language/module-code/export-star-as-dflt.js
+++ b/test/language/module-code/export-star-as-dflt.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2019 Adrian Heine. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: A default export cannot be provided by an export * or export * from "mod" declaration
+esid: sec-static-semantics-exportentriesformodule
+info: |
+    15.2..3.6 Static Semantics: ExportEntriesForModule
+
+    [...]
+
+    ExportFromClause : * as IdentifierName
+
+    1. Let exportName be the StringValue of IdentifierName.
+    2. Let entry be the ExportEntry Record { [[ModuleRequest]]: module, [[ImportName]]: "*", [[LocalName]]: null, [[ExportName]]: exportName }.
+    3. Return a new List containing entry.
+
+flags: [module]
+features: [export-star-as-namespace-from-module]
+---*/
+
+export * as default from './export-star-as-dflt_FIXTURE.js';
+import ns from './export-star-as-dflt.js';
+assert.sameValue(ns.default.x, 1, 'namespace was re-exported under the name `default`');

--- a/test/language/module-code/export-star-as-dflt_FIXTURE.js
+++ b/test/language/module-code/export-star-as-dflt_FIXTURE.js
@@ -1,0 +1,4 @@
+// Copyright (C) 2019 Adrian Heine. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+export const x = 1;


### PR DESCRIPTION
As I suggested in #1498 these are positive tests for `export * as [keyword]` and `export * as default`.