### PR TITLE
Test %TypedArray%.prototype.set with primitives

### DIFF
--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-primitive-toobject.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-primitive-toobject.js
@@ -31,11 +31,9 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   ta1.set("567");
   assert.compareArray(ta1, [5n, 6n, 7n, 4n], "string");
 
-  Number.prototype.length = 1;
-  Number.prototype[0] = 9n;
   var ta2 = new TA([1n, 2n, 3n]);
   ta2.set(-10, 2);
-  assert.compareArray(ta2, [1n, 2n, 9n], "number (modified prototype)");
+  assert.compareArray(ta2, [1n, 2n, 3n], "number");
 
   var ta3 = new TA([1n]);
   ta3.set(false);
@@ -45,8 +43,7 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   ta4.set(Symbol("desc"), 0);
   assert.compareArray(ta4, [1n, 2n], "symbol");
 
-  BigInt.prototype.length = -8;
   var ta5 = new TA([1n, 2n]);
   ta5.set(4n, 1);
-  assert.compareArray(ta5, [1n, 2n], "bigint (modified prototype)");
+  assert.compareArray(ta5, [1n, 2n], "bigint");
 });

--- a/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-primitive-toobject.js
+++ b/test/built-ins/TypedArray/prototype/set/BigInt/array-arg-primitive-toobject.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.set-array-offset
+description: >
+  Primitive `array` argument is coerced to an object.
+info: |
+  %TypedArray%.prototype.set ( typedArray [ , offset ] )
+
+  1. Assert: array is any ECMAScript language value other than an Object
+  with a [[TypedArrayName]] internal slot. If it is such an Object,
+  the definition in 22.2.3.23.2 applies.
+  [...]
+  14. Let src be ? ToObject(array).
+  15. Let srcLength be ? LengthOfArrayLike(src).
+  [...]
+  19. Let limit be targetByteIndex + targetElementSize × srcLength.
+  20. Repeat, while targetByteIndex < limit,
+    a. Let Pk be ! ToString(k).
+    b. Let value be ? Get(src, Pk).
+    c. If target.[[ContentType]] is BigInt, set value to ? ToBigInt(value).
+    [...]
+    f. Perform SetValueInBuffer(targetBuffer, targetByteIndex, targetType, value, true, Unordered).
+    [...]
+includes: [testBigIntTypedArray.js, compareArray.js]
+features: [BigInt, TypedArray, Symbol]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var ta1 = new TA([1n, 2n, 3n, 4n]);
+  ta1.set("567");
+  assert.compareArray(ta1, [5n, 6n, 7n, 4n], "string");
+
+  Number.prototype.length = 1;
+  Number.prototype[0] = 9n;
+  var ta2 = new TA([1n, 2n, 3n]);
+  ta2.set(-10, 2);
+  assert.compareArray(ta2, [1n, 2n, 9n], "number (modified prototype)");
+
+  var ta3 = new TA([1n]);
+  ta3.set(false);
+  assert.compareArray(ta3, [1n], "boolean");
+
+  var ta4 = new TA([1n, 2n]);
+  ta4.set(Symbol("desc"), 0);
+  assert.compareArray(ta4, [1n, 2n], "symbol");
+
+  BigInt.prototype.length = -8;
+  var ta5 = new TA([1n, 2n]);
+  ta5.set(4n, 1);
+  assert.compareArray(ta5, [1n, 2n], "bigint (modified prototype)");
+});

--- a/test/built-ins/TypedArray/prototype/set/array-arg-primitive-toobject.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-primitive-toobject.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.set-array-offset
+description: >
+  Primitive `array` argument is coerced to an object.
+info: |
+  %TypedArray%.prototype.set ( typedArray [ , offset ] )
+
+  1. Assert: array is any ECMAScript language value other than an Object
+  with a [[TypedArrayName]] internal slot. If it is such an Object,
+  the definition in 22.2.3.23.2 applies.
+  [...]
+  14. Let src be ? ToObject(array).
+  15. Let srcLength be ? LengthOfArrayLike(src).
+  [...]
+  19. Let limit be targetByteIndex + targetElementSize × srcLength.
+  20. Repeat, while targetByteIndex < limit,
+    a. Let Pk be ! ToString(k).
+    b. Let value be ? Get(src, Pk).
+    [...]
+    d. Otherwise, set value to ? ToNumber(value).
+    [...]
+    f. Perform SetValueInBuffer(targetBuffer, targetByteIndex, targetType, value, true, Unordered).
+    [...]
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, Symbol]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var ta1 = new TA([1, 2, 3, 4, 5]);
+  ta1.set("678", 1);
+  assert.compareArray(ta1, [1, 6, 7, 8, 5], "string");
+
+  var ta2 = new TA([1, 2, 3]);
+  ta2.set(0);
+  assert.compareArray(ta2, [1, 2, 3], "number");
+
+  Boolean.prototype.length = 1;
+  Boolean.prototype[0] = 7;
+  var ta3 = new TA([1, 2, 3]);
+  ta3.set(true, 2);
+  assert.compareArray(ta3, [1, 2, 7], "boolean (modified prototype)");
+
+  Symbol.prototype.length = -15;
+  var ta4 = new TA([1]);
+  ta4.set(Symbol());
+  assert.compareArray(ta4, [1], "symbol (modified prototype)");
+});

--- a/test/built-ins/TypedArray/prototype/set/array-arg-primitive-toobject.js
+++ b/test/built-ins/TypedArray/prototype/set/array-arg-primitive-toobject.js
@@ -36,14 +36,11 @@ testWithTypedArrayConstructors(function(TA) {
   ta2.set(0);
   assert.compareArray(ta2, [1, 2, 3], "number");
 
-  Boolean.prototype.length = 1;
-  Boolean.prototype[0] = 7;
   var ta3 = new TA([1, 2, 3]);
   ta3.set(true, 2);
-  assert.compareArray(ta3, [1, 2, 7], "boolean (modified prototype)");
+  assert.compareArray(ta3, [1, 2, 3], "boolean");
 
-  Symbol.prototype.length = -15;
   var ta4 = new TA([1]);
   ta4.set(Symbol());
-  assert.compareArray(ta4, [1], "symbol (modified prototype)");
+  assert.compareArray(ta4, [1], "symbol");
 });


### PR DESCRIPTION
JSC bug: [TypedArray.prototype.set is incorrect with primitives](https://bugs.webkit.org/show_bug.cgi?id=212730).