### PR TITLE
Don't call $DONE twice in S25.4.4_A2.1_T3.js

### DIFF
--- a/test/built-ins/Promise/prototype/then/S25.4.4_A2.1_T3.js
+++ b/test/built-ins/Promise/prototype/then/S25.4.4_A2.1_T3.js
@@ -37,6 +37,6 @@ Promise.resolve().then(function() {
     assert.sameValue(sequence.length, 3);
     checkSequence(sequence, "Expected 1,2,3");
   }).then($DONE, $DONE);
-}).then($DONE, $DONE);
+});
 
 sequence.push(1);


### PR DESCRIPTION
Reverts the change from 040eb5393a6c3e854a7ab5e86b54f3dac841162e to avoid calling $DONE twice in the test file.

From <https://github.com/tc39/test262/blob/master/CONTRIBUTING.md#writing-asynchronous-tests>:
> When executing such tests, the runner expects that the global `$DONE()` function will be called **exactly once** to signal test completion.