### PR TITLE
Redeclaration of arguments in direct eval in parameter expressions, ref gh-2478

### DIFF
--- a/src/direct-eval-code/arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.case
+++ b/src/direct-eval-code/arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.case
@@ -1,0 +1,11 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Declare "arguments" and assign to it in direct eval code
+template: arrow-func
+---*/
+
+//- parameter-code
+eval("var arguments = 'param'"), q = () => arguments
+//- body
+assert.sameValue(q(), "param");

--- a/src/direct-eval-code/arrow-func-declare-arguments-assign.case
+++ b/src/direct-eval-code/arrow-func-declare-arguments-assign.case
@@ -1,0 +1,9 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Declare "arguments" and assign to it in direct eval code
+template: arrow-func
+---*/
+
+//- parameter-code
+eval("var arguments = 'param'")

--- a/src/direct-eval-code/arrow-func/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/arrow-func/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,15 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+const f = (p = /*{ parameter-code }*/, arguments) => {}
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/arrow-func/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/arrow-func/a-following-parameter-is-named-arguments.template
@@ -7,9 +7,7 @@ name: Declare |arguments| when a following parameter is named |arguments|.
 esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
 const f = (p = /*{ parameter-code }*/, arguments) => {}
 assert.throws(SyntaxError, f);
 assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/arrow-func/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/arrow-func/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,15 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+const f = (arguments, p = /*{ parameter-code }*/) => {}
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/arrow-func/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/arrow-func/a-preceding-parameter-is-named-arguments.template
@@ -7,9 +7,7 @@ name: Declare |arguments| when a preceding parameter is named |arguments|.
 esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
 const f = (arguments, p = /*{ parameter-code }*/) => {}
 assert.throws(SyntaxError, f);
 assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment.template
+++ b/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = /*{ parameter-code }*/) => {
+  function arguments() {}
+  assert.sameValue(typeof arguments, "function");
+  /*{ body }*/
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment.template
+++ b/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment.template
@@ -7,9 +7,7 @@ name: Declare |arguments| when the function body contains an |arguments| functio
 esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = /*{ parameter-code }*/) => {
   function arguments() {}

--- a/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = /*{ parameter-code }*/) => {
+  function arguments() {}
+  assert.sameValue(typeof arguments, "function");
+  /*{ body }*/
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-func-decl.template
@@ -7,9 +7,7 @@ name: Declare |arguments| when the function body contains an |arguments| functio
 esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = /*{ parameter-code }*/) => {
   function arguments() {}

--- a/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = /*{ parameter-code }*/) => {
+  let arguments = "local";
+  assert.sameValue(arguments, "local");
+  /*{ body }*/
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-lex-bind.template
@@ -7,9 +7,7 @@ name: Declare |arguments| when the function body contains an |arguments| lexical
 esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = /*{ parameter-code }*/) => {
   let arguments = "local";

--- a/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = /*{ parameter-code }*/) => {
+  var arguments = "local";
+  assert.sameValue(arguments, "local");
+  /*{ body }*/
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/arrow-func/fn-body-cntns-arguments-var-bind.template
@@ -7,9 +7,7 @@ name: Declare |arguments| when the function body contains an |arguments| var-bin
 esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = /*{ parameter-code }*/) => {
   var arguments = "local";

--- a/src/direct-eval-code/arrow-func/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/arrow-func/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = /*{ parameter-code }*/) => {
+  assert.sameValue(arguments, "param");
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/arrow-func/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/arrow-func/no-pre-existing-arguments-bindings-are-present.template
@@ -7,9 +7,7 @@ name: Declare |arguments| when no pre-existing |arguments| bindings are present.
 esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = /*{ parameter-code }*/) => {
   assert.sameValue(arguments, "param");

--- a/src/direct-eval-code/declare-arguments-and-assign.case
+++ b/src/direct-eval-code/declare-arguments-and-assign.case
@@ -1,0 +1,9 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Declare "arguments" and assign to it in direct eval code
+template: default/*
+---*/
+
+//- parameter-code
+eval("var arguments = 'param'")

--- a/src/direct-eval-code/declare-arguments.case
+++ b/src/direct-eval-code/declare-arguments.case
@@ -1,0 +1,9 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Declare "arguments" and assign to it in direct eval code
+template: default/*
+---*/
+
+//- parameter-code
+eval("var arguments")

--- a/src/direct-eval-code/default/async-func-decl/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-decl/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/src/direct-eval-code/default/async-func-decl/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-decl/a-following-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = /*{ parameter-code }*/, arguments) {
   /*{ body }*/
 }

--- a/src/direct-eval-code/default/async-func-decl/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-decl/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/src/direct-eval-code/default/async-func-decl/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-decl/a-preceding-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(arguments, p = /*{ parameter-code }*/) {
   /*{ body }*/
 }

--- a/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-func-decl.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = /*{ parameter-code }*/) {
   function arguments() {}
 }

--- a/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = /*{ parameter-code }*/) {
+  let arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-lex-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = /*{ parameter-code }*/) {
   let arguments;
 }

--- a/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = /*{ parameter-code }*/) {
+  var arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-var-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = /*{ parameter-code }*/) {
   var arguments;
 }

--- a/src/direct-eval-code/default/async-func-decl/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-func-decl/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = /*{ parameter-code }*/) {}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-func-decl/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-func-decl/no-pre-existing-arguments-bindings-are-present.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = /*{ parameter-code }*/) {}
 f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/src/direct-eval-code/default/async-func-expr-named/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-expr-named/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+};
+f().then($DONE, error => {
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+  assert(error instanceof SyntaxError);
+}).then($DONE, $DONE);
+

--- a/src/direct-eval-code/default/async-func-expr-named/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-expr-named/a-following-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = /*{ parameter-code }*/, arguments) {
   /*{ body }*/
 };

--- a/src/direct-eval-code/default/async-func-expr-named/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-expr-named/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/src/direct-eval-code/default/async-func-expr-named/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-expr-named/a-preceding-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(arguments, p = /*{ parameter-code }*/) {
   /*{ body }*/
 }

--- a/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-func-decl.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = /*{ parameter-code }*/) {
   function arguments() {}
 }

--- a/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = /*{ parameter-code }*/) {
+  let arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-lex-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = /*{ parameter-code }*/) {
   let arguments;
 }

--- a/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = /*{ parameter-code }*/) {
+  var arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-var-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = /*{ parameter-code }*/) {
   var arguments;
 }

--- a/src/direct-eval-code/default/async-func-expr-named/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-func-expr-named/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = /*{ parameter-code }*/) {}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/src/direct-eval-code/default/async-func-expr-named/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-func-expr-named/no-pre-existing-arguments-bindings-are-present.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = /*{ parameter-code }*/) {}
 f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/src/direct-eval-code/default/async-func-expr-nameless/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-func-expr-nameless/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/a-following-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = /*{ parameter-code }*/, arguments) {
   /*{ body }*/
 }

