### PR TITLE
Fix `und-150` expectation

### DIFF
--- a/test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js
+++ b/test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js
@@ -23,7 +23,7 @@ var testDataMinimal = {
     "und": "en",
     "und-Thai": "th",
     "und-419": "es-419",
-    "und-150": "ru",
+    "und-150": "ru-150",
     "und-AT": "de-AT",
 
     // https://unicode-org.atlassian.net/browse/ICU-13786


### PR DESCRIPTION
`AddLikelySubtags("und-150")` yields `ru-Cyrl-150` its minimal form should be `ru-150` instead of just `ru` since `AddLikelySubtags("ru")` is `ru-Cyrl-RU`.