### PR TITLE
Improve [[IsHTMLDDA]] coverage for built-ins

### DIFF
--- a/test/annexB/built-ins/Array/from/iterator-method-emulates-undefined.js
+++ b/test/annexB/built-ins/Array/from/iterator-method-emulates-undefined.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.from
+description: >
+  [[IsHTMLDDA]] object as @@iterator method gets called.
+info: |
+  Array.from ( items [ , mapfn [ , thisArg ] ] )
+
+  [...]
+  4. Let usingIterator be ? GetMethod(items, @@iterator).
+  5. If usingIterator is not undefined, then
+    [...]
+    c. Let iteratorRecord be ? GetIterator(items, sync, usingIterator).
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  [...]
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+features: [Symbol.iterator, IsHTMLDDA]
+---*/
+
+var items = {};
+items[Symbol.iterator] = $262.IsHTMLDDA;
+
+assert.throws(TypeError, function() {
+  Array.from(items);
+});

--- a/test/annexB/built-ins/String/prototype/match/custom-matcher-emulates-undefined.js
+++ b/test/annexB/built-ins/String/prototype/match/custom-matcher-emulates-undefined.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.match
+description: >
+  [[IsHTMLDDA]] object as @@match method gets called.
+info: |
+  String.prototype.match ( regexp )
+
+  [...]
+  2. If regexp is neither undefined nor null, then
+    a. Let matcher be ? GetMethod(regexp, @@match).
+    b. If matcher is not undefined, then
+      i. Return ? Call(matcher, regexp, « O »).
+features: [Symbol.match, IsHTMLDDA]
+---*/
+
+var regexp = $262.IsHTMLDDA;
+var matcherGets = 0;
+Object.defineProperty(regexp, Symbol.match, {
+  get: function() {
+    matcherGets += 1;
+    return regexp;
+  },
+  configurable: true,
+});
+
+assert.sameValue("".match(regexp), null);
+assert.sameValue(matcherGets, 1);

--- a/test/annexB/built-ins/String/prototype/matchAll/custom-matcher-emulates-undefined.js
+++ b/test/annexB/built-ins/String/prototype/matchAll/custom-matcher-emulates-undefined.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.matchall
+description: >
+  [[IsHTMLDDA]] object as @@matchAll method gets called.
+info: |
+  String.prototype.matchAll ( regexp )
+
+  [...]
+  2. If regexp is neither undefined nor null, then
+    [...]
+    c. Let matcher be ? GetMethod(regexp, @@matchAll).
+    d. If matcher is not undefined, then
+      i. Return ? Call(matcher, regexp, « O »).
+features: [Symbol.matchAll, String.prototype.matchAll, IsHTMLDDA]
+---*/
+
+var regexp = $262.IsHTMLDDA;
+var matcherGets = 0;
+Object.defineProperty(regexp, Symbol.matchAll, {
+  get: function() {
+    matcherGets += 1;
+    return regexp;
+  },
+  configurable: true,
+});
+
+assert.sameValue("".matchAll(regexp), null);
+assert.sameValue(matcherGets, 1);

--- a/test/annexB/built-ins/String/prototype/replace/custom-replacer-emulates-undefined.js
+++ b/test/annexB/built-ins/String/prototype/replace/custom-replacer-emulates-undefined.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.replace
+description: >
+  [[IsHTMLDDA]] object as @@replace method gets called.
+info: |
+  String.prototype.replace ( searchValue, replaceValue )
+
+  [...]
+  2. If searchValue is neither undefined nor null, then
+    a. Let replacer be ? GetMethod(searchValue, @@replace).
+    b. If replacer is not undefined, then
+      i. Return ? Call(replacer, searchValue, « O, replaceValue »).
+features: [Symbol.replace, IsHTMLDDA]
+---*/
+
+var searchValue = $262.IsHTMLDDA;
+var replacerGets = 0;
+Object.defineProperty(searchValue, Symbol.replace, {
+  get: function() {
+    replacerGets += 1;
+    return searchValue;
+  },
+  configurable: true,
+});
+
+assert.sameValue("".replace(searchValue), null);
+assert.sameValue(replacerGets, 1);

