### PR TITLE
Refactor tests for static methods creation and fetching

### DIFF
--- a/test/language/computed-property-names/class/static/method-number.js
+++ b/test/language/computed-property-names/class/static/method-number.js
@@ -1,11 +1,61 @@
 // Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-object-initializer
+esid: sec-runtime-semantics-classdefinitionevaluation
 description: >
     In a class, static computed property method names can be a number
+info: |
+  Set order: "length", "name", "prototype", static methods
+
+  Runtime Semantics: ClassDefinitionEvaluation
+
+  ...
+  11. Let constructorInfo be ! DefineMethod of constructor with arguments proto and constructorParent.
+  12. Let F be constructorInfo.[[Closure]].
+  13. Perform SetFunctionName(F, className).
+  14. Perform MakeConstructor(F, false, proto).
+  ...
+  19. Else, let methods be NonConstructorMethodDefinitions of ClassBody.
+  20. For each ClassElement m in order from methods, do
+    a. If IsStatic of m is false, then
+      ...
+    b. Else,
+      i. Let status be PropertyDefinitionEvaluation of m with arguments F and false.
+    ...
+
+  ---
+
+  Object.getOwnPropertyNames ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, string).
+
+  Runtime Semantics: GetOwnPropertyKeys ( O, type )
+
+  1. Let obj be ? ToObject(O).
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+  3. Let nameList be a new empty List.
+  4. For each element nextKey of keys in List order, do
+    a. If Type(nextKey) is Symbol and type is symbol or Type(nextKey) is String and type is string, then
+      i. Append nextKey as the last element of nameList.
+  5. Return CreateArrayFromList(nameList).
+
+  [[OwnPropertyKeys]] ( )
+
+  1. Return ! OrdinaryOwnPropertyKeys(O).
+
+  OrdinaryOwnPropertyKeys ( O )
+
+  1. Let keys be a new empty List.
+  2. For each own property key P of O such that P is an array index, in ascending numeric index order, do
+    a. Add P as the last element of keys.
+  3. For each own property key P of O such that Type(P) is String and P is not an array index, in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  4. For each own property key P of O such that Type(P) is Symbol, in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  5. Return keys.
 includes: [compareArray.js]
 ---*/