--- a/src/direct-eval-code/default/async-func-expr-nameless/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-func-expr-nameless/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/a-preceding-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(arguments, p = /*{ parameter-code }*/) {
   /*{ body }*/
 }

--- a/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-func-decl.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = /*{ parameter-code }*/) {
   function arguments() {}
 }

--- a/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = /*{ parameter-code }*/) {
+  let arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-lex-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = /*{ parameter-code }*/) {
   let arguments;
 }

--- a/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = /*{ parameter-code }*/) {
+  var arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-var-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = /*{ parameter-code }*/) {
   var arguments;
 }

--- a/src/direct-eval-code/default/async-func-expr-nameless/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = /*{ parameter-code }*/) {}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-func-expr-nameless/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-func-expr-nameless/no-pre-existing-arguments-bindings-are-present.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = /*{ parameter-code }*/) {}
 f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/src/direct-eval-code/default/async-gen-func-decl/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-decl/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/a-following-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = /*{ parameter-code }*/, arguments) {
   /*{ body }*/
 }

--- a/src/direct-eval-code/default/async-gen-func-decl/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-decl/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/a-preceding-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(arguments, p = /*{ parameter-code }*/) {
   /*{ body }*/
 }

--- a/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-func-decl.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = /*{ parameter-code }*/) {
   function arguments() {}
 }

--- a/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = /*{ parameter-code }*/) {
+  let arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-lex-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = /*{ parameter-code }*/) {
   let arguments;
 }

--- a/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = /*{ parameter-code }*/) {
+  var arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-var-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = /*{ parameter-code }*/) {
   var arguments;
 }

--- a/src/direct-eval-code/default/async-gen-func-decl/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = /*{ parameter-code }*/) {}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-decl/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-gen-func-decl/no-pre-existing-arguments-bindings-are-present.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = /*{ parameter-code }*/) {}
 
 assert.throws(SyntaxError, f);

--- a/src/direct-eval-code/default/async-gen-func-expr/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-expr-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-expr/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/a-following-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = /*{ parameter-code }*/, arguments) {
   /*{ body }*/
 }

--- a/src/direct-eval-code/default/async-gen-func-expr/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-expr/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/a-preceding-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (arguments, p = /*{ parameter-code }*/) {
   /*{ body }*/
 }

--- a/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = /*{ parameter-code }*/) {
+  function arguments() {}
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-func-decl.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = /*{ parameter-code }*/) {
   function arguments() {}
 }

--- a/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = /*{ parameter-code }*/) {
+  let arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-lex-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = /*{ parameter-code }*/) {
   let arguments;
 }

--- a/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = /*{ parameter-code }*/) {
+  var arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-var-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = /*{ parameter-code }*/) {
   var arguments;
 }

--- a/src/direct-eval-code/default/async-gen-func-expr/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = /*{ parameter-code }*/) {}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-func-expr/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-gen-func-expr/no-pre-existing-arguments-bindings-are-present.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = /*{ parameter-code }*/) {}
 
 assert.throws(SyntaxError, f);

--- a/src/direct-eval-code/default/async-gen-meth/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-meth/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-meth/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-meth/a-following-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = /*{ parameter-code }*/, arguments) {
   /*{ body }*/
 }};

--- a/src/direct-eval-code/default/async-gen-meth/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-meth/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-meth/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-meth/a-preceding-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(arguments, p = /*{ parameter-code }*/) {
   /*{ body }*/
 }};

--- a/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-func-decl.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = /*{ parameter-code }*/) {
   function arguments() {}
 }};

--- a/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = /*{ parameter-code }*/) {
+  let arguments;
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-lex-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = /*{ parameter-code }*/) {
   let arguments;
 }};

--- a/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = /*{ parameter-code }*/) {
+  var arguments;
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-var-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = /*{ parameter-code }*/) {
   var arguments;
 }};

--- a/src/direct-eval-code/default/async-gen-meth/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-gen-meth/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,17 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = /*{ parameter-code }*/) {}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-meth/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-gen-meth/no-pre-existing-arguments-bindings-are-present.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = /*{ parameter-code }*/) {}};
 assert.throws(SyntaxError, o.f);
 assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-named-func-expr/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-named-func-expr/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/a-following-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = /*{ parameter-code }*/, arguments) {
   /*{ body }*/
 }

--- a/src/direct-eval-code/default/async-gen-named-func-expr/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-named-func-expr/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/a-preceding-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(arguments, p = /*{ parameter-code }*/) {
   /*{ body }*/
 }

--- a/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-func-decl.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = /*{ parameter-code }*/) {
   function arguments() {}
 }

--- a/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = /*{ parameter-code }*/) {
+  let arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+

--- a/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-lex-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = /*{ parameter-code }*/) {
   let arguments;
 }

--- a/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = /*{ parameter-code }*/) {
+  var arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-var-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = /*{ parameter-code }*/) {
   var arguments;
 }

--- a/src/direct-eval-code/default/async-gen-named-func-expr/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = /*{ parameter-code }*/) {}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/src/direct-eval-code/default/async-gen-named-func-expr/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-gen-named-func-expr/no-pre-existing-arguments-bindings-are-present.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = /*{ parameter-code }*/) {}
 
 assert.throws(SyntaxError, f);

--- a/src/direct-eval-code/default/async-meth/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-meth/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-meth-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-meth/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-meth/a-following-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = /*{ parameter-code }*/, arguments) {
   /*{ body }*/
 }};

--- a/src/direct-eval-code/default/async-meth/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-meth/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-meth-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-meth/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/async-meth/a-preceding-parameter-is-named-arguments.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(arguments, p = /*{ parameter-code }*/) {
   /*{ body }*/
 }};

--- a/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-meth-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-func-decl.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = /*{ parameter-code }*/) {
   function arguments() {}
 }};

--- a/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-meth-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = /*{ parameter-code }*/) {
+  let arguments;
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-lex-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = /*{ parameter-code }*/) {
   let arguments;
 }};

--- a/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-meth-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = /*{ parameter-code }*/) {
+  var arguments;
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-var-bind.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = /*{ parameter-code }*/) {
   var arguments;
 }};

