### PR TITLE
Test that pre-ES6 built-in prototypes are not instances

### DIFF
--- a/test/built-ins/Date/prototype/no-date-value.js
+++ b/test/built-ins/Date/prototype/no-date-value.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-properties-of-the-date-prototype-object
+description: >
+  The Date Prototype object does not have a [[DateValue]] internal slot.
+info: |
+  Properties of the Date Prototype Object
+
+  The Date prototype object:
+  [...]
+  * is not a Date instance and does not have a [[DateValue]] internal slot.
+
+  Date.prototype.getTime ( )
+
+  1. Return ? thisTimeValue(this value).
+
+  The abstract operation thisTimeValue takes argument value.
+
+  1. If Type(value) is Object and value has a [[DateValue]] internal slot, then
+    [...]
+  2. Throw a TypeError exception.
+---*/
+
+assert.throws(TypeError, function() {
+  Date.prototype.getTime();
+});

--- a/test/built-ins/Error/prototype/no-error-data.js
+++ b/test/built-ins/Error/prototype/no-error-data.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-properties-of-the-error-prototype-object
+description: >
+  The Error Prototype object does not have a [[ErrorData]] internal slot.
+info: |
+  Properties of the Error Prototype Object
+
+  The Error prototype object:
+  [...]
+  * is not an Error instance and does not have an [[ErrorData]] internal slot.
+
+  Object.prototype.toString ( )
+
+  [...]
+  8. Else if O has an [[ErrorData]] internal slot, let builtinTag be "Error".
+  [...]
+  15. Let tag be ? Get(O, @@toStringTag).
+  16. If Type(tag) is not String, set tag to builtinTag.
+  17. Return the string-concatenation of "[object ", tag, and "]".
+features: [Symbol.toStringTag]
+---*/
+
+// Although the spec doesn't define Error.prototype[@@toStringTag], set it
+// to non-string anyway because implementations are allowed to define it.
+Object.defineProperty(Error.prototype, Symbol.toStringTag, {
+  value: null,
+});
+
+assert.sameValue(
+  Object.prototype.toString.call(Error.prototype),
+  "[object Object]"
+);


### PR DESCRIPTION
Similar test for [`RegExp.prototype`](https://tc39.es/ecma262/#sec-properties-of-the-regexp-prototype-object): [`/test/built-ins/RegExp/prototype/no-regexp-matcher.js`](https://github.com/tc39/test262/blob/main/test/built-ins/RegExp/prototype/no-regexp-matcher.js).

JSC bug: [For many `X`, `X.prototype` is an `X` when it must be a plain object](https://bugs.webkit.org/show_bug.cgi?id=141610).