### PR TITLE
Add tests for \8 in template/strict strings.

### DIFF
--- a/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence-8.js
+++ b/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence-8.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2020 Sony Interactive Entertainment Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literal-lexical-components
+description: >
+    Invalid octal escape sequence (regardless of the presence of Annex B)
+info: |
+    A conforming implementation must not use the extended definition of
+    EscapeSequence described in B.1.2 when parsing a TemplateCharacter.
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+`\8`;

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-8-strict.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-8-strict.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Sony Interactive Entertainment Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-literals-string-literals
+description: >
+    LegacyOctalEscapeSequence is not enabled in strict mode code
+    (regardless of the presence of Annex B)
+info: |
+    A conforming implementation, when processing strict mode code, must not extend the
+    syntax of EscapeSequence to include LegacyOctalEscapeSequence as described in B.1.2.
+flags: [onlyStrict]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+'\8';


### PR DESCRIPTION
Resolves #2653.