--- a/src/direct-eval-code/default/async-meth/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-meth/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/async-meth-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [async,noStrict]
+features: [globalThis]
+---*/
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = /*{ parameter-code }*/) {}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/src/direct-eval-code/default/async-meth/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/async-meth/no-pre-existing-arguments-bindings-are-present.template
@@ -8,10 +8,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [async,noStrict]
 features: [globalThis]
 ---*/
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = /*{ parameter-code }*/) {}};
 o.f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/src/direct-eval-code/default/func-decl/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/func-decl/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-decl-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/func-decl/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/func-decl/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-decl-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-decl-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-decl-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = /*{ parameter-code }*/) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-decl-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = /*{ parameter-code }*/) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/func-decl/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/func-decl/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-decl-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = /*{ parameter-code }*/) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/func-expr/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/func-expr/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-expr-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/func-expr/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/func-expr/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-expr-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-expr-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-expr-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = /*{ parameter-code }*/) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-expr-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = /*{ parameter-code }*/) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/func-expr/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/func-expr/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/func-expr-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = /*{ parameter-code }*/) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-decl/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/gen-func-decl/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-decl-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-decl/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/gen-func-decl/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-decl-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = /*{ parameter-code }*/) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = /*{ parameter-code }*/) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-decl/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/gen-func-decl/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = /*{ parameter-code }*/) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-named/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/gen-func-expr-named/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-named-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-named/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/gen-func-expr-named/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = /*{ parameter-code }*/) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = /*{ parameter-code }*/) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-named/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/gen-func-expr-named/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = /*{ parameter-code }*/) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-nameless/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/gen-func-expr-nameless/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-nameless/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/gen-func-expr-nameless/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = /*{ parameter-code }*/) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = /*{ parameter-code }*/) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = /*{ parameter-code }*/) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-func-expr-nameless/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/gen-func-expr-nameless/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = /*{ parameter-code }*/) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-meth/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/gen-meth/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-meth-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-meth/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/gen-meth/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-meth-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-meth-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}};
+assert.throws(SyntaxError, o.f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-meth-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = /*{ parameter-code }*/) {
+  let arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-meth-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = /*{ parameter-code }*/) {
+  var arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/gen-meth/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/gen-meth/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/gen-meth-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = /*{ parameter-code }*/) {}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/meth/a-following-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/meth/a-following-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/meth-a-following-parameter-is-named-arguments-
+name: Declare |arguments| when a following parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = /*{ parameter-code }*/, arguments) {
+  /*{ body }*/
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/meth/a-preceding-parameter-is-named-arguments.template
+++ b/src/direct-eval-code/default/meth/a-preceding-parameter-is-named-arguments.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/meth-a-preceding-parameter-is-named-arguments-
+name: Declare |arguments| when a preceding parameter is named |arguments|.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(arguments, p = /*{ parameter-code }*/) {
+  /*{ body }*/
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/meth/fn-body-cntns-arguments-func-decl.template
+++ b/src/direct-eval-code/default/meth/fn-body-cntns-arguments-func-decl.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/meth-fn-body-cntns-arguments-func-decl-
+name: Declare |arguments| when the function body contains an |arguments| function declaration.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = /*{ parameter-code }*/) {
+  function arguments() {}
+}};
+assert.throws(SyntaxError, o.f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/meth/fn-body-cntns-arguments-lex-bind.template
+++ b/src/direct-eval-code/default/meth/fn-body-cntns-arguments-lex-bind.template
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/meth-fn-body-cntns-arguments-lex-bind-
+name: Declare |arguments| when the function body contains an |arguments| lexical binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = /*{ parameter-code }*/) {
+  let arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/meth/fn-body-cntns-arguments-var-bind.template
+++ b/src/direct-eval-code/default/meth/fn-body-cntns-arguments-var-bind.template
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/meth-fn-body-cntns-arguments-var-bind-
+name: Declare |arguments| when the function body contains an |arguments| var-binding.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = /*{ parameter-code }*/) {
+  var arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/src/direct-eval-code/default/meth/no-pre-existing-arguments-bindings-are-present.template
+++ b/src/direct-eval-code/default/meth/no-pre-existing-arguments-bindings-are-present.template
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron, André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/eval-code/direct/meth-no-pre-existing-arguments-bindings-are-present-
+name: Declare |arguments| when no pre-existing |arguments| bindings are present.
+esid: sec-evaldeclarationinstantiation
+flags: [noStrict]
+---*/
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = /*{ parameter-code }*/) {}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -1,0 +1,15 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.case
+// - src/direct-eval-code/arrow-func/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+const f = (p = eval("var arguments = 'param'"), q = () => arguments, arguments) => {}
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 const f = (p = eval("var arguments = 'param'"), q = () => arguments, arguments) => {}
 assert.throws(SyntaxError, f);
 assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
@@ -1,0 +1,15 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign.case
+// - src/direct-eval-code/arrow-func/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+const f = (p = eval("var arguments = 'param'"), arguments) => {}
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 const f = (p = eval("var arguments = 'param'"), arguments) => {}
 assert.throws(SyntaxError, f);
 assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -1,0 +1,15 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.case
+// - src/direct-eval-code/arrow-func/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+const f = (arguments, p = eval("var arguments = 'param'"), q = () => arguments) => {}
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 const f = (arguments, p = eval("var arguments = 'param'"), q = () => arguments) => {}
 assert.throws(SyntaxError, f);
 assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
@@ -1,0 +1,15 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign.case
+// - src/direct-eval-code/arrow-func/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+const f = (arguments, p = eval("var arguments = 'param'")) => {}
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 const f = (arguments, p = eval("var arguments = 'param'")) => {}
 assert.throws(SyntaxError, f);
 assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.case
