### PR TITLE
Improve array destructuring binding coverage

### DIFF
--- a/src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+++ b/src/dstr-binding/ary-init-iter-get-err-array-prototype.case
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Abrupt completion returned by GetIterator
+template: error
+info: |
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+features: [Symbol.iterator]
+---*/
+
+//- setup
+delete Array.prototype[Symbol.iterator];
+//- elems
+[x, y, z]
+//- vals
+[1, 2, 3]
+//- error
+TypeError

--- a/src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+++ b/src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
@@ -1,0 +1,46 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Array destructuring uses overriden Array.prototype[Symbol.iterator]
+template: default
+info: |
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+features: [Symbol.iterator, generators]
+---*/
+
+//- setup
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+//- elems
+[x, y, z]
+//- vals
+[1, 2, 3]
+//- body
+assert.sameValue(x, 1);
+assert.sameValue(y, 2);
+assert.sameValue(z, 42);

--- a/src/dstr-binding/ary-ptrn-rest-id-direct.case
+++ b/src/dstr-binding/ary-ptrn-rest-id-direct.case
@@ -1,0 +1,27 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+desc: Lone rest element (direct binding)
+template: default
+info: |
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+includes: [compareArray.js]
+---*/
+
+//- elems
+[...x]
+//- vals
+[1]
+//- body
+assert(Array.isArray(x));
+assert.compareArray(x, [1]);

