### PR TITLE
related-year-zh.js may not contain years

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/format/related-year-zh.js
+++ b/test/intl402/DateTimeFormat/prototype/format/related-year-zh.js
@@ -1,4 +1,5 @@
 // Copyright 2019 Google Inc, Igalia S.L. All rights reserved.
+// Copyright 2020 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -11,4 +12,6 @@ locale: [zh-u-ca-chinese]
 
 const df = new Intl.DateTimeFormat("zh-u-ca-chinese", {year: "numeric"});
 const date = new Date(2019, 5, 1);
-assert.sameValue(df.format(date), "2019己亥年");
+const formatted = df.format(date);
+const expected = ["2019己亥年", "己亥年"];
+assert(expected.includes(formatted));

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/related-year-zh.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/related-year-zh.js
@@ -1,4 +1,5 @@
 // Copyright 2019 Google Inc, Igalia S.L. All rights reserved.
+// Copyright 2020 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -9,21 +10,24 @@ description: >
 locale: [zh-u-ca-chinese]
 ---*/
 
-function verifyFormatParts(actual, expected, message) {
-  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
-  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
-  assert.sameValue(actual.length, expected.length, `${message}: length`);
-
-  for (let i = 0; i < actual.length; ++i) {
-    assert.sameValue(actual[i].type, expected[i].type, `${message}: parts[${i}].type`);
-    assert.sameValue(actual[i].value, expected[i].value, `${message}: parts[${i}].value`);
-  }
-}
-
 const df = new Intl.DateTimeFormat("zh-u-ca-chinese", {year: "numeric"});
 const date = new Date(2019, 5, 1);
-verifyFormatParts(df.formatToParts(date), [
+const actual = df.formatToParts(date);
+
+const expected = [
   {type: "relatedYear", value: "2019"},
   {type: "yearName", value: "己亥"},
   {type: "literal", value: "年"},
-]);
+];
+
+assert.sameValue(Array.isArray(actual), true, 'actual is Array');
+
+if (actual.length <= 2) {
+  expected.shift(); // removes the relatedYear
+}
+
+actual.forEach(({ type, value }, i) => {
+  const { type: eType, value: eValue } = expected[i];
+  assert.sameValue(type, eType, `actual[${i}].type should be ${eType}`);
+  assert.sameValue(value, eValue, `actual[${i}].value should be ${eValue}`);
+});


### PR DESCRIPTION
Apple ICU team is shipping macOS system ICU with newer CLDR, but it has many overrides on the top of it to make the formatted output suitable for the rest of the system (entire macOS components are using this system ICU).
So this is not using raw CLDR data.

In related-year-zh.js tests, Apple ICU intentionally overrides the CLDR data with the different format.
This change modifies the test to accept that alternative output.

I think this is OK since test262 is not a test for CLDR/ICU and the different output is OK so long as it is intentional :)
And formatToParts is showing right results for the generated output.