### PR TITLE
Property clearing code of RegExp constructor is wrong

### DIFF
--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -1,5 +1,6 @@
 // Copyright (C) 2011 2012 Norbert Lindenberg. All rights reserved.
 // Copyright (C) 2012 2013 Mozilla Corporation. All rights reserved.
+// Copyright (C) 2020 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 description: |
@@ -2001,6 +2002,7 @@ var regExpProperties = ["$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9",
 
 var regExpPropertiesDefaultValues = (function () {
   var values = Object.create(null);
+  (/(?:)/).test("");
   regExpProperties.forEach(function (property) {
     values[property] = RegExp[property];
   });
@@ -2014,9 +2016,7 @@ var regExpPropertiesDefaultValues = (function () {
  * RegExp constructor.
  */
 function testForUnwantedRegExpChanges(testFunc) {
-  regExpProperties.forEach(function (property) {
-    RegExp[property] = regExpPropertiesDefaultValues[property];
-  });
+  (/(?:)/).test("");
   testFunc();
   regExpProperties.forEach(function (property) {
     if (RegExp[property] !== regExpPropertiesDefaultValues[property]) {


### PR DESCRIPTION
This code is setting values to $1 etc., which can be non-writable or accessors.
For example, https://github.com/tc39/proposal-regexp-legacy-features/ is specifying them as accessors, and they should throw an error when
it is done in strict code. We should execute `(/(?:)/).test("");` to clear them.