--- a/test/language/expressions/arrow-function/dstr/ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/arrow-function/dstr/ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/arrow-function.template
+/*---
+description: Abrupt completion returned by GetIterator (arrow function expression)
+esid: sec-arrow-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    ArrowFunction : ArrowParameters => ConciseBody
+
+    [...]
+    4. Let closure be FunctionCreate(Arrow, parameters, ConciseBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var f = ([x, y, z]) => {};
+
+assert.throws(TypeError, function() {
+  f([1, 2, 3]);
+});

--- a/test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,80 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/arrow-function.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (arrow function expression)
+esid: sec-arrow-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ArrowFunction : ArrowParameters => ConciseBody
+
+    [...]
+    4. Let closure be FunctionCreate(Arrow, parameters, ConciseBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var f;
+f = ([x, y, z]) => {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+
+f([1, 2, 3]);
+assert.sameValue(callCount, 1, 'arrow function invoked exactly once');

--- a/test/language/expressions/arrow-function/dstr/ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/arrow-function/dstr/ary-ptrn-rest-id-direct.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/arrow-function.template
+/*---
+description: Lone rest element (direct binding) (arrow function expression)
+esid: sec-arrow-function-definitions-runtime-semantics-evaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ArrowFunction : ArrowParameters => ConciseBody
+
+    [...]
+    4. Let closure be FunctionCreate(Arrow, parameters, ConciseBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var f;
+f = ([...x]) => {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+
+f([1]);
+assert.sameValue(callCount, 1, 'arrow function invoked exactly once');

--- a/test/language/expressions/arrow-function/dstr/dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/arrow-function/dstr/dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/arrow-function-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (arrow function expression (default parameter))
+esid: sec-arrow-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ArrowFunction : ArrowParameters => ConciseBody
+
+    [...]
+    4. Let closure be FunctionCreate(Arrow, parameters, ConciseBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var f = ([x, y, z] = [1, 2, 3]) => {};
+
+assert.throws(TypeError, function() {
+  f();
+});

--- a/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,80 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/arrow-function-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (arrow function expression (default parameter))
+esid: sec-arrow-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ArrowFunction : ArrowParameters => ConciseBody
+
+    [...]
+    4. Let closure be FunctionCreate(Arrow, parameters, ConciseBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var f;
+f = ([x, y, z] = [1, 2, 3]) => {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+
+f();
+assert.sameValue(callCount, 1, 'arrow function invoked exactly once');

--- a/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/arrow-function-dflt.template
+/*---
+description: Lone rest element (direct binding) (arrow function expression (default parameter))
+esid: sec-arrow-function-definitions-runtime-semantics-evaluation
+features: [destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ArrowFunction : ArrowParameters => ConciseBody
+
+    [...]
+    4. Let closure be FunctionCreate(Arrow, parameters, ConciseBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var f;
+f = ([...x] = [1]) => {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+
+f();
+assert.sameValue(callCount, 1, 'arrow function invoked exactly once');

--- a/test/language/expressions/async-generator/dstr/ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/async-generator/dstr/ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/async-gen-func-expr.template
+/*---
+description: Abrupt completion returned by GetIterator (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+var f;
+f = async function*([x, y, z]) {
+  
+};
+
+assert.throws(TypeError, function() {
+  f([1, 2, 3]);
+});

--- a/test/language/expressions/async-generator/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/async-generator/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/async-gen-func-expr.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var f;
+f = async function*([x, y, z]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+
+f([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-generator/dstr/ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/async-generator/dstr/ary-ptrn-rest-id-direct.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/async-gen-func-expr.template
+/*---
+description: Lone rest element (direct binding) (async generator function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var f;
+f = async function*([...x]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+
+f([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-generator/dstr/dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/async-generator/dstr/dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/async-gen-func-expr-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (async generator function expression (default parameter))
+esid: sec-asyncgenerator-definitions-evaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+var f = async function*([x, y, z] = [1, 2, 3]) {
+  
+};
+
+assert.throws(TypeError, function() {
+  f();
+});

--- a/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/async-gen-func-expr-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (async generator function expression (default parameter))
+esid: sec-asyncgenerator-definitions-evaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var f;
+f = async function*([x, y, z] = [1, 2, 3]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+
+f().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/async-gen-func-expr-dflt.template
+/*---
+description: Lone rest element (direct binding) (async generator function expression (default parameter))
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {
+        AsyncGeneratorBody }
+
+        [...]
+        3. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, scope, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var f;
+f = async function*([...x] = [1]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+
+f().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-generator/dstr/named-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/async-generator/dstr/named-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/async-gen-func-named-expr.template
+/*---
+description: Abrupt completion returned by GetIterator (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+var f;
+f = async function* g([x, y, z]) {
+  
+};
+
+assert.throws(TypeError, function() {
+  f([1, 2, 3]);
+});

--- a/test/language/expressions/async-generator/dstr/named-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/async-generator/dstr/named-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/async-gen-func-named-expr.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var f;
+f = async function* h([x, y, z]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+
+f([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/async-gen-func-named-expr.template
+/*---
+description: Lone rest element (direct binding) (async generator named function expression)
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var f;
+f = async function* h([...x]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+
+f([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-generator/dstr/named-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/async-generator/dstr/named-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/async-gen-func-named-expr-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (async generator named function expression (default parameter))
+esid: sec-asyncgenerator-definitions-evaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+var f;
+f = async function* h([x, y, z] = [1, 2, 3]) {
+  
+};
+
+assert.throws(TypeError, function() {
+  f();
+});

--- a/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/async-gen-func-named-expr-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (async generator named function expression (default parameter))
+esid: sec-asyncgenerator-definitions-evaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var f;
+f = async function* h([x, y, z] = [1, 2, 3]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+
+f().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,45 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/async-gen-func-named-expr-dflt.template
+/*---
+description: Lone rest element (direct binding) (async generator named function expression (default parameter))
+esid: sec-asyncgenerator-definitions-evaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        7. Let closure be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters,
+           AsyncGeneratorBody, funcEnv, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var f;
+f = async function* h([...x] = [1]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+
+f().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-async-gen-meth.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+var C = class {
+  async *method([x, y, z]) {
+    
+  }
+};
+
+var method = C.prototype.method;
+
+assert.throws(TypeError, function() {
+  method([1, 2, 3]);
+});

--- a/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,87 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-async-gen-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var C = class {
+  async *method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-async-gen-meth.template
+/*---
+description: Lone rest element (direct binding) (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var C = class {
+  async *method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-async-gen-meth-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression async generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+var C = class {
+  async *method([x, y, z] = [1, 2, 3]) {
+    
+  }
+};
+
+var method = C.prototype.method;
+
+assert.throws(TypeError, function() {
+  method();
+});

--- a/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,87 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-async-gen-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression async generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var C = class {
+  async *method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-async-gen-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (class expression async generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var C = class {
+  async *method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-gen-meth-static-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-async-gen-meth-static.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+var C = class {
+  static async *method([x, y, z]) {
+    
+  }
+};
+
+var method = C.method;
+
+assert.throws(TypeError, function() {
+  method([1, 2, 3]);
+});

--- a/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,87 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-async-gen-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var C = class {
+  static async *method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-async-gen-meth-static.template
+/*---
+description: Lone rest element (direct binding) (static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var C = class {
+  static async *method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-async-gen-meth-static-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression async generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+var C = class {
+  static async *method([x, y, z] = [1, 2, 3]) {
+    
+  }
+};
+
+var method = C.method;
+
+assert.throws(TypeError, function() {
+  method();
+});

--- a/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,87 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-async-gen-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression async generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var C = class {
+  static async *method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-async-gen-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (static class expression async generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var C = class {
+  static async *method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,91 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-async-private-gen-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-methods-private, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var C = class {
+  async * #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-async-private-gen-meth.template
+/*---
+description: Lone rest element (direct binding) (private class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-methods-private, async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var C = class {
+  async * #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,91 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-async-private-gen-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression async generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-methods-private, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var C = class {
+  async * #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-async-private-gen-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (private class expression async generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-methods-private, async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var C = class {
+  async * #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,91 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-async-private-gen-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var C = class {
+  static async * #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-async-private-gen-meth-static.template
+/*---
+description: Lone rest element (direct binding) (private static class expression async generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-static-methods-private, async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var C = class {
+  static async * #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,91 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-async-private-gen-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression async generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, async-iteration]
+flags: [generated, async]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var C = class {
+  static async * #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-async-private-gen-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (private static class expression async generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-static-methods-private, async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var C = class {
+  static async * #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/expressions/class/dstr/gen-meth-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/gen-meth-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-gen-meth.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var C = class {
+  *method([x, y, z]) {}
+};
+var c = new C();
+
+assert.throws(TypeError, function() {
+  c.method([1, 2, 3]);
+});

--- a/test/language/expressions/class/dstr/gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,105 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-gen-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  *method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1, 2, 3]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/gen-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/gen-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-gen-meth.template
+/*---
+description: Lone rest element (direct binding) (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [generators, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  *method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-gen-meth-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var C = class {
+  *method([x, y, z] = [1, 2, 3]) {}
+};
+var c = new C();
+
+assert.throws(TypeError, function() {
+  c.method();
+});

--- a/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,105 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-gen-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  *method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-gen-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [generators, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  *method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/gen-meth-static-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/gen-meth-static-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-gen-meth-static.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var C = class {
+  static *method([x, y, z]) {}
+};
+
+assert.throws(TypeError, function() {
+  C.method([1, 2, 3]);
+});

--- a/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,105 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-gen-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  static *method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1, 2, 3]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-gen-meth-static.template
+/*---
+description: Lone rest element (direct binding) (static class expression generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [generators, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static *method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-gen-meth-static-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var C = class {
+  static *method([x, y, z] = [1, 2, 3]) {}
+};
+
+assert.throws(TypeError, function() {
+  C.method();
+});

--- a/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,105 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-gen-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  static *method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-gen-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (static class expression generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [generators, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static *method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/meth-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/meth-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,87 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-meth.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var C = class {
+  method([x, y, z]) {}
+};
+
+var c = new C();
+
+assert.throws(TypeError, function() {
+  c.method([1, 2, 3]);
+});

--- a/test/language/expressions/class/dstr/meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,102 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1, 2, 3]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,85 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-meth.template
+/*---
+description: Lone rest element (direct binding) (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/meth-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/meth-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,87 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-meth-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var C = class {
+  method([x, y, z] = [1, 2, 3]) {}
+};
+
+var c = new C();
+
+assert.throws(TypeError, function() {
+  c.method();
+});

--- a/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,102 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,85 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/meth-static-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/meth-static-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,85 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-meth-static.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var C = class {
+  static method([x, y, z]) {}
+};
+
+assert.throws(TypeError, function() {
+  C.method([1, 2, 3]);
+});

--- a/test/language/expressions/class/dstr/meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,102 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  static method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1, 2, 3]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,85 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-meth-static.template
+/*---
+description: Lone rest element (direct binding) (static class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/meth-static-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/class/dstr/meth-static-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,85 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-expr-meth-static-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var C = class {
+  static method([x, y, z] = [1, 2, 3]) {}
+};
+
+assert.throws(TypeError, function() {
+  C.method();
+});

--- a/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,102 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  static method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,85 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (static class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,109 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-private-gen-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-methods-private, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  * #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1, 2, 3]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,92 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-private-gen-meth.template
+/*---
+description: Lone rest element (direct binding) (private class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-methods-private, generators, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  * #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,109 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-private-gen-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  * #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,92 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-private-gen-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (private class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-methods-private, generators, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  * #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,109 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-private-gen-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  static * #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1, 2, 3]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,92 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-private-gen-meth-static.template
+/*---
+description: Lone rest element (direct binding) (private static class expression generator method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-static-methods-private, generators, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static * #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,109 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-private-gen-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  static * #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,92 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-private-gen-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (private static class expression generator method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-static-methods-private, generators, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation
+           for m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static * #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/private-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,106 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-private-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-methods-private, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1, 2, 3]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/private-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-private-meth.template
+/*---
+description: Lone rest element (direct binding) (private class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-methods-private, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,106 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-private-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-private-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (private class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,106 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-private-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, destructuring-binding]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  static #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1, 2, 3]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-private-meth-static.template
+/*---
+description: Lone rest element (direct binding) (private static class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-static-methods-private, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,106 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-expr-private-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var C = class {
+  static #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,89 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-expr-private-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (private static class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-static-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassExpression : class BindingIdentifieropt ClassTail
+
+    1. If BindingIdentifieropt is not present, let className be undefined.
+    2. Else, let className be StringValue of BindingIdentifier.
+    3. Let value be the result of ClassDefinitionEvaluation of ClassTail
+       with argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var C = class {
+  static #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/function/dstr/ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/function/dstr/ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/func-expr.template
+/*---
+description: Abrupt completion returned by GetIterator (function expression)
+esid: sec-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    FunctionExpression : function ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let closure be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var f = function([x, y, z]) {};
+
+assert.throws(TypeError, function() {
+  f([1, 2, 3]);
+});

--- a/test/language/expressions/function/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/function/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,81 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/func-expr.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (function expression)
+esid: sec-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    FunctionExpression : function ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let closure be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var f;
+f = function([x, y, z]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+
+f([1, 2, 3]);
+assert.sameValue(callCount, 1, 'function invoked exactly once');

--- a/test/language/expressions/function/dstr/ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/function/dstr/ary-ptrn-rest-id-direct.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/func-expr.template
+/*---
+description: Lone rest element (direct binding) (function expression)
+esid: sec-function-definitions-runtime-semantics-evaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    FunctionExpression : function ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let closure be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var f;
+f = function([...x]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+
+f([1]);
+assert.sameValue(callCount, 1, 'function invoked exactly once');

--- a/test/language/expressions/function/dstr/dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/function/dstr/dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/func-expr-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (function expression (default parameter))
+esid: sec-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    FunctionExpression : function ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let closure be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var f = function([x, y, z] = [1, 2, 3]) {};
+
+assert.throws(TypeError, function() {
+  f();
+});

--- a/test/language/expressions/function/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/function/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,81 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/func-expr-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (function expression (default parameter))
+esid: sec-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    FunctionExpression : function ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let closure be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var f;
+f = function([x, y, z] = [1, 2, 3]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+
+f();
+assert.sameValue(callCount, 1, 'function invoked exactly once');

--- a/test/language/expressions/function/dstr/dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/function/dstr/dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/func-expr-dflt.template
+/*---
+description: Lone rest element (direct binding) (function expression (default parameter))
+esid: sec-function-definitions-runtime-semantics-evaluation
+features: [destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    FunctionExpression : function ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let closure be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var f;
+f = function([...x] = [1]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+
+f();
+assert.sameValue(callCount, 1, 'function invoked exactly once');

--- a/test/language/expressions/generators/dstr/ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/generators/dstr/ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/gen-func-expr.template
+/*---
+description: Abrupt completion returned by GetIterator (generator function expression)
+esid: sec-generator-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        3. Let closure be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var f = function*([x, y, z]) {};
+
+assert.throws(TypeError, function() {
+  f([1, 2, 3]);
+});

--- a/test/language/expressions/generators/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/generators/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,81 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/gen-func-expr.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (generator function expression)
+esid: sec-generator-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        3. Let closure be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var f;
+f = function*([x, y, z]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+
+f([1, 2, 3]).next();
+assert.sameValue(callCount, 1, 'generator function invoked exactly once');

--- a/test/language/expressions/generators/dstr/ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/generators/dstr/ary-ptrn-rest-id-direct.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/gen-func-expr.template
+/*---
+description: Lone rest element (direct binding) (generator function expression)
+esid: sec-generator-function-definitions-runtime-semantics-evaluation
+features: [generators, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        3. Let closure be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var f;
+f = function*([...x]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+
+f([1]).next();
+assert.sameValue(callCount, 1, 'generator function invoked exactly once');

--- a/test/language/expressions/generators/dstr/dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/generators/dstr/dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/gen-func-expr-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (generator function expression (default parameter))
+esid: sec-generator-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        3. Let closure be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var f = function*([x, y, z] = [1, 2, 3]) {};
+
+assert.throws(TypeError, function() {
+  f();
+});

--- a/test/language/expressions/generators/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/generators/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,81 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/gen-func-expr-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (generator function expression (default parameter))
+esid: sec-generator-function-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        3. Let closure be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var f;
+f = function*([x, y, z] = [1, 2, 3]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+
+f().next();
+assert.sameValue(callCount, 1, 'generator function invoked exactly once');

--- a/test/language/expressions/generators/dstr/dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/generators/dstr/dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/gen-func-expr-dflt.template
+/*---
+description: Lone rest element (direct binding) (generator function expression (default parameter))
+esid: sec-generator-function-definitions-runtime-semantics-evaluation
+features: [generators, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        3. Let closure be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var f;
+f = function*([...x] = [1]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+
+f().next();
+assert.sameValue(callCount, 1, 'generator function invoked exactly once');

--- a/test/language/expressions/object/dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/async-gen-meth.template
+/*---
+description: Abrupt completion returned by GetIterator (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+var obj = {
+  async *method([x, y, z]) {
+    
+  }
+};
+
+assert.throws(TypeError, function() {
+  obj.method([1, 2, 3]);
+});

--- a/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/async-gen-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var obj = {
+  async *method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/async-gen-meth.template
+/*---
+description: Lone rest element (direct binding) (async generator method)
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var obj = {
+  async *method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/async-gen-method-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (async generator method (default parameter))
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+var obj = {
+  async *method([x, y, z] = [1, 2, 3]) {
+    
+  }
+};
+
+assert.throws(TypeError, function() {
+  obj.method();
+});

--- a/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,68 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/async-gen-method-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (async generator method (default parameter))
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+var obj = {
+  async *method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,51 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/async-gen-method-dflt.template
+/*---
+description: Lone rest element (direct binding) (async generator method (default parameter))
+esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+var obj = {
+  async *method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/expressions/object/dstr/gen-meth-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/object/dstr/gen-meth-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/gen-meth.template
+/*---
+description: Abrupt completion returned by GetIterator (generator method)
+esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var obj = {
+  *method([x, y, z]) {}
+};
+
+assert.throws(TypeError, function() {
+  obj.method([1, 2, 3]);
+});

--- a/test/language/expressions/object/dstr/gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/object/dstr/gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,87 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/gen-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (generator method)
+esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var obj = {
+  *method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method([1, 2, 3]).next();
+assert.sameValue(callCount, 1, 'generator method invoked exactly once');

--- a/test/language/expressions/object/dstr/gen-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/object/dstr/gen-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/gen-meth.template
+/*---
+description: Lone rest element (direct binding) (generator method)
+esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
+features: [generators, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var obj = {
+  *method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method([1]).next();
+assert.sameValue(callCount, 1, 'generator method invoked exactly once');

--- a/test/language/expressions/object/dstr/gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/object/dstr/gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/gen-meth-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (generator method (default parameter))
+esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var obj = {
+  *method([x, y, z] = [1, 2, 3]) {}
+};
+
+assert.throws(TypeError, function() {
+  obj.method();
+});

--- a/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,87 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/gen-method-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (generator method (default parameter))
+esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var obj = {
+  *method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method().next();
+assert.sameValue(callCount, 1, 'generator method invoked exactly once');

--- a/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,70 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/gen-method-dflt.template
+/*---
+description: Lone rest element (direct binding) (generator method (default parameter))
+esid: sec-generator-function-definitions-runtime-semantics-propertydefinitionevaluation
+features: [generators, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    GeneratorMethod :
+        * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var obj = {
+  *method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method().next();
+assert.sameValue(callCount, 1, 'generator method invoked exactly once');

--- a/test/language/expressions/object/dstr/meth-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/object/dstr/meth-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/meth.template
+/*---
+description: Abrupt completion returned by GetIterator (method)
+esid: sec-runtime-semantics-definemethod
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters,
+       FunctionBody, scope, strict). If functionPrototype was passed as a
+       parameter then pass its value as the functionPrototype optional argument
+       of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var obj = {
+  method([x, y, z]) {}
+};
+
+assert.throws(TypeError, function() {
+  obj.method([1, 2, 3]);
+});

--- a/test/language/expressions/object/dstr/meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/object/dstr/meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (method)
+esid: sec-runtime-semantics-definemethod
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters,
+       FunctionBody, scope, strict). If functionPrototype was passed as a
+       parameter then pass its value as the functionPrototype optional argument
+       of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var obj = {
+  method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method([1, 2, 3]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/object/dstr/meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/object/dstr/meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/meth.template
+/*---
+description: Lone rest element (direct binding) (method)
+esid: sec-runtime-semantics-definemethod
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters,
+       FunctionBody, scope, strict). If functionPrototype was passed as a
+       parameter then pass its value as the functionPrototype optional argument
+       of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var obj = {
+  method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method([1]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/object/dstr/meth-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/expressions/object/dstr/meth-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/meth-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (method (default parameter))
+esid: sec-runtime-semantics-definemethod
+features: [Symbol.iterator, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters,
+       FunctionBody, scope, strict). If functionPrototype was passed as a
+       parameter then pass its value as the functionPrototype optional argument
+       of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+var obj = {
+  method([x, y, z] = [1, 2, 3]) {}
+};
+
+assert.throws(TypeError, function() {
+  obj.method();
+});

--- a/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (method (default parameter))
+esid: sec-runtime-semantics-definemethod
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters,
+       FunctionBody, scope, strict). If functionPrototype was passed as a
+       parameter then pass its value as the functionPrototype optional argument
+       of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+var obj = {
+  method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,67 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (method (default parameter))
+esid: sec-runtime-semantics-definemethod
+features: [destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters,
+       FunctionBody, scope, strict). If functionPrototype was passed as a
+       parameter then pass its value as the functionPrototype optional argument
+       of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+var obj = {
+  method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+obj.method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/async-generator/dstr/ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/async-generator/dstr/ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/async-gen-func-decl.template
+/*---
+description: Abrupt completion returned by GetIterator (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+async function* f([x, y, z]) {
+  
+};
+
+assert.throws(TypeError, function() {
+  f([1, 2, 3]);
+});

--- a/test/language/statements/async-generator/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/async-generator/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/async-gen-func-decl.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+async function* f([x, y, z]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+f([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/dstr/ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/async-generator/dstr/ary-ptrn-rest-id-direct.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/async-gen-func-decl.template
+/*---
+description: Lone rest element (direct binding) (async generator function declaration)
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+async function* f([...x]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+f([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/dstr/dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/async-generator/dstr/dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,44 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/async-gen-func-decl-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (async generator function declaration (default parameter))
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+async function* f([x, y, z] = [1, 2, 3]) {
+  
+};
+
+assert.throws(TypeError, function() {
+  f();
+});

--- a/test/language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/async-gen-func-decl-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (async generator function declaration (default parameter))
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+async function* f([x, y, z] = [1, 2, 3]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+f().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,43 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/async-gen-func-decl-dflt.template
+/*---
+description: Lone rest element (direct binding) (async generator function declaration (default parameter))
+esid: sec-asyncgenerator-definitions-instantiatefunctionobject
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier
+        ( FormalParameters ) { AsyncGeneratorBody }
+
+        [...]
+        3. Let F be ! AsyncGeneratorFunctionCreate(Normal, FormalParameters, AsyncGeneratorBody,
+            scope, strict).
+        [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+async function* f([...x] = [1]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+f().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-async-gen-meth.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+class C {
+  async *method([x, y, z]) {
+    
+  }
+};
+
+var method = C.prototype.method;
+
+assert.throws(TypeError, function() {
+  method([1, 2, 3]);
+});

--- a/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-async-gen-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+class C {
+  async *method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-async-gen-meth.template
+/*---
+description: Lone rest element (direct binding) (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  async *method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/async-gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-async-gen-meth-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression async generator method (default parameters))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+class C {
+  async *method([x, y, z] = [1, 2, 3]) {
+    
+  }
+};
+
+var method = C.prototype.method;
+
+assert.throws(TypeError, function() {
+  method();
+});

--- a/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-async-gen-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression async generator method (default parameters))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+class C {
+  async *method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-async-gen-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (class expression async generator method (default parameters))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  async *method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-gen-meth-static-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-async-gen-meth-static.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression async generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+class C {
+  static async *method([x, y, z]) {
+    
+  }
+};
+
+var method = C.method;
+
+assert.throws(TypeError, function() {
+  method([1, 2, 3]);
+});

--- a/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-async-gen-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression async generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+class C {
+  static async *method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-async-gen-meth-static.template
+/*---
+description: Lone rest element (direct binding) (static class expression async generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  static async *method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,71 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-async-gen-meth-static-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression async generator method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, async-iteration]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+
+class C {
+  static async *method([x, y, z] = [1, 2, 3]) {
+    
+  }
+};
+
+var method = C.method;
+
+assert.throws(TypeError, function() {
+  method();
+});

--- a/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-async-gen-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression async generator method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+class C {
+  static async *method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,69 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-async-gen-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (static class expression async generator method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  static async *method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,90 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-async-private-gen-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-methods-private, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+class C {
+  async * #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-async-private-gen-meth.template
+/*---
+description: Lone rest element (direct binding) (private class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-methods-private, async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  async * #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,90 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-async-private-gen-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression async generator method (default parameters))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-methods-private, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+class C {
+  async * #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-async-private-gen-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (private class expression async generator method (default parameters))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-methods-private, async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  async * #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,90 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-async-private-gen-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression async generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+class C {
+  static async * #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1, 2, 3]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-async-private-gen-meth-static.template
+/*---
+description: Lone rest element (direct binding) (private static class expression async generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [class, class-static-methods-private, async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  static async * #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1]).next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,90 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-async-private-gen-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression async generator method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, async-iteration]
+flags: [generated, async]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+
+var callCount = 0;
+class C {
+  static async * #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,73 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-async-private-gen-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (private static class expression async generator method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [class, class-static-methods-private, async-iteration]
+flags: [generated, async]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    Runtime Semantics: PropertyDefinitionEvaluation
+
+    AsyncGeneratorMethod :
+        async [no LineTerminator here] * PropertyName ( UniqueFormalParameters )
+            { AsyncGeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this AsyncGeneratorMethod is strict mode code, let strict be true.
+       Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be ! AsyncGeneratorFunctionCreate(Method, UniqueFormalParameters,
+       AsyncGeneratorBody, scope, strict).
+    [...]
+
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+
+var callCount = 0;
+class C {
+  static async * #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method().next().then(() => {
+    assert.sameValue(callCount, 1, 'invoked exactly once');    
+}).then($DONE, $DONE);

--- a/test/language/statements/class/dstr/gen-meth-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/gen-meth-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,87 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-gen-meth.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+class C {
+  *method([x, y, z]) {}
+};
+var c = new C();
+
+assert.throws(TypeError, function() {
+  c.method([1, 2, 3]);
+});

--- a/test/language/statements/class/dstr/gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,103 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-gen-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  *method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1, 2, 3]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/gen-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/gen-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-gen-meth.template
+/*---
+description: Lone rest element (direct binding) (class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [generators, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  *method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,87 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-gen-meth-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression method (default parameter))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+class C {
+  *method([x, y, z] = [1, 2, 3]) {}
+};
+var c = new C();
+
+assert.throws(TypeError, function() {
+  c.method();
+});

--- a/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,103 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-gen-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression method (default parameters))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  *method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-gen-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (class expression method (default parameters))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [generators, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  *method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/gen-meth-static-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/gen-meth-static-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-gen-meth-static.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+class C {
+  static *method([x, y, z]) {}
+};
+
+assert.throws(TypeError, function() {
+  C.method([1, 2, 3]);
+});

--- a/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,103 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-gen-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  static *method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1, 2, 3]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-gen-meth-static.template
+/*---
+description: Lone rest element (direct binding) (static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [generators, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  static *method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/gen-meth-static-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/gen-meth-static-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-gen-meth-static-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression generator method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+class C {
+  static *method([x, y, z] = [1, 2, 3]) {}
+};
+
+assert.throws(TypeError, function() {
+  C.method();
+});

--- a/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,103 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-gen-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression generator method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  static *method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-gen-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (static class expression generator method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [generators, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  static *method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/meth-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/meth-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-meth.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+class C {
+  method([x, y, z]) {}
+};
+
+var c = new C();
+
+assert.throws(TypeError, function() {
+  c.method([1, 2, 3]);
+});

--- a/test/language/statements/class/dstr/meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,101 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1, 2, 3]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-meth.template
+/*---
+description: Lone rest element (direct binding) (class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method([1]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/meth-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/meth-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,86 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-meth-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (class expression method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+class C {
+  method([x, y, z] = [1, 2, 3]) {}
+};
+
+var c = new C();
+
+assert.throws(TypeError, function() {
+  c.method();
+});

--- a/test/language/statements/class/dstr/meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,101 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (class expression method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (class expression method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+new C().method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/meth-static-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/meth-static-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-meth-static.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+class C {
+  static method([x, y, z]) {}
+};
+
+assert.throws(TypeError, function() {
+  C.method([1, 2, 3]);
+});

--- a/test/language/statements/class/dstr/meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,101 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  static method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1, 2, 3]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-meth-static.template
+/*---
+description: Lone rest element (direct binding) (static class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  static method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method([1]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/meth-static-dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/class/dstr/meth-static-dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/cls-decl-meth-static-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (static class expression method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+class C {
+  static method([x, y, z] = [1, 2, 3]) {}
+};
+
+assert.throws(TypeError, function() {
+  C.method();
+});

--- a/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,101 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (static class expression method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  static method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+};
+
+C.method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,84 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (static class expression method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  static method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+};
+
+C.method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,107 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-private-gen-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-methods-private, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  * #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1, 2, 3]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,90 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-private-gen-meth.template
+/*---
+description: Lone rest element (direct binding) (private class expression method)
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-methods-private, generators, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  * #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,107 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-private-gen-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression method (default parameters))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, class, class-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  * #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,90 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-private-gen-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (private class expression method (default parameters))
+esid: sec-class-definitions-runtime-semantics-evaluation
+features: [class, class-methods-private, generators, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  * #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,107 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-private-gen-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  static * #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1, 2, 3]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,90 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-private-gen-meth-static.template
+/*---
+description: Lone rest element (direct binding) (private static class expression generator method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [class, class-static-methods-private, generators, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  static * #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1]).next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,107 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-private-gen-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression generator method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  static * #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,90 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-private-gen-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (private static class expression generator method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [class, class-static-methods-private, generators, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.4.13 Runtime Semantics: PropertyDefinitionEvaluation
+
+    GeneratorMethod : * PropertyName ( StrictFormalParameters ) { GeneratorBody }
+
+    1. Let propKey be the result of evaluating PropertyName.
+    2. ReturnIfAbrupt(propKey).
+    3. If the function code for this GeneratorMethod is strict mode code,
+       let strict be true. Otherwise let strict be false.
+    4. Let scope be the running execution context's LexicalEnvironment.
+    5. Let closure be GeneratorFunctionCreate(Method,
+       StrictFormalParameters, GeneratorBody, scope, strict).
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  static * #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method().next();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/private-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,105 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-private-meth.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, class, class-methods-private, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1, 2, 3]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-meth-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/private-meth-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-private-meth.template
+/*---
+description: Lone rest element (direct binding) (private class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [class, class-methods-private, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method([1]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,105 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-private-meth-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private class expression method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, class, class-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-private-meth-dflt.template
+/*---
+description: Lone rest element (direct binding) (private class expression method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [class, class-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+           i. Let status be the result of performing
+              PropertyDefinitionEvaluation for m with arguments proto and
+              false.
+        [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  get method() {
+    return this.#method;
+  }
+};
+
+new C().method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/private-meth-static-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,105 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-private-meth-static.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, destructuring-binding]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  static #method([x, y, z]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1, 2, 3]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-meth-static-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/private-meth-static-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-private-meth-static.template
+/*---
+description: Lone rest element (direct binding) (private static class expression method)
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [class, class-static-methods-private, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  static #method([...x]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method([1]);
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,105 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/cls-decl-private-meth-static-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (private static class expression method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [Symbol.iterator, generators, class, class-static-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+class C {
+  static #method([x, y, z] = [1, 2, 3]) {
+    assert.sameValue(x, 1);
+    assert.sameValue(y, 2);
+    assert.sameValue(z, 42);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,88 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/cls-decl-private-meth-static-dflt.template
+/*---
+description: Lone rest element (direct binding) (private static class expression method (default parameter))
+esid: sec-runtime-semantics-bindingclassdeclarationevaluation
+features: [class, class-static-methods-private, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    ClassDeclaration : class BindingIdentifier ClassTail
+
+    1. Let className be StringValue of BindingIdentifier.
+    2. Let value be the result of ClassDefinitionEvaluation of ClassTail with
+       argument className.
+    [...]
+
+    14.5.14 Runtime Semantics: ClassDefinitionEvaluation
+
+    21. For each ClassElement m in order from methods
+        a. If IsStatic of m is false, then
+        b. Else,
+           Let status be the result of performing PropertyDefinitionEvaluation for
+           m with arguments F and false.
+    [...]
+
+    14.3.8 Runtime Semantics: DefineMethod
+
+    MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+
+    [...]
+    6. Let closure be FunctionCreate(kind, StrictFormalParameters, FunctionBody,
+       scope, strict). If functionPrototype was passed as a parameter then pass its
+       value as the functionPrototype optional argument of FunctionCreate.
+    [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+class C {
+  static #method([...x] = [1]) {
+    assert(Array.isArray(x));
+    assert.compareArray(x, [1]);
+    callCount = callCount + 1;
+  }
+
+  static get method() {
+    return this.#method;
+  }
+};
+
+C.method();
+assert.sameValue(callCount, 1, 'method invoked exactly once');

--- a/test/language/statements/const/dstr/ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/const/dstr/ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/const-stmt.template
+/*---
+description: Abrupt completion returned by GetIterator (`const` statement)
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context's LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+assert.throws(TypeError, function() {
+  const [x, y, z] = [1, 2, 3];
+});

--- a/test/language/statements/const/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/const/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/const-stmt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (`const` statement)
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context's LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+const [x, y, z] = [1, 2, 3];
+
+assert.sameValue(x, 1);
+assert.sameValue(y, 2);
+assert.sameValue(z, 42);

--- a/test/language/statements/const/dstr/ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/const/dstr/ary-ptrn-rest-id-direct.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/const-stmt.template
+/*---
+description: Lone rest element (direct binding) (`const` statement)
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context's LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+const [...x] = [1];
+
+assert(Array.isArray(x));
+assert.compareArray(x, [1]);

--- a/test/language/statements/for-of/dstr/const-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/for-of/dstr/const-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/for-of-const.template
+/*---
+description: Abrupt completion returned by GetIterator (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+assert.throws(TypeError, function() {
+  for (const [x, y, z] of [[1, 2, 3]]) {
+    return;
+  }
+});

--- a/test/language/statements/for-of/dstr/const-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/for-of/dstr/const-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,79 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/for-of-const.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var iterCount = 0;
+
+for (const [x, y, z] of [[1, 2, 3]]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'iteration occurred as expected');

--- a/test/language/statements/for-of/dstr/const-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/for-of/dstr/const-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/for-of-const.template
+/*---
+description: Lone rest element (direct binding) (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var iterCount = 0;
+
+for (const [...x] of [[1]]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'iteration occurred as expected');

--- a/test/language/statements/for-of/dstr/let-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/for-of/dstr/let-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/for-of-let.template
+/*---
+description: Abrupt completion returned by GetIterator (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+assert.throws(TypeError, function() {
+  for (let [x, y, z] of [[1, 2, 3]]) {
+    return;
+  }
+});

--- a/test/language/statements/for-of/dstr/let-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/for-of/dstr/let-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,79 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/for-of-let.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var iterCount = 0;
+
+for (let [x, y, z] of [[1, 2, 3]]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'Iteration occurred as expected');

--- a/test/language/statements/for-of/dstr/let-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/for-of/dstr/let-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/for-of-let.template
+/*---
+description: Lone rest element (direct binding) (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    IterationStatement :
+        for ( ForDeclaration of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForDeclaration, Statement, keyResult,
+       lexicalBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              [...]
+          iii. Else,
+               1. Assert: lhsKind is lexicalBinding.
+               2. Assert: lhs is a ForDeclaration.
+               3. Let status be the result of performing BindingInitialization
+                  for lhs passing nextValue and iterationEnv as arguments.
+          [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var iterCount = 0;
+
+for (let [...x] of [[1]]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'Iteration occurred as expected');

--- a/test/language/statements/for-of/dstr/var-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/for-of/dstr/var-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/for-of-var.template
+/*---
+description: Abrupt completion returned by GetIterator (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+       varBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+assert.throws(TypeError, function() {
+  for (var [x, y, z] of [[1, 2, 3]]) {
+    return;
+  }
+});

--- a/test/language/statements/for-of/dstr/var-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/for-of/dstr/var-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/for-of-var.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+       varBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var iterCount = 0;
+
+for (var [x, y, z] of [[1, 2, 3]]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'Iteration occurred as expected');

--- a/test/language/statements/for-of/dstr/var-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/for-of/dstr/var-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/for-of-var.template
+/*---
+description: Lone rest element (direct binding) (for-of statement)
+esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    IterationStatement :
+        for ( var ForBinding of AssignmentExpression ) Statement
+
+    [...]
+    3. Return ForIn/OfBodyEvaluation(ForBinding, Statement, keyResult,
+       varBinding, labelSet).
+
+    13.7.5.13 Runtime Semantics: ForIn/OfBodyEvaluation
+
+    [...]
+    3. Let destructuring be IsDestructuring of lhs.
+    [...]
+    5. Repeat
+       [...]
+       h. If destructuring is false, then
+          [...]
+       i. Else
+          i. If lhsKind is assignment, then
+             [...]
+          ii. Else if lhsKind is varBinding, then
+              1. Assert: lhs is a ForBinding.
+              2. Let status be the result of performing BindingInitialization
+                 for lhs passing nextValue and undefined as the arguments.
+          [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var iterCount = 0;
+
+for (var [...x] of [[1]]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'Iteration occurred as expected');

--- a/test/language/statements/for/dstr/const-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/for/dstr/const-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/for-const.template
+/*---
+description: Abrupt completion returned by GetIterator (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+assert.throws(TypeError, function() {
+  for (const [x, y, z] = [1, 2, 3]; ; ) {
+    return;
+  }
+});

--- a/test/language/statements/for/dstr/const-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/for/dstr/const-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,79 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/for-const.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var iterCount = 0;
+
+for (const [x, y, z] = [1, 2, 3]; iterCount < 1; ) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'Iteration occurred as expected');

--- a/test/language/statements/for/dstr/const-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/for/dstr/const-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/for-const.template
+/*---
+description: Lone rest element (direct binding) (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var iterCount = 0;
+
+for (const [...x] = [1]; iterCount < 1; ) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'Iteration occurred as expected');

--- a/test/language/statements/for/dstr/let-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/for/dstr/let-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,61 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/for-let.template
+/*---
+description: Abrupt completion returned by GetIterator (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+assert.throws(TypeError, function() {
+  for (let [x, y, z] = [1, 2, 3]; ; ) {
+    return;
+  }
+});

--- a/test/language/statements/for/dstr/let-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/for/dstr/let-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,79 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/for-let.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var iterCount = 0;
+
+for (let [x, y, z] = [1, 2, 3]; iterCount < 1; ) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'Iteration occurred as expected');

--- a/test/language/statements/for/dstr/let-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/for/dstr/let-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/for-let.template
+/*---
+description: Lone rest element (direct binding) (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    IterationStatement :
+        for ( LexicalDeclaration Expressionopt ; Expressionopt ) Statement
+
+    [...]
+    7. Let forDcl be the result of evaluating LexicalDeclaration.
+    [...]
+
+    LexicalDeclaration : LetOrConst BindingList ;
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return NormalCompletion(empty).
+
+    BindingList : BindingList , LexicalBinding
+
+    1. Let next be the result of evaluating BindingList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating LexicalBinding.
+
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context’s LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var iterCount = 0;
+
+for (let [...x] = [1]; iterCount < 1; ) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'Iteration occurred as expected');

--- a/test/language/statements/for/dstr/var-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/for/dstr/var-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/for-var.template
+/*---
+description: Abrupt completion returned by GetIterator (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( var VariableDeclarationList ; Expressionopt ; Expressionopt ) Statement
+
+    1. Let varDcl be the result of evaluating VariableDeclarationList.
+    [...]
+
+    13.3.2.4 Runtime Semantics: Evaluation
+
+    VariableDeclarationList : VariableDeclarationList , VariableDeclaration
+
+    1. Let next be the result of evaluating VariableDeclarationList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating VariableDeclaration.
+
+    VariableDeclaration : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let rval be GetValue(rhs).
+    3. ReturnIfAbrupt(rval).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing rval and undefined as arguments.
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+assert.throws(TypeError, function() {
+  for (var [x, y, z] = [1, 2, 3]; iterCount < 1; ) {
+    return;
+  }
+});

--- a/test/language/statements/for/dstr/var-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/for/dstr/var-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,72 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/for-var.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    IterationStatement :
+        for ( var VariableDeclarationList ; Expressionopt ; Expressionopt ) Statement
+
+    1. Let varDcl be the result of evaluating VariableDeclarationList.
+    [...]
+
+    13.3.2.4 Runtime Semantics: Evaluation
+
+    VariableDeclarationList : VariableDeclarationList , VariableDeclaration
+
+    1. Let next be the result of evaluating VariableDeclarationList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating VariableDeclaration.
+
+    VariableDeclaration : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let rval be GetValue(rhs).
+    3. ReturnIfAbrupt(rval).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing rval and undefined as arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var iterCount = 0;
+
+for (var [x, y, z] = [1, 2, 3]; iterCount < 1; ) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'Iteration occurred as expected');

--- a/test/language/statements/for/dstr/var-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/for/dstr/var-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/for-var.template
+/*---
+description: Lone rest element (direct binding) (for statement)
+esid: sec-for-statement-runtime-semantics-labelledevaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    IterationStatement :
+        for ( var VariableDeclarationList ; Expressionopt ; Expressionopt ) Statement
+
+    1. Let varDcl be the result of evaluating VariableDeclarationList.
+    [...]
+
+    13.3.2.4 Runtime Semantics: Evaluation
+
+    VariableDeclarationList : VariableDeclarationList , VariableDeclaration
+
+    1. Let next be the result of evaluating VariableDeclarationList.
+    2. ReturnIfAbrupt(next).
+    3. Return the result of evaluating VariableDeclaration.
+
+    VariableDeclaration : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let rval be GetValue(rhs).
+    3. ReturnIfAbrupt(rval).
+    4. Return the result of performing BindingInitialization for BindingPattern
+       passing rval and undefined as arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var iterCount = 0;
+
+for (var [...x] = [1]; iterCount < 1; ) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  iterCount += 1;
+}
+
+assert.sameValue(iterCount, 1, 'Iteration occurred as expected');

--- a/test/language/statements/function/dstr/ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/function/dstr/ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/func-decl.template
+/*---
+description: Abrupt completion returned by GetIterator (function declaration)
+esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    FunctionDeclaration :
+        function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let F be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+function f([x, y, z]) {}
+
+assert.throws(TypeError, function() {
+  f([1, 2, 3]);
+});

--- a/test/language/statements/function/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/function/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,80 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/func-decl.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (function declaration)
+esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    FunctionDeclaration :
+        function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let F be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+function f([x, y, z]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+f([1, 2, 3]);
+assert.sameValue(callCount, 1, 'function invoked exactly once');

--- a/test/language/statements/function/dstr/ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/function/dstr/ary-ptrn-rest-id-direct.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/func-decl.template
+/*---
+description: Lone rest element (direct binding) (function declaration)
+esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    FunctionDeclaration :
+        function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let F be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+function f([...x]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+f([1]);
+assert.sameValue(callCount, 1, 'function invoked exactly once');

--- a/test/language/statements/function/dstr/dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/function/dstr/dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,64 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/func-decl-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (function declaration (default parameter))
+esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [Symbol.iterator, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    FunctionDeclaration :
+        function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let F be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+function f([x, y, z] = [1, 2, 3]) {}
+
+assert.throws(TypeError, function() {
+  f();
+});

--- a/test/language/statements/function/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/function/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,80 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/func-decl-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (function declaration (default parameter))
+esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    FunctionDeclaration :
+        function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let F be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+function f([x, y, z] = [1, 2, 3]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+f();
+assert.sameValue(callCount, 1, 'function invoked exactly once');

--- a/test/language/statements/function/dstr/dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/function/dstr/dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/func-decl-dflt.template
+/*---
+description: Lone rest element (direct binding) (function declaration (default parameter))
+esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    FunctionDeclaration :
+        function BindingIdentifier ( FormalParameters ) { FunctionBody }
+
+        [...]
+        3. Let F be FunctionCreate(Normal, FormalParameters, FunctionBody,
+           scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+function f([...x] = [1]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+f();
+assert.sameValue(callCount, 1, 'function invoked exactly once');

--- a/test/language/statements/generators/dstr/ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/generators/dstr/ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/gen-func-decl.template
+/*---
+description: Abrupt completion returned by GetIterator (generator function declaration)
+esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        2. Let F be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+function* f([x, y, z]) {}
+
+assert.throws(TypeError, function() {
+  f([1, 2, 3]);
+});

--- a/test/language/statements/generators/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/generators/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,79 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/gen-func-decl.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (generator function declaration)
+esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        2. Let F be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+function* f([x, y, z]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+f([1, 2, 3]).next();
+assert.sameValue(callCount, 1, 'generator function invoked exactly once');

--- a/test/language/statements/generators/dstr/ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/generators/dstr/ary-ptrn-rest-id-direct.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/gen-func-decl.template
+/*---
+description: Lone rest element (direct binding) (generator function declaration)
+esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [generators, destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        2. Let F be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+function* f([...x]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+f([1]).next();
+assert.sameValue(callCount, 1, 'generator function invoked exactly once');

--- a/test/language/statements/generators/dstr/dflt-ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/generators/dstr/dflt-ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,63 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/gen-func-decl-dflt.template
+/*---
+description: Abrupt completion returned by GetIterator (generator function declaration (default parameter))
+esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        2. Let F be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+function* f([x, y, z] = [1, 2, 3]) {}
+
+assert.throws(TypeError, function() {
+  f();
+});

--- a/test/language/statements/generators/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/generators/dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,79 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/gen-func-decl-dflt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (generator function declaration (default parameter))
+esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [Symbol.iterator, generators, destructuring-binding, default-parameters]
+flags: [generated]
+info: |
+    GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        2. Let F be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var callCount = 0;
+function* f([x, y, z] = [1, 2, 3]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  callCount = callCount + 1;
+};
+f().next();
+assert.sameValue(callCount, 1, 'generator function invoked exactly once');

--- a/test/language/statements/generators/dstr/dflt-ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/generators/dstr/dflt-ary-ptrn-rest-id-direct.js
@@ -1,0 +1,62 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/gen-func-decl-dflt.template
+/*---
+description: Lone rest element (direct binding) (generator function declaration (default parameter))
+esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
+features: [generators, destructuring-binding, default-parameters]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }
+
+        [...]
+        2. Let F be GeneratorFunctionCreate(Normal, FormalParameters,
+           GeneratorBody, scope, strict).
+        [...]
+
+    9.2.1 [[Call]] ( thisArgument, argumentsList)
+
+    [...]
+    7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+    [...]
+
+    9.2.1.3 OrdinaryCallEvaluateBody ( F, argumentsList )
+
+    1. Let status be FunctionDeclarationInstantiation(F, argumentsList).
+    [...]
+
+    9.2.12 FunctionDeclarationInstantiation(func, argumentsList)
+
+    [...]
+    23. Let iteratorRecord be Record {[[iterator]]:
+        CreateListIterator(argumentsList), [[done]]: false}.
+    24. If hasDuplicates is true, then
+        [...]
+    25. Else,
+        b. Let formalStatus be IteratorBindingInitialization for formals with
+           iteratorRecord and env as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var callCount = 0;
+function* f([...x] = [1]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  callCount = callCount + 1;
+};
+f().next();
+assert.sameValue(callCount, 1, 'generator function invoked exactly once');

--- a/test/language/statements/let/dstr/ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/let/dstr/ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/let-stmt.template
+/*---
+description: Abrupt completion returned by GetIterator (`let` statement)
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context's LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+assert.throws(TypeError, function() {
+  let [x, y, z] = [1, 2, 3];
+});

--- a/test/language/statements/let/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/let/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/let-stmt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (`let` statement)
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context's LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+let [x, y, z] = [1, 2, 3];
+
+assert.sameValue(x, 1);
+assert.sameValue(y, 2);
+assert.sameValue(z, 42);

--- a/test/language/statements/let/dstr/ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/let/dstr/ary-ptrn-rest-id-direct.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/let-stmt.template
+/*---
+description: Lone rest element (direct binding) (`let` statement)
+esid: sec-let-and-const-declarations-runtime-semantics-evaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    LexicalBinding : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let value be GetValue(rhs).
+    3. ReturnIfAbrupt(value).
+    4. Let env be the running execution context's LexicalEnvironment.
+    5. Return the result of performing BindingInitialization for BindingPattern
+       using value and env as the arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+let [...x] = [1];
+
+assert(Array.isArray(x));
+assert.compareArray(x, [1]);

--- a/test/language/statements/try/dstr/ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/try/dstr/ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,40 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/try.template
+/*---
+description: Abrupt completion returned by GetIterator (try statement)
+esid: sec-runtime-semantics-catchclauseevaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    Catch : catch ( CatchParameter ) Block
+
+    [...]
+    5. Let status be the result of performing BindingInitialization for
+       CatchParameter passing thrownValue and catchEnv as arguments.
+    [...]
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+assert.throws(TypeError, function() {
+  try {
+    throw [1, 2, 3];
+  } catch ([x, y, z]) {}
+});

--- a/test/language/statements/try/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/try/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/try.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (try statement)
+esid: sec-runtime-semantics-catchclauseevaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    Catch : catch ( CatchParameter ) Block
+
+    [...]
+    5. Let status be the result of performing BindingInitialization for
+       CatchParameter passing thrownValue and catchEnv as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var ranCatch = false;
+
+try {
+  throw [1, 2, 3];
+} catch ([x, y, z]) {
+  assert.sameValue(x, 1);
+  assert.sameValue(y, 2);
+  assert.sameValue(z, 42);
+  ranCatch = true;
+}
+
+assert(ranCatch, 'executed `catch` block');

--- a/test/language/statements/try/dstr/ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/try/dstr/ary-ptrn-rest-id-direct.js
@@ -1,0 +1,42 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/try.template
+/*---
+description: Lone rest element (direct binding) (try statement)
+esid: sec-runtime-semantics-catchclauseevaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    Catch : catch ( CatchParameter ) Block
+
+    [...]
+    5. Let status be the result of performing BindingInitialization for
+       CatchParameter passing thrownValue and catchEnv as arguments.
+    [...]
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var ranCatch = false;
+
+try {
+  throw [1];
+} catch ([...x]) {
+  assert(Array.isArray(x));
+  assert.compareArray(x, [1]);
+  ranCatch = true;
+}
+
+assert(ranCatch, 'executed `catch` block');

--- a/test/language/statements/variable/dstr/ary-init-iter-get-err-array-prototype.js
+++ b/test/language/statements/variable/dstr/ary-init-iter-get-err-array-prototype.js
@@ -1,0 +1,39 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-init-iter-get-err-array-prototype.case
+// - src/dstr-binding/error/var-stmt.template
+/*---
+description: Abrupt completion returned by GetIterator (`var` statement)
+esid: sec-variable-statement-runtime-semantics-evaluation
+features: [Symbol.iterator, destructuring-binding]
+flags: [generated]
+info: |
+    VariableDeclaration : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let rval be GetValue(rhs).
+    3. ReturnIfAbrupt(rval).
+    4. Return the result of performing BindingInitialization for
+       BindingPattern passing rval and undefined as arguments.
+
+    Runtime Semantics: BindingInitialization
+
+    BindingPattern : ArrayBindingPattern
+
+    1. Let iteratorRecord be ? GetIterator(value).
+
+    GetIterator ( obj [ , hint [ , method ] ] )
+
+    [...]
+    4. Let iterator be ? Call(method, obj).
+
+    Call ( F, V [ , argumentsList ] )
+
+    [...]
+    2. If IsCallable(F) is false, throw a TypeError exception.
+
+---*/
+delete Array.prototype[Symbol.iterator];
+
+assert.throws(TypeError, function() {
+  var [x, y, z] = [1, 2, 3];
+});