+// - src/direct-eval-code/arrow-func/fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = eval("var arguments = 'param'"), q = () => arguments) => {
+  function arguments() {}
+  assert.sameValue(typeof arguments, "function");
+  assert.sameValue(q(), "param");
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = eval("var arguments = 'param'"), q = () => arguments) => {
   function arguments() {}

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign.case
+// - src/direct-eval-code/arrow-func/fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = eval("var arguments = 'param'")) => {
+  function arguments() {}
+  assert.sameValue(typeof arguments, "function");
+  
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = eval("var arguments = 'param'")) => {
   function arguments() {}

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.case
+// - src/direct-eval-code/arrow-func/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = eval("var arguments = 'param'"), q = () => arguments) => {
+  function arguments() {}
+  assert.sameValue(typeof arguments, "function");
+  assert.sameValue(q(), "param");
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = eval("var arguments = 'param'"), q = () => arguments) => {
   function arguments() {}

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign.case
+// - src/direct-eval-code/arrow-func/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = eval("var arguments = 'param'")) => {
+  function arguments() {}
+  assert.sameValue(typeof arguments, "function");
+  
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = eval("var arguments = 'param'")) => {
   function arguments() {}

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.case
+// - src/direct-eval-code/arrow-func/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = eval("var arguments = 'param'"), q = () => arguments) => {
+  let arguments = "local";
+  assert.sameValue(arguments, "local");
+  assert.sameValue(q(), "param");
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = eval("var arguments = 'param'"), q = () => arguments) => {
   let arguments = "local";

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign.case
+// - src/direct-eval-code/arrow-func/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = eval("var arguments = 'param'")) => {
+  let arguments = "local";
+  assert.sameValue(arguments, "local");
+  
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = eval("var arguments = 'param'")) => {
   let arguments = "local";

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.case
+// - src/direct-eval-code/arrow-func/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = eval("var arguments = 'param'"), q = () => arguments) => {
+  var arguments = "local";
+  assert.sameValue(arguments, "local");
+  assert.sameValue(q(), "param");
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = eval("var arguments = 'param'"), q = () => arguments) => {
   var arguments = "local";

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign.case
+// - src/direct-eval-code/arrow-func/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = eval("var arguments = 'param'")) => {
+  var arguments = "local";
+  assert.sameValue(arguments, "local");
+  
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = eval("var arguments = 'param'")) => {
   var arguments = "local";

--- a/test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.case
+// - src/direct-eval-code/arrow-func/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = eval("var arguments = 'param'"), q = () => arguments) => {
+  assert.sameValue(arguments, "param");
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+++ b/test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = eval("var arguments = 'param'"), q = () => arguments) => {
   assert.sameValue(arguments, "param");

--- a/test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/arrow-func-declare-arguments-assign.case
+// - src/direct-eval-code/arrow-func/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+let count = 0;
+const f = (p = eval("var arguments = 'param'")) => {
+  assert.sameValue(arguments, "param");
+  count++;
+}
+f();
+assert.sameValue(count, 1);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js
+++ b/test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js
@@ -7,9 +7,7 @@ esid: sec-evaldeclarationinstantiation
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
 let count = 0;
 const f = (p = eval("var arguments = 'param'")) => {
   assert.sameValue(arguments, "param");

--- a/test/language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-decl/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = eval("var arguments = 'param'"), arguments) {
+  
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = eval("var arguments = 'param'"), arguments) {
   
 }

--- a/test/language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-decl/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = eval("var arguments"), arguments) {
+  
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = eval("var arguments"), arguments) {
   
 }

--- a/test/language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-decl/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(arguments, p = eval("var arguments = 'param'")) {
+  
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(arguments, p = eval("var arguments = 'param'")) {
   
 }

--- a/test/language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-decl/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(arguments, p = eval("var arguments")) {
+  
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(arguments, p = eval("var arguments")) {
   
 }

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = eval("var arguments = 'param'")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = eval("var arguments")) {
+  function arguments() {}
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = eval("var arguments")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = eval("var arguments = 'param'")) {
+  let arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = eval("var arguments = 'param'")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = eval("var arguments")) {
+  let arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = eval("var arguments")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = eval("var arguments = 'param'")) {
+  var arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = eval("var arguments = 'param'")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-decl/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = eval("var arguments")) {
+  var arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = eval("var arguments")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-decl/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = eval("var arguments = 'param'")) {}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = eval("var arguments = 'param'")) {}
 f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/test/language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-decl/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function f(p = eval("var arguments")) {}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function f(p = eval("var arguments")) {}
 f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/test/language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-named/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = eval("var arguments = 'param'"), arguments) {
+  
+};
+f().then($DONE, error => {
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+  assert(error instanceof SyntaxError);
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = eval("var arguments = 'param'"), arguments) {
   
 };

--- a/test/language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-named/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = eval("var arguments"), arguments) {
+  
+};
+f().then($DONE, error => {
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+  assert(error instanceof SyntaxError);
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = eval("var arguments"), arguments) {
   
 };

--- a/test/language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-named/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(arguments, p = eval("var arguments = 'param'")) {
+  
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(arguments, p = eval("var arguments = 'param'")) {
   
 }

--- a/test/language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-named/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(arguments, p = eval("var arguments")) {
+  
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(arguments, p = eval("var arguments")) {
   
 }

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = eval("var arguments = 'param'")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = eval("var arguments")) {
+  function arguments() {}
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = eval("var arguments")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = eval("var arguments = 'param'")) {
+  let arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = eval("var arguments = 'param'")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = eval("var arguments")) {
+  let arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = eval("var arguments")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = eval("var arguments = 'param'")) {
+  var arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = eval("var arguments = 'param'")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,22 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-named/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = eval("var arguments")) {
+  var arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = eval("var arguments")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-named/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = eval("var arguments = 'param'")) {}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = eval("var arguments = 'param'")) {}
 f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/test/language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-named/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function f(p = eval("var arguments")) {}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);
+

--- a/test/language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function f(p = eval("var arguments")) {}
 f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/test/language/eval-code/direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-nameless/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = eval("var arguments = 'param'"), arguments) {
+  
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = eval("var arguments = 'param'"), arguments) {
   
 }

--- a/test/language/eval-code/direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-nameless/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = eval("var arguments"), arguments) {
+  
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = eval("var arguments"), arguments) {
   
 }

--- a/test/language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-nameless/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(arguments, p = eval("var arguments = 'param'")) {
+  
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(arguments, p = eval("var arguments = 'param'")) {
   
 }

--- a/test/language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-nameless/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(arguments, p = eval("var arguments")) {
+  
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(arguments, p = eval("var arguments")) {
   
 }

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = eval("var arguments = 'param'")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = eval("var arguments")) {
+  function arguments() {}
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = eval("var arguments")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = eval("var arguments = 'param'")) {
+  let arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = eval("var arguments = 'param'")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = eval("var arguments")) {
+  let arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = eval("var arguments")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = eval("var arguments = 'param'")) {
+  var arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = eval("var arguments = 'param'")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-nameless/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = eval("var arguments")) {
+  var arguments;
+}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = eval("var arguments")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-func-expr-nameless/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = eval("var arguments = 'param'")) {}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = eval("var arguments = 'param'")) {}
 f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/test/language/eval-code/direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-func-expr-nameless/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function(p = eval("var arguments")) {}
+f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function(p = eval("var arguments")) {}
 f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-decl/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = eval("var arguments = 'param'"), arguments) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = eval("var arguments = 'param'"), arguments) {
   
 }

--- a/test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-decl/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = eval("var arguments"), arguments) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = eval("var arguments"), arguments) {
   
 }

--- a/test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-decl/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(arguments, p = eval("var arguments = 'param'")) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(arguments, p = eval("var arguments = 'param'")) {
   
 }

