### PR TITLE
fix link to branch `preserved-website-directory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Test262 runs CI tests against every PR and commit. The only tests that are requi
 
 ### Where did `website/` go?
 
-It's been removed. If you need to access the code that contained in that directory, we've preserved it in a branch, [available here](https://github.com/tc39/test262/compare/preserved-website-directory).
+It's been removed. If you need to access the code that contained in that directory, we've preserved it in a branch, [available here](https://github.com/tc39/test262/tree/preserved-website-directory).


### PR DESCRIPTION
Currently, we direct the readers to `compare` page. Which is odd, since readers
hope to land on the branch's page. Let's fix this by changing the link to point
to the branch's page.