### PR TITLE
Intl.DisplayNames.length should be 2

### DIFF
--- a/test/intl402/DisplayNames/length.js
+++ b/test/intl402/DisplayNames/length.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-Intl.DisplayNames
 description: >
-  Intl.DisplayNames.length is 0.
+  Intl.DisplayNames.length is 2.
 info: |
   ECMAScript Standard Built-in Objects:
 
@@ -24,7 +24,7 @@ features: [Intl.DisplayNames]
 ---*/
 
 verifyProperty(Intl.DisplayNames, "length", {
-  value: 0,
+  value: 2,
   enumerable: false,
   writable: false,
   configurable: true,


### PR DESCRIPTION
`locales` and `options` are not optional parameters. So the length should be 2.