### PR TITLE
Gracefully handle nullish arguments in harness/compareArray

### DIFF
--- a/harness/compareArray.js
+++ b/harness/compareArray.js
@@ -30,10 +30,12 @@ compareArray.format = function(array) {
   return `[${array.map(String).join(', ')}]`;
 };
 
-assert.compareArray = function(actual, expected, message) {
+assert.compareArray = function(actual, expected, message = '') {
+  assert(actual != null, `First argument shouldn't be nullish. ${message}`);
+  assert(expected != null, `Second argument shouldn't be nullish. ${message}`);
   var format = compareArray.format;
   assert(
     compareArray(actual, expected),
-    `Expected ${format(actual)} and ${format(expected)} to have the same contents. ${(message || '')}`
+    `Expected ${format(actual)} and ${format(expected)} to have the same contents. ${message}`
   );
 };

--- a/test/harness/compare-array-falsy-arguments.js
+++ b/test/harness/compare-array-falsy-arguments.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    compareArray gracefully handles nullish arguments.
+includes: [compareArray.js]
+---*/
+
+function assertThrows(func, errorMessage) {
+    var caught = false;
+    try {
+        func();
+    } catch (error) {
+        caught = true;
+        assert.sameValue(error.constructor, Test262Error);
+        assert.sameValue(error.message, errorMessage);
+    }
+
+    assert(caught, `Expected ${func} to throw, but it didn't.`);
+}
+
+assertThrows(() => assert.compareArray(), "First argument shouldn't be nullish. ");
+assertThrows(() => assert.compareArray(null, []), "First argument shouldn't be nullish. ");
+assertThrows(() => assert.compareArray(null, [], "foo"), "First argument shouldn't be nullish. foo");
+
+assertThrows(() => assert.compareArray([]), "Second argument shouldn't be nullish. ");
+assertThrows(() => assert.compareArray([], undefined, "foo"), "Second argument shouldn't be nullish. foo");


### PR DESCRIPTION
Quite a few tests, including ones in `test/built-ins/RegExp/lookBehind`, pass result of `RegExp.prototype.exec` to `assert.compareArray`. Without this change & stack trace, it is impossible to figure out which test case is failing:

```diff
 test/built-ins/RegExp/lookBehind/simple-fixed-length.js:
-  default: "TypeError: null is not an object (evaluating 'a.length')"
-  strict mode: "TypeError: null is not an object (evaluating 'a.length')"
+  default: "Test262Error: First argument shouldn't be nullish. #5"
+  strict mode: "Test262Error: First argument shouldn't be nullish. #5"
```