### PR TITLE
Add tests for \9 in template/strict strings.

### DIFF
--- a/test/language/expressions/tagged-template/invalid-escape-sequences.js
+++ b/test/language/expressions/tagged-template/invalid-escape-sequences.js
@@ -17,6 +17,16 @@ esid: sec-template-literal-lexical-components
 
 (strs => {
   assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\8');
+})`\8`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
+  assert.sameValue(strs.raw[0], '\\9');
+})`\9`;
+
+(strs => {
+  assert.sameValue(strs[0], undefined, 'Cooked template value should be undefined for illegal escape sequences');
   assert.sameValue(strs.raw[0], '\\xg');
 })`\xg`;
 

--- a/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence-9.js
+++ b/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence-9.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2020 Sony Interactive Entertainment Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-template-literal-lexical-components
+description: >
+    Invalid octal escape sequence (regardless of the presence of Annex B)
+info: |
+    A conforming implementation must not use the extended definition of
+    EscapeSequence described in B.1.2 when parsing a TemplateCharacter.
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+`\9`;

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-9-strict.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-9-strict.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Sony Interactive Entertainment Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-literals-string-literals
+description: >
+    LegacyOctalEscapeSequence is not enabled in strict mode code
+    (regardless of the presence of Annex B)
+info: |
+    A conforming implementation, when processing strict mode code, must not extend the
+    syntax of EscapeSequence to include LegacyOctalEscapeSequence as described in B.1.2.
+flags: [onlyStrict]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+'\9';


### PR DESCRIPTION
Supplement to #2654, per @syg's request.

I just included tests for \8 in that PR but we really should check \9 as well for completeness.