### PR TITLE
Improve coverage for __proto__ in object literals

### DIFF
--- a/test/annexB/language/expressions/object/__proto__-poisoned-object-prototype.js
+++ b/test/annexB/language/expressions/object/__proto__-poisoned-object-prototype.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-__proto__-property-names-in-object-initializers
+description: >
+  The value of the `__proto__` property key is assigned to the [[Prototype]].
+  Object.prototype.__proto__ setter should not be called.
+info: |
+  __proto__ Property Names in Object Initializers
+
+  PropertyDefinition : PropertyName : AssignmentExpression
+
+  [...]
+  7. If isProtoSetter is true, then
+    a. If Type(propValue) is either Object or Null, then
+      i. Return object.[[SetPrototypeOf]](propValue).
+---*/
+
+Object.defineProperty(Object.prototype, '__proto__', {
+  set: function() {
+    throw new Test262Error('should not be called');
+  },
+});
+
+var proto = {};
+
+var object = {
+  __proto__: proto
+};
+
+assert(!object.hasOwnProperty('__proto__'));
+assert.sameValue(Object.getPrototypeOf(object), proto);

--- a/test/language/expressions/object/__proto__-permitted-dup-shorthand.js
+++ b/test/language/expressions/object/__proto__-permitted-dup-shorthand.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object-initializer
+description: Permitted duplicate `__proto__` property (shorthand)
+info: |
+    Annex B defines an early error for duplicate PropertyName of `__proto__`,
+    but this does not apply to properties created from other productions.
+
+    B.3.1 __proto__ Property Names in Object Initializers
+
+    It is a Syntax Error if PropertyNameList of PropertyDefinitionList contains
+    any duplicate entries for "__proto__" and at least two of those entries
+    were obtained from productions of the form
+    PropertyDefinition : PropertyName : AssignmentExpression .
+---*/
+
+var __proto__ = 2;
+var obj = {
+  __proto__,
+  __proto__,
+};
+
+assert(obj.hasOwnProperty("__proto__"));
+assert.sameValue(obj.__proto__, 2);

--- a/test/language/expressions/object/__proto__-permitted-dup.js
+++ b/test/language/expressions/object/__proto__-permitted-dup.js
@@ -2,7 +2,6 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-object-initializer
-es6id: 12.2.6
 description: Permitted duplicate `__proto__` property
 info: |
     Annex B defines an early error for duplicate PropertyName of `__proto__`,
@@ -14,6 +13,7 @@ info: |
     any duplicate entries for "__proto__" and at least two of those entries
     were obtained from productions of the form
     PropertyDefinition : PropertyName : AssignmentExpression .
+features: [generators, async-functions, async-iteration]
 ---*/
 
 var obj = {
@@ -24,6 +24,9 @@ var obj = {
   proto__: null,
   ['__proto__']: null,
   __proto__() {},
+  * __proto__() {},
+  async __proto__() {},
+  async * __proto__() {},
   get __proto__() { return 33; },
   set __proto__(_) { return 44; }
 };


### PR DESCRIPTION
JSC bugs:
* [`__proto__` shorthand property should not modify prototype in Object Literal construction](https://bugs.webkit.org/show_bug.cgi?id=142382).
* [`__proto__` in object literal should perform `[[SetPrototypeOf]]` directly](https://bugs.webkit.org/show_bug.cgi?id=215769).
* [Invalid early error for object literal method named `"__proto__"`](https://bugs.webkit.org/show_bug.cgi?id=215760).