+
 class C {
   static a() { return 'A'; }
   static [1]() { return 'B'; }
@@ -16,11 +66,11 @@ assert.sameValue(C.a(), 'A', "`C.a()` returns `'A'`. Defined as `static a() { re
 assert.sameValue(C[1](), 'B', "`C[1]()` returns `'B'`. Defined as `static [1]() { return 'B'; }`");
 assert.sameValue(C.c(), 'C', "`C.c()` returns `'C'`. Defined as `static c() { return 'C'; }`");
 assert.sameValue(C[2](), 'D', "`C[2]()` returns `'D'`. Defined as `static [2]() { return 'D'; }`");
-assert(
-  compareArray(Object.keys(C), []),
-  "`compareArray(Object.keys(C), [])` returns `true`"
+assert.compareArray(
+  Object.keys(C),
+  []
 );
-assert(
-  compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'name', 'prototype', 'a', 'c']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['1', '2', 'length', 'name', 'prototype', 'a', 'c'])` returns `true`"
+assert.compareArray(
+  Object.getOwnPropertyNames(C),
+  ['1', '2', 'length', 'name', 'prototype', 'a', 'c']
 );

--- a/test/language/computed-property-names/class/static/method-string.js
+++ b/test/language/computed-property-names/class/static/method-string.js
@@ -1,11 +1,61 @@
 // Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-object-initializer
+esid: sec-runtime-semantics-classdefinitionevaluation
 description: >
     In a class, static computed property method names can be a string
+info: |
+  Set order: "length", "name", "prototype", static methods
+
+  Runtime Semantics: ClassDefinitionEvaluation
+
+  ...
+  11. Let constructorInfo be ! DefineMethod of constructor with arguments proto and constructorParent.
+  12. Let F be constructorInfo.[[Closure]].
+  13. Perform SetFunctionName(F, className).
+  14. Perform MakeConstructor(F, false, proto).
+  ...
+  19. Else, let methods be NonConstructorMethodDefinitions of ClassBody.
+  20. For each ClassElement m in order from methods, do
+    a. If IsStatic of m is false, then
+      ...
+    b. Else,
+      i. Let status be PropertyDefinitionEvaluation of m with arguments F and false.
+    ...
+
+  ---
+
+  Object.getOwnPropertyNames ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, string).
+
+  Runtime Semantics: GetOwnPropertyKeys ( O, type )
+
+  1. Let obj be ? ToObject(O).
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+  3. Let nameList be a new empty List.
+  4. For each element nextKey of keys in List order, do
+    a. If Type(nextKey) is Symbol and type is symbol or Type(nextKey) is String and type is string, then
+      i. Append nextKey as the last element of nameList.
+  5. Return CreateArrayFromList(nameList).
+
+  [[OwnPropertyKeys]] ( )
+
+  1. Return ! OrdinaryOwnPropertyKeys(O).
+
+  OrdinaryOwnPropertyKeys ( O )
+
+  1. Let keys be a new empty List.
+  2. For each own property key P of O such that P is an array index, in ascending numeric index order, do
+    a. Add P as the last element of keys.
+  3. For each own property key P of O such that Type(P) is String and P is not an array index, in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  4. For each own property key P of O such that Type(P) is Symbol, in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  5. Return keys.
 includes: [compareArray.js]
 ---*/
+
 class C {
   static a() { return 'A'}
   static ['b']() { return 'B'; }
@@ -16,11 +66,11 @@ assert.sameValue(C.a(), 'A', "`C.a()` returns `'A'`. Defined as `static a() { re
 assert.sameValue(C.b(), 'B', "`C.b()` returns `'B'`. Defined as `static ['b']() { return 'B'; }`");
 assert.sameValue(C.c(), 'C', "`C.c()` returns `'C'`. Defined as `static c() { return 'C'; }`");
 assert.sameValue(C.d(), 'D', "`C.d()` returns `'D'`. Defined as `static ['d']() { return 'D'; }`");
-assert(
-  compareArray(Object.keys(C), []),
-  "`compareArray(Object.keys(C), [])` returns `true`"
+assert.compareArray(
+  Object.keys(C),
+  []
 );
-assert(
-  compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'b', 'c', 'd']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'b', 'c', 'd'])` returns `true`"
+assert.compareArray(
+  Object.getOwnPropertyNames(C),
+  ['length', 'name', 'prototype', 'a', 'b', 'c', 'd']
 );

--- a/test/language/computed-property-names/class/static/method-symbol.js
+++ b/test/language/computed-property-names/class/static/method-symbol.js
@@ -1,12 +1,66 @@
 // Copyright (C) 2014 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-object-initializer
+esid: sec-runtime-semantics-classdefinitionevaluation
 description: >
-    In a class, static computed property method names can be a symbol
+  In a class, static computed property method names can be a symbol
+info: |
+  Set order: "length", "name", "prototype", static methods
+
+  Runtime Semantics: ClassDefinitionEvaluation
+
+  ...
+  11. Let constructorInfo be ! DefineMethod of constructor with arguments proto and constructorParent.
+  12. Let F be constructorInfo.[[Closure]].
+  13. Perform SetFunctionName(F, className).
+  14. Perform MakeConstructor(F, false, proto).
+  ...
+  19. Else, let methods be NonConstructorMethodDefinitions of ClassBody.
+  20. For each ClassElement m in order from methods, do
+    a. If IsStatic of m is false, then
+      ...
+    b. Else,
+      i. Let status be PropertyDefinitionEvaluation of m with arguments F and false.
+    ...
+
+  ---
+
+  Object.getOwnPropertyNames ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, string).
+
+  Object.getOwnPropertySymbols ( O )
+
+  1. Return ? GetOwnPropertyKeys(O, symbol).
+
+  Runtime Semantics: GetOwnPropertyKeys ( O, type )
+
+  1. Let obj be ? ToObject(O).
+  2. Let keys be ? obj.[[OwnPropertyKeys]]().
+  3. Let nameList be a new empty List.
+  4. For each element nextKey of keys in List order, do
+    a. If Type(nextKey) is Symbol and type is symbol or Type(nextKey) is String and type is string, then
+      i. Append nextKey as the last element of nameList.
+  5. Return CreateArrayFromList(nameList).
+
+  [[OwnPropertyKeys]] ( )
+
+  1. Return ! OrdinaryOwnPropertyKeys(O).
+
+  OrdinaryOwnPropertyKeys ( O )
+
+  1. Let keys be a new empty List.
+  2. For each own property key P of O such that P is an array index, in ascending numeric index order, do
+    a. Add P as the last element of keys.
+  3. For each own property key P of O such that Type(P) is String and P is not an array index, in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  4. For each own property key P of O such that Type(P) is Symbol, in ascending chronological order of property creation, do
+    a. Add P as the last element of keys.
+  5. Return keys.
 includes: [compareArray.js]
 features: [Symbol]
 ---*/
+
 var sym1 = Symbol();
 var sym2 = Symbol();
 class C {
@@ -19,15 +73,15 @@ assert.sameValue(C.a(), 'A', "`C.a()` returns `'A'`. Defined as `static a() { re
 assert.sameValue(C[sym1](), 'B', "`C[sym1]()` returns `'B'`. Defined as `static [sym1]() { return 'B'; }`");
 assert.sameValue(C.c(), 'C', "`C.c()` returns `'C'`. Defined as `static c() { return 'C'; }`");
 assert.sameValue(C[sym2](), 'D', "`C[sym2]()` returns `'D'`. Defined as `static [sym2]() { return 'D'; }`");
-assert(
-  compareArray(Object.keys(C), []),
-  "`compareArray(Object.keys(C), [])` returns `true`"
+assert.compareArray(
+  Object.keys(C),
+  []
 );
-assert(
-  compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'c']),
-  "`compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype', 'a', 'c'])` returns `true`"
+assert.compareArray(
+  Object.getOwnPropertyNames(C),
+  ['length', 'name', 'prototype', 'a', 'c']
 );
-assert(
-  compareArray(Object.getOwnPropertySymbols(C), [sym1, sym2]),
-  "`compareArray(Object.getOwnPropertySymbols(C), [sym1, sym2])` returns `true`"
+assert.compareArray(
+  Object.getOwnPropertySymbols(C),
+  [sym1, sym2]
 );


### PR DESCRIPTION
Ref #2504
Ref https://github.com/tc39/ecma262/pull/1490

@scole66 The tests are now correct with the current specs since https://github.com/tc39/ecma262/pull/1490 has been merged.

There wasn't much to change I added some info content to help clarifying how the properties are set during the class evaluation and fetched from `Object.getOwnPropertyNames` and `Object.getOwnPropertySymbols`.

I also removed the assert messages as `compareArray` does a good job showing the actual and expected values if anything fails.

For the current tests failures, let's ping @codehag @anba @syg.