--- a/test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-decl/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(arguments, p = eval("var arguments")) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(arguments, p = eval("var arguments")) {
   
 }

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = eval("var arguments = 'param'")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = eval("var arguments")) {
+  function arguments() {}
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = eval("var arguments")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = eval("var arguments = 'param'")) {
+  let arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = eval("var arguments = 'param'")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = eval("var arguments")) {
+  let arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = eval("var arguments")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = eval("var arguments = 'param'")) {
+  var arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = eval("var arguments = 'param'")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-decl/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = eval("var arguments")) {
+  var arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = eval("var arguments")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-decl/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = eval("var arguments = 'param'")) {}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = eval("var arguments = 'param'")) {}
 
 assert.throws(SyntaxError, f);

--- a/test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-decl/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+async function * f(p = eval("var arguments")) {}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 async function * f(p = eval("var arguments")) {}
 
 assert.throws(SyntaxError, f);

--- a/test/language/eval-code/direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-expr/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = eval("var arguments = 'param'"), arguments) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = eval("var arguments = 'param'"), arguments) {
   
 }

--- a/test/language/eval-code/direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-expr/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = eval("var arguments"), arguments) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = eval("var arguments"), arguments) {
   
 }

--- a/test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-expr/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (arguments, p = eval("var arguments = 'param'")) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (arguments, p = eval("var arguments = 'param'")) {
   
 }

--- a/test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-expr/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (arguments, p = eval("var arguments")) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (arguments, p = eval("var arguments")) {
   
 }

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = eval("var arguments = 'param'")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = eval("var arguments")) {
+  function arguments() {}
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = eval("var arguments")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = eval("var arguments = 'param'")) {
+  let arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = eval("var arguments = 'param'")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = eval("var arguments")) {
+  let arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = eval("var arguments")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = eval("var arguments = 'param'")) {
+  var arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = eval("var arguments = 'param'")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-expr/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = eval("var arguments")) {
+  var arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = eval("var arguments")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-func-expr/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = eval("var arguments = 'param'")) {}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = eval("var arguments = 'param'")) {}
 
 assert.throws(SyntaxError, f);

--- a/test/language/eval-code/direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-func-expr/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * (p = eval("var arguments")) {}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * (p = eval("var arguments")) {}
 
 assert.throws(SyntaxError, f);

--- a/test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-meth/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = eval("var arguments = 'param'"), arguments) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = eval("var arguments = 'param'"), arguments) {
   
 }};

--- a/test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-meth/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = eval("var arguments"), arguments) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = eval("var arguments"), arguments) {
   
 }};

--- a/test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-meth/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(arguments, p = eval("var arguments = 'param'")) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(arguments, p = eval("var arguments = 'param'")) {
   
 }};

--- a/test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-meth/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(arguments, p = eval("var arguments")) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(arguments, p = eval("var arguments")) {
   
 }};

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = eval("var arguments = 'param'")) {
   function arguments() {}
 }};

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = eval("var arguments")) {
+  function arguments() {}
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = eval("var arguments")) {
   function arguments() {}
 }};

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = eval("var arguments = 'param'")) {
+  let arguments;
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = eval("var arguments = 'param'")) {
   let arguments;
 }};

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = eval("var arguments")) {
+  let arguments;
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = eval("var arguments")) {
   let arguments;
 }};

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = eval("var arguments = 'param'")) {
+  var arguments;
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = eval("var arguments = 'param'")) {
   var arguments;
 }};

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-meth/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = eval("var arguments")) {
+  var arguments;
+}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = eval("var arguments")) {
   var arguments;
 }};

--- a/test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,17 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-meth/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = eval("var arguments = 'param'")) {}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = eval("var arguments = 'param'")) {}};
 assert.throws(SyntaxError, o.f);
 assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,17 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-meth/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async *f(p = eval("var arguments")) {}};
+assert.throws(SyntaxError, o.f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async *f(p = eval("var arguments")) {}};
 assert.throws(SyntaxError, o.f);
 assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = eval("var arguments = 'param'"), arguments) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = eval("var arguments = 'param'"), arguments) {
   
 }

--- a/test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = eval("var arguments"), arguments) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = eval("var arguments"), arguments) {
   
 }

--- a/test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(arguments, p = eval("var arguments = 'param'")) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(arguments, p = eval("var arguments = 'param'")) {
   
 }

--- a/test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(arguments, p = eval("var arguments")) {
+  
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(arguments, p = eval("var arguments")) {
   
 }

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = eval("var arguments = 'param'")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = eval("var arguments")) {
+  function arguments() {}
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = eval("var arguments")) {
   function arguments() {}
 }

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = eval("var arguments = 'param'")) {
+  let arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = eval("var arguments = 'param'")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = eval("var arguments")) {
+  let arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = eval("var arguments")) {
   let arguments;
 }

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = eval("var arguments = 'param'")) {
+  var arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = eval("var arguments = 'param'")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,20 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = eval("var arguments")) {
+  var arguments;
+}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = eval("var arguments")) {
   var arguments;
 }

--- a/test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = eval("var arguments = 'param'")) {}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = eval("var arguments = 'param'")) {}
 
 assert.throws(SyntaxError, f);

--- a/test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-gen-named-func-expr/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let f = async function * f(p = eval("var arguments")) {}
+
+assert.throws(SyntaxError, f);
+assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");

--- a/test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let f = async function * f(p = eval("var arguments")) {}
 
 assert.throws(SyntaxError, f);

--- a/test/language/eval-code/direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-meth/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = eval("var arguments = 'param'"), arguments) {
+  
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = eval("var arguments = 'param'"), arguments) {
   
 }};

--- a/test/language/eval-code/direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-meth/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = eval("var arguments"), arguments) {
+  
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = eval("var arguments"), arguments) {
   
 }};

--- a/test/language/eval-code/direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-meth/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(arguments, p = eval("var arguments = 'param'")) {
+  
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(arguments, p = eval("var arguments = 'param'")) {
   
 }};

--- a/test/language/eval-code/direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-meth/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(arguments, p = eval("var arguments")) {
+  
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(arguments, p = eval("var arguments")) {
   
 }};

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = eval("var arguments = 'param'")) {
   function arguments() {}
 }};

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = eval("var arguments")) {
+  function arguments() {}
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = eval("var arguments")) {
   function arguments() {}
 }};

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = eval("var arguments = 'param'")) {
+  let arguments;
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = eval("var arguments = 'param'")) {
   let arguments;
 }};

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = eval("var arguments")) {
+  let arguments;
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = eval("var arguments")) {
   let arguments;
 }};

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = eval("var arguments = 'param'")) {
+  var arguments;
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = eval("var arguments = 'param'")) {
   var arguments;
 }};

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,21 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-meth/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = eval("var arguments")) {
+  var arguments;
+}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = eval("var arguments")) {
   var arguments;
 }};

--- a/test/language/eval-code/direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/async-meth/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = eval("var arguments = 'param'")) {}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = eval("var arguments = 'param'")) {}};
 o.f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/test/language/eval-code/direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/async-meth/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+features: [globalThis]
