### PR TITLE
Migrate test/harness/* away from dependence on $ERROR(). Close gh-742

### DIFF
--- a/test/harness/assert-false.js
+++ b/test/harness/assert-false.js
@@ -13,7 +13,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -21,5 +21,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-notsamevalue-nan.js
+++ b/test/harness/assert-notsamevalue-nan.js
@@ -13,7 +13,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -21,5 +21,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-notsamevalue-tostring.js
+++ b/test/harness/assert-notsamevalue-tostring.js
@@ -15,10 +15,10 @@ try {
 } catch (err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR('Expected a Test262Error, but a "' + err.constructor.name + '" was thrown.');
+    throw new Error('Expected a Test262Error, but a "' + err.constructor.name + '" was thrown.');
   }
 }
 
 if (!threw) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-obj.js
+++ b/test/harness/assert-obj.js
@@ -13,7 +13,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -21,5 +21,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-samevalue-objects.js
+++ b/test/harness/assert-samevalue-objects.js
@@ -13,7 +13,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -21,5 +21,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-samevalue-tostring.js
+++ b/test/harness/assert-samevalue-tostring.js
@@ -15,10 +15,10 @@ try {
 } catch (err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR('Expected a Test262Error, but a "' + err.constructor.name + '" was thrown.');
+    throw new Error('Expected a Test262Error, but a "' + err.constructor.name + '" was thrown.');
   }
 }
 
 if (!threw) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-samevalue-zeros.js
+++ b/test/harness/assert-samevalue-zeros.js
@@ -13,7 +13,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -22,5 +22,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-throws-incorrect-ctor.js
+++ b/test/harness/assert-throws-incorrect-ctor.js
@@ -16,7 +16,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -24,5 +24,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-throws-no-arg.js
+++ b/test/harness/assert-throws-no-arg.js
@@ -13,7 +13,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -21,5 +21,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-throws-no-error.js
+++ b/test/harness/assert-throws-no-error.js
@@ -13,7 +13,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -21,5 +21,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-throws-null-fn.js
+++ b/test/harness/assert-throws-null-fn.js
@@ -13,7 +13,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -21,7 +21,7 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }
 
 threw = false;
@@ -31,7 +31,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -39,7 +39,7 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }
 
 threw = false;
@@ -49,7 +49,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -57,5 +57,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-throws-null.js
+++ b/test/harness/assert-throws-null.js
@@ -15,7 +15,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -23,5 +23,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-throws-primitive.js
+++ b/test/harness/assert-throws-primitive.js
@@ -14,7 +14,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -22,5 +22,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-throws-single-arg.js
+++ b/test/harness/assert-throws-single-arg.js
@@ -12,7 +12,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -20,5 +20,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assert-tostring.js
+++ b/test/harness/assert-tostring.js
@@ -15,10 +15,10 @@ try {
 } catch (err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR('Expected a Test262Error, but a "' + err.constructor.name + '" was thrown.');
+    throw new Error('Expected a Test262Error, but a "' + err.constructor.name + '" was thrown.');
   }
 }
 
 if (!threw) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/assertRelativeDateMs.js
+++ b/test/harness/assertRelativeDateMs.js
@@ -26,9 +26,9 @@ try {
   thrown = err;
 }
 if (!thrown) {
-  $ERROR('Expected error, but no error was thrown.');
+  throw new Error('Expected error, but no error was thrown.');
 } else if (thrown.constructor !== Test262Error) {
-  $ERROR('Expected error of type Test262Error.');
+  throw new Error('Expected error of type Test262Error.');
 }
 
 thrown = null;
@@ -38,9 +38,9 @@ try {
   thrown = err;
 }
 if (!thrown) {
-  $ERROR('Expected error, but no error was thrown.');
+  throw new Error('Expected error, but no error was thrown.');
 } else if (thrown.constructor !== Test262Error) {
-  $ERROR('Expected error of type Test262Error.');
+  throw new Error('Expected error of type Test262Error.');
 }
 
 thrown = null;
@@ -50,9 +50,9 @@ try {
   thrown = err;
 }
 if (!thrown) {
-  $ERROR('Expected error, but no error was thrown.');
+  throw new Error('Expected error, but no error was thrown.');
 } else if (thrown.constructor !== Test262Error) {
-  $ERROR('Expected error of type Test262Error.');
+  throw new Error('Expected error of type Test262Error.');
 }
 
 thrown = null;
@@ -62,9 +62,9 @@ try {
   thrown = err;
 }
 if (!thrown) {
-  $ERROR('Expected error, but no error was thrown.');
+  throw new Error('Expected error, but no error was thrown.');
 } else if (thrown.constructor !== Test262Error) {
-  $ERROR('Expected error of type Test262Error.');
+  throw new Error('Expected error of type Test262Error.');
 }
 
 thrown = null;
@@ -74,7 +74,7 @@ try {
   thrown = err;
 }
 if (!thrown) {
-  $ERROR('Expected error, but no error was thrown.');
+  throw new Error('Expected error, but no error was thrown.');
 } else if (thrown.constructor !== Test262Error) {
-  $ERROR('Expected error of type Test262Error.');
+  throw new Error('Expected error of type Test262Error.');
 }

--- a/test/harness/compare-array-different-elements.js
+++ b/test/harness/compare-array-different-elements.js
@@ -11,5 +11,5 @@ var first = [0, 'a', undefined];
 var second = [0, 'b', undefined];
 
 if (compareArray(first, second) !== false) {
-  $ERROR('Arrays containing different elements are not equivalent.');
+  throw new Error('Arrays containing different elements are not equivalent.');
 }

--- a/test/harness/compare-array-different-length.js
+++ b/test/harness/compare-array-different-length.js
@@ -8,9 +8,9 @@ includes: [compareArray.js]
 ---*/
 
 if (compareArray([], [undefined]) !== false) {
-  $ERROR('Arrays of differing lengths are not equivalent.');
+  throw new Error('Arrays of differing lengths are not equivalent.');
 }
 
 if (compareArray([undefined], []) !== false) {
-  $ERROR('Arrays of differing lengths are not equivalent.');
+  throw new Error('Arrays of differing lengths are not equivalent.');
 }

