### PR TITLE
Improve RegExp.prototype[@@replace] poisoned stdlib test

### DIFF
--- a/test/built-ins/RegExp/prototype/Symbol.replace/poisoned-stdlib.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/poisoned-stdlib.js
@@ -17,6 +17,17 @@ assert(delete String.prototype.indexOf);
 assert(delete String.prototype.slice);
 assert(delete String.prototype.substring);
 
+for (let i = 0; i < 5; ++i) {
+    Object.defineProperty(Array.prototype, i, {
+        get: function() {
+            throw new Test262Error(i + " getter should be unreachable.");
+        },
+        set: function(_value) {
+            throw new Test262Error(i + " setter should be unreachable.");
+        },
+    });
+}
+
 var str = "1a2";
 
 assert.sameValue(/a/[Symbol.replace](str, "$`b"), "11b2");


### PR DESCRIPTION
JSC bug: [Use `@putByValDirect` instead `Array.prototype.@push` in builtins](https://bugs.webkit.org/show_bug.cgi?id=175432).

Follow-up of #2481.