### PR TITLE
Fix testing for throw in an iterator via yield* throws

### DIFF
--- a/test/annexB/language/expressions/yield/star-iterable-throw-emulates-undefined-throws-when-called.js
+++ b/test/annexB/language/expressions/yield/star-iterable-throw-emulates-undefined-throws-when-called.js
@@ -35,6 +35,14 @@ var inner = {
 
 var outer = (function* () { yield* inner; })();
 outer.next();
-outer.throw();
+
+assert.throws(TypeError, function() {
+  // `IsHTMLDDA` is called here with `iter` as `this` and `emptyString` as the
+  // sole argument, and it's specified to return `null` under these conditions.
+  // As `iter`'s iteration isn't ending because of a throw, the iteration
+  // protocol will then throw a `TypeError` because `null` isn't an object.
+  var emptyString = "";
+  outer.throw(emptyString);
+});
 
 assert.sameValue(returnCalls, 0);


### PR DESCRIPTION
IsHTMLDDA is specified in INTERPRETING.md to return null on [[Call]]
when called with no arguments or with single argument "". Returning null
causes the iterator protocol to throw.

Also see star-iterable-return-emulates-undefined-throws-when-called.js