### PR TITLE
Accessing order of fractionalSecondDigits should be earlier than timeZoneName

### DIFF
--- a/test/intl402/DateTimeFormat/constructor-options-order-fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/constructor-options-order-fractionalSecondDigits.js
@@ -1,4 +1,5 @@
 // Copyright 2019 Googe Inc. All rights reserved.
+// Copyright 2020 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -31,9 +32,8 @@ const expected = [
   "localeMatcher",
   // InitializeDateTimeFormat step 22.
   "second",
-  "timeZoneName",
-  // InitializeDateTimeFormat step 23.
   "fractionalSecondDigits",
+  "timeZoneName",
   // InitializeDateTimeFormat step 26.
   "formatMatcher",
 ];


### PR DESCRIPTION
In this PR[1], fractionalSecondDigits is listed earlier than timeZoneName in table 6[2].
So, accessing order of fractionalSecondDigits in [3]'s step-29 should be earlier than timeZoneName.

[1]: https://github.com/tc39/ecma402/pull/347
[2]: https://tc39.es/ecma402/#sec-datetimeformat-abstracts
[3]: https://tc39.es/ecma402/#sec-initializedatetimeformat