--- a/test/harness/compare-array-empty.js
+++ b/test/harness/compare-array-empty.js
@@ -8,5 +8,5 @@ includes: [compareArray.js]
 ---*/
 
 if (compareArray([], []) !== true) {
-  $ERROR('Empty arrays are equivalent.');
+  throw new Error('Empty arrays are equivalent.');
 }

--- a/test/harness/compare-array-same-elements-different-order.js
+++ b/test/harness/compare-array-same-elements-different-order.js
@@ -12,5 +12,5 @@ var first = [0, 1, '', 's', null, undefined, obj];
 var second = [0, 1, '', 's', undefined, null, obj];
 
 if (compareArray(first, second) !== false) {
-  $ERROR('Arrays containing the same elements in different order are not equivalent.');
+  throw new Error('Arrays containing the same elements in different order are not equivalent.');
 }

--- a/test/harness/compare-array-same-elements-same-order.js
+++ b/test/harness/compare-array-same-elements-same-order.js
@@ -12,5 +12,5 @@ var first = [0, 1, '', 's', undefined, null, obj];
 var second = [0, 1, '', 's', undefined, null, obj];
 
 if (compareArray(first, second) !== true) {
-  $ERROR('Arrays containing the same elements in the same order are equivalent.');
+  throw new Error('Arrays containing the same elements in the same order are equivalent.');
 }

--- a/test/harness/compare-array-sparse.js
+++ b/test/harness/compare-array-sparse.js
@@ -8,21 +8,21 @@ includes: [compareArray.js]
 ---*/
 
 if (compareArray([,], [,]) !== true) {
-  $ERROR('Sparse arrays of the same length are equivalent.');
+  throw new Error('Sparse arrays of the same length are equivalent.');
 }
 
 if (compareArray([,], [,,]) !== false) {
-  $ERROR('Sparse arrays of differing lengths are not equivalent.');
+  throw new Error('Sparse arrays of differing lengths are not equivalent.');
 }
 
 if (compareArray([,,], [,]) !== false) {
-  $ERROR('Sparse arrays of differing lengths are not equivalent.');
+  throw new Error('Sparse arrays of differing lengths are not equivalent.');
 }
 
 if (compareArray([,], []) !== false) {
-  $ERROR('Sparse arrays are not equivalent to empty arrays.');
+  throw new Error('Sparse arrays are not equivalent to empty arrays.');
 }
 
 if (compareArray([], [,]) !== false) {
-  $ERROR('Sparse arrays are not equivalent to empty arrays.');
+  throw new Error('Sparse arrays are not equivalent to empty arrays.');
 }

--- a/test/harness/detachArrayBuffer-host-detachArrayBuffer.js
+++ b/test/harness/detachArrayBuffer-host-detachArrayBuffer.js
@@ -26,18 +26,18 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
   }
   if (err.message !== '$262.detachArrayBuffer called.') {
-    $ERROR(`Expected error message: ${err.message}`);
+    throw new Error(`Expected error message: ${err.message}`);
   }
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }
 
 

