### PR TITLE
Coverage: delete undefined.property. Fixes gh-2763

### DIFF
--- a/test/language/expressions/delete/11.4.1-0-1.js
+++ b/test/language/expressions/delete/11.4.1-0-1.js
@@ -5,17 +5,14 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-0-1
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: delete operator as UnaryExpression
 flags: [noStrict]
 ---*/
 
-function testcase() {
-  var x = 1;
-  var y = 2;
-  var z = 3;
+var x = 1;
+var y = 2;
+var z = 3;
 
-  assert((!delete x || delete y), '(!delete x || delete y)');
-  assert(delete delete z, 'delete delete z');
- }
-testcase();
+assert((!delete x || delete y), '(!delete x || delete y)');
+assert(delete delete z, 'delete delete z');

--- a/test/language/expressions/delete/11.4.1-2-2.js
+++ b/test/language/expressions/delete/11.4.1-2-2.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-2-2
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns true when deleting returned value from a
     function
 ---*/
 
-  var bIsFooCalled = false;
-  var foo = function(){bIsFooCalled = true;};
+var bIsFooCalled = false;
+var foo = function() {
+  bIsFooCalled = true;
+};
 
-  var d = delete foo();
+var d = delete foo();
 
 assert.sameValue(d, true, 'd');
 assert.sameValue(bIsFooCalled, true, 'bIsFooCalled');

--- a/test/language/expressions/delete/11.4.1-3-1.js
+++ b/test/language/expressions/delete/11.4.1-3-1.js
@@ -2,14 +2,11 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-3-1
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns true when deleting an unresolvable
     reference
 flags: [noStrict]
 ---*/
 
-  // just cooking up a long/veryLikely unique name
-  var d = delete __ES3_1_test_suite_test_11_4_1_3_unique_id_0__;
-
-assert.sameValue(d, true, 'd');
+assert.sameValue(delete unresolvable, true, 'delete unresolvable === true');

--- a/test/language/expressions/delete/11.4.1-3-2.js
+++ b/test/language/expressions/delete/11.4.1-3-2.js
@@ -2,13 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-3-2
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator throws ReferenceError when deleting an explicitly
     qualified yet unresolvable reference (base obj undefined)
 ---*/
 
-  // just cooking up a long/veryLikely unique name
 assert.throws(ReferenceError, function() {
-    var d = delete __ES3_1_test_suite_test_11_4_1_3_unique_id_2__.x;
+  delete unresolvable.x;
 });

--- a/test/language/expressions/delete/11.4.1-3-3.js
+++ b/test/language/expressions/delete/11.4.1-3-3.js
@@ -2,13 +2,11 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-3-3
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns true when deleting an explicitly qualified
     yet unresolvable reference (property undefined for base obj)
 ---*/
 
-  var __ES3_1_test_suite_test_11_4_1_3_unique_id_3__ = {};
-  var d = delete __ES3_1_test_suite_test_11_4_1_3_unique_id_3__.x;
-
-assert.sameValue(d, true, 'd');
+var o = {};
+assert.sameValue(delete o.x, true);

--- a/test/language/expressions/delete/11.4.1-4-a-1-s.js
+++ b/test/language/expressions/delete/11.4.1-4-a-1-s.js
@@ -2,19 +2,19 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-4-a-1-s
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     Strict Mode - TypeError is thrown when deleting non-configurable
     data property
 flags: [onlyStrict]
 ---*/
 
