### PR TITLE
Async negative syntaxerror tests dont have a defined semantic interpretation. Fixes gh-1229

### DIFF
--- a/test/language/expressions/async-generator/dstr/ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/async-generator/dstr/ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (async generator function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/async-generator/dstr/ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (async generator function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/async-generator/dstr/ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (async generator function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/async-generator/dstr/ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (async generator function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/async-generator/dstr/ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (async generator function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/async-generator/dstr/ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (async generator function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (async generator function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (async generator function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (async generator function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (async generator function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (async generator function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (async generator function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (async generator named function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (async generator named function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (async generator named function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (async generator named function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (async generator named function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (async generator named function expression)
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (async generator named function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (async generator named function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (async generator named function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (async generator named function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (async generator named function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (async generator named function expression (default parameter))
 esid: sec-asyncgenerator-definitions-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (private class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (private class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (private class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (private class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (private class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (private class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (private static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (private static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (private static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (private static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (private static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (private static class expression async generator method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (private static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (private static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (private static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (private static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (private static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (private static class expression async generator method (default parameter))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (async generator method)
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (async generator method)
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (async generator method)
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (async generator method)
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (async generator method)
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (async generator method)
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (async generator method (default parameter))
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (async generator method (default parameter))
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (async generator method (default parameter))
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (async generator method (default parameter))
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (async generator method (default parameter))
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (async generator method (default parameter))
 esid: sec-asyncgenerator-definitions-propertydefinitionevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/async-generator/dstr/ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (async generator function declaration)
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/ary-ptrn-rest-init-id.js
+++ b/test/language/statements/async-generator/dstr/ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (async generator function declaration)
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/async-generator/dstr/ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (async generator function declaration)
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/async-generator/dstr/ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (async generator function declaration)
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/async-generator/dstr/ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (async generator function declaration)
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/async-generator/dstr/ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (async generator function declaration)
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (async generator function declaration (default parameter))
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (async generator function declaration (default parameter))
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (async generator function declaration (default parameter))
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (async generator function declaration (default parameter))
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (async generator function declaration (default parameter))
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (async generator function declaration (default parameter))
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (private class expression method)
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (private class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (private class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (private class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (private class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (private class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (private class expression async generator method (default parameters))
 esid: sec-class-definitions-runtime-semantics-evaluation
 features: [class, class-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (private static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (private static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (private static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (private static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (private static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (private static class expression async generator method)
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (private static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (private static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (private static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (private static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (private static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (private static class expression async generator method (default parameter))
 esid: sec-runtime-semantics-bindingclassdeclarationevaluation
 features: [class, class-static-methods-private, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-yield-ident-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-yield-ident-invalid.js
@@ -5,7 +5,7 @@
 description: When a `yield` token appears within the Initializer of an AssignmentElement outside of a generator function body, it behaves as an IdentifierReference. (for-await-of statement in an async function declaration)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, onlyStrict, async]
+flags: [generated, onlyStrict]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-array-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-array-invalid.js
@@ -5,7 +5,7 @@
 description: It is a Syntax Error if LeftHandSideExpression is either an ObjectLiteral or an ArrayLiteral and if the lexical token sequence matched by LeftHandSideExpression cannot be parsed with no tokens left over using AssignmentPattern as the goal symbol. (for-await-of statement in an async function declaration)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-array-yield-ident-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-array-yield-ident-invalid.js
@@ -5,7 +5,7 @@
 description: When a `yield` token appears within the DestructuringAssignmentTarget of a nested destructuring assignment outside of strict mode, it behaves as an IdentifierReference. (for-await-of statement in an async function declaration)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, onlyStrict, async]
+flags: [generated, onlyStrict]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-obj-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-obj-invalid.js
@@ -5,7 +5,7 @@
 description: It is a Syntax Error if LeftHandSideExpression is either an ObjectLiteral or an ArrayLiteral and if the lexical token sequence matched by LeftHandSideExpression cannot be parsed with no tokens left over using AssignmentPattern as the goal symbol. (for-await-of statement in an async function declaration)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-obj-yield-ident-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-obj-yield-ident-invalid.js
@@ -5,7 +5,7 @@
 description: When a `yield` token appears within the Initializer of a nested destructuring assignment outside of a generator function body, it behaves as a IdentifierReference. (for-await-of statement in an async function declaration)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, onlyStrict, async]
+flags: [generated, onlyStrict]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-target-simple-strict.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-target-simple-strict.js
@@ -5,7 +5,7 @@
 description: It is a Syntax Error if LeftHandSideExpression is neither an ObjectLiteral nor an ArrayLiteral and IsValidSimpleAssignmentTarget(LeftHandSideExpression) is false. (for-await-of statement in an async function declaration)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, onlyStrict, async]
+flags: [generated, onlyStrict]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-target-yield-invalid.js
+++ b/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-target-yield-invalid.js
@@ -5,7 +5,7 @@
 description: When a `yield` token appears within the DestructuringAssignmentTarget of an AssignmentElement and outside of a generator function body, it behaves as an IdentifierReference. (for-await-of statement in an async function declaration)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, onlyStrict, async]
+flags: [generated, onlyStrict]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (nested array pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (nested object pattern) does not support initializer (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-ary.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-ary.js
@@ -5,7 +5,7 @@
 description: Rest element (array binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-id.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-id.js
@@ -5,7 +5,7 @@
 description: Rest element (identifier) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-obj.js
+++ b/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-not-final-obj.js
@@ -5,7 +5,7 @@
 description: Rest element (object binding pattern) may not be followed by any element (for-await-of statement)
 esid: sec-for-in-and-for-of-statements-runtime-semantics-labelledevaluation
 features: [destructuring-binding, async-iteration]
-flags: [generated, async]
+flags: [generated]
 negative:
   phase: parse
   type: SyntaxError

--- a/tools/generation/test/expected/async/async-function-declaration-async-negative-invalid.js
+++ b/tools/generation/test/expected/async/async-function-declaration-async-negative-invalid.js
@@ -1,0 +1,17 @@
+// This file was procedurally generated from the following sources:
+// - tools/generation/test/fixtures/async-negative-invalid.case
+// - tools/generation/test/fixtures/async/async.template
+/*---
+description: Early SyntaxError tests should not include "async" in flags[] (async function declaration)
+esid: prod-AsyncFunctionDeclaration
+flags: [generated]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+$DONOTEVALUATE();
+
+async function fn() {
+  await 1;
+  1=1;
+}

--- a/tools/generation/test/fixtures/async-negative-invalid.case
+++ b/tools/generation/test/fixtures/async-negative-invalid.case
@@ -1,0 +1,15 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Early SyntaxError tests should not include "async" in flags[]
+template: async
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+//- setup
+$DONOTEVALUATE();
+//- body
+1=1;

--- a/tools/generation/test/fixtures/async/async.template
+++ b/tools/generation/test/fixtures/async/async.template
@@ -1,0 +1,13 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+path: async/async-function-declaration-
+name: async function declaration
+esid: prod-AsyncFunctionDeclaration
+flags: [async]
+---*/
+
+async function fn() {
+  await 1;
+  /*{ body }*/
+}

--- a/tools/generation/test/run.py
+++ b/tools/generation/test/run.py
@@ -54,6 +54,11 @@ class TestGeneration(unittest.TestCase):
         self.assertEqual(result['returncode'], 0)
         self.compareTrees('normal')
 
+    def test_async(self):
+        result = self.fixture('async-negative-invalid.case')
+        self.assertEqual(result['returncode'], 0)
+        self.compareTrees('async')
+
     def test_negative(self):
         result = self.fixture('negative.case')
         self.assertEqual(result['returncode'], 0)


### PR DESCRIPTION
@leobalter explanation here: https://github.com/tc39/test262/issues/1229#issuecomment-686494799