+flags: [generated, async, noStrict]
+---*/
+
+
+const oldArguments = globalThis.arguments;
+
+
+let o = { async f(p = eval("var arguments")) {}};
+o.f().then($DONE, error => {
+  assert(error instanceof SyntaxError);
+  assert.sameValue(globalThis.arguments, oldArguments, "globalThis.arguments unchanged");
+}).then($DONE, $DONE);

--- a/test/language/eval-code/direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -8,10 +8,7 @@ features: [globalThis]
 flags: [generated, async, noStrict]
 ---*/
 
-
 const oldArguments = globalThis.arguments;
-
-
 let o = { async f(p = eval("var arguments")) {}};
 o.f().then($DONE, error => {
   assert(error instanceof SyntaxError);

--- a/test/language/eval-code/direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-decl/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = eval("var arguments = 'param'"), arguments) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-decl/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = eval("var arguments"), arguments) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-decl/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(arguments, p = eval("var arguments = 'param'")) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-decl/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(arguments, p = eval("var arguments")) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = eval("var arguments")) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = eval("var arguments = 'param'")) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = eval("var arguments")) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = eval("var arguments = 'param'")) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-decl/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = eval("var arguments")) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-decl/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = eval("var arguments = 'param'")) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-decl/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function f(p = eval("var arguments")) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-expr/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = eval("var arguments = 'param'"), arguments) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-expr/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = eval("var arguments"), arguments) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-expr/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(arguments, p = eval("var arguments = 'param'")) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-expr/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(arguments, p = eval("var arguments")) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = eval("var arguments")) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = eval("var arguments = 'param'")) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = eval("var arguments")) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = eval("var arguments = 'param'")) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-expr/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = eval("var arguments")) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/func-expr/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = eval("var arguments = 'param'")) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/func-expr/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function(p = eval("var arguments")) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-decl/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = eval("var arguments = 'param'"), arguments) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-decl/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = eval("var arguments"), arguments) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-decl/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(arguments, p = eval("var arguments = 'param'")) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-decl/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(arguments, p = eval("var arguments")) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = eval("var arguments")) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = eval("var arguments = 'param'")) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = eval("var arguments")) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = eval("var arguments = 'param'")) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-decl/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = eval("var arguments")) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-decl/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = eval("var arguments = 'param'")) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-decl/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+function * f(p = eval("var arguments")) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-named/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = eval("var arguments = 'param'"), arguments) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-named/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = eval("var arguments"), arguments) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-named/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(arguments, p = eval("var arguments = 'param'")) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-named/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(arguments, p = eval("var arguments")) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = eval("var arguments")) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = eval("var arguments = 'param'")) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = eval("var arguments")) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = eval("var arguments = 'param'")) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-named/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = eval("var arguments")) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-named/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = eval("var arguments = 'param'")) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-named/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * f(p = eval("var arguments")) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = eval("var arguments = 'param'"), arguments) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = eval("var arguments"), arguments) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (arguments, p = eval("var arguments = 'param'")) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (arguments, p = eval("var arguments")) {
+  
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = eval("var arguments")) {
+  function arguments() {}
+}
+assert.throws(SyntaxError, f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = eval("var arguments = 'param'")) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = eval("var arguments")) {
+  let arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = eval("var arguments = 'param'")) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = eval("var arguments")) {
+  var arguments;
+}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = eval("var arguments = 'param'")) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-func-expr-nameless/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let f = function * (p = eval("var arguments")) {}
+assert.throws(SyntaxError, f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-meth/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = eval("var arguments = 'param'"), arguments) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-meth/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = eval("var arguments"), arguments) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-meth/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(arguments, p = eval("var arguments = 'param'")) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-meth/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(arguments, p = eval("var arguments")) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}};
+assert.throws(SyntaxError, o.f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = eval("var arguments")) {
+  function arguments() {}
+}};
+assert.throws(SyntaxError, o.f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = eval("var arguments = 'param'")) {
+  let arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = eval("var arguments")) {
+  let arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = eval("var arguments = 'param'")) {
+  var arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-meth/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = eval("var arguments")) {
+  var arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/gen-meth/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = eval("var arguments = 'param'")) {}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/gen-meth/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { * f(p = eval("var arguments")) {}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/meth/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = eval("var arguments = 'param'"), arguments) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/meth/a-following-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a following parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = eval("var arguments"), arguments) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/meth/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(arguments, p = eval("var arguments = 'param'")) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
+++ b/test/language/eval-code/direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/meth/a-preceding-parameter-is-named-arguments.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when a preceding parameter is named |arguments|.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(arguments, p = eval("var arguments")) {
+  
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/meth/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = eval("var arguments = 'param'")) {
+  function arguments() {}
+}};
+assert.throws(SyntaxError, o.f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
+++ b/test/language/eval-code/direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/meth/fn-body-cntns-arguments-func-decl.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| function declaration.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = eval("var arguments")) {
+  function arguments() {}
+}};
+assert.throws(SyntaxError, o.f);
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/meth/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = eval("var arguments = 'param'")) {
+  let arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/meth/fn-body-cntns-arguments-lex-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| lexical binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = eval("var arguments")) {
+  let arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/meth/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = eval("var arguments = 'param'")) {
+  var arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
+++ b/test/language/eval-code/direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
@@ -1,0 +1,18 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/meth/fn-body-cntns-arguments-var-bind.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when the function body contains an |arguments| var-binding.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = eval("var arguments")) {
+  var arguments;
+}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+++ b/test/language/eval-code/direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments-and-assign.case
+// - src/direct-eval-code/default/meth/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = eval("var arguments = 'param'")) {}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/test/language/eval-code/direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+++ b/test/language/eval-code/direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
@@ -1,0 +1,16 @@
+// This file was procedurally generated from the following sources:
+// - src/direct-eval-code/declare-arguments.case
+// - src/direct-eval-code/default/meth/no-pre-existing-arguments-bindings-are-present.template
+/*---
+description: Declare "arguments" and assign to it in direct eval code (Declare |arguments| when no pre-existing |arguments| bindings are present.)
+esid: sec-evaldeclarationinstantiation
+flags: [generated, noStrict]
+---*/
+
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");
+
+let o = { f(p = eval("var arguments")) {}};
+assert.throws(SyntaxError, o.f);
+
+assert.sameValue("arguments" in this, false, "No global 'arguments' binding");

--- a/tools/generation/lib/expander.py
+++ b/tools/generation/lib/expander.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2016 the V8 project authors. All rights reserved.
 # This code is governed by the BSD license found in the LICENSE file.
 
