### PR TITLE
Remove 0 from the range of fractionalSecondDigits 

### DIFF
--- a/test/intl402/DateTimeFormat/constructor-options-fractionalSecondDigits-valid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-fractionalSecondDigits-valid.js
@@ -14,9 +14,6 @@ features: [Intl.DateTimeFormat-fractionalSecondDigits]
 
 const validOptions = [
   [undefined, undefined],
-  [-0, undefined],
-  [0, undefined],
-  ["0", undefined],
   [1, 1],
   ["1", 1],
   [2, 2],
@@ -25,9 +22,8 @@ const validOptions = [
   ["3", 3],
   [2.9, 2],
   ["2.9", 2],
-  [0.00001, undefined],
+  [1.00001, 1],
   [{ toString() { return "3"; } }, 3],
-  [{ valueOf() { return -0; }, toString: undefined }, undefined],
 ];
 for (const [fractionalSecondDigits, expected] of validOptions) {
   const dtf = new Intl.DateTimeFormat("en", { fractionalSecondDigits });

--- a/test/intl402/DateTimeFormat/prototype/format/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/format/fractionalSecondDigits.js
@@ -12,7 +12,7 @@ const d1 = new Date(2019, 7, 10,  1, 2, 3, 234);
 const d2 = new Date(2019, 7, 10,  1, 2, 3, 567);
 
 let dtf = new Intl.DateTimeFormat(
-    'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: 0});
+    'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: undefined});
 assert.sameValue(dtf.format(d1), "02:03", "no fractionalSecondDigits");
 assert.sameValue(dtf.format(d2), "02:03", "no fractionalSecondDigits");
 

--- a/test/intl402/DateTimeFormat/prototype/formatRange/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRange/fractionalSecondDigits.js
@@ -13,7 +13,7 @@ const d2 = new Date(2019, 7, 10,  1, 2, 3, 567);
 const d3 = new Date(2019, 7, 10,  1, 2, 13, 987);
 
 let dtf = new Intl.DateTimeFormat(
-    'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: 0});
+    'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: undefined});
 assert.sameValue(dtf.formatRange(d1, d2), "02:03", "no fractionalSecondDigits");
 assert.sameValue(dtf.formatRange(d1, d3), "02:03 – 02:13", "no fractionalSecondDigits");
 

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/fractionalSecondDigits.js
@@ -27,8 +27,18 @@ const d1 = new Date(2019, 7, 10,  1, 2, 3, 234);
 const d2 = new Date(2019, 7, 10,  1, 2, 3, 567);
 const d3 = new Date(2019, 7, 10,  1, 2, 13, 987);
 
+assert.throws(RangeError, () => {
+    new Intl.DateTimeFormat(
+      'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: 0});
+  }, "fractionalSecondDigits 0 should throw RangeError for out of range");
+
+assert.throws(RangeError, () => {
+    new Intl.DateTimeFormat(
+      'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: 4});
+  }, "fractionalSecondDigits 4 should throw RangeError for out of range");
+
 let dtf = new Intl.DateTimeFormat(
-    'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: 0});
+    'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: undefined});
 
 compare(dtf.formatRangeToParts(d1, d2), [
   { type: "minute", value: "02", source: "shared" },

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/fractionalSecondDigits.js
@@ -31,8 +31,23 @@ function assertParts(parts, minute, second, fractionalSecond, message) {
   }
 }
 
-let dtf = new Intl.DateTimeFormat(
+assert.throws(RangeError, () => {
+  new Intl.DateTimeFormat(
     'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: 0});
+}, "fractionalSecondDigits 0 should throw RangeError for out of range");
+
+assert.throws(RangeError, () => {
+  new Intl.DateTimeFormat(
+    'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: 4});
+}, "fractionalSecondDigits 4 should throw RangeError for out of range");
+
+let dtf = new Intl.DateTimeFormat(
+    'en', { minute: "numeric", second: "numeric"});
+assertParts(dtf.formatToParts(d1), "02", "03", null, "no fractionalSecondDigits round down");
+assertParts(dtf.formatToParts(d2), "02", "03", null, "no fractionalSecondDigits round down");
+
+dtf = new Intl.DateTimeFormat(
+    'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: undefined});
 assertParts(dtf.formatToParts(d1), "02", "03", null, "no fractionalSecondDigits round down");
 assertParts(dtf.formatToParts(d2), "02", "03", null, "no fractionalSecondDigits round down");
 


### PR DESCRIPTION
Update the test to sync with the least version of https://github.com/tc39/ecma402/pull/347
and remove 0 from the range of fractionalSecondDigits and just use undefined for that.