--- a/test/annexB/built-ins/String/prototype/replaceAll/custom-replacer-emulates-undefined.js
+++ b/test/annexB/built-ins/String/prototype/replaceAll/custom-replacer-emulates-undefined.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.replaceall
+description: >
+  [[IsHTMLDDA]] object as @@replace method gets called.
+info: |
+  String.prototype.replaceAll ( searchValue, replaceValue )
+
+  [...]
+  2. If searchValue is neither undefined nor null, then
+    [...]
+    c. Let replacer be ? GetMethod(searchValue, @@replace).
+    d. If replacer is not undefined, then
+      i. Return ? Call(replacer, searchValue, « O, replaceValue »).
+features: [Symbol.replace, String.prototype.replaceAll, IsHTMLDDA]
+---*/
+
+var searchValue = $262.IsHTMLDDA;
+var replacerGets = 0;
+Object.defineProperty(searchValue, Symbol.replaceAll, {
+  get: function() {
+    replacerGets += 1;
+    return searchValue;
+  },
+  configurable: true,
+});
+
+assert.sameValue("".replaceAll(searchValue), null);
+assert.sameValue(replacerGets, 1);

--- a/test/annexB/built-ins/String/prototype/search/custom-searcher-emulates-undefined.js
+++ b/test/annexB/built-ins/String/prototype/search/custom-searcher-emulates-undefined.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.search
+description: >
+  [[IsHTMLDDA]] object as @@search method gets called.
+info: |
+  String.prototype.search ( regexp )
+
+  [...]
+  2. If regexp is neither undefined nor null, then
+    a. Let searcher be ? GetMethod(regexp, @@search).
+    b. If searcher is not undefined, then
+      i. Return ? Call(searcher, regexp, « O »).
+features: [Symbol.search, IsHTMLDDA]
+---*/
+
+var regexp = $262.IsHTMLDDA;
+var searcherGets = 0;
+Object.defineProperty(regexp, Symbol.search, {
+  get: function() {
+    searcherGets += 1;
+    return regexp;
+  },
+  configurable: true,
+});
+
+assert.sameValue("".search(regexp), null);
+assert.sameValue(searcherGets, 1);

--- a/test/annexB/built-ins/String/prototype/split/custom-splitter-emulates-undefined.js
+++ b/test/annexB/built-ins/String/prototype/split/custom-splitter-emulates-undefined.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.split
+description: >
+  [[IsHTMLDDA]] object as @@split method gets called.
+info: |
+  String.prototype.split ( separator, limit )
+
+  [...]
+  2. If separator is neither undefined nor null, then
+    a. Let splitter be ? GetMethod(separator, @@split).
+    b. If splitter is not undefined, then
+      i. Return ? Call(splitter, separator, « O, limit »).
+features: [Symbol.split, IsHTMLDDA]
+---*/
+
+var separator = $262.IsHTMLDDA;
+var splitterGets = 0;
+Object.defineProperty(separator, Symbol.split, {
+  get: function() {
+    splitterGets += 1;
+    return separator;
+  },
+  configurable: true,
+});
+
+assert.sameValue("".split(separator), null);
+assert.sameValue(splitterGets, 1);

--- a/test/annexB/built-ins/TypedArrayConstructors/from/iterator-method-emulates-undefined.js
+++ b/test/annexB/built-ins/TypedArrayConstructors/from/iterator-method-emulates-undefined.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.from
+description: >
+  [[IsHTMLDDA]] object as @@iterator method gets called.
+info: |
+  %TypedArray%.from ( source [ , mapfn [ , thisArg ] ] )
+
+  [...]
+  5. Let usingIterator be ? GetMethod(items, @@iterator).
+  6. If usingIterator is not undefined, then
+    a. Let values be ? IterableToList(source, usingIterator).
+
+  IterableToList ( items, method )
+
+  1. Let iteratorRecord be ? GetIterator(items, sync, method).
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  [...]
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+includes: [testTypedArray.js]
+features: [Symbol.iterator, TypedArray, IsHTMLDDA]
+---*/
+
+var items = {};
+items[Symbol.iterator] = $262.IsHTMLDDA;
+
+testWithTypedArrayConstructors(function(TypedArray) {
+  assert.throws(TypeError, function() {
+    TypedArray.from(items);
+  });
+});


### PR DESCRIPTION
JSC bug: [Use @isUndefinedOrNull instead of abstract equality with null](https://bugs.webkit.org/show_bug.cgi?id=210954).
Follow-up of #2579.