-import re, os
+import glob, os, re
 
 from .case import Case
 from .template import Template
@@ -16,10 +16,15 @@ class Expander:
 
     def _load_templates(self, template_class, encoding):
         directory = os.path.join(self.case_dir, template_class)
-        file_names = map(
-            lambda x: os.path.join(directory, x),
-            filter(self.is_template_file, os.listdir(directory))
-        )
+        file_names = []
+
+        for expanded_directory in glob.glob(directory):
+            file_names.extend(
+                map(
+                    lambda x: os.path.join(expanded_directory, x),
+                    filter(self.is_template_file, os.listdir(expanded_directory))
+                )
+            )
 
         self.templates[template_class] = [
             Template(x, encoding) for x in file_names

--- a/tools/generation/test/expected/glob/normal/a-features-glob.js
+++ b/tools/generation/test/expected/glob/normal/a-features-glob.js
@@ -1,0 +1,14 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/glob.case
+// - tools/generation/test/fixtures/glob/a/features.template
+/*---
+description: foobar (First template name)
+es6id: 1.2.3
+features: [f1]
+flags: [generated, a, b]
+includes: [foo.js]
+info: |
+    case info
+---*/
+
+'This is "teardown" code.';

--- a/tools/generation/test/expected/glob/normal/a-info-multiline-folding-glob.js
+++ b/tools/generation/test/expected/glob/normal/a-info-multiline-folding-glob.js
@@ -1,0 +1,30 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/glob.case
+// - tools/generation/test/fixtures/glob/a/info-multiline-folding.template
+/*---
+description: foobar (First template name)
+es6id: 1.2.3
+flags: [generated, a, b]
+includes: [foo.js]
+info: |
+    This is an "info" field with an
+
+    empty line
+    Trailing white space in the template:
+    should be preserved:
+
+
+    case info
+---*/
+
+// Trailing white space in the test body:
+// should be preserved:
+
+
+
+
+
+
+
+
+'This is "teardown" code.';

--- a/tools/generation/test/expected/glob/normal/a-nested/path2-glob.js
+++ b/tools/generation/test/expected/glob/normal/a-nested/path2-glob.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/glob.case
+// - tools/generation/test/fixtures/glob/a/normal2.template
+/*---
+description: foobar (Second template name)
+esid: sec-a-generic-id
+flags: [generated, a, b]
+includes: [foo.js, bar.js]
+info: |
+    template info
+
+    case info
+---*/
+
+before-Third value (Special characters like `≠` should be tolerated.)Second value-after
+
+/* Improperly-terminated comments should not break the tokenizer *
+
+'This is "teardown" code.';

--- a/tools/generation/test/expected/glob/normal/a-no-info-glob.js
+++ b/tools/generation/test/expected/glob/normal/a-no-info-glob.js
@@ -1,0 +1,15 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/glob.case
+// - tools/generation/test/fixtures/glob/a/no-info.template
+/*---
+description: foobar (First template name)
+es6id: 1.2.3
+flags: [generated, a, b]
+includes: [foo.js]
+info: |
+    case info
+---*/
+
+First value
+
+'This is "teardown" code.';

--- a/tools/generation/test/expected/glob/normal/a-path1-glob.js
+++ b/tools/generation/test/expected/glob/normal/a-path1-glob.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/glob.case
+// - tools/generation/test/fixtures/glob/a/normal.template
+/*---
+description: foobar (First template name)
+es6id: 1.2.3
+flags: [generated, a, b, c, d]
+includes: [foo.js]
+info: |
+    template info
+
+    case info
+---*/
+
+before-First value-between-Third value (Special characters like `≠` should be tolerated.)-after
+
+before*Second value*between*First value*after
+
+before/* " */Third value (Special characters like `≠` should be tolerated.)after
+
+// Special characters like `≠` should be tolerated.
+
+The following should not be expanded:
+
+/* */*{ first }*/
+/*
+*/*{ first }*/
+//*{ first }*/
+// /*{ first }*/
+Quote characters: " ' `
+"Quote characters: ' ' `"
+'Quote characters: " " `'
+`
+Quote characters: " ' '`
+
+'This is "teardown" code.';

--- a/tools/generation/test/expected/glob/normal/b-features-glob.js
+++ b/tools/generation/test/expected/glob/normal/b-features-glob.js
@@ -1,0 +1,14 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/glob.case
+// - tools/generation/test/fixtures/glob/b/features.template
+/*---
+description: foobar (First template name)
+es6id: 1.2.3
+features: [f1]
+flags: [generated, a, b]
+includes: [foo.js]
+info: |
+    case info
+---*/
+
+'This is "teardown" code.';

--- a/tools/generation/test/expected/glob/normal/b-info-multiline-folding-glob.js
+++ b/tools/generation/test/expected/glob/normal/b-info-multiline-folding-glob.js
@@ -1,0 +1,30 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/glob.case
+// - tools/generation/test/fixtures/glob/b/info-multiline-folding.template
+/*---
+description: foobar (First template name)
+es6id: 1.2.3
+flags: [generated, a, b]
+includes: [foo.js]
+info: |
+    This is an "info" field with an
+
+    empty line
+    Trailing white space in the template:
+    should be preserved:
+
+
+    case info
+---*/
+
+// Trailing white space in the test body:
+// should be preserved:
+
+
+
+
+
+
+
+
+'This is "teardown" code.';

--- a/tools/generation/test/expected/glob/normal/b-nested/path2-glob.js
+++ b/tools/generation/test/expected/glob/normal/b-nested/path2-glob.js
@@ -1,0 +1,19 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/glob.case
+// - tools/generation/test/fixtures/glob/b/normal2.template
+/*---
+description: foobar (Second template name)
+esid: sec-a-generic-id
+flags: [generated, a, b]
+includes: [foo.js, bar.js]
+info: |
+    template info
+
+    case info
+---*/
+
+before-Third value (Special characters like `≠` should be tolerated.)Second value-after
+
+/* Improperly-terminated comments should not break the tokenizer *
+
+'This is "teardown" code.';

--- a/tools/generation/test/expected/glob/normal/b-no-info-glob.js
+++ b/tools/generation/test/expected/glob/normal/b-no-info-glob.js
@@ -1,0 +1,15 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/glob.case
+// - tools/generation/test/fixtures/glob/b/no-info.template
+/*---
+description: foobar (First template name)
+es6id: 1.2.3
+flags: [generated, a, b]
+includes: [foo.js]
+info: |
+    case info
+---*/
+
+First value
+
+'This is "teardown" code.';

--- a/tools/generation/test/expected/glob/normal/b-path1-glob.js
+++ b/tools/generation/test/expected/glob/normal/b-path1-glob.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/glob.case
+// - tools/generation/test/fixtures/glob/b/normal.template
+/*---
+description: foobar (First template name)
+es6id: 1.2.3
+flags: [generated, a, b, c, d]
+includes: [foo.js]
+info: |
+    template info
+
+    case info
+---*/
+
+before-First value-between-Third value (Special characters like `≠` should be tolerated.)-after
+
+before*Second value*between*First value*after
+
+before/* " */Third value (Special characters like `≠` should be tolerated.)after
+
+// Special characters like `≠` should be tolerated.
+
+The following should not be expanded:
+
+/* */*{ first }*/
+/*
+*/*{ first }*/
+//*{ first }*/
+// /*{ first }*/
+Quote characters: " ' `
+"Quote characters: ' ' `"
+'Quote characters: " " `'
+`
+Quote characters: " ' '`
+
+'This is "teardown" code.';

--- a/tools/generation/test/fixtures/glob.case
+++ b/tools/generation/test/fixtures/glob.case
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+template: glob/*
+desc: foobar
+info: case info
+flags: [a, b]
+includes: [foo.js]
+---*/
+
+Because this test appears before any "region" delimiters, it should not appear
+in the generated files.
+
+// - first
+this is not a valid region delimiter
+
+/* *//- first
+this is also not a valid region delimiter
+
+//- first
+First value
+//- second
+Second value
+//- third
+Third value (Special characters like `≠` should be tolerated.)
+//- fourth
+Quote characters: " ' `
+//- teardown
+'This is "teardown" code.';

--- a/tools/generation/test/fixtures/glob/a/features.template
+++ b/tools/generation/test/fixtures/glob/a/features.template
@@ -1,0 +1,8 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: First template name
+path: glob/normal/a-features-
+es6id: 1.2.3
+features: [f1]
+---*/

--- a/tools/generation/test/fixtures/glob/a/info-multiline-folding.template
+++ b/tools/generation/test/fixtures/glob/a/info-multiline-folding.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: First template name
+path: glob/normal/a-info-multiline-folding-
+es6id: 1.2.3
+info: |
+    This is an "info" field with an
+
+    empty line
+    Trailing white space in the template:
+    should be preserved:
+
+
+
+
+
+
+
+---*/
+
+// Trailing white space in the test body:
+// should be preserved:
+
+
+
+
+
+
+

--- a/tools/generation/test/fixtures/glob/a/no-info.template
+++ b/tools/generation/test/fixtures/glob/a/no-info.template
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: First template name
+path: glob/normal/a-no-info-
+es6id: 1.2.3
+---*/
+
+/*{ first }*/

--- a/tools/generation/test/fixtures/glob/a/normal.template
+++ b/tools/generation/test/fixtures/glob/a/normal.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: First template name
+path: glob/normal/a-path1-
+es6id: 1.2.3
+info: template info
+flags: [c, d]
+---*/
+
+before-/*{ first }*/-between-/*{ third }*/-after
+
+before*/*{ second }*/*between*/*{ first }*/*after
+
+before/* " *//*{ third }*/after
+
+// Special characters like `≠` should be tolerated.
+
+The following should not be expanded:
+
+/* */*{ first }*/
+/*
+*/*{ first }*/
+//*{ first }*/
+// /*{ first }*/
+/*{ fourth }*/
+"/*{ fourth }*/"
+'/*{ fourth }*/'
+`
+/*{ fourth }*/`

--- a/tools/generation/test/fixtures/glob/a/normal2.template
+++ b/tools/generation/test/fixtures/glob/a/normal2.template
@@ -1,0 +1,13 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: Second template name
+path: glob/normal/a-nested/path2-
+esid: sec-a-generic-id
+includes: [bar.js]
+info: template info
+---*/
+
+before-/*{ third }*//*{ second }*/-after
+
+/* Improperly-terminated comments should not break the tokenizer *

--- a/tools/generation/test/fixtures/glob/b/features.template
+++ b/tools/generation/test/fixtures/glob/b/features.template
@@ -1,0 +1,8 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: First template name
+path: glob/normal/b-features-
+es6id: 1.2.3
+features: [f1]
+---*/

--- a/tools/generation/test/fixtures/glob/b/info-multiline-folding.template
+++ b/tools/generation/test/fixtures/glob/b/info-multiline-folding.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: First template name
+path: glob/normal/b-info-multiline-folding-
+es6id: 1.2.3
+info: |
+    This is an "info" field with an
+
+    empty line
+    Trailing white space in the template:
+    should be preserved:
+
+
+
+
+
+
+
+---*/
+
+// Trailing white space in the test body:
+// should be preserved:
+
+
+
+
+
+
+

--- a/tools/generation/test/fixtures/glob/b/no-info.template
+++ b/tools/generation/test/fixtures/glob/b/no-info.template
@@ -1,0 +1,9 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: First template name
+path: glob/normal/b-no-info-
+es6id: 1.2.3
+---*/
+
+/*{ first }*/

--- a/tools/generation/test/fixtures/glob/b/normal.template
+++ b/tools/generation/test/fixtures/glob/b/normal.template
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: First template name
+path: glob/normal/b-path1-
+es6id: 1.2.3
+info: template info
+flags: [c, d]
+---*/
+
+before-/*{ first }*/-between-/*{ third }*/-after
+
+before*/*{ second }*/*between*/*{ first }*/*after
+
+before/* " *//*{ third }*/after
+
+// Special characters like `≠` should be tolerated.
+
+The following should not be expanded:
+
+/* */*{ first }*/
+/*
+*/*{ first }*/
+//*{ first }*/
+// /*{ first }*/
+/*{ fourth }*/
+"/*{ fourth }*/"
+'/*{ fourth }*/'
+`
+/*{ fourth }*/`

--- a/tools/generation/test/fixtures/glob/b/normal2.template
+++ b/tools/generation/test/fixtures/glob/b/normal2.template
@@ -1,0 +1,13 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+name: Second template name
+path: glob/normal/b-nested/path2-
+esid: sec-a-generic-id
+includes: [bar.js]
+info: template info
+---*/
+
+before-/*{ third }*//*{ second }*/-after
+
+/* Improperly-terminated comments should not break the tokenizer *

--- a/tools/generation/test/run.py
+++ b/tools/generation/test/run.py
@@ -49,6 +49,11 @@ class TestGeneration(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(OUT_DIR, ignore_errors=True)
 
+    def test_glob(self):
+        result = self.fixture('glob.case')
+        self.assertEqual(result['returncode'], 0)
+        self.compareTrees('glob')
+
     def test_normal(self):
         result = self.fixture('normal.case')
         self.assertEqual(result['returncode'], 0)


### PR DESCRIPTION
@anba I used your report and spidermonkey tests (from here https://github.com/tc39/test262/issues/2478) as the basis for the test cases & templates. Can you take a look? 