### PR TITLE
Add feature tag for cleanupSome

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -133,6 +133,10 @@ import.meta
 WeakRef
 FinalizationRegistry
 
+# FinalizationRegistry#cleanupSome
+# link pending
+cleanupSome
+
 # Optional Chaining
 # https://github.com/tc39/proposal-optional-chaining
 optional-chaining

--- a/harness/async-gc.js
+++ b/harness/async-gc.js
@@ -3,9 +3,8 @@
 /*---
 description: >
     Collection of functions used to capture references cleanup from garbage collectors
-features: [Symbol, async-functions]
+features: [cleanupSome, FinalizationRegistry, Symbol, async-functions]
 flags: [non-deterministic]
-features: [FinalizationRegistry]
 defines: [asyncGC, asyncGCDeref, resolveAsyncGC]
 ---*/
 

--- a/test/built-ins/FinalizationRegistry/gc-has-one-chance-to-call-cleanupCallback.js
+++ b/test/built-ins/FinalizationRegistry/gc-has-one-chance-to-call-cleanupCallback.js
@@ -25,7 +25,7 @@ info: |
   2. For each FinalizationRegistry finalizationRegistry such that finalizationRegistry.[[Cells]] contains cell, such that cell.[[Target]] is obj,
     a. Set cell.[[Target]] to empty.
     b. Optionally, perform ! HostCleanupFinalizationRegistry(finalizationRegistry).
-features: [FinalizationRegistry, async-functions, host-gc-required]
+features: [cleanupSome, FinalizationRegistry, async-functions, host-gc-required]
 flags: [async, non-deterministic]
 includes: [async-gc.js]
 ---*/

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/callback-not-callable-throws.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/callback-not-callable-throws.js
@@ -12,7 +12,7 @@ info: |
   3. If finalizationRegistry does not have a [[Cells]] internal slot, throw a TypeError exception.
   4. If callback is not undefined and IsCallable(callback) is false, throw a TypeError exception.
   ...
-features: [FinalizationRegistry]
+features: [cleanupSome, FinalizationRegistry]
 ---*/
 
 assert.sameValue(typeof FinalizationRegistry.prototype.cleanupSome, 'function');

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/cleanup-prevented-with-reference.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/cleanup-prevented-with-reference.js
@@ -13,7 +13,7 @@ info: |
   4. If callback is not undefined and IsCallable(callback) is false, throw a TypeError exception.
   5. Perform ? CleanupFinalizationRegistry(finalizationRegistry, callback).
   6. Return undefined.
-features: [FinalizationRegistry, host-gc-required]
+features: [cleanupSome, FinalizationRegistry, host-gc-required]
 includes: [async-gc.js]
 flags: [async, non-deterministic]
 ---*/

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/cleanup-prevented-with-unregister.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/cleanup-prevented-with-unregister.js
@@ -22,7 +22,7 @@ info: |
       i. Remove cell from finalizationRegistry.[[Cells]].
       ii. Set removed to true.
   3. Return removed.
-features: [FinalizationRegistry, host-gc-required]
+features: [cleanupSome, FinalizationRegistry, host-gc-required]
 includes: [async-gc.js]
 flags: [async, non-deterministic]
 ---*/

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/custom-this.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/custom-this.js
@@ -13,7 +13,7 @@ info: |
   4. If callback is not undefined and IsCallable(callback) is false, throw a TypeError exception.
   5. Perform ! CleanupFinalizationRegistry(finalizationRegistry, callback).
   6. Return undefined.
-features: [FinalizationRegistry]
+features: [cleanupSome, FinalizationRegistry]
 ---*/
 
 var fn = function() {};

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/holdings-multiple-values.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/holdings-multiple-values.js
@@ -23,7 +23,7 @@ info: |
   ...
 
 
