### PR TITLE
Assert that instance methods can be named "prototype"

### DIFF
--- a/src/class-elements/grammar-special-prototype-accessor-meth-valid.case
+++ b/src/class-elements/grammar-special-prototype-accessor-meth-valid.case
@@ -1,0 +1,51 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Accessor Methods can be named "prototype"
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    MethodDefinition : get PropertyName ( ) { FunctionBody }
+
+    [...]
+    9. Let desc be the PropertyDescriptor { [[Get]]: closure, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    10. Return ? DefinePropertyOrThrow(object, propKey, desc).
+
+    MethodDefinition : set PropertyName ( PropertySetParameterList ) { FunctionBody }
+
+    [...]
+    8. Let desc be the PropertyDescriptor { [[Set]]: closure, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    9. Return ? DefinePropertyOrThrow(object, propKey, desc).
+template: syntax/valid
+includes: [propertyHelper.js]
+---*/
+
+//- elements
+get prototype() { return 13; }
+set prototype(_) {}
+//- teardown
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+assert.sameValue(C.prototype.prototype, 13);
+verifyProperty(C.prototype, 'prototype', {
+    enumerable: false,
+    configurable: true,
+});

--- a/src/class-elements/grammar-special-prototype-async-gen-meth-valid.case
+++ b/src/class-elements/grammar-special-prototype-async-gen-meth-valid.case
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Async Generator Methods can be named "prototype"
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    AsyncGeneratorMethod : async * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+    [...]
+    10. Let desc be PropertyDescriptor { [[Value]]: closure, [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    11. Return ? DefinePropertyOrThrow(object, propKey, desc).
+template: syntax/valid
+features: [async-iteration]
+includes: [propertyHelper.js]
+---*/
+
+//- elements
+async * prototype() {}
+//- teardown
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/src/class-elements/grammar-special-prototype-async-meth-valid.case
+++ b/src/class-elements/grammar-special-prototype-async-meth-valid.case
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Async Methods can be named "prototype"
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    AsyncMethod : async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+
+    [...]
+    8. Let desc be the PropertyDescriptor { [[Value]]: closure, [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    9. Return ? DefinePropertyOrThrow(object, propKey, desc).
+template: syntax/valid
+features: [async-functions]
+includes: [propertyHelper.js]
+---*/
+
+//- elements
+async prototype() {}
+//- teardown
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/src/class-elements/grammar-special-prototype-gen-meth-valid.case
+++ b/src/class-elements/grammar-special-prototype-gen-meth-valid.case
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Generator Methods can be named "prototype"
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    GeneratorMethod : * PropertyName ( UniqueFormalParameters ) { GeneratorBody }
+
+    [...]
+    10. Let desc be the PropertyDescriptor { [[Value]]: closure, [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    11. Return ? DefinePropertyOrThrow(object, propKey, desc).
+template: syntax/valid
+features: [generators]
+includes: [propertyHelper.js]
+---*/
+
+//- elements
+* prototype() {}
+//- teardown
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/src/class-elements/grammar-special-prototype-meth-valid.case
+++ b/src/class-elements/grammar-special-prototype-meth-valid.case
@@ -1,0 +1,44 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Methods can be named "prototype"
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt } 
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    MethodDefinition : PropertyName ( UniqueFormalParameters ) { FunctionBody }
+
+    [...]
+    3. Let desc be the PropertyDescriptor { [[Value]]: methodDef.[[Closure]], [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    4. Return ? DefinePropertyOrThrow(object, methodDef.[[Key]], desc).
+template: syntax/valid
+includes: [propertyHelper.js]
+---*/
+
+//- elements
+prototype() {}
+//- teardown
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/test/language/expressions/class/elements/syntax/valid/grammar-special-prototype-accessor-meth-valid.js
+++ b/test/language/expressions/class/elements/syntax/valid/grammar-special-prototype-accessor-meth-valid.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-special-prototype-accessor-meth-valid.case
+// - src/class-elements/syntax/valid/cls-expr-elements-valid-syntax.template
+/*---
+description: Accessor Methods can be named "prototype" (class expression)
+esid: prod-ClassElement
+features: [class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    MethodDefinition : get PropertyName ( ) { FunctionBody }
+
+    [...]
+    9. Let desc be the PropertyDescriptor { [[Get]]: closure, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    10. Return ? DefinePropertyOrThrow(object, propKey, desc).
+
+    MethodDefinition : set PropertyName ( PropertySetParameterList ) { FunctionBody }
+
+    [...]
+    8. Let desc be the PropertyDescriptor { [[Set]]: closure, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    9. Return ? DefinePropertyOrThrow(object, propKey, desc).
+
+---*/
+
+
+var C = class {
+  get prototype() { return 13; }
+  set prototype(_) {}
+};
+
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+assert.sameValue(C.prototype.prototype, 13);
+verifyProperty(C.prototype, 'prototype', {
+    enumerable: false,
+    configurable: true,
+});

--- a/test/language/expressions/class/elements/syntax/valid/grammar-special-prototype-async-gen-meth-valid.js
+++ b/test/language/expressions/class/elements/syntax/valid/grammar-special-prototype-async-gen-meth-valid.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-special-prototype-async-gen-meth-valid.case
+// - src/class-elements/syntax/valid/cls-expr-elements-valid-syntax.template
+/*---
+description: Async Generator Methods can be named "prototype" (class expression)
+esid: prod-ClassElement
+features: [async-iteration, class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    AsyncGeneratorMethod : async * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+    [...]
+    10. Let desc be PropertyDescriptor { [[Value]]: closure, [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    11. Return ? DefinePropertyOrThrow(object, propKey, desc).
+
+---*/
+
+
+var C = class {
+  async * prototype() {}
+};
+
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/test/language/expressions/class/elements/syntax/valid/grammar-special-prototype-async-meth-valid.js
+++ b/test/language/expressions/class/elements/syntax/valid/grammar-special-prototype-async-meth-valid.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-special-prototype-async-meth-valid.case
+// - src/class-elements/syntax/valid/cls-expr-elements-valid-syntax.template
+/*---
+description: Async Methods can be named "prototype" (class expression)
+esid: prod-ClassElement
+features: [async-functions, class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    AsyncMethod : async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+
+    [...]
+    8. Let desc be the PropertyDescriptor { [[Value]]: closure, [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    9. Return ? DefinePropertyOrThrow(object, propKey, desc).
+
+---*/
+
+
+var C = class {
+  async prototype() {}
+};
+
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/test/language/expressions/class/elements/syntax/valid/grammar-special-prototype-gen-meth-valid.js
+++ b/test/language/expressions/class/elements/syntax/valid/grammar-special-prototype-gen-meth-valid.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-special-prototype-gen-meth-valid.case
+// - src/class-elements/syntax/valid/cls-expr-elements-valid-syntax.template
+/*---
+description: Generator Methods can be named "prototype" (class expression)
+esid: prod-ClassElement
+features: [generators, class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    GeneratorMethod : * PropertyName ( UniqueFormalParameters ) { GeneratorBody }
+
+    [...]
+    10. Let desc be the PropertyDescriptor { [[Value]]: closure, [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    11. Return ? DefinePropertyOrThrow(object, propKey, desc).
+
+---*/
+
+
+var C = class {
+  * prototype() {}
+};
+
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/test/language/expressions/class/elements/syntax/valid/grammar-special-prototype-meth-valid.js
+++ b/test/language/expressions/class/elements/syntax/valid/grammar-special-prototype-meth-valid.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-special-prototype-meth-valid.case
+// - src/class-elements/syntax/valid/cls-expr-elements-valid-syntax.template
+/*---
+description: Methods can be named "prototype" (class expression)
+esid: prod-ClassElement
+features: [class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt } 
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    MethodDefinition : PropertyName ( UniqueFormalParameters ) { FunctionBody }
+
+    [...]
+    3. Let desc be the PropertyDescriptor { [[Value]]: methodDef.[[Closure]], [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    4. Return ? DefinePropertyOrThrow(object, methodDef.[[Key]], desc).
+
+---*/
+
+
+var C = class {
+  prototype() {}
+};
+
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/test/language/statements/class/elements/syntax/valid/grammar-special-prototype-accessor-meth-valid.js
+++ b/test/language/statements/class/elements/syntax/valid/grammar-special-prototype-accessor-meth-valid.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-special-prototype-accessor-meth-valid.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax.template
+/*---
+description: Accessor Methods can be named "prototype" (class declaration)
+esid: prod-ClassElement
+features: [class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    MethodDefinition : get PropertyName ( ) { FunctionBody }
+
+    [...]
+    9. Let desc be the PropertyDescriptor { [[Get]]: closure, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    10. Return ? DefinePropertyOrThrow(object, propKey, desc).
+
+    MethodDefinition : set PropertyName ( PropertySetParameterList ) { FunctionBody }
+
+    [...]
+    8. Let desc be the PropertyDescriptor { [[Set]]: closure, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    9. Return ? DefinePropertyOrThrow(object, propKey, desc).
+
+---*/
+
+
+class C {
+  get prototype() { return 13; }
+  set prototype(_) {}
+}
+
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+assert.sameValue(C.prototype.prototype, 13);
+verifyProperty(C.prototype, 'prototype', {
+    enumerable: false,
+    configurable: true,
+});

--- a/test/language/statements/class/elements/syntax/valid/grammar-special-prototype-async-gen-meth-valid.js
+++ b/test/language/statements/class/elements/syntax/valid/grammar-special-prototype-async-gen-meth-valid.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-special-prototype-async-gen-meth-valid.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax.template
+/*---
+description: Async Generator Methods can be named "prototype" (class declaration)
+esid: prod-ClassElement
+features: [async-iteration, class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    AsyncGeneratorMethod : async * PropertyName ( UniqueFormalParameters ) { AsyncGeneratorBody }
+
+    [...]
+    10. Let desc be PropertyDescriptor { [[Value]]: closure, [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    11. Return ? DefinePropertyOrThrow(object, propKey, desc).
+
+---*/
+
+
+class C {
+  async * prototype() {}
+}
+
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/test/language/statements/class/elements/syntax/valid/grammar-special-prototype-async-meth-valid.js
+++ b/test/language/statements/class/elements/syntax/valid/grammar-special-prototype-async-meth-valid.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-special-prototype-async-meth-valid.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax.template
+/*---
+description: Async Methods can be named "prototype" (class declaration)
+esid: prod-ClassElement
+features: [async-functions, class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    AsyncMethod : async PropertyName ( UniqueFormalParameters ) { AsyncFunctionBody }
+
+    [...]
+    8. Let desc be the PropertyDescriptor { [[Value]]: closure, [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    9. Return ? DefinePropertyOrThrow(object, propKey, desc).
+
+---*/
+
+
+class C {
+  async prototype() {}
+}
+
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/test/language/statements/class/elements/syntax/valid/grammar-special-prototype-gen-meth-valid.js
+++ b/test/language/statements/class/elements/syntax/valid/grammar-special-prototype-gen-meth-valid.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-special-prototype-gen-meth-valid.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax.template
+/*---
+description: Generator Methods can be named "prototype" (class declaration)
+esid: prod-ClassElement
+features: [generators, class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt }
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    GeneratorMethod : * PropertyName ( UniqueFormalParameters ) { GeneratorBody }
+
+    [...]
+    10. Let desc be the PropertyDescriptor { [[Value]]: closure, [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    11. Return ? DefinePropertyOrThrow(object, propKey, desc).
+
+---*/
+
+
+class C {
+  * prototype() {}
+}
+
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});

--- a/test/language/statements/class/elements/syntax/valid/grammar-special-prototype-meth-valid.js
+++ b/test/language/statements/class/elements/syntax/valid/grammar-special-prototype-meth-valid.js
@@ -1,0 +1,49 @@
+// This file was procedurally generated from the following sources:
+// - src/class-elements/grammar-special-prototype-meth-valid.case
+// - src/class-elements/syntax/valid/cls-decl-elements-valid-syntax.template
+/*---
+description: Methods can be named "prototype" (class declaration)
+esid: prod-ClassElement
+features: [class]
+flags: [generated]
+includes: [propertyHelper.js]
+info: |
+    Runtime Semantics: ClassDefinitionEvaluation
+
+    ClassTail : ClassHeritage_opt { ClassBody_opt } 
+
+    [...]
+    6. Let proto be OrdinaryObjectCreate(protoParent).
+    [...]
+    14. Perform MakeConstructor(F, false, proto).
+    [...]
+    20. For each ClassElement m in order from methods, do
+        a. If IsStatic of m is false, then
+            i. Let status be PropertyDefinitionEvaluation of m with arguments proto and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    With parameters object and enumerable.
+
+    MethodDefinition : PropertyName ( UniqueFormalParameters ) { FunctionBody }
+
+    [...]
+    3. Let desc be the PropertyDescriptor { [[Value]]: methodDef.[[Closure]], [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true }.
+    4. Return ? DefinePropertyOrThrow(object, methodDef.[[Key]], desc).
+
+---*/
+
+
+class C {
+  prototype() {}
+}
+
+assert(C.hasOwnProperty('prototype'));
+assert(C.prototype.hasOwnProperty('prototype'));
+assert.notSameValue(C.prototype.prototype, C.prototype);
+verifyProperty(C.prototype, 'prototype', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+});


### PR DESCRIPTION
JSC bug: [Incorrect early errors for class methods named `"constructor"` and `"prototype"`](https://bugs.webkit.org/show_bug.cgi?id=215413).