-        var obj = {};
-        Object.defineProperty(obj, "prop", {
-            value: "abc",
-            configurable: false
-        });
-assert.throws(TypeError, function() {
-            delete obj.prop;
+var obj = {};
+Object.defineProperty(obj, 'prop', {
+  value: 'abc',
+  configurable: false,
 });
-assert.sameValue(obj.prop, "abc", 'obj.prop');
+assert.throws(TypeError, function() {
+  delete obj.prop;
+});
+assert.sameValue(obj.prop, 'abc', 'obj.prop');

--- a/test/language/expressions/delete/11.4.1-4-a-2-s.js
+++ b/test/language/expressions/delete/11.4.1-4-a-2-s.js
@@ -2,21 +2,21 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-4-a-2-s
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     Strict Mode - TypeError is thrown when deleting non-configurable
     accessor property
 flags: [onlyStrict]
 ---*/
 
-        var obj = {};
-        Object.defineProperty(obj, "prop", {
-            get: function () {
-                return "abc"; 
-            },
-            configurable: false
-        });
-assert.throws(TypeError, function() {
-            delete obj.prop;
+var obj = {};
+Object.defineProperty(obj, 'prop', {
+  get: function() {
+    return 'abc';
+  },
+  configurable: false,
 });
-assert.sameValue(obj.prop, "abc", 'obj.prop');
+assert.throws(TypeError, function() {
+  delete obj.prop;
+});
+assert.sameValue(obj.prop, 'abc', 'obj.prop');

--- a/test/language/expressions/delete/11.4.1-4-a-3-s.js
+++ b/test/language/expressions/delete/11.4.1-4-a-3-s.js
@@ -2,17 +2,21 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-4-a-3-s
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     TypeError isn't thrown when deleting configurable data property
 ---*/
 
-        var obj = {};
-        Object.defineProperty(obj, "prop", {
-            value: "abc",
-            configurable: true
-        });
+var obj = {};
+Object.defineProperty(obj, 'prop', {
+  value: 'abc',
+  configurable: true,
+});
 
-        delete obj.prop;
+delete obj.prop;
 
-assert.sameValue(obj.hasOwnProperty("prop"), false, 'obj.hasOwnProperty("prop")');
+assert.sameValue(
+  obj.hasOwnProperty('prop'),
+  false,
+  'obj.hasOwnProperty("prop")'
+);

--- a/test/language/expressions/delete/11.4.1-4-a-4-s.js
+++ b/test/language/expressions/delete/11.4.1-4-a-4-s.js
@@ -2,19 +2,23 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-4-a-4-s
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     TypeError isn't thrown when deleting configurable accessor property
 ---*/
 
-        var obj = {};
-        Object.defineProperty(obj, "prop", {
-            get: function () {
-                return "abc"; 
-            },
-            configurable: true
-        });
+var obj = {};
+Object.defineProperty(obj, 'prop', {
+  get: function() {
+    return 'abc';
+  },
+  configurable: true,
+});
 
-        delete obj.prop;
+delete obj.prop;
 
-assert.sameValue(obj.hasOwnProperty("prop"), false, 'obj.hasOwnProperty("prop")');
+assert.sameValue(
+  obj.hasOwnProperty('prop'),
+  false,
+  'obj.hasOwnProperty("prop")'
+);

--- a/test/language/expressions/delete/11.4.1-4.a-1.js
+++ b/test/language/expressions/delete/11.4.1-4.a-1.js
@@ -5,18 +5,21 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-1
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns true when deleting a configurable data
     property
 ---*/
 
-  var o = {};
+var o = {};
 
-  var desc = { value: 1, configurable: true };
-  Object.defineProperty(o, "foo", desc);
+var desc = {
+  value: 1,
+  configurable: true,
+};
+Object.defineProperty(o, 'foo', desc);
 
-  var d = delete o.foo;
+var d = delete o.foo;
 
 assert.sameValue(d, true, 'd');
-assert.sameValue(o.hasOwnProperty("foo"), false, 'o.hasOwnProperty("foo")');
+assert.sameValue(o.hasOwnProperty('foo'), false, 'o.hasOwnProperty("foo")');

--- a/test/language/expressions/delete/11.4.1-4.a-10.js
+++ b/test/language/expressions/delete/11.4.1-4.a-10.js
@@ -5,7 +5,7 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-10
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns true for property (stringify) defined on
     built-in object (JSON)

--- a/test/language/expressions/delete/11.4.1-4.a-11.js
+++ b/test/language/expressions/delete/11.4.1-4.a-11.js
@@ -5,21 +5,19 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-11
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns true on deleting arguments
     properties(arguments.callee)
 flags: [noStrict]
 ---*/
 
-function testcase() {
-  function foo(a,b)
-  {
-    return (delete arguments.callee); 
+(function() {
+  function foo(a, b) {
+    return delete arguments.callee;
   }
   var d = delete arguments.callee;
 
   assert.sameValue(d, true, 'd');
   assert.sameValue(arguments.callee, undefined, 'arguments.callee');
- }
-testcase();
+})();

--- a/test/language/expressions/delete/11.4.1-4.a-12.js
+++ b/test/language/expressions/delete/11.4.1-4.a-12.js
@@ -5,14 +5,14 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-12
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: delete operator returns false when deleting a property(length)
 flags: [noStrict]
 ---*/
 
-  var a = [1,2,3]
-  a.x = 10;
-  var d = delete a.length
+var a = [1, 2, 3];
+a.x = 10;
+var d = delete a.length;
 
 assert.sameValue(d, false, 'd');
 assert.sameValue(a.length, 3, 'a.length');

--- a/test/language/expressions/delete/11.4.1-4.a-13.js
+++ b/test/language/expressions/delete/11.4.1-4.a-13.js
@@ -5,19 +5,15 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-13
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: delete operator returns false when deleting Array object
 flags: [noStrict]
 ---*/
 
-function testcase() {
+var a = [1, 2, 3];
+a.x = 10;
 
-  var a = [1,2,3]
-  a.x = 10;
+var d = delete a;
 
-  var d = delete a 
-
-  assert.sameValue(d, false, 'd');
-  assert.sameValue(Array.isArray(a), true, 'Array.isArray(a)');
- }
-testcase();
+assert.sameValue(d, false, 'd');
+assert.sameValue(Array.isArray(a), true, 'Array.isArray(a)');

--- a/test/language/expressions/delete/11.4.1-4.a-14.js
+++ b/test/language/expressions/delete/11.4.1-4.a-14.js
@@ -5,13 +5,13 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-14
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: delete operator returns true when deleting Array elements
 ---*/
 
-  var a = [1,2,3]
-  a.x = 10;
-  var d = delete a[1]
+var a = [1, 2, 3];
+a.x = 10;
+var d = delete a[1];
 
 assert.sameValue(d, true, 'd');
 assert.sameValue(a[1], undefined, 'a[1]');

--- a/test/language/expressions/delete/11.4.1-4.a-15.js
+++ b/test/language/expressions/delete/11.4.1-4.a-15.js
@@ -5,13 +5,13 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-15
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: delete operator returns true when deleting Array expandos
 ---*/
 
-  var a = [1,2,3]
-  a.x = 10;
-  var d = delete a.x;
+var a = [1, 2, 3];
+a.x = 10;
+var d = delete a.x;
 
 assert.sameValue(d, true, 'd');
 assert.sameValue(a.x, undefined, 'a.x');

--- a/test/language/expressions/delete/11.4.1-4.a-16.js
+++ b/test/language/expressions/delete/11.4.1-4.a-16.js
@@ -5,13 +5,12 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-16
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: delete operator returns false on deleting arguments object
 flags: [noStrict]
 ---*/
 
-function testcase() {
+(function() {
   assert.sameValue(delete arguments, false, 'delete arguments');
   assert.notSameValue(arguments, undefined, 'arguments');
- }
-testcase();
+})();

--- a/test/language/expressions/delete/11.4.1-4.a-17.js
+++ b/test/language/expressions/delete/11.4.1-4.a-17.js
@@ -5,14 +5,13 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-17
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: delete operator returns true on deleting a arguments element
 ---*/
 
-  function foo(a,b)
-  {
-    var d = delete arguments[0];
-    return (d === true && arguments[0] === undefined);  
-  }
+function foo(a, b) {
+  var d = delete arguments[0];
+  return d === true && arguments[0] === undefined;
+}
 
-assert.sameValue(foo(1,2), true, 'foo(1,2)');
+assert.sameValue(foo(1, 2), true, 'foo(1,2)');

--- a/test/language/expressions/delete/11.4.1-4.a-2.js
+++ b/test/language/expressions/delete/11.4.1-4.a-2.js
@@ -5,21 +5,26 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-2
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns true when deleting a configurable accessor
     property
 ---*/
 
-  var o = {};
+var o = {};
 
-  // define an accessor
-  // dummy getter
-  var getter = function () { return 1; }
-  var desc = { get: getter, configurable: true };
-  Object.defineProperty(o, "foo", desc);
-    
-  var d = delete o.foo;
+// define an accessor
+// dummy getter
+var getter = function() {
+  return 1;
+};
+var desc = {
+  get: getter,
+  configurable: true,
+};
+Object.defineProperty(o, 'foo', desc);
+
+var d = delete o.foo;
 
 assert.sameValue(d, true, 'd');
-assert.sameValue(o.hasOwnProperty("foo"), false, 'o.hasOwnProperty("foo")');
+assert.sameValue(o.hasOwnProperty('foo'), false, 'o.hasOwnProperty("foo")');

--- a/test/language/expressions/delete/11.4.1-4.a-3-s.js
+++ b/test/language/expressions/delete/11.4.1-4.a-3-s.js
@@ -5,18 +5,20 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-3-s
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator throws TypeError when deleting a non-configurable
     data property in strict mode
 flags: [onlyStrict]
 ---*/
 
-  var o = {};
-  var desc = { value : 1 }; // all other attributes default to false
-  Object.defineProperty(o, "foo", desc);
-  
-  // Now, deleting o.foo should throw TypeError because [[Configurable]] on foo is false.
+var o = {};
+var desc = {
+  value: 1,
+}; // all other attributes default to false
+Object.defineProperty(o, 'foo', desc);
+
+// Now, deleting o.foo should throw TypeError because [[Configurable]] on foo is false.
 assert.throws(TypeError, function() {
-    delete o.foo;
+  delete o.foo;
 });

--- a/test/language/expressions/delete/11.4.1-4.a-3.js
+++ b/test/language/expressions/delete/11.4.1-4.a-3.js
@@ -5,19 +5,22 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-3
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns false when deleting a non-configurable
     data property
 flags: [noStrict]
 ---*/
 
-  var o = {};
-  var desc = { value : 1, configurable: false }; // all other attributes default to false
-  Object.defineProperty(o, "foo", desc);
-  
-  // Now, deleting o.foo should fail because [[Configurable]] on foo is false.
-  var d = delete o.foo;
+var o = {};
+var desc = {
+  value: 1,
+  configurable: false,
+}; // all other attributes default to false
+Object.defineProperty(o, 'foo', desc);
+
+// Now, deleting o.foo should fail because [[Configurable]] on foo is false.
+var d = delete o.foo;
 
 assert.sameValue(d, false, 'd');
-assert.sameValue(o.hasOwnProperty("foo"), true, 'o.hasOwnProperty("foo")');
+assert.sameValue(o.hasOwnProperty('foo'), true, 'o.hasOwnProperty("foo")');

--- a/test/language/expressions/delete/11.4.1-4.a-4.js
+++ b/test/language/expressions/delete/11.4.1-4.a-4.js
@@ -5,14 +5,14 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-4
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns false when deleting a non-configurable
     data property (NaN)
 flags: [noStrict]
 ---*/
 
-  // NaN (15.1.1.1) has [[Configurable]] set to false.
-  var d = delete NaN;
+// NaN (15.1.1.1) has [[Configurable]] set to false.
+var d = delete NaN;
 
 assert.sameValue(d, false, 'd');

--- a/test/language/expressions/delete/11.4.1-4.a-5.js
+++ b/test/language/expressions/delete/11.4.1-4.a-5.js
@@ -5,24 +5,20 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-5
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns false when deleting the declaration of the environment object
     inside 'with'
 flags: [noStrict]
 ---*/
 
-function testcase() {
-  var o = new Object();
-  o.x = 1;
-  var d;
-  with(o)
-  {
-    d = delete o;
-  }
+var o = new Object();
+o.x = 1;
+var d;
+with(o) {
+  d = delete o;
+}
 
-  assert.sameValue(d, false, 'd');
-  assert.sameValue(typeof(o), 'object', 'typeof(o)');
-  assert.sameValue(o.x, 1, 'o.x');
- }
-testcase();
+assert.sameValue(d, false, 'd');
+assert.sameValue(typeof o, 'object', 'typeof(o)');
+assert.sameValue(o.x, 1, 'o.x');

--- a/test/language/expressions/delete/11.4.1-4.a-6.js
+++ b/test/language/expressions/delete/11.4.1-4.a-6.js
@@ -5,18 +5,17 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-6
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: delete operator returns true when deleting a property inside 'with'
 flags: [noStrict]
 ---*/
 
-  var o = new Object();
-  o.x = 1;
-  var d;
-  with(o)
-  {
-    d = delete x;
-  }
+var o = new Object();
+o.x = 1;
+var d;
+with(o) {
+  d = delete x;
+}
 
 assert.sameValue(d, true, 'd');
 assert.sameValue(o.x, undefined, 'o.x');

--- a/test/language/expressions/delete/11.4.1-4.a-7.js
+++ b/test/language/expressions/delete/11.4.1-4.a-7.js
@@ -5,16 +5,13 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-7
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: delete operator inside 'eval'
 flags: [noStrict]
 ---*/
 
-function testcase() {
-  var x = 1;
-  var d = eval("delete x");
+var x = 1;
+var d = eval('delete x');
 
-  assert.sameValue(d, false, 'd');
-  assert.sameValue(x, 1, 'x');
- }
-testcase();
+assert.sameValue(d, false, 'd');
+assert.sameValue(x, 1, 'x');

--- a/test/language/expressions/delete/11.4.1-4.a-8-s.js
+++ b/test/language/expressions/delete/11.4.1-4.a-8-s.js
@@ -5,7 +5,7 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-8-s
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator throws TypeError when deleting a non-configurable
     data property in strict mode
@@ -13,7 +13,7 @@ flags: [onlyStrict]
 ---*/
 
 var global = this;
-  // NaN (15.1.1.1) has [[Configurable]] set to false.
+// NaN (15.1.1.1) has [[Configurable]] set to false.
 assert.throws(TypeError, function() {
-    delete global.NaN;
+  delete global.NaN;
 });

--- a/test/language/expressions/delete/11.4.1-4.a-8.js
+++ b/test/language/expressions/delete/11.4.1-4.a-8.js
@@ -5,7 +5,7 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-8
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: delete operator returns true for built-in objects (JSON)
 flags: [noStrict]
 ---*/

--- a/test/language/expressions/delete/11.4.1-4.a-9-s.js
+++ b/test/language/expressions/delete/11.4.1-4.a-9-s.js
@@ -5,14 +5,13 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-9-s
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator throws TypeError when deleting a non-configurable
     data property (Math.LN2) in strict mode
 flags: [onlyStrict]
 ---*/
 
-
 assert.throws(TypeError, function() {
-    delete Math.LN2;
+  delete Math.LN2;
 });

--- a/test/language/expressions/delete/11.4.1-4.a-9.js
+++ b/test/language/expressions/delete/11.4.1-4.a-9.js
@@ -5,13 +5,13 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.1-4.a-9
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns false when deleting a non-configurable
     data property (Math.LN2)
 flags: [noStrict]
 ---*/
 
-  var d = delete Math.LN2;
+var d = delete Math.LN2;
 
 assert.sameValue(d, false, 'd');

--- a/test/language/expressions/delete/11.4.1-5-1.js
+++ b/test/language/expressions/delete/11.4.1-5-1.js
@@ -2,20 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-5-1
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns false when deleting a direct reference to
     a var
 flags: [noStrict]
 ---*/
 
-function testcase() {
-  var x = 1;
+var x = 1;
 
-  // Now, deleting 'x' directly should fail;
-  var d = delete x;
+// Now, deleting 'x' directly should fail;
+var d = delete x;
 
-  assert.sameValue(d, false, 'd');
-  assert.sameValue(x, 1, 'x');
- }
-testcase();
+assert.sameValue(d, false, 'd');
+assert.sameValue(x, 1, 'x');

--- a/test/language/expressions/delete/11.4.1-5-2.js
+++ b/test/language/expressions/delete/11.4.1-5-2.js
@@ -2,19 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-5-2
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns false when deleting a direct reference to
     a function argument
 flags: [noStrict]
 ---*/
 
-  function foo(a,b) {
-  
-    // Now, deleting 'a' directly should fail
-    // because 'a' is direct reference to a function argument;
-    var d = delete a;
-    return (d === false && a === 1);
-  }
+function foo(a, b) {
+  // Now, deleting 'a' directly should fail
+  // because 'a' is direct reference to a function argument;
+  var d = delete a;
+  return d === false && a === 1;
+}
 
-assert(foo(1,2), 'foo(1,2) !== true');
+assert(foo(1, 2), 'foo(1,2) !== true');

--- a/test/language/expressions/delete/11.4.1-5-3.js
+++ b/test/language/expressions/delete/11.4.1-5-3.js
@@ -2,20 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-5-3
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator returns false when deleting a direct reference to
     a function name
 flags: [noStrict]
 ---*/
 
-function testcase() {
-  var foo = function(){};
+var foo = function() {};
 
-  // Now, deleting 'foo' directly should fail;
-  var d = delete foo;
+// Now, deleting 'foo' directly should fail;
+var d = delete foo;
 
-  assert.sameValue(d, false, 'd');
-  assert.sameValue(typeof foo, 'function', 'typeof foo');
- }
-testcase();
+assert.sameValue(d, false, 'd');
+assert.sameValue(typeof foo, 'function', 'typeof foo');

--- a/test/language/expressions/delete/11.4.1-5-a-27-s.js
+++ b/test/language/expressions/delete/11.4.1-5-a-27-s.js
@@ -2,16 +2,21 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-5-a-27-s
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     Strict Mode - TypeError is thrown after deleting a property,
     calling preventExtensions, and attempting to reassign the property
 flags: [onlyStrict]
 ---*/
 
-        var a = {x:0, get y() { return 0;}};
-        delete a.x;
-        Object.preventExtensions(a);
+var a = {
+  x: 0,
+  get y() {
+    return 0;
+  },
+};
+delete a.x;
+Object.preventExtensions(a);
 assert.throws(TypeError, function() {
-            a.x = 1;
+  a.x = 1;
 });

--- a/test/language/expressions/delete/11.4.1-5-a-28-s.js
+++ b/test/language/expressions/delete/11.4.1-5-a-28-s.js
@@ -2,9 +2,9 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es5id: 11.4.1-5-a-28-s
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Strict Mode - TypeError is not thrown when deleting RegExp.length
 ---*/
 
-    var a = new RegExp();
-    var b = delete RegExp.length;
+var a = new RegExp();
+var b = delete RegExp.length;

--- a/test/language/expressions/delete/11.4.4-4.a-3-s.js
+++ b/test/language/expressions/delete/11.4.4-4.a-3-s.js
@@ -5,18 +5,20 @@
 info: |
     This test is actually testing the [[Delete]] internal method (8.12.8). Since the
     language provides no way to directly exercise [[Delete]], the tests are placed here.
-es5id: 11.4.4-4.a-3-s
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     delete operator throws TypeError when deleting a non-configurable
     data property in strict mode
 flags: [onlyStrict]
 ---*/
 
-  var o = {};
-  var desc = { value : 1 }; // all other attributes default to false
-  Object.defineProperty(o, "foo", desc);
-  
-  // Now, deleting o.foo should throw TypeError because [[Configurable]] on foo is false.
+var o = {};
+var desc = {
+  value: 1,
+}; // all other attributes default to false
+Object.defineProperty(o, 'foo', desc);
+
+// Now, deleting o.foo should throw TypeError because [[Configurable]] on foo is false.
 assert.throws(TypeError, function() {
-    delete o.foo;
+  delete o.foo;
 });

--- a/test/language/expressions/delete/S11.4.1_A2.1.js
+++ b/test/language/expressions/delete/S11.4.1_A2.1.js
@@ -3,7 +3,7 @@
 
 /*---
 info: If Type(x) is not Reference, return true
-es5id: 11.4.1_A2.1
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking primitive value and Object value cases
 ---*/
 

--- a/test/language/expressions/delete/S11.4.1_A2.2_T1.js
+++ b/test/language/expressions/delete/S11.4.1_A2.2_T1.js
@@ -3,7 +3,7 @@
 
 /*---
 info: If GetBase(x) doesn't have a property GetPropertyName(x), return true
-es5id: 11.4.1_A2.2_T1
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking undeclared variable case
 flags: [noStrict]
 ---*/

--- a/test/language/expressions/delete/S11.4.1_A2.2_T2.js
+++ b/test/language/expressions/delete/S11.4.1_A2.2_T2.js
@@ -3,15 +3,17 @@
 
 /*---
 info: If GetBase(x) doesn't have a property GetPropertyName(x), return true
-es5id: 11.4.1_A2.2_T2
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking Object object and Function object cases
 ---*/
 
 //CHECK#1
-function MyFunction(){}
+function MyFunction() {}
 var MyObject = new MyFunction();
 if (delete MyObject.prop !== true) {
-  $ERROR('#1: function MyFunction(){}; var MyObject = new MyFunction(); delete MyObject.prop === true');
+  $ERROR(
+    '#1: function MyFunction(){}; var MyObject = new MyFunction(); delete MyObject.prop === true'
+  );
 }
 
 //CHECK#2

--- a/test/language/expressions/delete/S11.4.1_A2.2_T3.js
+++ b/test/language/expressions/delete/S11.4.1_A2.2_T3.js
@@ -3,7 +3,7 @@
 
 /*---
 info: If GetBase(x) doesn't have a property GetPropertyName(x), return true
-es5id: 11.4.1_A2.2_T3
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking undeclared variable case
 ---*/
 

--- a/test/language/expressions/delete/S11.4.1_A3.1.js
+++ b/test/language/expressions/delete/S11.4.1_A3.1.js
@@ -3,7 +3,7 @@
 
 /*---
 info: If the property has the DontDelete attribute, return false
-es5id: 11.4.1_A3.1
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking declared variable
 flags: [noStrict]
 ---*/
@@ -21,7 +21,7 @@ if (delete this.y !== false) {
 }
 
 //CHECK#3
-function MyFunction(){};
+function MyFunction() {}
 if (delete MyFunction !== false) {
   $ERROR('#3: function MyFunction(){}; delete MyFunction === false');
 }
@@ -29,5 +29,7 @@ if (delete MyFunction !== false) {
 //CHECK#4
 var MyObject = new MyFunction();
 if (delete MyObject !== false) {
-  $ERROR('#4: function MyFunction(){}; var MyObject = new MyFunction(); delete MyObject === false');
+  $ERROR(
+    '#4: function MyFunction(){}; var MyObject = new MyFunction(); delete MyObject === false'
+  );
 }

--- a/test/language/expressions/delete/S11.4.1_A3.2_T1.js
+++ b/test/language/expressions/delete/S11.4.1_A3.2_T1.js
@@ -3,7 +3,7 @@
 
 /*---
 info: If the property doesn't have the DontDelete attribute, return true
-es5id: 11.4.1_A3.2_T1
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking declared variable
 flags: [noStrict]
 ---*/

--- a/test/language/expressions/delete/S11.4.1_A3.2_T2.js
+++ b/test/language/expressions/delete/S11.4.1_A3.2_T2.js
@@ -3,13 +3,15 @@
 
 /*---
 info: If the property doesn't have the DontDelete attribute, return true
-es5id: 11.4.1_A3.2_T2
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking declared variable
 ---*/
 
 //CHECK#1
-function MyFunction(){};
+function MyFunction() {}
 MyFunction.prop = 1;
 if (delete MyFunction.prop !== true) {
-  $ERROR('#1: function MyFunction(){}; MyFunction.prop = 1; delete MyFunction.prop === true');
+  $ERROR(
+    '#1: function MyFunction(){}; MyFunction.prop = 1; delete MyFunction.prop === true'
+  );
 }

--- a/test/language/expressions/delete/S11.4.1_A3.2_T3.js
+++ b/test/language/expressions/delete/S11.4.1_A3.2_T3.js
@@ -3,14 +3,16 @@
 
 /*---
 info: If the property doesn't have the DontDelete attribute, return true
-es5id: 11.4.1_A3.2_T3
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking declared variable
 ---*/
 
 //CHECK#1
-function MyFunction(){};
+function MyFunction() {}
 var MyObject = new MyFunction();
 MyObject.prop = 1;
 if (delete MyObject.prop !== true) {
-  $ERROR('#1: function MyFunction(){}; var MyObject = new MyFunction(); MyFunction.prop = 1; delete MyObject.prop === true');
+  $ERROR(
+    '#1: function MyFunction(){}; var MyObject = new MyFunction(); MyFunction.prop = 1; delete MyObject.prop === true'
+  );
 }

--- a/test/language/expressions/delete/S11.4.1_A3.3_T1.js
+++ b/test/language/expressions/delete/S11.4.1_A3.3_T1.js
@@ -3,7 +3,7 @@
 
 /*---
 info: If the property doesn't have the DontDelete attribute, remove the property
-es5id: 11.4.1_A3.3_T1
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking declared variable
 flags: [noStrict]
 ---*/

--- a/test/language/expressions/delete/S11.4.1_A3.3_T2.js
+++ b/test/language/expressions/delete/S11.4.1_A3.3_T2.js
@@ -3,15 +3,17 @@
 
 /*---
 info: If the property doesn't have the DontDelete attribute, remove the property
-es5id: 11.4.1_A3.3_T2
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking declared variable
 ---*/
 
 //CHECK#1
-function MyFunction(){};
+function MyFunction() {}
 MyFunction.prop = 1;
 delete MyFunction.prop;
 if (MyFunction.prop !== undefined) {
-  $ERROR('#1: function MyFunction(){}; MyFunction.prop = 1; delete MyFunction.prop; MyFunction.prop === undefined. Actual: ' + (MyFunction.prop));
-
+  $ERROR(
+    '#1: function MyFunction(){}; MyFunction.prop = 1; delete MyFunction.prop; MyFunction.prop === undefined. Actual: ' +
+    MyFunction.prop
+  );
 }

--- a/test/language/expressions/delete/S11.4.1_A3.3_T3.js
+++ b/test/language/expressions/delete/S11.4.1_A3.3_T3.js
@@ -3,15 +3,18 @@
 
 /*---
 info: If the property doesn't have the DontDelete attribute, remove the property
-es5id: 11.4.1_A3.3_T3
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking declared variable
 ---*/
 
 //CHECK#1
-function MyFunction(){};
+function MyFunction() {}
 var MyObjectVar = new MyFunction();
 MyObjectVar.prop = 1;
 delete MyObjectVar.prop;
 if (MyObjectVar.prop !== undefined) {
-  $ERROR('#1: function MyFunction(){}; var MyObjectVar = new MyFunction(); MyFunction.prop = 1; delete MyObjectVar.prop; MyObjectVar.prop === undefined. Actual: ' + (MyObjectVar.prop));
+  $ERROR(
+    '#1: function MyFunction(){}; var MyObjectVar = new MyFunction(); MyFunction.prop = 1; delete MyObjectVar.prop; MyObjectVar.prop === undefined. Actual: ' +
+    MyObjectVar.prop
+  );
 }

--- a/test/language/expressions/delete/S11.4.1_A3.3_T4.js
+++ b/test/language/expressions/delete/S11.4.1_A3.3_T4.js
@@ -3,14 +3,16 @@
 
 /*---
 info: If the property doesn't have the DontDelete attribute, remove the property
-es5id: 11.4.1_A3.3_T4
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking declared variable
 flags: [noStrict]
 ---*/
 
 //CHECK#1
-function MyFunction(){};
+function MyFunction() {}
 var MyObjectVar = new MyFunction();
 if (delete MyObjectVar !== false) {
-  $ERROR('#1: function MyFunction(){}; var MyObjectVar = new MyFunction(); delete MyObjectVar === false');
+  $ERROR(
+    '#1: function MyFunction(){}; var MyObjectVar = new MyFunction(); delete MyObjectVar === false'
+  );
 }

--- a/test/language/expressions/delete/S11.4.1_A3.3_T5.js
+++ b/test/language/expressions/delete/S11.4.1_A3.3_T5.js
@@ -3,16 +3,19 @@
 
 /*---
 info: If the property doesn't have the DontDelete attribute, remove the property
-es5id: 11.4.1_A3.3_T5
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking declared variable
 flags: [noStrict]
 ---*/
 
 //CHECK#1
-function MyFunction(){};
+function MyFunction() {}
 MyObjectNotVar = new MyFunction();
 MyObjectNotVar.prop = 1;
 delete MyObjectNotVar.prop;
 if (MyObjectNotVar.prop !== undefined) {
-  $ERROR('#1: function MyFunction(){}; MyObjectNotVar = new MyFunction(); MyFunction.prop = 1; delete MyObjectNotVar.prop; MyObjectNotVar.prop === undefined. Actual: ' + (MyObjectNotVar.prop));
+  $ERROR(
+    '#1: function MyFunction(){}; MyObjectNotVar = new MyFunction(); MyFunction.prop = 1; delete MyObjectNotVar.prop; MyObjectNotVar.prop === undefined. Actual: ' +
+    MyObjectNotVar.prop
+  );
 }

--- a/test/language/expressions/delete/S11.4.1_A3.3_T6.js
+++ b/test/language/expressions/delete/S11.4.1_A3.3_T6.js
@@ -3,14 +3,16 @@
 
 /*---
 info: If the property doesn't have the DontDelete attribute, remove the property
-es5id: 11.4.1_A3.3_T6
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking declared variable
 flags: [noStrict]
 ---*/
 
 //CHECK#1
-function MyFunction(){};
+function MyFunction() {}
 var MyObjectVar = new MyFunction();
 if (delete MyObjectNotVar !== true) {
-  $ERROR('#1: function MyFunction(){}; var MyObjectNotVar = new MyFunction(); delete MyObjectNotVar === true');
+  $ERROR(
+    '#1: function MyFunction(){}; var MyObjectNotVar = new MyFunction(); delete MyObjectNotVar === true'
+  );
 }

--- a/test/language/expressions/delete/S11.4.1_A4.js
+++ b/test/language/expressions/delete/S11.4.1_A4.js
@@ -5,7 +5,7 @@
 info: |
     "Delete" operator removes property, which is reference to the object, not
     the object
-es5id: 11.4.1_A4
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Checking two reference by one object
 flags: [noStrict]
 ---*/
@@ -14,6 +14,9 @@ flags: [noStrict]
 var obj = new Object();
 var ref = obj;
 delete ref;
-if (typeof obj !== "object") {
-  $ERROR('#1: obj = new Object(); ref = obj; delete ref; typeof obj === "object". Actual: ' + (typeof obj));
+if (typeof obj !== 'object') {
+  $ERROR(
+    '#1: obj = new Object(); ref = obj; delete ref; typeof obj === "object". Actual: ' +
+    typeof obj
+  );
 }

--- a/test/language/expressions/delete/S11.4.1_A5.js
+++ b/test/language/expressions/delete/S11.4.1_A5.js
@@ -6,7 +6,7 @@ info: |
     A strict delete should either succeed, returning true, or it
     should fail by throwing a TypeError. Under no circumstances
     should a strict delete return false.
-es5id: 11.4.1_A5
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     See if a strict delete returns false when deleting a  non-standard
     property.

--- a/test/language/expressions/delete/S8.12.7_A1.js
+++ b/test/language/expressions/delete/S8.12.7_A1.js
@@ -5,23 +5,23 @@
 info: |
     When the [[Delete]] method of O is called with property name P,
     and If the property has the DontDelete attribute, return false
-es5id: 8.12.7_A1
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Try to delete Math.E, that has the DontDelete attribute
 flags: [noStrict]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
-if (delete Math.E !== false){
-  $ERROR('#1: delete Math.E === false. Actual: ' + (delete Math.E));
-};
+if (delete Math.E !== false) {
+  $ERROR('#1: delete Math.E === false. Actual: ' + delete Math.E);
+}
 //
 //////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
-if (Math.E === undefined){
+if (Math.E === undefined) {
   $ERROR('#2: delete Math.E; Math.E !== undefined');
-};
+}
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/language/expressions/delete/S8.12.7_A2_T1.js
+++ b/test/language/expressions/delete/S8.12.7_A2_T1.js
@@ -5,7 +5,7 @@
 info: |
     When the [[Delete]] method of O is called with property name P,
     and if O doesn't have a property with name P, return true
-es5id: 8.12.7_A2_T1
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Try to delete not existent properties
 ---*/
 
@@ -13,25 +13,34 @@ var __color__map = {};
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
-if (delete __color__map.red !== true){
-  $ERROR('#1: var __color__map = {}; delete __color__map.red === true. Actual: ' + (delete __color__map.red));
-};
+if (delete __color__map.red !== true) {
+  $ERROR(
+    '#1: var __color__map = {}; delete __color__map.red === true. Actual: ' +
+    delete __color__map.red
+  );
+}
 //
 //////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
-if (delete __color__map["green"] !== true){
-  $ERROR('#2: var __color__map = {}; delete __color__map["green"] === true. Actual: ' + (delete __color__map["green"]));
-};
+if (delete __color__map['green'] !== true) {
+  $ERROR(
+    '#2: var __color__map = {}; delete __color__map["green"] === true. Actual: ' +
+    delete __color__map['green']
+  );
+}
 //
 //////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#3
 var blue = 1;
-if (delete __color__map[blue] !== true){
-  $ERROR('#3: var __color__map = {}; var blue = 1; delete __color__map[blue] === true. Actual: ' + (delete __color__map[blue]));
-};
+if (delete __color__map[blue] !== true) {
+  $ERROR(
+    '#3: var __color__map = {}; var blue = 1; delete __color__map[blue] === true. Actual: ' +
+    delete __color__map[blue]
+  );
+}
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/language/expressions/delete/S8.12.7_A2_T2.js
+++ b/test/language/expressions/delete/S8.12.7_A2_T2.js
@@ -5,20 +5,26 @@
 info: |
     When the [[Delete]] method of O is called with property name P,
     and if O doesn't have a property with name P, return true
-es5id: 8.12.7_A2_T2
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: >
     Try to delete not existent properties of O, but existent property
     of prototype
 ---*/
 
-function Palette(){};
-Palette.prototype = {red:0xFF0000, green:0x00FF00};
-var __palette = new Palette;
+function Palette() {}
+Palette.prototype = {
+  red: 0xff0000,
+  green: 0x00ff00,
+};
+var __palette = new Palette();
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
-if (__palette.red !== 0xFF0000){
-  $ERROR('#1: function Palette(){}; Palette.prototype = {red:0xFF0000, green:0x00FF00}; __palette = new Palette; __palette.red === 0xFF0000. Actual: ' + (__palette.red));
+if (__palette.red !== 0xff0000) {
+  $ERROR(
+    '#1: function Palette(){}; Palette.prototype = {red:0xFF0000, green:0x00FF00}; __palette = new Palette; __palette.red === 0xFF0000. Actual: ' +
+    __palette.red
+  );
 }
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -26,15 +32,21 @@ if (__palette.red !== 0xFF0000){
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (delete __palette.red !== true) {
-  $ERROR('#2 function Palette(){}; Palette.prototype = {red:0xFF0000, green:0x00FF00}; __palette = new Palette; delete __palette.red === true. Actual: ' + (delete __palette.red));
+  $ERROR(
+    '#2 function Palette(){}; Palette.prototype = {red:0xFF0000, green:0x00FF00}; __palette = new Palette; delete __palette.red === true. Actual: ' +
+    delete __palette.red
+  );
 }
 //
 //////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#3
-if (__palette.red !== 0xFF0000){
-  $ERROR('#3: function Palette(){}; Palette.prototype = {red:0xFF0000, green:0x00FF00}; __palette = new Palette; __palette.red === 0xFF0000. Actual: ' + (__palette.red));
+if (__palette.red !== 0xff0000) {
+  $ERROR(
+    '#3: function Palette(){}; Palette.prototype = {red:0xFF0000, green:0x00FF00}; __palette = new Palette; __palette.red === 0xFF0000. Actual: ' +
+    __palette.red
+  );
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/language/expressions/delete/S8.12.7_A3.js
+++ b/test/language/expressions/delete/S8.12.7_A3.js
@@ -5,44 +5,60 @@
 info: |
     When the [[Delete]] method of O is called with property name P,
     removes the property with name P from O and return true
-es5id: 8.12.7_A3
+esid: sec-delete-operator-runtime-semantics-evaluation
 description: Delete existent properties
 ---*/
 
-var BLUE_NUM=1;
-var BLUE_STR="1";
-var YELLOW_NUM=2;
-var YELLOW_STR="2";
-var __color__map = {red:0xFF0000, BLUE_NUM:0x0000FF, green:0x00FF00, YELLOW_STR:0xFFFF00};
+var BLUE_NUM = 1;
+var BLUE_STR = '1';
+var YELLOW_NUM = 2;
+var YELLOW_STR = '2';
+var __color__map = {
+  red: 0xff0000,
+  BLUE_NUM: 0x0000ff,
+  green: 0x00ff00,
+  YELLOW_STR: 0xffff00,
+};
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#1
-if (delete __color__map[YELLOW_NUM] !== true){
-  $ERROR('#1: var BLUE_NUM=1; var BLUE_STR="1"; var YELLOW_NUM=2; var YELLOW_STR="2"; var __color__map = {red:0xFF0000, BLUE_NUM:0x0000FF, green:0x00FF00, YELLOW_STR:0xFFFF00}; delete __color__map[YELLOW_NUM] === true;');
-};
+if (delete __color__map[YELLOW_NUM] !== true) {
+  $ERROR(
+    '#1: var BLUE_NUM=1; var BLUE_STR="1"; var YELLOW_NUM=2; var YELLOW_STR="2"; var __color__map = {red:0xFF0000, BLUE_NUM:0x0000FF, green:0x00FF00, YELLOW_STR:0xFFFF00}; delete __color__map[YELLOW_NUM] === true;'
+  );
+}
 //
 //////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#2
 if (__color__map[YELLOW_STR] !== undefined) {
-  $ERROR('#2: var BLUE_NUM=1; var BLUE_STR="1"; var YELLOW_NUM=2; var YELLOW_STR="2"; var __color__map = {red:0xFF0000, BLUE_NUM:0x0000FF, green:0x00FF00, YELLOW_STR:0xFFFF00}; delete __color__map[YELLOW_NUM]; __color__map[YELLOW_STR] === undefined. Actual: ' + (__color__map[YELLOW_STR]));
+  $ERROR(
+    '#2: var BLUE_NUM=1; var BLUE_STR="1"; var YELLOW_NUM=2; var YELLOW_STR="2"; var __color__map = {red:0xFF0000, BLUE_NUM:0x0000FF, green:0x00FF00, YELLOW_STR:0xFFFF00}; delete __color__map[YELLOW_NUM]; __color__map[YELLOW_STR] === undefined. Actual: ' +
+    __color__map[YELLOW_STR]
+  );
 }
 //
 //////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#3
-if (delete __color__map[BLUE_STR] !== true){
-  $ERROR('#3: var BLUE_NUM=1; var BLUE_STR="1"; var YELLOW_NUM=2; var YELLOW_STR="2"; var __color__map = {red:0xFF0000, BLUE_NUM:0x0000FF, green:0x00FF00, YELLOW_STR:0xFFFF00}; delete __color__map[BLUE_STR] === true. Actual: ' + (delete __color__map[BLUE_STR]));
-};
+if (delete __color__map[BLUE_STR] !== true) {
+  $ERROR(
+    '#3: var BLUE_NUM=1; var BLUE_STR="1"; var YELLOW_NUM=2; var YELLOW_STR="2"; var __color__map = {red:0xFF0000, BLUE_NUM:0x0000FF, green:0x00FF00, YELLOW_STR:0xFFFF00}; delete __color__map[BLUE_STR] === true. Actual: ' +
+    delete __color__map[BLUE_STR]
+  );
+}
 //
 //////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////
 //CHECK#4
 if (__color__map[BLUE_NUM] !== undefined) {
-  $ERROR('#4: var BLUE_NUM=1; var BLUE_STR="1"; var YELLOW_NUM=2; var YELLOW_STR="2"; var __color__map = {red:0xFF0000, BLUE_NUM:0x0000FF, green:0x00FF00, YELLOW_STR:0xFFFF00}; delete __color__map[BLUE_STR]; __color__map[BLUE_NUM] === undefined. Actual: ' + (__color__map[BLUE_NUM]));
+  $ERROR(
+    '#4: var BLUE_NUM=1; var BLUE_STR="1"; var YELLOW_NUM=2; var YELLOW_STR="2"; var __color__map = {red:0xFF0000, BLUE_NUM:0x0000FF, green:0x00FF00, YELLOW_STR:0xFFFF00}; delete __color__map[BLUE_STR]; __color__map[BLUE_NUM] === undefined. Actual: ' +
+    __color__map[BLUE_NUM]
+  );
 }
 //
 //////////////////////////////////////////////////////////////////////////////

--- a/test/language/expressions/delete/delete-unresolvable-base-object-reference-throws-typeerror.js
+++ b/test/language/expressions/delete/delete-unresolvable-base-object-reference-throws-typeerror.js
@@ -1,0 +1,12 @@
+// Copyright (c) 2020 Rick Waldron.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-delete-operator-runtime-semantics-evaluation
+description: >
+  delete operations throws TypeError exception when base object is unresolvable reference.
+---*/
+
+assert.throws(TypeError, () => {
+  delete Object[0][0];
+});

--- a/test/language/expressions/delete/super-property-method.js
+++ b/test/language/expressions/delete/super-property-method.js
@@ -7,7 +7,9 @@ features: [class]
 ---*/
 
 class X {
-  method() { return this; }
+  method() {
+    return this;
+  }
 }
 
 class Y extends X {


### PR DESCRIPTION
Coverage fix is in the first commit: https://github.com/tc39/test262/pull/2764/commits/84237e129f7a4bffe8419b9e866b3b7241109c87

The second commit is a general cleanup of the delete operator tests. 