-features: [FinalizationRegistry, Symbol, host-gc-required]
+features: [cleanupSome, FinalizationRegistry, Symbol, host-gc-required]
 includes: [async-gc.js]
 flags: [async, non-deterministic]
 ---*/

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/length.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/length.js
@@ -21,7 +21,7 @@ info: |
   function object has the attributes { [[Writable]]: false,
   [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
-features: [FinalizationRegistry]
+features: [cleanupSome, FinalizationRegistry]
 ---*/
 
 verifyProperty(FinalizationRegistry.prototype.cleanupSome, 'length', {

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/name.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/name.js
@@ -20,7 +20,7 @@ info: |
   object, if it exists, has the attributes { [[Writable]]: false,
   [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
-features: [FinalizationRegistry]
+features: [cleanupSome, FinalizationRegistry]
 ---*/
 
 verifyProperty(FinalizationRegistry.prototype.cleanupSome, 'name', {

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/prop-desc.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/prop-desc.js
@@ -12,7 +12,7 @@ info: |
   has the attributes { [[Writable]]: true, [[Enumerable]]: false,
   [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js]
-features: [FinalizationRegistry]
+features: [cleanupSome, FinalizationRegistry]
 ---*/
 
 assert.sameValue(typeof FinalizationRegistry.prototype.cleanupSome, 'function');

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/reentrancy.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/reentrancy.js
@@ -8,7 +8,7 @@ description: >
 info: |
   FinalizationRegistry.prototype.cleanupSome ( [ callback ] )
 
-features: [FinalizationRegistry, host-gc-required]
+features: [cleanupSome, FinalizationRegistry, host-gc-required]
 includes: [async-gc.js]
 flags: [async, non-deterministic]
 ---*/

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/return-undefined-with-gc.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/return-undefined-with-gc.js
@@ -13,7 +13,7 @@ info: |
   4. If callback is not undefined and IsCallable(callback) is false, throw a TypeError exception.
   5. Perform ? CleanupFinalizationRegistry(finalizationRegistry, callback).
   6. Return undefined.
-features: [FinalizationRegistry, arrow-function, async-functions, async-iteration, class, host-gc-required]
+features: [cleanupSome, FinalizationRegistry, arrow-function, async-functions, async-iteration, class, host-gc-required]
 includes: [async-gc.js]
 flags: [async, non-deterministic]
 ---*/

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/return-undefined.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/return-undefined.js
@@ -13,7 +13,7 @@ info: |
   4. If callback is not undefined and IsCallable(callback) is false, throw a TypeError exception.
   5. Perform ? CleanupFinalizationRegistry(finalizationRegistry, callback).
   6. Return undefined.
-features: [FinalizationRegistry, arrow-function, async-functions, async-iteration, class]
+features: [cleanupSome, FinalizationRegistry, arrow-function, async-functions, async-iteration, class]
 ---*/
 
 var fn = function() {};

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/this-does-not-have-internal-cells-throws.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/this-does-not-have-internal-cells-throws.js
@@ -12,7 +12,7 @@ info: |
   3. If finalizationRegistry does not have a [[Cells]] internal slot, throw a TypeError exception.
   4. If callback is not undefined and IsCallable(callback) is false, throw a TypeError exception.
   ...
-features: [WeakSet, WeakMap, FinalizationRegistry, WeakRef]
+features: [cleanupSome, WeakSet, WeakMap, FinalizationRegistry, WeakRef]
 ---*/
 
 assert.sameValue(typeof FinalizationRegistry.prototype.cleanupSome, 'function');

--- a/test/built-ins/FinalizationRegistry/prototype/cleanupSome/this-not-object-throws.js
+++ b/test/built-ins/FinalizationRegistry/prototype/cleanupSome/this-not-object-throws.js
@@ -12,7 +12,7 @@ info: |
   3. If finalizationRegistry does not have a [[Cells]] internal slot, throw a TypeError exception.
   4. If callback is not undefined and IsCallable(callback) is false, throw a TypeError exception.
   ...
-features: [FinalizationRegistry]
+features: [cleanupSome, FinalizationRegistry]
 ---*/
 
 assert.sameValue(typeof FinalizationRegistry.prototype.cleanupSome, 'function');

--- a/test/built-ins/FinalizationRegistry/prototype/unregister/unregister-cleaned-up-cell.js
+++ b/test/built-ins/FinalizationRegistry/prototype/unregister/unregister-cleaned-up-cell.js
@@ -29,7 +29,7 @@ info: |
       i. Remove cell from finalizationRegistry.[[Cells]].
       ii. Set removed to true.
   3. Return removed.
-features: [FinalizationRegistry, host-gc-required]
+features: [cleanupSome, FinalizationRegistry, host-gc-required]
 includes: [async-gc.js]
 flags: [async, non-deterministic]
 ---*/

--- a/test/built-ins/WeakRef/prototype/deref/gc-cleanup-not-prevented-with-wr-deref.js
+++ b/test/built-ins/WeakRef/prototype/deref/gc-cleanup-not-prevented-with-wr-deref.js
@@ -13,7 +13,7 @@ info: |
     a. Perform ! KeepDuringJob(target).
     b. Return target.
   6. Return undefined.
-features: [WeakRef, host-gc-required]
+features: [cleanupSome, WeakRef, host-gc-required]
 includes: [async-gc.js]
 flags: [async, non-deterministic]
 ---*/


### PR DESCRIPTION
The WeakRefs proposal advanced to Stage 4 but cleanupSome moved back to a Stage 2 status.

The tests should remain in Test262 for now but this feature flag should help users to filter tests out.