### PR TITLE
Intl.Segmenter iterator result should have isWordLike only if type is "word"

### DIFF
--- a/test/intl402/Segmenter/prototype/segment/segment-grapheme-iterable.js
+++ b/test/intl402/Segmenter/prototype/segment/segment-grapheme-iterable.js
@@ -1,4 +1,5 @@
 // Copyright 2018 the V8 project authors. All rights reserved.
+// Copyright 2020 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -31,6 +32,7 @@ for (const text of [
   let segments = [];
   for (const v of seg.segment(text)) {
     assert.sameValue(undefined, v.isWordLike);
+    assert.sameValue(false, v.hasOwnProperty("isWordLike"));
     assert.sameValue("string", typeof v.segment);
     assert(v.segment.length > 0);
     segments.push(v.segment);

--- a/test/intl402/Segmenter/prototype/segment/segment-sentence-iterable.js
+++ b/test/intl402/Segmenter/prototype/segment/segment-sentence-iterable.js
@@ -1,4 +1,5 @@
 // Copyright 2018 the V8 project authors. All rights reserved.
+// Copyright 2020 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -31,6 +32,7 @@ for (const text of [
   let segments = [];
   for (const v of seg.segment(text)) {
     assert.sameValue(undefined, v.isWordLike);
+    assert.sameValue(false, v.hasOwnProperty("isWordLike"));
     assert.sameValue("string", typeof v.segment);
     assert(v.segment.length > 0);
     segments.push(v.segment);

--- a/test/intl402/Segmenter/prototype/segment/segment-word-iterable.js
+++ b/test/intl402/Segmenter/prototype/segment/segment-word-iterable.js
@@ -1,4 +1,5 @@
 // Copyright 2018 the V8 project authors. All rights reserved.
+// Copyright 2020 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -31,6 +32,7 @@ for (const text of [
   let segments = [];
   for (const v of seg.segment(text)) {
     assert.sameValue("boolean", typeof v.isWordLike);
+    assert.sameValue(true, v.hasOwnProperty("isWordLike"));
     assert.sameValue("string", typeof v.segment);
     assert(v.segment.length > 0);
     segments.push(v.segment);


### PR DESCRIPTION
Update according to https://github.com/tc39/proposal-intl-segmenter/pull/128.