--- a/test/language/statements/variable/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+++ b/test/language/statements/variable/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-elem-id-iter-val-array-prototype.case
+// - src/dstr-binding/default/var-stmt.template
+/*---
+description: Array destructuring uses overriden Array.prototype[Symbol.iterator] (`var` statement)
+esid: sec-variable-statement-runtime-semantics-evaluation
+features: [Symbol.iterator, generators, destructuring-binding]
+flags: [generated]
+info: |
+    VariableDeclaration : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let rval be GetValue(rhs).
+    3. ReturnIfAbrupt(rval).
+    4. Return the result of performing BindingInitialization for
+       BindingPattern passing rval and undefined as arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    SingleNameBinding : BindingIdentifier Initializer_opt
+
+    1. Let bindingId be StringValue of BindingIdentifier.
+    2. Let lhs be ? ResolveBinding(bindingId, environment).
+    3. If iteratorRecord.[[Done]] is false, then
+        a. Let next be IteratorStep(iteratorRecord).
+        b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        c. ReturnIfAbrupt(next).
+        d. If next is false, set iteratorRecord.[[Done]] to true.
+        e. Else,
+            i. Let v be IteratorValue(next).
+            ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            iii. ReturnIfAbrupt(v).
+    [...]
+    7. Return InitializeReferencedBinding(lhs, v).
+
+---*/
+Array.prototype[Symbol.iterator] = function* () {
+    if (this.length > 0) {
+        yield this[0];
+    }
+    if (this.length > 1) {
+        yield this[1];
+    }
+    if (this.length > 2) {
+        yield 42;
+    }
+};
+
+var [x, y, z] = [1, 2, 3];
+
+assert.sameValue(x, 1);
+assert.sameValue(y, 2);
+assert.sameValue(z, 42);

