### PR TITLE
Intl.NumberFormat + currency will throw an error if maximumFractionDigits is less than currencyDigits

### DIFF
--- a/test/intl402/NumberFormat/dft-currency-mnfd-range-check-mxfd.js
+++ b/test/intl402/NumberFormat/dft-currency-mnfd-range-check-mxfd.js
@@ -1,21 +1,79 @@
 // Copyright 2017 the V8 project authors. All rights reserved.
+// Copyright 2020 Apple Inc. All rights reserved.
 // This code is governed by the license found in the LICENSE file.
 
 /*---
 esid: sec-setnfdigitoptions
 description: >
     When a currency is used in Intl.NumberFormat and minimumFractionDigits is
-    not provided, maximumFractionDigits should be set as provided.
+    not provided, maximumFractionDigits should be set as provided if it is larger
+    than currencyDigits.
 ---*/
+
+assert.throws(RangeError, () => {
+    new Intl.NumberFormat('en', {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 1
+    });
+});
 
 assert.sameValue((new Intl.NumberFormat('en', {
     style: 'currency',
     currency: 'USD',
-    maximumFractionDigits: 1
-})).resolvedOptions().maximumFractionDigits, 1);
+    maximumFractionDigits: 2
+})).resolvedOptions().maximumFractionDigits, 2);
+
+assert.sameValue((new Intl.NumberFormat('en', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 3
+})).resolvedOptions().maximumFractionDigits, 3);
+
+assert.sameValue((new Intl.NumberFormat('en', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 20
+})).resolvedOptions().maximumFractionDigits, 20);
+
+assert.throws(RangeError, () => {
+    new Intl.NumberFormat('en', {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 21
+    })
+});
+
+assert.throws(RangeError, () => {
+    new Intl.NumberFormat('en', {
+        style: 'currency',
+        currency: 'CLF',
+        maximumFractionDigits: 3
+    })
+});
 
 assert.sameValue((new Intl.NumberFormat('en', {
     style: 'currency',
     currency: 'CLF',
-    maximumFractionDigits: 3
-})).resolvedOptions().maximumSignificantDigits, 3);
+    maximumFractionDigits: 4
+})).resolvedOptions().maximumFractionDigits, 4);
+
+assert.sameValue((new Intl.NumberFormat('en', {
+    style: 'currency',
+    currency: 'CLF',
+    maximumFractionDigits: 5
+})).resolvedOptions().maximumFractionDigits, 5);
+
+assert.sameValue((new Intl.NumberFormat('en', {
+    style: 'currency',
+    currency: 'CLF',
+    maximumFractionDigits: 20
+})).resolvedOptions().maximumFractionDigits, 20);
+
+assert.throws(RangeError, () => {
+    new Intl.NumberFormat('en', {
+        style: 'currency',
+        currency: 'CLF',
+        maximumFractionDigits: 21
+    })
+});


### PR DESCRIPTION
In 12.1.1 SetNumberFormatDigitOptions step 12.d[1], mnfd (minimum fraction digits) becomes the same to currencyDigits (mxfdDefault in this case).
It is 2 for USD, 4 for CLF. So, if maximumFractionDigits is less than that, we should throw RangeError.

[1]: https://tc39.es/ecma402/#sec-setnfdigitoptions