--- a/test/harness/detachArrayBuffer.js
+++ b/test/harness/detachArrayBuffer.js
@@ -19,7 +19,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== ReferenceError) {
-    $ERROR(
+    throw new Error(
       'Expected a ReferenceError, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -27,7 +27,7 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a ReferenceError, but no error was thrown.');
+  throw new Error('Expected a ReferenceError, but no error was thrown.');
 }
 
 

--- a/test/harness/nativeFunctionMatcher.js
+++ b/test/harness/nativeFunctionMatcher.js
@@ -31,7 +31,7 @@ includes: [nativeFunctionMatcher.js]
   try {
     validateNativeFunctionSource(s);
   } catch (unused) {
-    $ERROR(`${JSON.stringify(s)} should pass`);
+    throw new Error(`${JSON.stringify(s)} should pass`);
   }
 });
 
@@ -55,6 +55,6 @@ includes: [nativeFunctionMatcher.js]
     fail = true;
   } catch (unused) {}
   if (fail) {
-    $ERROR(`${JSON.stringify(s)} should fail`);
+    throw new Error(`${JSON.stringify(s)} should fail`);
   }
 });

--- a/test/harness/promiseHelper.js
+++ b/test/harness/promiseHelper.js
@@ -22,7 +22,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -30,6 +30,6 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }
 

--- a/test/harness/propertyhelper-verifyconfigurable-not-configurable.js
+++ b/test/harness/propertyhelper-verifyconfigurable-not-configurable.js
@@ -19,7 +19,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -27,5 +27,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/propertyhelper-verifyenumerable-not-enumerable-symbol.js
+++ b/test/harness/propertyhelper-verifyenumerable-not-enumerable-symbol.js
@@ -28,5 +28,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/propertyhelper-verifyenumerable-not-enumerable.js
+++ b/test/harness/propertyhelper-verifyenumerable-not-enumerable.js
@@ -26,5 +26,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/propertyhelper-verifynotconfigurable-configurable.js
+++ b/test/harness/propertyhelper-verifynotconfigurable-configurable.js
@@ -18,7 +18,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -26,5 +26,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/propertyhelper-verifynotenumerable-enumerable.js
+++ b/test/harness/propertyhelper-verifynotenumerable-enumerable.js
@@ -18,7 +18,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );

--- a/test/harness/propertyhelper-verifynotwritable-not-writable-strict.js
+++ b/test/harness/propertyhelper-verifynotwritable-not-writable-strict.js
@@ -17,5 +17,5 @@ Object.defineProperty(obj, 'a', {
 verifyNotWritable(obj, 'a');
 
 if (obj.a !== 123) {
-  $ERROR('`verifyNotWritable` should be non-destructive.');
+  throw new Error('`verifyNotWritable` should be non-destructive.');
 }

--- a/test/harness/propertyhelper-verifynotwritable-writable.js
+++ b/test/harness/propertyhelper-verifynotwritable-writable.js
@@ -18,7 +18,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -26,5 +26,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/propertyhelper-verifywritable-not-writable.js
+++ b/test/harness/propertyhelper-verifywritable-not-writable.js
@@ -18,7 +18,7 @@ try {
 } catch(err) {
   threw = true;
   if (err.constructor !== Test262Error) {
-    $ERROR(
+    throw new Error(
       'Expected a Test262Error, but a "' + err.constructor.name +
       '" was thrown.'
     );
@@ -26,5 +26,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/propertyhelper-verifywritable-writable.js
+++ b/test/harness/propertyhelper-verifywritable-writable.js
@@ -16,5 +16,5 @@ Object.defineProperty(obj, 'a', {
 verifyWritable(obj, 'a');
 
 if (obj.a !== 123) {
-  $ERROR('`verifyWritable` should be non-destructive.');
+  throw new Error('`verifyWritable` should be non-destructive.');
 }

--- a/test/harness/sta-error.js
+++ b/test/harness/sta-error.js
@@ -24,5 +24,5 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }

--- a/test/harness/testTypedArray-conversions-call-error.js
+++ b/test/harness/testTypedArray-conversions-call-error.js
@@ -24,7 +24,7 @@ try {
 }
 
 if (threw === false) {
-  $ERROR('Expected a TypeError, but no error was thrown.');
+  throw new Error('Expected a TypeError, but no error was thrown.');
 }
 
 

--- a/test/harness/verifyProperty-value-error.js
+++ b/test/harness/verifyProperty-value-error.js
@@ -30,10 +30,10 @@ try {
   }
 
   if (err.message !== 'descriptor value should be 2') {
-    $ERROR('The error thrown did not define the specified message.');
+    throw new Error('The error thrown did not define the specified message.');
   }
 }
 
 if (threw === false) {
-  $ERROR('Expected a Test262Error, but no error was thrown.');
+  throw new Error('Expected a Test262Error, but no error was thrown.');
 }


### PR DESCRIPTION
Finally taking steps towards dropping the long deprecated `$ERROR` api.