--- a/test/language/statements/variable/dstr/ary-ptrn-rest-id-direct.js
+++ b/test/language/statements/variable/dstr/ary-ptrn-rest-id-direct.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/dstr-binding/ary-ptrn-rest-id-direct.case
+// - src/dstr-binding/default/var-stmt.template
+/*---
+description: Lone rest element (direct binding) (`var` statement)
+esid: sec-variable-statement-runtime-semantics-evaluation
+features: [destructuring-binding]
+flags: [generated]
+includes: [compareArray.js]
+info: |
+    VariableDeclaration : BindingPattern Initializer
+
+    1. Let rhs be the result of evaluating Initializer.
+    2. Let rval be GetValue(rhs).
+    3. ReturnIfAbrupt(rval).
+    4. Return the result of performing BindingInitialization for
+       BindingPattern passing rval and undefined as arguments.
+
+    Runtime Semantics: IteratorBindingInitialization
+
+    BindingRestElement : ... BindingIdentifier
+
+    [...]
+    2. Let A be ! ArrayCreate(0).
+    3. Let n be 0.
+    4. Repeat,
+        [...]
+        f. Perform ! CreateDataPropertyOrThrow(A, ! ToString(n), nextValue).
+        g. Set n to n + 1.
+
+---*/
+
+var [...x] = [1];
+
+assert(Array.isArray(x));
+assert.compareArray(x, [1]);


### PR DESCRIPTION
JSC bug: [Remove `ArrayPatternNode::emitDirectBinding`](https://bugs.webkit.org/show_bug.cgi?id=187085).