### PR TITLE
Coverage: Computed Property Names. Fixes gh-1741

### DIFF
--- a/src/computed-property-names/computed-property-name-from-additive-expression-add.case
+++ b/src/computed-property-names/computed-property-name-from-additive-expression-add.case
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from additive expression "add"
+template: evaluation
+features: [computed-property-names]
+---*/
+
+//- ComputedPropertyName
+1 + 1
+//- value
+2

--- a/src/computed-property-names/computed-property-name-from-additive-expression-subtract.case
+++ b/src/computed-property-names/computed-property-name-from-additive-expression-subtract.case
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from additive expression "subtract"
+template: evaluation
+features: [computed-property-names]
+---*/
+
+//- ComputedPropertyName
+1 - 1
+//- value
+0

--- a/src/computed-property-names/computed-property-name-from-arrow-function-expression.case
+++ b/src/computed-property-names/computed-property-name-from-arrow-function-expression.case
@@ -1,0 +1,12 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from arrow function
+template: evaluation
+features: [computed-property-names]
+---*/
+//- ComputedPropertyName
+() => { }
+//- value
+1

--- a/src/computed-property-names/computed-property-name-from-assignment-expression-assignment.case
+++ b/src/computed-property-names/computed-property-name-from-assignment-expression-assignment.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from assignment expression
+template: evaluation
+features: [computed-property-names]
+---*/
+//- setup
+let x = 0;
+//- ComputedPropertyName
+x = 1
+//- value
+2
+//- teardown
+assert.sameValue(x, 1);

--- a/src/computed-property-names/computed-property-name-from-assignment-expression-bitwise-or.case
+++ b/src/computed-property-names/computed-property-name-from-assignment-expression-bitwise-or.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from assignment expression bitwise or
+template: evaluation
+features: [computed-property-names]
+---*/
+//- setup
+let x = 0;
+//- ComputedPropertyName
+x |= 1
+//- value
+2
+//- teardown
+assert.sameValue(x, 1);

--- a/src/computed-property-names/computed-property-name-from-assignment-expression-coalesce.case
+++ b/src/computed-property-names/computed-property-name-from-assignment-expression-coalesce.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from assignment expression coalesce
+template: evaluation
+features: [computed-property-names]
+---*/
+//- setup
+let x = null;
+//- ComputedPropertyName
+x ??= 1
+//- value
+2
+//- teardown
+assert.sameValue(x, 1);

--- a/src/computed-property-names/computed-property-name-from-assignment-expression-logical-and.case
+++ b/src/computed-property-names/computed-property-name-from-assignment-expression-logical-and.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from assignment expression logical and
+template: evaluation
+features: [computed-property-names]
+---*/
+//- setup
+let x = 0;
+//- ComputedPropertyName
+x &&= 1
+//- value
+2
+//- teardown
+assert.sameValue(x, 0);

--- a/src/computed-property-names/computed-property-name-from-assignment-expression-logical-or.case
+++ b/src/computed-property-names/computed-property-name-from-assignment-expression-logical-or.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from assignment expression logical or
+template: evaluation
+features: [computed-property-names]
+---*/
+//- setup
+let x = 0;
+//- ComputedPropertyName
+x ||= 1
+//- value
+2
+//- teardown
+assert.sameValue(x, 1);

--- a/src/computed-property-names/computed-property-name-from-async-arrow-function-expression.case
+++ b/src/computed-property-names/computed-property-name-from-async-arrow-function-expression.case
@@ -1,0 +1,12 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from function expression
+template: evaluation
+features: [computed-property-names]
+---*/
+//- ComputedPropertyName
+async () => {}
+//- value
+1

--- a/src/computed-property-names/computed-property-name-from-condition-expression-false.case
+++ b/src/computed-property-names/computed-property-name-from-condition-expression-false.case
@@ -1,0 +1,12 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from condition expression
+template: evaluation
+features: [computed-property-names]
+---*/
+//- ComputedPropertyName
+false ? 1 : 2
+//- value
+1

--- a/src/computed-property-names/computed-property-name-from-condition-expression-true.case
+++ b/src/computed-property-names/computed-property-name-from-condition-expression-true.case
@@ -1,0 +1,12 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from condition expression
+template: evaluation
+features: [computed-property-names]
+---*/
+//- ComputedPropertyName
+true ? 1 : 2
+//- value
+2

--- a/src/computed-property-names/computed-property-name-from-decimal-e-notational-literal.case
+++ b/src/computed-property-names/computed-property-name-from-decimal-e-notational-literal.case
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from decimal e notational literal
+template: evaluation
+features: [computed-property-names]
+---*/
+
+//- ComputedPropertyName
+1.e1
+//- value
+2

--- a/src/computed-property-names/computed-property-name-from-decimal-literal.case
+++ b/src/computed-property-names/computed-property-name-from-decimal-literal.case
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from decimal literal
+template: evaluation
+features: [computed-property-names]
+---*/
+
+//- ComputedPropertyName
+1.1
+//- value
+2

--- a/src/computed-property-names/computed-property-name-from-exponetiation-expression.case
+++ b/src/computed-property-names/computed-property-name-from-exponetiation-expression.case
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from exponentiation expression
+template: evaluation
+features: [computed-property-names]
+---*/
+
+//- ComputedPropertyName
+2 ** 2
+//- value
+4

--- a/src/computed-property-names/computed-property-name-from-expression-coalesce.case
+++ b/src/computed-property-names/computed-property-name-from-expression-coalesce.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from coalesce
+template: evaluation
+features: [computed-property-names]
+---*/
+//- setup
+let x;
+//- ComputedPropertyName
+x ?? 1
+//- value
+2
+//- teardown
+assert.sameValue(x, undefined);

--- a/src/computed-property-names/computed-property-name-from-expression-logical-and.case
+++ b/src/computed-property-names/computed-property-name-from-expression-logical-and.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from logical and
+template: evaluation
+features: [computed-property-names]
+---*/
+//- setup
+let x = 0;
+//- ComputedPropertyName
+x && 1
+//- value
+2
+//- teardown
+assert.sameValue(x, 0);

--- a/src/computed-property-names/computed-property-name-from-expression-logical-or.case
+++ b/src/computed-property-names/computed-property-name-from-expression-logical-or.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from logical or
+template: evaluation
+features: [computed-property-names]
+---*/
+//- setup
+let x = 0;
+//- ComputedPropertyName
+x || 1
+//- value
+2
+//- teardown
+assert.sameValue(x, 0);

--- a/src/computed-property-names/computed-property-name-from-function-declaration.case
+++ b/src/computed-property-names/computed-property-name-from-function-declaration.case
@@ -1,0 +1,14 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from function
+template: evaluation
+features: [computed-property-names]
+---*/
+//- setup
+function f() {}
+//- ComputedPropertyName
+f()
+//- value
+1

--- a/src/computed-property-names/computed-property-name-from-function-expression.case
+++ b/src/computed-property-names/computed-property-name-from-function-expression.case
@@ -1,0 +1,12 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from function expression
+template: evaluation
+features: [computed-property-names]
+---*/
+//- ComputedPropertyName
+function () {}
+//- value
+1

--- a/src/computed-property-names/computed-property-name-from-generator-function-declaration.case
+++ b/src/computed-property-names/computed-property-name-from-generator-function-declaration.case
@@ -1,0 +1,14 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from generator function
+template: evaluation
+features: [computed-property-names]
+---*/
+//- setup
+function * g() { return 1; }
+//- ComputedPropertyName
+g()
+//- value
+1

--- a/src/computed-property-names/computed-property-name-from-identifier.case
+++ b/src/computed-property-names/computed-property-name-from-identifier.case
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from string literal
+template: evaluation
+features: [computed-property-names]
+---*/
+
+//- setup
+let x = 1;
+
+//- ComputedPropertyName
+x
+//- value
+'2'

--- a/src/computed-property-names/computed-property-name-from-integer-e-notational-literal.case
+++ b/src/computed-property-names/computed-property-name-from-integer-e-notational-literal.case
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from numeric literal
+template: evaluation
+features: [computed-property-names]
+---*/
+
+//- ComputedPropertyName
+1
+//- value
+2

--- a/src/computed-property-names/computed-property-name-from-integer-separators.case
+++ b/src/computed-property-names/computed-property-name-from-integer-separators.case
@@ -1,0 +1,12 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from integer with separators
+template: evaluation
+features: [computed-property-names]
+---*/
+//- ComputedPropertyName
+1_2_3_4_5_6_7_8
+//- value
+1_2_3_4_5_6_7_8

--- a/src/computed-property-names/computed-property-name-from-math.case
+++ b/src/computed-property-names/computed-property-name-from-math.case
@@ -1,0 +1,12 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from math
+template: evaluation
+features: [computed-property-names]
+---*/
+//- ComputedPropertyName
+1 + 2 - 3 * 4 / 5 ** 6
+//- value
+2.999232

--- a/src/computed-property-names/computed-property-name-from-multiplicative-expression-div.case
+++ b/src/computed-property-names/computed-property-name-from-multiplicative-expression-div.case
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from multiplicative expression "divide"
+template: evaluation
+features: [computed-property-names]
+---*/
+
+//- ComputedPropertyName
+1 / 1
+//- value
+1

--- a/src/computed-property-names/computed-property-name-from-multiplicative-expression-mult.case
+++ b/src/computed-property-names/computed-property-name-from-multiplicative-expression-mult.case
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from multiplicative expression "multiply"
+template: evaluation
+features: [computed-property-names]
+---*/
+
+//- ComputedPropertyName
+1 * 1
+//- value
+1

--- a/src/computed-property-names/computed-property-name-from-numeric-literal.case
+++ b/src/computed-property-names/computed-property-name-from-numeric-literal.case
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from numeric literal
+template: evaluation
+features: [computed-property-names]
+---*/
+
+//- ComputedPropertyName
+1
+//- value
+2

--- a/src/computed-property-names/computed-property-name-from-string-literal.case
+++ b/src/computed-property-names/computed-property-name-from-string-literal.case
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from string literal
+template: evaluation
+features: [computed-property-names]
+---*/
+
+//- ComputedPropertyName
+'1'
+//- value
+'2'

--- a/src/computed-property-names/computed-property-name-from-yield-expression.case
+++ b/src/computed-property-names/computed-property-name-from-yield-expression.case
@@ -1,0 +1,12 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+desc: Computed property name from condition expression
+template: evaluation
+features: [computed-property-names]
+---*/
+//- ComputedPropertyName
+true ? 1 : 2
+//- value
+2

--- a/src/computed-property-names/evaluation/class-declaration-accessors.template
+++ b/src/computed-property-names/evaluation/class-declaration-accessors.template
@@ -1,0 +1,72 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/cpn-accessors-
+name: ComputedPropertyName in ClassDeclaration
+esid: prod-ComputedPropertyName
+info: |
+  ClassExpression:
+    classBindingIdentifier opt ClassTail
+
+  ClassTail:
+    ClassHeritage opt { ClassBody opt }
+
+  ClassBody:
+    ClassElementList
+
+  ClassElementList:
+    ClassElement
+
+  ClassElement:
+    MethodDefinition
+
+  MethodDefinition:
+    PropertyName ...
+    get PropertyName ...
+    set PropertyName ...
+
+  PropertyName:
+    ComputedPropertyName
+
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+---*/
+
+class C {
+  get [/*{ComputedPropertyName}*/]() {
+    return /*{value}*/;
+  }
+
+  set [/*{ComputedPropertyName}*/](v) {
+    return /*{value}*/;
+  }
+
+  static get [/*{ComputedPropertyName}*/]() {
+    return /*{value}*/;
+  }
+
+  static set [/*{ComputedPropertyName}*/](v) {
+    return /*{value}*/;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[/*{ComputedPropertyName}*/],
+  /*{value}*/
+);
+assert.sameValue(
+  c[/*{ComputedPropertyName}*/] = /*{value}*/,
+  /*{value}*/
+);
+
+assert.sameValue(
+  C[/*{ComputedPropertyName}*/],
+  /*{value}*/
+);
+assert.sameValue(
+  C[/*{ComputedPropertyName}*/] = /*{value}*/,
+  /*{value}*/
+);

--- a/src/computed-property-names/evaluation/class-declaration-fields-methods.template
+++ b/src/computed-property-names/evaluation/class-declaration-fields-methods.template
@@ -1,0 +1,55 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/cpn-fields-methods-
+name: ComputedPropertyName in ClassExpression
+esid: prod-ComputedPropertyName
+info: |
+  ClassExpression:
+    classBindingIdentifier opt ClassTail
+
+  ClassTail:
+    ClassHeritage opt { ClassBody opt }
+
+  ClassBody:
+    ClassElementList
+
+  ClassElementList:
+    ClassElement
+
+  ClassElement:
+    MethodDefinition
+
+  MethodDefinition:
+    PropertyName ...
+    get PropertyName ...
+    set PropertyName ...
+
+  PropertyName:
+    ComputedPropertyName
+
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+---*/
+
+let C = class {
+  [/*{ComputedPropertyName}*/] = () => {
+    return /*{value}*/;
+  };
+
+  static [/*{ComputedPropertyName}*/] = () => {
+    return /*{value}*/;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[/*{ComputedPropertyName}*/](),
+  /*{value}*/
+);
+assert.sameValue(
+  C[/*{ComputedPropertyName}*/](),
+  /*{value}*/
+);

--- a/src/computed-property-names/evaluation/class-declaration-fields.template
+++ b/src/computed-property-names/evaluation/class-declaration-fields.template
@@ -1,0 +1,51 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/cpn-fields-
+name: ComputedPropertyName in ClassExpression
+esid: prod-ComputedPropertyName
+info: |
+  ClassExpression:
+    classBindingIdentifier opt ClassTail
+
+  ClassTail:
+    ClassHeritage opt { ClassBody opt }
+
+  ClassBody:
+    ClassElementList
+
+  ClassElementList:
+    ClassElement
+
+  ClassElement:
+    MethodDefinition
+
+  MethodDefinition:
+    PropertyName ...
+    get PropertyName ...
+    set PropertyName ...
+
+  PropertyName:
+    ComputedPropertyName
+
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+---*/
+
+let C = class {
+  [/*{ComputedPropertyName}*/] = /*{value}*/;
+
+  static [/*{ComputedPropertyName}*/] = /*{value}*/;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[/*{ComputedPropertyName}*/],
+  /*{value}*/
+);
+assert.sameValue(
+  C[/*{ComputedPropertyName}*/],
+  /*{value}*/
+);

--- a/src/computed-property-names/evaluation/class-declaration.template
+++ b/src/computed-property-names/evaluation/class-declaration.template
@@ -1,0 +1,54 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/statements/class/cpn-
+name: ComputedPropertyName in ClassDeclaration
+esid: prod-ComputedPropertyName
+info: |
+  ClassExpression:
+    classBindingIdentifier opt ClassTail
+
+  ClassTail:
+    ClassHeritage opt { ClassBody opt }
+
+  ClassBody:
+    ClassElementList
+
+  ClassElementList:
+    ClassElement
+
+  ClassElement:
+    MethodDefinition
+
+  MethodDefinition:
+    PropertyName ...
+    get PropertyName ...
+    set PropertyName ...
+
+  PropertyName:
+    ComputedPropertyName
+
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+---*/
+
+class C {
+  [/*{ComputedPropertyName}*/]() {
+    return /*{value}*/;
+  }
+  static [/*{ComputedPropertyName}*/]() {
+    return /*{value}*/;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[/*{ComputedPropertyName}*/](),
+  /*{value}*/
+);
+assert.sameValue(
+  C[/*{ComputedPropertyName}*/](),
+  /*{value}*/
+);

--- a/src/computed-property-names/evaluation/class-expression-accessors.template
+++ b/src/computed-property-names/evaluation/class-expression-accessors.template
@@ -1,0 +1,72 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/cpn-accessors-
+name: ComputedPropertyName in ClassExpression
+esid: prod-ComputedPropertyName
+info: |
+  ClassExpression:
+    classBindingIdentifier opt ClassTail
+
+  ClassTail:
+    ClassHeritage opt { ClassBody opt }
+
+  ClassBody:
+    ClassElementList
+
+  ClassElementList:
+    ClassElement
+
+  ClassElement:
+    MethodDefinition
+
+  MethodDefinition:
+    PropertyName ...
+    get PropertyName ...
+    set PropertyName ...
+
+  PropertyName:
+    ComputedPropertyName
+
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+---*/
+
+let C = class {
+  get [/*{ComputedPropertyName}*/]() {
+    return /*{value}*/;
+  }
+
+  set [/*{ComputedPropertyName}*/](v) {
+    return /*{value}*/;
+  }
+
+  static get [/*{ComputedPropertyName}*/]() {
+    return /*{value}*/;
+  }
+
+  static set [/*{ComputedPropertyName}*/](v) {
+    return /*{value}*/;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[/*{ComputedPropertyName}*/],
+  /*{value}*/
+);
+assert.sameValue(
+  c[/*{ComputedPropertyName}*/] = /*{value}*/,
+  /*{value}*/
+);
+
+assert.sameValue(
+  C[/*{ComputedPropertyName}*/],
+  /*{value}*/
+);
+assert.sameValue(
+  C[/*{ComputedPropertyName}*/] = /*{value}*/,
+  /*{value}*/
+);

--- a/src/computed-property-names/evaluation/class-expression-fields-methods.template
+++ b/src/computed-property-names/evaluation/class-expression-fields-methods.template
@@ -1,0 +1,55 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/cpn-fields-methods-
+name: ComputedPropertyName in ClassExpression
+esid: prod-ComputedPropertyName
+info: |
+  ClassExpression:
+    classBindingIdentifier opt ClassTail
+
+  ClassTail:
+    ClassHeritage opt { ClassBody opt }
+
+  ClassBody:
+    ClassElementList
+
+  ClassElementList:
+    ClassElement
+
+  ClassElement:
+    MethodDefinition
+
+  MethodDefinition:
+    PropertyName ...
+    get PropertyName ...
+    set PropertyName ...
+
+  PropertyName:
+    ComputedPropertyName
+
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+---*/
+
+let C = class {
+  [/*{ComputedPropertyName}*/] = () => {
+    return /*{value}*/;
+  };
+
+  static [/*{ComputedPropertyName}*/] = () => {
+    return /*{value}*/;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[/*{ComputedPropertyName}*/](),
+  /*{value}*/
+);
+assert.sameValue(
+  C[/*{ComputedPropertyName}*/](),
+  /*{value}*/
+);

--- a/src/computed-property-names/evaluation/class-expression-fields.template
+++ b/src/computed-property-names/evaluation/class-expression-fields.template
@@ -1,0 +1,51 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/cpn-fields-
+name: ComputedPropertyName in ClassExpression
+esid: prod-ComputedPropertyName
+info: |
+  ClassExpression:
+    classBindingIdentifier opt ClassTail
+
+  ClassTail:
+    ClassHeritage opt { ClassBody opt }
+
+  ClassBody:
+    ClassElementList
+
+  ClassElementList:
+    ClassElement
+
+  ClassElement:
+    MethodDefinition
+
+  MethodDefinition:
+    PropertyName ...
+    get PropertyName ...
+    set PropertyName ...
+
+  PropertyName:
+    ComputedPropertyName
+
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+---*/
+
+let C = class {
+  [/*{ComputedPropertyName}*/] = /*{value}*/;
+
+  static [/*{ComputedPropertyName}*/] = /*{value}*/;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[/*{ComputedPropertyName}*/],
+  /*{value}*/
+);
+assert.sameValue(
+  C[/*{ComputedPropertyName}*/],
+  /*{value}*/
+);

--- a/src/computed-property-names/evaluation/class-expression.template
+++ b/src/computed-property-names/evaluation/class-expression.template
@@ -1,0 +1,54 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/class/cpn-
+name: ComputedPropertyName in ClassExpression
+esid: prod-ComputedPropertyName
+info: |
+  ClassExpression:
+    classBindingIdentifier opt ClassTail
+
+  ClassTail:
+    ClassHeritage opt { ClassBody opt }
+
+  ClassBody:
+    ClassElementList
+
+  ClassElementList:
+    ClassElement
+
+  ClassElement:
+    MethodDefinition
+
+  MethodDefinition:
+    PropertyName ...
+    get PropertyName ...
+    set PropertyName ...
+
+  PropertyName:
+    ComputedPropertyName
+
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+---*/
+
+let C = class {
+  [/*{ComputedPropertyName}*/]() {
+    return /*{value}*/;
+  }
+  static [/*{ComputedPropertyName}*/]() {
+    return /*{value}*/;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[/*{ComputedPropertyName}*/](),
+  /*{value}*/
+);
+assert.sameValue(
+  C[/*{ComputedPropertyName}*/](),
+  /*{value}*/
+);

--- a/src/computed-property-names/evaluation/object-literal.template
+++ b/src/computed-property-names/evaluation/object-literal.template
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/object/cpn-
+name: ComputedPropertyName in ObjectLiteral
+esid: prod-ComputedPropertyName
+info: |
+  ObjectLiteral:
+    { PropertyDefinitionList }
+
+  PropertyDefinitionList:
+    PropertyDefinition
+
+  PropertyDefinition:
+    PropertyName: AssignmentExpression
+
+  PropertyName:
+    ComputedPropertyName
+
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+---*/
+
+let o = {
+  [/*{ComputedPropertyName}*/]: /*{value}*/
+};
+
+assert.sameValue(
+  o[/*{ComputedPropertyName}*/],
+  /*{value}*/
+);

--- a/src/computed-property-names/evaluation/yield-expression.template
+++ b/src/computed-property-names/evaluation/yield-expression.template
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/object/cpn-
+name: ComputedPropertyName in ObjectLiteral
+esid: prod-ComputedPropertyName
+info: |
+  ObjectLiteral:
+    { PropertyDefinitionList }
+
+  PropertyDefinitionList:
+    PropertyDefinition
+
+  PropertyDefinition:
+    PropertyName: AssignmentExpression
+
+  PropertyName:
+    ComputedPropertyName
+
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+---*/
+
+let o = {
+  [/*{ComputedPropertyName}*/]: /*{value}*/
+};
+
+assert.sameValue(
+  o[/*{ComputedPropertyName}*/],
+  /*{value}*/
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-additive-expression-add.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-additive-expression-add.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-add.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from additive expression "add" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [1 + 1]() {
+    return 2;
+  }
+
+  set [1 + 1](v) {
+    return 2;
+  }
+
+  static get [1 + 1]() {
+    return 2;
+  }
+
+  static set [1 + 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 1],
+  2
+);
+assert.sameValue(
+  c[1 + 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[1 + 1],
+  2
+);
+assert.sameValue(
+  C[1 + 1] = 2,
+  2
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-additive-expression-subtract.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-additive-expression-subtract.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-subtract.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from additive expression "subtract" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [1 - 1]() {
+    return 0;
+  }
+
+  set [1 - 1](v) {
+    return 0;
+  }
+
+  static get [1 - 1]() {
+    return 0;
+  }
+
+  static set [1 - 1](v) {
+    return 0;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 - 1],
+  0
+);
+assert.sameValue(
+  c[1 - 1] = 0,
+  0
+);
+
+assert.sameValue(
+  C[1 - 1],
+  0
+);
+assert.sameValue(
+  C[1 - 1] = 0,
+  0
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-arrow-function-expression.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-arrow-function-expression.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from arrow function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [() => { }]() {
+    return 1;
+  }
+
+  set [() => { }](v) {
+    return 1;
+  }
+
+  static get [() => { }]() {
+    return 1;
+  }
+
+  static set [() => { }](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[() => { }],
+  1
+);
+assert.sameValue(
+  c[() => { }] = 1,
+  1
+);
+
+assert.sameValue(
+  C[() => { }],
+  1
+);
+assert.sameValue(
+  C[() => { }] = 1,
+  1
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-assignment-expression-assignment.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-assignment-expression-assignment.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-assignment.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from assignment expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  get [x = 1]() {
+    return 2;
+  }
+
+  set [x = 1](v) {
+    return 2;
+  }
+
+  static get [x = 1]() {
+    return 2;
+  }
+
+  static set [x = 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x = 1],
+  2
+);
+assert.sameValue(
+  c[x = 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x = 1],
+  2
+);
+assert.sameValue(
+  C[x = 1] = 2,
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-assignment-expression-bitwise-or.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-assignment-expression-bitwise-or.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-bitwise-or.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from assignment expression bitwise or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  get [x |= 1]() {
+    return 2;
+  }
+
+  set [x |= 1](v) {
+    return 2;
+  }
+
+  static get [x |= 1]() {
+    return 2;
+  }
+
+  static set [x |= 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x |= 1],
+  2
+);
+assert.sameValue(
+  c[x |= 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x |= 1],
+  2
+);
+assert.sameValue(
+  C[x |= 1] = 2,
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-assignment-expression-coalesce.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-assignment-expression-coalesce.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from assignment expression coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = null;
+
+
+let C = class {
+  get [x ??= 1]() {
+    return 2;
+  }
+
+  set [x ??= 1](v) {
+    return 2;
+  }
+
+  static get [x ??= 1]() {
+    return 2;
+  }
+
+  static set [x ??= 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ??= 1],
+  2
+);
+assert.sameValue(
+  c[x ??= 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x ??= 1],
+  2
+);
+assert.sameValue(
+  C[x ??= 1] = 2,
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-assignment-expression-logical-and.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-assignment-expression-logical-and.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from assignment expression logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  get [x &&= 1]() {
+    return 2;
+  }
+
+  set [x &&= 1](v) {
+    return 2;
+  }
+
+  static get [x &&= 1]() {
+    return 2;
+  }
+
+  static set [x &&= 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x &&= 1],
+  2
+);
+assert.sameValue(
+  c[x &&= 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x &&= 1],
+  2
+);
+assert.sameValue(
+  C[x &&= 1] = 2,
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-assignment-expression-logical-or.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-assignment-expression-logical-or.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from assignment expression logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  get [x ||= 1]() {
+    return 2;
+  }
+
+  set [x ||= 1](v) {
+    return 2;
+  }
+
+  static get [x ||= 1]() {
+    return 2;
+  }
+
+  static set [x ||= 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ||= 1],
+  2
+);
+assert.sameValue(
+  c[x ||= 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x ||= 1],
+  2
+);
+assert.sameValue(
+  C[x ||= 1] = 2,
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-async-arrow-function-expression.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-async-arrow-function-expression.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-async-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [async () => {}]() {
+    return 1;
+  }
+
+  set [async () => {}](v) {
+    return 1;
+  }
+
+  static get [async () => {}]() {
+    return 1;
+  }
+
+  static set [async () => {}](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[async () => {}],
+  1
+);
+assert.sameValue(
+  c[async () => {}] = 1,
+  1
+);
+
+assert.sameValue(
+  C[async () => {}],
+  1
+);
+assert.sameValue(
+  C[async () => {}] = 1,
+  1
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-condition-expression-false.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-condition-expression-false.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-false.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [false ? 1 : 2]() {
+    return 1;
+  }
+
+  set [false ? 1 : 2](v) {
+    return 1;
+  }
+
+  static get [false ? 1 : 2]() {
+    return 1;
+  }
+
+  static set [false ? 1 : 2](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[false ? 1 : 2],
+  1
+);
+assert.sameValue(
+  c[false ? 1 : 2] = 1,
+  1
+);
+
+assert.sameValue(
+  C[false ? 1 : 2],
+  1
+);
+assert.sameValue(
+  C[false ? 1 : 2] = 1,
+  1
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-condition-expression-true.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-condition-expression-true.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-true.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [true ? 1 : 2]() {
+    return 2;
+  }
+
+  set [true ? 1 : 2](v) {
+    return 2;
+  }
+
+  static get [true ? 1 : 2]() {
+    return 2;
+  }
+
+  static set [true ? 1 : 2](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  c[true ? 1 : 2] = 2,
+  2
+);
+
+assert.sameValue(
+  C[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2] = 2,
+  2
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-decimal-e-notational-literal.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-decimal-e-notational-literal.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from decimal e notational literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [1.e1]() {
+    return 2;
+  }
+
+  set [1.e1](v) {
+    return 2;
+  }
+
+  static get [1.e1]() {
+    return 2;
+  }
+
+  static set [1.e1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.e1],
+  2
+);
+assert.sameValue(
+  c[1.e1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[1.e1],
+  2
+);
+assert.sameValue(
+  C[1.e1] = 2,
+  2
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-decimal-literal.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-decimal-literal.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-literal.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from decimal literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [1.1]() {
+    return 2;
+  }
+
+  set [1.1](v) {
+    return 2;
+  }
+
+  static get [1.1]() {
+    return 2;
+  }
+
+  static set [1.1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.1],
+  2
+);
+assert.sameValue(
+  c[1.1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[1.1],
+  2
+);
+assert.sameValue(
+  C[1.1] = 2,
+  2
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-exponetiation-expression.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-exponetiation-expression.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [2 ** 2]() {
+    return 4;
+  }
+
+  set [2 ** 2](v) {
+    return 4;
+  }
+
+  static get [2 ** 2]() {
+    return 4;
+  }
+
+  static set [2 ** 2](v) {
+    return 4;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[2 ** 2],
+  4
+);
+assert.sameValue(
+  c[2 ** 2] = 4,
+  4
+);
+
+assert.sameValue(
+  C[2 ** 2],
+  4
+);
+assert.sameValue(
+  C[2 ** 2] = 4,
+  4
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-expression-coalesce.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-expression-coalesce.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x;
+
+
+let C = class {
+  get [x ?? 1]() {
+    return 2;
+  }
+
+  set [x ?? 1](v) {
+    return 2;
+  }
+
+  static get [x ?? 1]() {
+    return 2;
+  }
+
+  static set [x ?? 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ?? 1],
+  2
+);
+assert.sameValue(
+  c[x ?? 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x ?? 1],
+  2
+);
+assert.sameValue(
+  C[x ?? 1] = 2,
+  2
+);
+
+assert.sameValue(x, undefined);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-expression-logical-and.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-expression-logical-and.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  get [x && 1]() {
+    return 2;
+  }
+
+  set [x && 1](v) {
+    return 2;
+  }
+
+  static get [x && 1]() {
+    return 2;
+  }
+
+  static set [x && 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x && 1],
+  2
+);
+assert.sameValue(
+  c[x && 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x && 1],
+  2
+);
+assert.sameValue(
+  C[x && 1] = 2,
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-expression-logical-or.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-expression-logical-or.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  get [x || 1]() {
+    return 2;
+  }
+
+  set [x || 1](v) {
+    return 2;
+  }
+
+  static get [x || 1]() {
+    return 2;
+  }
+
+  static set [x || 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x || 1],
+  2
+);
+assert.sameValue(
+  c[x || 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x || 1],
+  2
+);
+assert.sameValue(
+  C[x || 1] = 2,
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-function-declaration.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-function-declaration.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-declaration.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function f() {}
+
+
+let C = class {
+  get [f()]() {
+    return 1;
+  }
+
+  set [f()](v) {
+    return 1;
+  }
+
+  static get [f()]() {
+    return 1;
+  }
+
+  static set [f()](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[f()],
+  1
+);
+assert.sameValue(
+  c[f()] = 1,
+  1
+);
+
+assert.sameValue(
+  C[f()],
+  1
+);
+assert.sameValue(
+  C[f()] = 1,
+  1
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-function-expression.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-function-expression.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-expression.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [function () {}]() {
+    return 1;
+  }
+
+  set [function () {}](v) {
+    return 1;
+  }
+
+  static get [function () {}]() {
+    return 1;
+  }
+
+  static set [function () {}](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[function () {}],
+  1
+);
+assert.sameValue(
+  c[function () {}] = 1,
+  1
+);
+
+assert.sameValue(
+  C[function () {}],
+  1
+);
+assert.sameValue(
+  C[function () {}] = 1,
+  1
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-generator-function-declaration.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-generator-function-declaration.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-generator-function-declaration.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from generator function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function * g() { return 1; }
+
+
+let C = class {
+  get [g()]() {
+    return 1;
+  }
+
+  set [g()](v) {
+    return 1;
+  }
+
+  static get [g()]() {
+    return 1;
+  }
+
+  static set [g()](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[g()],
+  1
+);
+assert.sameValue(
+  c[g()] = 1,
+  1
+);
+
+assert.sameValue(
+  C[g()],
+  1
+);
+assert.sameValue(
+  C[g()] = 1,
+  1
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-identifier.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-identifier.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-identifier.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 1;
+
+
+
+let C = class {
+  get [x]() {
+    return '2';
+  }
+
+  set [x](v) {
+    return '2';
+  }
+
+  static get [x]() {
+    return '2';
+  }
+
+  static set [x](v) {
+    return '2';
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x],
+  '2'
+);
+assert.sameValue(
+  c[x] = '2',
+  '2'
+);
+
+assert.sameValue(
+  C[x],
+  '2'
+);
+assert.sameValue(
+  C[x] = '2',
+  '2'
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-integer-e-notational-literal.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-integer-e-notational-literal.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [1]() {
+    return 2;
+  }
+
+  set [1](v) {
+    return 2;
+  }
+
+  static get [1]() {
+    return 2;
+  }
+
+  static set [1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1],
+  2
+);
+assert.sameValue(
+  c[1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[1],
+  2
+);
+assert.sameValue(
+  C[1] = 2,
+  2
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-integer-separators.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-integer-separators.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-separators.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from integer with separators (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [1_2_3_4_5_6_7_8]() {
+    return 1_2_3_4_5_6_7_8;
+  }
+
+  set [1_2_3_4_5_6_7_8](v) {
+    return 1_2_3_4_5_6_7_8;
+  }
+
+  static get [1_2_3_4_5_6_7_8]() {
+    return 1_2_3_4_5_6_7_8;
+  }
+
+  static set [1_2_3_4_5_6_7_8](v) {
+    return 1_2_3_4_5_6_7_8;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1_2_3_4_5_6_7_8],
+  1_2_3_4_5_6_7_8
+);
+assert.sameValue(
+  c[1_2_3_4_5_6_7_8] = 1_2_3_4_5_6_7_8,
+  1_2_3_4_5_6_7_8
+);
+
+assert.sameValue(
+  C[1_2_3_4_5_6_7_8],
+  1_2_3_4_5_6_7_8
+);
+assert.sameValue(
+  C[1_2_3_4_5_6_7_8] = 1_2_3_4_5_6_7_8,
+  1_2_3_4_5_6_7_8
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-math.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-math.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-math.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from math (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [1 + 2 - 3 * 4 / 5 ** 6]() {
+    return 2.999232;
+  }
+
+  set [1 + 2 - 3 * 4 / 5 ** 6](v) {
+    return 2.999232;
+  }
+
+  static get [1 + 2 - 3 * 4 / 5 ** 6]() {
+    return 2.999232;
+  }
+
+  static set [1 + 2 - 3 * 4 / 5 ** 6](v) {
+    return 2.999232;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 2 - 3 * 4 / 5 ** 6],
+  2.999232
+);
+assert.sameValue(
+  c[1 + 2 - 3 * 4 / 5 ** 6] = 2.999232,
+  2.999232
+);
+
+assert.sameValue(
+  C[1 + 2 - 3 * 4 / 5 ** 6],
+  2.999232
+);
+assert.sameValue(
+  C[1 + 2 - 3 * 4 / 5 ** 6] = 2.999232,
+  2.999232
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-multiplicative-expression-div.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-multiplicative-expression-div.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-div.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from multiplicative expression "divide" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [1 / 1]() {
+    return 1;
+  }
+
+  set [1 / 1](v) {
+    return 1;
+  }
+
+  static get [1 / 1]() {
+    return 1;
+  }
+
+  static set [1 / 1](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 / 1],
+  1
+);
+assert.sameValue(
+  c[1 / 1] = 1,
+  1
+);
+
+assert.sameValue(
+  C[1 / 1],
+  1
+);
+assert.sameValue(
+  C[1 / 1] = 1,
+  1
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-multiplicative-expression-mult.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-multiplicative-expression-mult.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-mult.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from multiplicative expression "multiply" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [1 * 1]() {
+    return 1;
+  }
+
+  set [1 * 1](v) {
+    return 1;
+  }
+
+  static get [1 * 1]() {
+    return 1;
+  }
+
+  static set [1 * 1](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 * 1],
+  1
+);
+assert.sameValue(
+  c[1 * 1] = 1,
+  1
+);
+
+assert.sameValue(
+  C[1 * 1],
+  1
+);
+assert.sameValue(
+  C[1 * 1] = 1,
+  1
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-numeric-literal.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-numeric-literal.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-numeric-literal.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [1]() {
+    return 2;
+  }
+
+  set [1](v) {
+    return 2;
+  }
+
+  static get [1]() {
+    return 2;
+  }
+
+  static set [1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1],
+  2
+);
+assert.sameValue(
+  c[1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[1],
+  2
+);
+assert.sameValue(
+  C[1] = 2,
+  2
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-string-literal.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-string-literal.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-string-literal.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get ['1']() {
+    return '2';
+  }
+
+  set ['1'](v) {
+    return '2';
+  }
+
+  static get ['1']() {
+    return '2';
+  }
+
+  static set ['1'](v) {
+    return '2';
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c['1'],
+  '2'
+);
+assert.sameValue(
+  c['1'] = '2',
+  '2'
+);
+
+assert.sameValue(
+  C['1'],
+  '2'
+);
+assert.sameValue(
+  C['1'] = '2',
+  '2'
+);

--- a/test/language/expressions/class/cpn-accessors-computed-property-name-from-yield-expression.js
+++ b/test/language/expressions/class/cpn-accessors-computed-property-name-from-yield-expression.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-yield-expression.case
+// - src/computed-property-names/evaluation/class-expression-accessors.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  get [true ? 1 : 2]() {
+    return 2;
+  }
+
+  set [true ? 1 : 2](v) {
+    return 2;
+  }
+
+  static get [true ? 1 : 2]() {
+    return 2;
+  }
+
+  static set [true ? 1 : 2](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  c[true ? 1 : 2] = 2,
+  2
+);
+
+assert.sameValue(
+  C[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2] = 2,
+  2
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-additive-expression-add.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-additive-expression-add.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-add.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from additive expression "add" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 + 1]() {
+    return 2;
+  }
+  static [1 + 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 1](),
+  2
+);
+assert.sameValue(
+  C[1 + 1](),
+  2
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-additive-expression-subtract.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-additive-expression-subtract.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-subtract.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from additive expression "subtract" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 - 1]() {
+    return 0;
+  }
+  static [1 - 1]() {
+    return 0;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 - 1](),
+  0
+);
+assert.sameValue(
+  C[1 - 1](),
+  0
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-arrow-function-expression.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-arrow-function-expression.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from arrow function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [() => { }]() {
+    return 1;
+  }
+  static [() => { }]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[() => { }](),
+  1
+);
+assert.sameValue(
+  C[() => { }](),
+  1
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-assignment-expression-assignment.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-assignment-expression-assignment.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-assignment.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from assignment expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x = 1]() {
+    return 2;
+  }
+  static [x = 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x = 1](),
+  2
+);
+assert.sameValue(
+  C[x = 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-computed-property-name-from-assignment-expression-bitwise-or.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-assignment-expression-bitwise-or.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-bitwise-or.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from assignment expression bitwise or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x |= 1]() {
+    return 2;
+  }
+  static [x |= 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x |= 1](),
+  2
+);
+assert.sameValue(
+  C[x |= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-computed-property-name-from-assignment-expression-coalesce.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-assignment-expression-coalesce.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from assignment expression coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = null;
+
+
+let C = class {
+  [x ??= 1]() {
+    return 2;
+  }
+  static [x ??= 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ??= 1](),
+  2
+);
+assert.sameValue(
+  C[x ??= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-computed-property-name-from-assignment-expression-logical-and.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-assignment-expression-logical-and.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from assignment expression logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x &&= 1]() {
+    return 2;
+  }
+  static [x &&= 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x &&= 1](),
+  2
+);
+assert.sameValue(
+  C[x &&= 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-computed-property-name-from-assignment-expression-logical-or.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-assignment-expression-logical-or.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from assignment expression logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x ||= 1]() {
+    return 2;
+  }
+  static [x ||= 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ||= 1](),
+  2
+);
+assert.sameValue(
+  C[x ||= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-computed-property-name-from-async-arrow-function-expression.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-async-arrow-function-expression.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-async-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [async () => {}]() {
+    return 1;
+  }
+  static [async () => {}]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[async () => {}](),
+  1
+);
+assert.sameValue(
+  C[async () => {}](),
+  1
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-condition-expression-false.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-condition-expression-false.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-false.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [false ? 1 : 2]() {
+    return 1;
+  }
+  static [false ? 1 : 2]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[false ? 1 : 2](),
+  1
+);
+assert.sameValue(
+  C[false ? 1 : 2](),
+  1
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-condition-expression-true.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-condition-expression-true.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-true.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [true ? 1 : 2]() {
+    return 2;
+  }
+  static [true ? 1 : 2]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2](),
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2](),
+  2
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-decimal-e-notational-literal.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-decimal-e-notational-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from decimal e notational literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1.e1]() {
+    return 2;
+  }
+  static [1.e1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.e1](),
+  2
+);
+assert.sameValue(
+  C[1.e1](),
+  2
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-decimal-literal.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-decimal-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-literal.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from decimal literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1.1]() {
+    return 2;
+  }
+  static [1.1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.1](),
+  2
+);
+assert.sameValue(
+  C[1.1](),
+  2
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-exponetiation-expression.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-exponetiation-expression.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [2 ** 2]() {
+    return 4;
+  }
+  static [2 ** 2]() {
+    return 4;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[2 ** 2](),
+  4
+);
+assert.sameValue(
+  C[2 ** 2](),
+  4
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-expression-coalesce.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-expression-coalesce.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x;
+
+
+let C = class {
+  [x ?? 1]() {
+    return 2;
+  }
+  static [x ?? 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ?? 1](),
+  2
+);
+assert.sameValue(
+  C[x ?? 1](),
+  2
+);
+
+assert.sameValue(x, undefined);

--- a/test/language/expressions/class/cpn-computed-property-name-from-expression-logical-and.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-expression-logical-and.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x && 1]() {
+    return 2;
+  }
+  static [x && 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x && 1](),
+  2
+);
+assert.sameValue(
+  C[x && 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-computed-property-name-from-expression-logical-or.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-expression-logical-or.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x || 1]() {
+    return 2;
+  }
+  static [x || 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x || 1](),
+  2
+);
+assert.sameValue(
+  C[x || 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-computed-property-name-from-function-declaration.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-function-declaration.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-declaration.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function f() {}
+
+
+let C = class {
+  [f()]() {
+    return 1;
+  }
+  static [f()]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[f()](),
+  1
+);
+assert.sameValue(
+  C[f()](),
+  1
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-function-expression.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-function-expression.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-expression.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [function () {}]() {
+    return 1;
+  }
+  static [function () {}]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[function () {}](),
+  1
+);
+assert.sameValue(
+  C[function () {}](),
+  1
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-generator-function-declaration.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-generator-function-declaration.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-generator-function-declaration.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from generator function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function * g() { return 1; }
+
+
+let C = class {
+  [g()]() {
+    return 1;
+  }
+  static [g()]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[g()](),
+  1
+);
+assert.sameValue(
+  C[g()](),
+  1
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-identifier.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-identifier.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-identifier.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 1;
+
+
+
+let C = class {
+  [x]() {
+    return '2';
+  }
+  static [x]() {
+    return '2';
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x](),
+  '2'
+);
+assert.sameValue(
+  C[x](),
+  '2'
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-integer-e-notational-literal.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-integer-e-notational-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1]() {
+    return 2;
+  }
+  static [1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1](),
+  2
+);
+assert.sameValue(
+  C[1](),
+  2
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-integer-separators.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-integer-separators.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-separators.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from integer with separators (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1_2_3_4_5_6_7_8]() {
+    return 1_2_3_4_5_6_7_8;
+  }
+  static [1_2_3_4_5_6_7_8]() {
+    return 1_2_3_4_5_6_7_8;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1_2_3_4_5_6_7_8](),
+  1_2_3_4_5_6_7_8
+);
+assert.sameValue(
+  C[1_2_3_4_5_6_7_8](),
+  1_2_3_4_5_6_7_8
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-math.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-math.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-math.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from math (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 + 2 - 3 * 4 / 5 ** 6]() {
+    return 2.999232;
+  }
+  static [1 + 2 - 3 * 4 / 5 ** 6]() {
+    return 2.999232;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 2 - 3 * 4 / 5 ** 6](),
+  2.999232
+);
+assert.sameValue(
+  C[1 + 2 - 3 * 4 / 5 ** 6](),
+  2.999232
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-multiplicative-expression-div.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-multiplicative-expression-div.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-div.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from multiplicative expression "divide" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 / 1]() {
+    return 1;
+  }
+  static [1 / 1]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 / 1](),
+  1
+);
+assert.sameValue(
+  C[1 / 1](),
+  1
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-multiplicative-expression-mult.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-multiplicative-expression-mult.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-mult.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from multiplicative expression "multiply" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 * 1]() {
+    return 1;
+  }
+  static [1 * 1]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 * 1](),
+  1
+);
+assert.sameValue(
+  C[1 * 1](),
+  1
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-numeric-literal.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-numeric-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-numeric-literal.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1]() {
+    return 2;
+  }
+  static [1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1](),
+  2
+);
+assert.sameValue(
+  C[1](),
+  2
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-string-literal.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-string-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-string-literal.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  ['1']() {
+    return '2';
+  }
+  static ['1']() {
+    return '2';
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c['1'](),
+  '2'
+);
+assert.sameValue(
+  C['1'](),
+  '2'
+);

--- a/test/language/expressions/class/cpn-computed-property-name-from-yield-expression.js
+++ b/test/language/expressions/class/cpn-computed-property-name-from-yield-expression.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-yield-expression.case
+// - src/computed-property-names/evaluation/class-expression.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [true ? 1 : 2]() {
+    return 2;
+  }
+  static [true ? 1 : 2]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2](),
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2](),
+  2
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-additive-expression-add.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-additive-expression-add.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-add.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from additive expression "add" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 + 1] = 2;
+
+  static [1 + 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 1],
+  2
+);
+assert.sameValue(
+  C[1 + 1],
+  2
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-additive-expression-subtract.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-additive-expression-subtract.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-subtract.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from additive expression "subtract" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 - 1] = 0;
+
+  static [1 - 1] = 0;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 - 1],
+  0
+);
+assert.sameValue(
+  C[1 - 1],
+  0
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-arrow-function-expression.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-arrow-function-expression.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from arrow function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [() => { }] = 1;
+
+  static [() => { }] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[() => { }],
+  1
+);
+assert.sameValue(
+  C[() => { }],
+  1
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-assignment-expression-assignment.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-assignment-expression-assignment.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-assignment.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from assignment expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x = 1] = 2;
+
+  static [x = 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x = 1],
+  2
+);
+assert.sameValue(
+  C[x = 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-assignment-expression-bitwise-or.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-assignment-expression-bitwise-or.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-bitwise-or.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from assignment expression bitwise or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x |= 1] = 2;
+
+  static [x |= 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x |= 1],
+  2
+);
+assert.sameValue(
+  C[x |= 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-assignment-expression-coalesce.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-assignment-expression-coalesce.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from assignment expression coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = null;
+
+
+let C = class {
+  [x ??= 1] = 2;
+
+  static [x ??= 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ??= 1],
+  2
+);
+assert.sameValue(
+  C[x ??= 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-assignment-expression-logical-and.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-assignment-expression-logical-and.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from assignment expression logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x &&= 1] = 2;
+
+  static [x &&= 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x &&= 1],
+  2
+);
+assert.sameValue(
+  C[x &&= 1],
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-assignment-expression-logical-or.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-assignment-expression-logical-or.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from assignment expression logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x ||= 1] = 2;
+
+  static [x ||= 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ||= 1],
+  2
+);
+assert.sameValue(
+  C[x ||= 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-async-arrow-function-expression.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-async-arrow-function-expression.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-async-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [async () => {}] = 1;
+
+  static [async () => {}] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[async () => {}],
+  1
+);
+assert.sameValue(
+  C[async () => {}],
+  1
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-condition-expression-false.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-condition-expression-false.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-false.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [false ? 1 : 2] = 1;
+
+  static [false ? 1 : 2] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[false ? 1 : 2],
+  1
+);
+assert.sameValue(
+  C[false ? 1 : 2],
+  1
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-condition-expression-true.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-condition-expression-true.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-true.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [true ? 1 : 2] = 2;
+
+  static [true ? 1 : 2] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2],
+  2
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-decimal-e-notational-literal.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-decimal-e-notational-literal.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from decimal e notational literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1.e1] = 2;
+
+  static [1.e1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.e1],
+  2
+);
+assert.sameValue(
+  C[1.e1],
+  2
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-decimal-literal.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-decimal-literal.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-literal.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from decimal literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1.1] = 2;
+
+  static [1.1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.1],
+  2
+);
+assert.sameValue(
+  C[1.1],
+  2
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-exponetiation-expression.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-exponetiation-expression.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [2 ** 2] = 4;
+
+  static [2 ** 2] = 4;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[2 ** 2],
+  4
+);
+assert.sameValue(
+  C[2 ** 2],
+  4
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-expression-coalesce.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-expression-coalesce.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x;
+
+
+let C = class {
+  [x ?? 1] = 2;
+
+  static [x ?? 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ?? 1],
+  2
+);
+assert.sameValue(
+  C[x ?? 1],
+  2
+);
+
+assert.sameValue(x, undefined);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-expression-logical-and.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-expression-logical-and.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x && 1] = 2;
+
+  static [x && 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x && 1],
+  2
+);
+assert.sameValue(
+  C[x && 1],
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-expression-logical-or.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-expression-logical-or.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x || 1] = 2;
+
+  static [x || 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x || 1],
+  2
+);
+assert.sameValue(
+  C[x || 1],
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-function-declaration.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-function-declaration.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-declaration.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function f() {}
+
+
+let C = class {
+  [f()] = 1;
+
+  static [f()] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[f()],
+  1
+);
+assert.sameValue(
+  C[f()],
+  1
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-function-expression.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-function-expression.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-expression.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [function () {}] = 1;
+
+  static [function () {}] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[function () {}],
+  1
+);
+assert.sameValue(
+  C[function () {}],
+  1
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-generator-function-declaration.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-generator-function-declaration.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-generator-function-declaration.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from generator function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function * g() { return 1; }
+
+
+let C = class {
+  [g()] = 1;
+
+  static [g()] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[g()],
+  1
+);
+assert.sameValue(
+  C[g()],
+  1
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-identifier.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-identifier.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-identifier.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 1;
+
+
+
+let C = class {
+  [x] = '2';
+
+  static [x] = '2';
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x],
+  '2'
+);
+assert.sameValue(
+  C[x],
+  '2'
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-integer-e-notational-literal.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-integer-e-notational-literal.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1] = 2;
+
+  static [1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1],
+  2
+);
+assert.sameValue(
+  C[1],
+  2
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-integer-separators.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-integer-separators.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-separators.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from integer with separators (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1_2_3_4_5_6_7_8] = 1_2_3_4_5_6_7_8;
+
+  static [1_2_3_4_5_6_7_8] = 1_2_3_4_5_6_7_8;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1_2_3_4_5_6_7_8],
+  1_2_3_4_5_6_7_8
+);
+assert.sameValue(
+  C[1_2_3_4_5_6_7_8],
+  1_2_3_4_5_6_7_8
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-math.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-math.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-math.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from math (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 + 2 - 3 * 4 / 5 ** 6] = 2.999232;
+
+  static [1 + 2 - 3 * 4 / 5 ** 6] = 2.999232;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 2 - 3 * 4 / 5 ** 6],
+  2.999232
+);
+assert.sameValue(
+  C[1 + 2 - 3 * 4 / 5 ** 6],
+  2.999232
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-multiplicative-expression-div.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-multiplicative-expression-div.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-div.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from multiplicative expression "divide" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 / 1] = 1;
+
+  static [1 / 1] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 / 1],
+  1
+);
+assert.sameValue(
+  C[1 / 1],
+  1
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-multiplicative-expression-mult.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-multiplicative-expression-mult.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-mult.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from multiplicative expression "multiply" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 * 1] = 1;
+
+  static [1 * 1] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 * 1],
+  1
+);
+assert.sameValue(
+  C[1 * 1],
+  1
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-numeric-literal.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-numeric-literal.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-numeric-literal.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1] = 2;
+
+  static [1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1],
+  2
+);
+assert.sameValue(
+  C[1],
+  2
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-string-literal.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-string-literal.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-string-literal.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  ['1'] = '2';
+
+  static ['1'] = '2';
+};
+
+let c = new C();
+
+assert.sameValue(
+  c['1'],
+  '2'
+);
+assert.sameValue(
+  C['1'],
+  '2'
+);

--- a/test/language/expressions/class/cpn-fields-computed-property-name-from-yield-expression.js
+++ b/test/language/expressions/class/cpn-fields-computed-property-name-from-yield-expression.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-yield-expression.case
+// - src/computed-property-names/evaluation/class-expression-fields.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [true ? 1 : 2] = 2;
+
+  static [true ? 1 : 2] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2],
+  2
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-additive-expression-add.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-additive-expression-add.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-add.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from additive expression "add" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 + 1] = () => {
+    return 2;
+  };
+
+  static [1 + 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 1](),
+  2
+);
+assert.sameValue(
+  C[1 + 1](),
+  2
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-additive-expression-subtract.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-additive-expression-subtract.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-subtract.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from additive expression "subtract" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 - 1] = () => {
+    return 0;
+  };
+
+  static [1 - 1] = () => {
+    return 0;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 - 1](),
+  0
+);
+assert.sameValue(
+  C[1 - 1](),
+  0
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-arrow-function-expression.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-arrow-function-expression.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from arrow function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [() => { }] = () => {
+    return 1;
+  };
+
+  static [() => { }] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[() => { }](),
+  1
+);
+assert.sameValue(
+  C[() => { }](),
+  1
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-assignment-expression-assignment.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-assignment-expression-assignment.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-assignment.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from assignment expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x = 1] = () => {
+    return 2;
+  };
+
+  static [x = 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x = 1](),
+  2
+);
+assert.sameValue(
+  C[x = 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-assignment-expression-bitwise-or.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-assignment-expression-bitwise-or.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-bitwise-or.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from assignment expression bitwise or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x |= 1] = () => {
+    return 2;
+  };
+
+  static [x |= 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x |= 1](),
+  2
+);
+assert.sameValue(
+  C[x |= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-assignment-expression-coalesce.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-assignment-expression-coalesce.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from assignment expression coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = null;
+
+
+let C = class {
+  [x ??= 1] = () => {
+    return 2;
+  };
+
+  static [x ??= 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ??= 1](),
+  2
+);
+assert.sameValue(
+  C[x ??= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-assignment-expression-logical-and.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-assignment-expression-logical-and.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from assignment expression logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x &&= 1] = () => {
+    return 2;
+  };
+
+  static [x &&= 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x &&= 1](),
+  2
+);
+assert.sameValue(
+  C[x &&= 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-assignment-expression-logical-or.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-assignment-expression-logical-or.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from assignment expression logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x ||= 1] = () => {
+    return 2;
+  };
+
+  static [x ||= 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ||= 1](),
+  2
+);
+assert.sameValue(
+  C[x ||= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-async-arrow-function-expression.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-async-arrow-function-expression.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-async-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [async () => {}] = () => {
+    return 1;
+  };
+
+  static [async () => {}] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[async () => {}](),
+  1
+);
+assert.sameValue(
+  C[async () => {}](),
+  1
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-condition-expression-false.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-condition-expression-false.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-false.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [false ? 1 : 2] = () => {
+    return 1;
+  };
+
+  static [false ? 1 : 2] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[false ? 1 : 2](),
+  1
+);
+assert.sameValue(
+  C[false ? 1 : 2](),
+  1
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-condition-expression-true.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-condition-expression-true.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-true.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [true ? 1 : 2] = () => {
+    return 2;
+  };
+
+  static [true ? 1 : 2] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2](),
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2](),
+  2
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-decimal-e-notational-literal.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-decimal-e-notational-literal.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from decimal e notational literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1.e1] = () => {
+    return 2;
+  };
+
+  static [1.e1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.e1](),
+  2
+);
+assert.sameValue(
+  C[1.e1](),
+  2
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-decimal-literal.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-decimal-literal.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-literal.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from decimal literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1.1] = () => {
+    return 2;
+  };
+
+  static [1.1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.1](),
+  2
+);
+assert.sameValue(
+  C[1.1](),
+  2
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-exponetiation-expression.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-exponetiation-expression.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [2 ** 2] = () => {
+    return 4;
+  };
+
+  static [2 ** 2] = () => {
+    return 4;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[2 ** 2](),
+  4
+);
+assert.sameValue(
+  C[2 ** 2](),
+  4
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-expression-coalesce.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-expression-coalesce.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x;
+
+
+let C = class {
+  [x ?? 1] = () => {
+    return 2;
+  };
+
+  static [x ?? 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ?? 1](),
+  2
+);
+assert.sameValue(
+  C[x ?? 1](),
+  2
+);
+
+assert.sameValue(x, undefined);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-expression-logical-and.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-expression-logical-and.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x && 1] = () => {
+    return 2;
+  };
+
+  static [x && 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x && 1](),
+  2
+);
+assert.sameValue(
+  C[x && 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-expression-logical-or.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-expression-logical-or.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x || 1] = () => {
+    return 2;
+  };
+
+  static [x || 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x || 1](),
+  2
+);
+assert.sameValue(
+  C[x || 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-function-declaration.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-function-declaration.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-declaration.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function f() {}
+
+
+let C = class {
+  [f()] = () => {
+    return 1;
+  };
+
+  static [f()] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[f()](),
+  1
+);
+assert.sameValue(
+  C[f()](),
+  1
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-function-expression.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-function-expression.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-expression.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [function () {}] = () => {
+    return 1;
+  };
+
+  static [function () {}] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[function () {}](),
+  1
+);
+assert.sameValue(
+  C[function () {}](),
+  1
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-generator-function-declaration.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-generator-function-declaration.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-generator-function-declaration.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from generator function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function * g() { return 1; }
+
+
+let C = class {
+  [g()] = () => {
+    return 1;
+  };
+
+  static [g()] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[g()](),
+  1
+);
+assert.sameValue(
+  C[g()](),
+  1
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-identifier.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-identifier.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-identifier.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 1;
+
+
+
+let C = class {
+  [x] = () => {
+    return '2';
+  };
+
+  static [x] = () => {
+    return '2';
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x](),
+  '2'
+);
+assert.sameValue(
+  C[x](),
+  '2'
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-integer-e-notational-literal.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-integer-e-notational-literal.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1] = () => {
+    return 2;
+  };
+
+  static [1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1](),
+  2
+);
+assert.sameValue(
+  C[1](),
+  2
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-integer-separators.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-integer-separators.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-separators.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from integer with separators (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1_2_3_4_5_6_7_8] = () => {
+    return 1_2_3_4_5_6_7_8;
+  };
+
+  static [1_2_3_4_5_6_7_8] = () => {
+    return 1_2_3_4_5_6_7_8;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1_2_3_4_5_6_7_8](),
+  1_2_3_4_5_6_7_8
+);
+assert.sameValue(
+  C[1_2_3_4_5_6_7_8](),
+  1_2_3_4_5_6_7_8
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-math.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-math.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-math.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from math (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 + 2 - 3 * 4 / 5 ** 6] = () => {
+    return 2.999232;
+  };
+
+  static [1 + 2 - 3 * 4 / 5 ** 6] = () => {
+    return 2.999232;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 2 - 3 * 4 / 5 ** 6](),
+  2.999232
+);
+assert.sameValue(
+  C[1 + 2 - 3 * 4 / 5 ** 6](),
+  2.999232
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-multiplicative-expression-div.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-multiplicative-expression-div.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-div.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from multiplicative expression "divide" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 / 1] = () => {
+    return 1;
+  };
+
+  static [1 / 1] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 / 1](),
+  1
+);
+assert.sameValue(
+  C[1 / 1](),
+  1
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-multiplicative-expression-mult.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-multiplicative-expression-mult.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-mult.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from multiplicative expression "multiply" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 * 1] = () => {
+    return 1;
+  };
+
+  static [1 * 1] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 * 1](),
+  1
+);
+assert.sameValue(
+  C[1 * 1](),
+  1
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-numeric-literal.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-numeric-literal.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-numeric-literal.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1] = () => {
+    return 2;
+  };
+
+  static [1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1](),
+  2
+);
+assert.sameValue(
+  C[1](),
+  2
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-string-literal.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-string-literal.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-string-literal.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  ['1'] = () => {
+    return '2';
+  };
+
+  static ['1'] = () => {
+    return '2';
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c['1'](),
+  '2'
+);
+assert.sameValue(
+  C['1'](),
+  '2'
+);

--- a/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-yield-expression.js
+++ b/test/language/expressions/class/cpn-fields-methods-computed-property-name-from-yield-expression.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-yield-expression.case
+// - src/computed-property-names/evaluation/class-expression-fields-methods.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [true ? 1 : 2] = () => {
+    return 2;
+  };
+
+  static [true ? 1 : 2] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2](),
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2](),
+  2
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-additive-expression-add.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-additive-expression-add.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-add.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from additive expression "add" (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [1 + 1]: 2
+};
+
+assert.sameValue(
+  o[1 + 1],
+  2
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-additive-expression-subtract.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-additive-expression-subtract.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-subtract.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from additive expression "subtract" (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [1 - 1]: 0
+};
+
+assert.sameValue(
+  o[1 - 1],
+  0
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-arrow-function-expression.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-arrow-function-expression.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-arrow-function-expression.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from arrow function (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [() => { }]: 1
+};
+
+assert.sameValue(
+  o[() => { }],
+  1
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-assignment-expression-assignment.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-assignment-expression-assignment.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-assignment.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from assignment expression (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let o = {
+  [x = 1]: 2
+};
+
+assert.sameValue(
+  o[x = 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/object/cpn-computed-property-name-from-assignment-expression-bitwise-or.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-assignment-expression-bitwise-or.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-bitwise-or.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from assignment expression bitwise or (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let o = {
+  [x |= 1]: 2
+};
+
+assert.sameValue(
+  o[x |= 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/object/cpn-computed-property-name-from-assignment-expression-coalesce.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-assignment-expression-coalesce.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-coalesce.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from assignment expression coalesce (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = null;
+
+
+let o = {
+  [x ??= 1]: 2
+};
+
+assert.sameValue(
+  o[x ??= 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/object/cpn-computed-property-name-from-assignment-expression-logical-and.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-assignment-expression-logical-and.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-and.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from assignment expression logical and (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let o = {
+  [x &&= 1]: 2
+};
+
+assert.sameValue(
+  o[x &&= 1],
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/object/cpn-computed-property-name-from-assignment-expression-logical-or.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-assignment-expression-logical-or.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-or.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from assignment expression logical or (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let o = {
+  [x ||= 1]: 2
+};
+
+assert.sameValue(
+  o[x ||= 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/expressions/object/cpn-computed-property-name-from-async-arrow-function-expression.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-async-arrow-function-expression.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-async-arrow-function-expression.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [async () => {}]: 1
+};
+
+assert.sameValue(
+  o[async () => {}],
+  1
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-condition-expression-false.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-condition-expression-false.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-false.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [false ? 1 : 2]: 1
+};
+
+assert.sameValue(
+  o[false ? 1 : 2],
+  1
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-condition-expression-true.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-condition-expression-true.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-true.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [true ? 1 : 2]: 2
+};
+
+assert.sameValue(
+  o[true ? 1 : 2],
+  2
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-decimal-e-notational-literal.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-decimal-e-notational-literal.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-e-notational-literal.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from decimal e notational literal (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [1.e1]: 2
+};
+
+assert.sameValue(
+  o[1.e1],
+  2
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-decimal-literal.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-decimal-literal.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-literal.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from decimal literal (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [1.1]: 2
+};
+
+assert.sameValue(
+  o[1.1],
+  2
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-exponetiation-expression.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-exponetiation-expression.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from exponentiation expression (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [2 ** 2]: 4
+};
+
+assert.sameValue(
+  o[2 ** 2],
+  4
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-expression-coalesce.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-expression-coalesce.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-coalesce.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from coalesce (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x;
+
+
+let o = {
+  [x ?? 1]: 2
+};
+
+assert.sameValue(
+  o[x ?? 1],
+  2
+);
+
+assert.sameValue(x, undefined);

--- a/test/language/expressions/object/cpn-computed-property-name-from-expression-logical-and.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-expression-logical-and.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-and.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from logical and (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let o = {
+  [x && 1]: 2
+};
+
+assert.sameValue(
+  o[x && 1],
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/object/cpn-computed-property-name-from-expression-logical-or.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-expression-logical-or.js
@@ -1,0 +1,37 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-or.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from logical or (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let o = {
+  [x || 1]: 2
+};
+
+assert.sameValue(
+  o[x || 1],
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/expressions/object/cpn-computed-property-name-from-function-declaration.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-function-declaration.js
@@ -1,0 +1,35 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-declaration.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from function (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function f() {}
+
+
+let o = {
+  [f()]: 1
+};
+
+assert.sameValue(
+  o[f()],
+  1
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-function-expression.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-function-expression.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-expression.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [function () {}]: 1
+};
+
+assert.sameValue(
+  o[function () {}],
+  1
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-generator-function-declaration.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-generator-function-declaration.js
@@ -1,0 +1,35 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-generator-function-declaration.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from generator function (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function * g() { return 1; }
+
+
+let o = {
+  [g()]: 1
+};
+
+assert.sameValue(
+  o[g()],
+  1
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-identifier.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-identifier.js
@@ -1,0 +1,36 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-identifier.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 1;
+
+
+
+let o = {
+  [x]: '2'
+};
+
+assert.sameValue(
+  o[x],
+  '2'
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-integer-e-notational-literal.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-integer-e-notational-literal.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-e-notational-literal.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [1]: 2
+};
+
+assert.sameValue(
+  o[1],
+  2
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-integer-separators.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-integer-separators.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-separators.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from integer with separators (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [1_2_3_4_5_6_7_8]: 1_2_3_4_5_6_7_8
+};
+
+assert.sameValue(
+  o[1_2_3_4_5_6_7_8],
+  1_2_3_4_5_6_7_8
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-math.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-math.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-math.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from math (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [1 + 2 - 3 * 4 / 5 ** 6]: 2.999232
+};
+
+assert.sameValue(
+  o[1 + 2 - 3 * 4 / 5 ** 6],
+  2.999232
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-multiplicative-expression-div.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-multiplicative-expression-div.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-div.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from multiplicative expression "divide" (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [1 / 1]: 1
+};
+
+assert.sameValue(
+  o[1 / 1],
+  1
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-multiplicative-expression-mult.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-multiplicative-expression-mult.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-mult.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from multiplicative expression "multiply" (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [1 * 1]: 1
+};
+
+assert.sameValue(
+  o[1 * 1],
+  1
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-numeric-literal.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-numeric-literal.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-numeric-literal.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [1]: 2
+};
+
+assert.sameValue(
+  o[1],
+  2
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-string-literal.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-string-literal.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-string-literal.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  ['1']: '2'
+};
+
+assert.sameValue(
+  o['1'],
+  '2'
+);

--- a/test/language/expressions/object/cpn-computed-property-name-from-yield-expression.js
+++ b/test/language/expressions/object/cpn-computed-property-name-from-yield-expression.js
@@ -1,0 +1,34 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-yield-expression.case
+// - src/computed-property-names/evaluation/object-literal.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ObjectLiteral)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ObjectLiteral:
+      { PropertyDefinitionList }
+
+    PropertyDefinitionList:
+      PropertyDefinition
+
+    PropertyDefinition:
+      PropertyName: AssignmentExpression
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let o = {
+  [true ? 1 : 2]: 2
+};
+
+assert.sameValue(
+  o[true ? 1 : 2],
+  2
+);

--- a/test/language/expressions/object/method-definition/computed-property-name-yield-expression.js
+++ b/test/language/expressions/object/method-definition/computed-property-name-yield-expression.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    When the `yield` keyword occurs within the PropertyName of a
+    non-generator MethodDefinition within a generator function, it behaves as a
+    YieldExpression.
+info: |
+  ComputedPropertyName:
+    [ AssignmentExpression ]
+
+  AssignmentExpression[In, Yield, Await]:
+    [+Yield]YieldExpression[?In, ?Await]
+
+features: [computed-property-names, generators]
+flags: [noStrict]
+---*/
+
+function * g() {
+  let o = {
+    [yield 10]: 1,
+    a: 'a'
+  };
+
+  yield 20;
+  return o;
+}
+
+let iter = g();
+assert.sameValue(iter.next().value, 10);
+assert.sameValue(iter.next().value, 20);
+
+let outcome = iter.next().value;
+
+assert.sameValue(outcome[undefined], 1);
+assert.sameValue(outcome.a, 'a');
+

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-additive-expression-add.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-additive-expression-add.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-add.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from additive expression "add" (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [1 + 1]() {
+    return 2;
+  }
+
+  set [1 + 1](v) {
+    return 2;
+  }
+
+  static get [1 + 1]() {
+    return 2;
+  }
+
+  static set [1 + 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 1],
+  2
+);
+assert.sameValue(
+  c[1 + 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[1 + 1],
+  2
+);
+assert.sameValue(
+  C[1 + 1] = 2,
+  2
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-additive-expression-subtract.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-additive-expression-subtract.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-subtract.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from additive expression "subtract" (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [1 - 1]() {
+    return 0;
+  }
+
+  set [1 - 1](v) {
+    return 0;
+  }
+
+  static get [1 - 1]() {
+    return 0;
+  }
+
+  static set [1 - 1](v) {
+    return 0;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 - 1],
+  0
+);
+assert.sameValue(
+  c[1 - 1] = 0,
+  0
+);
+
+assert.sameValue(
+  C[1 - 1],
+  0
+);
+assert.sameValue(
+  C[1 - 1] = 0,
+  0
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-arrow-function-expression.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-arrow-function-expression.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from arrow function (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [() => { }]() {
+    return 1;
+  }
+
+  set [() => { }](v) {
+    return 1;
+  }
+
+  static get [() => { }]() {
+    return 1;
+  }
+
+  static set [() => { }](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[() => { }],
+  1
+);
+assert.sameValue(
+  c[() => { }] = 1,
+  1
+);
+
+assert.sameValue(
+  C[() => { }],
+  1
+);
+assert.sameValue(
+  C[() => { }] = 1,
+  1
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-assignment-expression-assignment.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-assignment-expression-assignment.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-assignment.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from assignment expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  get [x = 1]() {
+    return 2;
+  }
+
+  set [x = 1](v) {
+    return 2;
+  }
+
+  static get [x = 1]() {
+    return 2;
+  }
+
+  static set [x = 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x = 1],
+  2
+);
+assert.sameValue(
+  c[x = 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x = 1],
+  2
+);
+assert.sameValue(
+  C[x = 1] = 2,
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-assignment-expression-bitwise-or.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-assignment-expression-bitwise-or.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-bitwise-or.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from assignment expression bitwise or (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  get [x |= 1]() {
+    return 2;
+  }
+
+  set [x |= 1](v) {
+    return 2;
+  }
+
+  static get [x |= 1]() {
+    return 2;
+  }
+
+  static set [x |= 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x |= 1],
+  2
+);
+assert.sameValue(
+  c[x |= 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x |= 1],
+  2
+);
+assert.sameValue(
+  C[x |= 1] = 2,
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-assignment-expression-coalesce.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-assignment-expression-coalesce.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from assignment expression coalesce (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = null;
+
+
+class C {
+  get [x ??= 1]() {
+    return 2;
+  }
+
+  set [x ??= 1](v) {
+    return 2;
+  }
+
+  static get [x ??= 1]() {
+    return 2;
+  }
+
+  static set [x ??= 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ??= 1],
+  2
+);
+assert.sameValue(
+  c[x ??= 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x ??= 1],
+  2
+);
+assert.sameValue(
+  C[x ??= 1] = 2,
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-assignment-expression-logical-and.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-assignment-expression-logical-and.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from assignment expression logical and (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  get [x &&= 1]() {
+    return 2;
+  }
+
+  set [x &&= 1](v) {
+    return 2;
+  }
+
+  static get [x &&= 1]() {
+    return 2;
+  }
+
+  static set [x &&= 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x &&= 1],
+  2
+);
+assert.sameValue(
+  c[x &&= 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x &&= 1],
+  2
+);
+assert.sameValue(
+  C[x &&= 1] = 2,
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-assignment-expression-logical-or.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-assignment-expression-logical-or.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from assignment expression logical or (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  get [x ||= 1]() {
+    return 2;
+  }
+
+  set [x ||= 1](v) {
+    return 2;
+  }
+
+  static get [x ||= 1]() {
+    return 2;
+  }
+
+  static set [x ||= 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ||= 1],
+  2
+);
+assert.sameValue(
+  c[x ||= 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x ||= 1],
+  2
+);
+assert.sameValue(
+  C[x ||= 1] = 2,
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-async-arrow-function-expression.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-async-arrow-function-expression.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-async-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [async () => {}]() {
+    return 1;
+  }
+
+  set [async () => {}](v) {
+    return 1;
+  }
+
+  static get [async () => {}]() {
+    return 1;
+  }
+
+  static set [async () => {}](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[async () => {}],
+  1
+);
+assert.sameValue(
+  c[async () => {}] = 1,
+  1
+);
+
+assert.sameValue(
+  C[async () => {}],
+  1
+);
+assert.sameValue(
+  C[async () => {}] = 1,
+  1
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-condition-expression-false.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-condition-expression-false.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-false.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [false ? 1 : 2]() {
+    return 1;
+  }
+
+  set [false ? 1 : 2](v) {
+    return 1;
+  }
+
+  static get [false ? 1 : 2]() {
+    return 1;
+  }
+
+  static set [false ? 1 : 2](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[false ? 1 : 2],
+  1
+);
+assert.sameValue(
+  c[false ? 1 : 2] = 1,
+  1
+);
+
+assert.sameValue(
+  C[false ? 1 : 2],
+  1
+);
+assert.sameValue(
+  C[false ? 1 : 2] = 1,
+  1
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-condition-expression-true.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-condition-expression-true.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-true.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [true ? 1 : 2]() {
+    return 2;
+  }
+
+  set [true ? 1 : 2](v) {
+    return 2;
+  }
+
+  static get [true ? 1 : 2]() {
+    return 2;
+  }
+
+  static set [true ? 1 : 2](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  c[true ? 1 : 2] = 2,
+  2
+);
+
+assert.sameValue(
+  C[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2] = 2,
+  2
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-decimal-e-notational-literal.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-decimal-e-notational-literal.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from decimal e notational literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [1.e1]() {
+    return 2;
+  }
+
+  set [1.e1](v) {
+    return 2;
+  }
+
+  static get [1.e1]() {
+    return 2;
+  }
+
+  static set [1.e1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.e1],
+  2
+);
+assert.sameValue(
+  c[1.e1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[1.e1],
+  2
+);
+assert.sameValue(
+  C[1.e1] = 2,
+  2
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-decimal-literal.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-decimal-literal.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-literal.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from decimal literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [1.1]() {
+    return 2;
+  }
+
+  set [1.1](v) {
+    return 2;
+  }
+
+  static get [1.1]() {
+    return 2;
+  }
+
+  static set [1.1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.1],
+  2
+);
+assert.sameValue(
+  c[1.1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[1.1],
+  2
+);
+assert.sameValue(
+  C[1.1] = 2,
+  2
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-exponetiation-expression.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-exponetiation-expression.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from exponentiation expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [2 ** 2]() {
+    return 4;
+  }
+
+  set [2 ** 2](v) {
+    return 4;
+  }
+
+  static get [2 ** 2]() {
+    return 4;
+  }
+
+  static set [2 ** 2](v) {
+    return 4;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[2 ** 2],
+  4
+);
+assert.sameValue(
+  c[2 ** 2] = 4,
+  4
+);
+
+assert.sameValue(
+  C[2 ** 2],
+  4
+);
+assert.sameValue(
+  C[2 ** 2] = 4,
+  4
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-expression-coalesce.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-expression-coalesce.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from coalesce (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x;
+
+
+class C {
+  get [x ?? 1]() {
+    return 2;
+  }
+
+  set [x ?? 1](v) {
+    return 2;
+  }
+
+  static get [x ?? 1]() {
+    return 2;
+  }
+
+  static set [x ?? 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ?? 1],
+  2
+);
+assert.sameValue(
+  c[x ?? 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x ?? 1],
+  2
+);
+assert.sameValue(
+  C[x ?? 1] = 2,
+  2
+);
+
+assert.sameValue(x, undefined);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-expression-logical-and.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-expression-logical-and.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from logical and (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  get [x && 1]() {
+    return 2;
+  }
+
+  set [x && 1](v) {
+    return 2;
+  }
+
+  static get [x && 1]() {
+    return 2;
+  }
+
+  static set [x && 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x && 1],
+  2
+);
+assert.sameValue(
+  c[x && 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x && 1],
+  2
+);
+assert.sameValue(
+  C[x && 1] = 2,
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-expression-logical-or.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-expression-logical-or.js
@@ -1,0 +1,77 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from logical or (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  get [x || 1]() {
+    return 2;
+  }
+
+  set [x || 1](v) {
+    return 2;
+  }
+
+  static get [x || 1]() {
+    return 2;
+  }
+
+  static set [x || 1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x || 1],
+  2
+);
+assert.sameValue(
+  c[x || 1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[x || 1],
+  2
+);
+assert.sameValue(
+  C[x || 1] = 2,
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-function-declaration.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-function-declaration.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-declaration.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from function (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function f() {}
+
+
+class C {
+  get [f()]() {
+    return 1;
+  }
+
+  set [f()](v) {
+    return 1;
+  }
+
+  static get [f()]() {
+    return 1;
+  }
+
+  static set [f()](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[f()],
+  1
+);
+assert.sameValue(
+  c[f()] = 1,
+  1
+);
+
+assert.sameValue(
+  C[f()],
+  1
+);
+assert.sameValue(
+  C[f()] = 1,
+  1
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-function-expression.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-function-expression.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [function () {}]() {
+    return 1;
+  }
+
+  set [function () {}](v) {
+    return 1;
+  }
+
+  static get [function () {}]() {
+    return 1;
+  }
+
+  static set [function () {}](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[function () {}],
+  1
+);
+assert.sameValue(
+  c[function () {}] = 1,
+  1
+);
+
+assert.sameValue(
+  C[function () {}],
+  1
+);
+assert.sameValue(
+  C[function () {}] = 1,
+  1
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-generator-function-declaration.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-generator-function-declaration.js
@@ -1,0 +1,75 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-generator-function-declaration.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from generator function (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function * g() { return 1; }
+
+
+class C {
+  get [g()]() {
+    return 1;
+  }
+
+  set [g()](v) {
+    return 1;
+  }
+
+  static get [g()]() {
+    return 1;
+  }
+
+  static set [g()](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[g()],
+  1
+);
+assert.sameValue(
+  c[g()] = 1,
+  1
+);
+
+assert.sameValue(
+  C[g()],
+  1
+);
+assert.sameValue(
+  C[g()] = 1,
+  1
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-identifier.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-identifier.js
@@ -1,0 +1,76 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-identifier.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 1;
+
+
+
+class C {
+  get [x]() {
+    return '2';
+  }
+
+  set [x](v) {
+    return '2';
+  }
+
+  static get [x]() {
+    return '2';
+  }
+
+  static set [x](v) {
+    return '2';
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x],
+  '2'
+);
+assert.sameValue(
+  c[x] = '2',
+  '2'
+);
+
+assert.sameValue(
+  C[x],
+  '2'
+);
+assert.sameValue(
+  C[x] = '2',
+  '2'
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-integer-e-notational-literal.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-integer-e-notational-literal.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [1]() {
+    return 2;
+  }
+
+  set [1](v) {
+    return 2;
+  }
+
+  static get [1]() {
+    return 2;
+  }
+
+  static set [1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1],
+  2
+);
+assert.sameValue(
+  c[1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[1],
+  2
+);
+assert.sameValue(
+  C[1] = 2,
+  2
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-integer-separators.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-integer-separators.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-separators.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from integer with separators (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [1_2_3_4_5_6_7_8]() {
+    return 1_2_3_4_5_6_7_8;
+  }
+
+  set [1_2_3_4_5_6_7_8](v) {
+    return 1_2_3_4_5_6_7_8;
+  }
+
+  static get [1_2_3_4_5_6_7_8]() {
+    return 1_2_3_4_5_6_7_8;
+  }
+
+  static set [1_2_3_4_5_6_7_8](v) {
+    return 1_2_3_4_5_6_7_8;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1_2_3_4_5_6_7_8],
+  1_2_3_4_5_6_7_8
+);
+assert.sameValue(
+  c[1_2_3_4_5_6_7_8] = 1_2_3_4_5_6_7_8,
+  1_2_3_4_5_6_7_8
+);
+
+assert.sameValue(
+  C[1_2_3_4_5_6_7_8],
+  1_2_3_4_5_6_7_8
+);
+assert.sameValue(
+  C[1_2_3_4_5_6_7_8] = 1_2_3_4_5_6_7_8,
+  1_2_3_4_5_6_7_8
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-math.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-math.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-math.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from math (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [1 + 2 - 3 * 4 / 5 ** 6]() {
+    return 2.999232;
+  }
+
+  set [1 + 2 - 3 * 4 / 5 ** 6](v) {
+    return 2.999232;
+  }
+
+  static get [1 + 2 - 3 * 4 / 5 ** 6]() {
+    return 2.999232;
+  }
+
+  static set [1 + 2 - 3 * 4 / 5 ** 6](v) {
+    return 2.999232;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 2 - 3 * 4 / 5 ** 6],
+  2.999232
+);
+assert.sameValue(
+  c[1 + 2 - 3 * 4 / 5 ** 6] = 2.999232,
+  2.999232
+);
+
+assert.sameValue(
+  C[1 + 2 - 3 * 4 / 5 ** 6],
+  2.999232
+);
+assert.sameValue(
+  C[1 + 2 - 3 * 4 / 5 ** 6] = 2.999232,
+  2.999232
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-multiplicative-expression-div.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-multiplicative-expression-div.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-div.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from multiplicative expression "divide" (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [1 / 1]() {
+    return 1;
+  }
+
+  set [1 / 1](v) {
+    return 1;
+  }
+
+  static get [1 / 1]() {
+    return 1;
+  }
+
+  static set [1 / 1](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 / 1],
+  1
+);
+assert.sameValue(
+  c[1 / 1] = 1,
+  1
+);
+
+assert.sameValue(
+  C[1 / 1],
+  1
+);
+assert.sameValue(
+  C[1 / 1] = 1,
+  1
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-multiplicative-expression-mult.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-multiplicative-expression-mult.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-mult.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from multiplicative expression "multiply" (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [1 * 1]() {
+    return 1;
+  }
+
+  set [1 * 1](v) {
+    return 1;
+  }
+
+  static get [1 * 1]() {
+    return 1;
+  }
+
+  static set [1 * 1](v) {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 * 1],
+  1
+);
+assert.sameValue(
+  c[1 * 1] = 1,
+  1
+);
+
+assert.sameValue(
+  C[1 * 1],
+  1
+);
+assert.sameValue(
+  C[1 * 1] = 1,
+  1
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-numeric-literal.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-numeric-literal.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-numeric-literal.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [1]() {
+    return 2;
+  }
+
+  set [1](v) {
+    return 2;
+  }
+
+  static get [1]() {
+    return 2;
+  }
+
+  static set [1](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1],
+  2
+);
+assert.sameValue(
+  c[1] = 2,
+  2
+);
+
+assert.sameValue(
+  C[1],
+  2
+);
+assert.sameValue(
+  C[1] = 2,
+  2
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-string-literal.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-string-literal.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-string-literal.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get ['1']() {
+    return '2';
+  }
+
+  set ['1'](v) {
+    return '2';
+  }
+
+  static get ['1']() {
+    return '2';
+  }
+
+  static set ['1'](v) {
+    return '2';
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c['1'],
+  '2'
+);
+assert.sameValue(
+  c['1'] = '2',
+  '2'
+);
+
+assert.sameValue(
+  C['1'],
+  '2'
+);
+assert.sameValue(
+  C['1'] = '2',
+  '2'
+);

--- a/test/language/statements/class/cpn-accessors-computed-property-name-from-yield-expression.js
+++ b/test/language/statements/class/cpn-accessors-computed-property-name-from-yield-expression.js
@@ -1,0 +1,74 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-yield-expression.case
+// - src/computed-property-names/evaluation/class-declaration-accessors.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  get [true ? 1 : 2]() {
+    return 2;
+  }
+
+  set [true ? 1 : 2](v) {
+    return 2;
+  }
+
+  static get [true ? 1 : 2]() {
+    return 2;
+  }
+
+  static set [true ? 1 : 2](v) {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  c[true ? 1 : 2] = 2,
+  2
+);
+
+assert.sameValue(
+  C[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2] = 2,
+  2
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-additive-expression-add.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-additive-expression-add.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-add.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from additive expression "add" (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [1 + 1]() {
+    return 2;
+  }
+  static [1 + 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 1](),
+  2
+);
+assert.sameValue(
+  C[1 + 1](),
+  2
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-additive-expression-subtract.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-additive-expression-subtract.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-subtract.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from additive expression "subtract" (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [1 - 1]() {
+    return 0;
+  }
+  static [1 - 1]() {
+    return 0;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 - 1](),
+  0
+);
+assert.sameValue(
+  C[1 - 1](),
+  0
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-arrow-function-expression.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-arrow-function-expression.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from arrow function (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [() => { }]() {
+    return 1;
+  }
+  static [() => { }]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[() => { }](),
+  1
+);
+assert.sameValue(
+  C[() => { }](),
+  1
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-assignment-expression-assignment.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-assignment-expression-assignment.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-assignment.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from assignment expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  [x = 1]() {
+    return 2;
+  }
+  static [x = 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x = 1](),
+  2
+);
+assert.sameValue(
+  C[x = 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-computed-property-name-from-assignment-expression-bitwise-or.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-assignment-expression-bitwise-or.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-bitwise-or.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from assignment expression bitwise or (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  [x |= 1]() {
+    return 2;
+  }
+  static [x |= 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x |= 1](),
+  2
+);
+assert.sameValue(
+  C[x |= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-computed-property-name-from-assignment-expression-coalesce.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-assignment-expression-coalesce.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from assignment expression coalesce (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = null;
+
+
+class C {
+  [x ??= 1]() {
+    return 2;
+  }
+  static [x ??= 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ??= 1](),
+  2
+);
+assert.sameValue(
+  C[x ??= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-computed-property-name-from-assignment-expression-logical-and.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-assignment-expression-logical-and.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from assignment expression logical and (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  [x &&= 1]() {
+    return 2;
+  }
+  static [x &&= 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x &&= 1](),
+  2
+);
+assert.sameValue(
+  C[x &&= 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-computed-property-name-from-assignment-expression-logical-or.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-assignment-expression-logical-or.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from assignment expression logical or (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  [x ||= 1]() {
+    return 2;
+  }
+  static [x ||= 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ||= 1](),
+  2
+);
+assert.sameValue(
+  C[x ||= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-computed-property-name-from-async-arrow-function-expression.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-async-arrow-function-expression.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-async-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [async () => {}]() {
+    return 1;
+  }
+  static [async () => {}]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[async () => {}](),
+  1
+);
+assert.sameValue(
+  C[async () => {}](),
+  1
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-condition-expression-false.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-condition-expression-false.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-false.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [false ? 1 : 2]() {
+    return 1;
+  }
+  static [false ? 1 : 2]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[false ? 1 : 2](),
+  1
+);
+assert.sameValue(
+  C[false ? 1 : 2](),
+  1
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-condition-expression-true.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-condition-expression-true.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-true.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [true ? 1 : 2]() {
+    return 2;
+  }
+  static [true ? 1 : 2]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2](),
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2](),
+  2
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-decimal-e-notational-literal.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-decimal-e-notational-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from decimal e notational literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [1.e1]() {
+    return 2;
+  }
+  static [1.e1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.e1](),
+  2
+);
+assert.sameValue(
+  C[1.e1](),
+  2
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-decimal-literal.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-decimal-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-literal.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from decimal literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [1.1]() {
+    return 2;
+  }
+  static [1.1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.1](),
+  2
+);
+assert.sameValue(
+  C[1.1](),
+  2
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-exponetiation-expression.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-exponetiation-expression.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from exponentiation expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [2 ** 2]() {
+    return 4;
+  }
+  static [2 ** 2]() {
+    return 4;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[2 ** 2](),
+  4
+);
+assert.sameValue(
+  C[2 ** 2](),
+  4
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-expression-coalesce.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-expression-coalesce.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from coalesce (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x;
+
+
+class C {
+  [x ?? 1]() {
+    return 2;
+  }
+  static [x ?? 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ?? 1](),
+  2
+);
+assert.sameValue(
+  C[x ?? 1](),
+  2
+);
+
+assert.sameValue(x, undefined);

--- a/test/language/statements/class/cpn-computed-property-name-from-expression-logical-and.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-expression-logical-and.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from logical and (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  [x && 1]() {
+    return 2;
+  }
+  static [x && 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x && 1](),
+  2
+);
+assert.sameValue(
+  C[x && 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-computed-property-name-from-expression-logical-or.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-expression-logical-or.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from logical or (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+class C {
+  [x || 1]() {
+    return 2;
+  }
+  static [x || 1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x || 1](),
+  2
+);
+assert.sameValue(
+  C[x || 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-computed-property-name-from-function-declaration.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-function-declaration.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-declaration.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from function (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function f() {}
+
+
+class C {
+  [f()]() {
+    return 1;
+  }
+  static [f()]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[f()](),
+  1
+);
+assert.sameValue(
+  C[f()](),
+  1
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-function-expression.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-function-expression.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [function () {}]() {
+    return 1;
+  }
+  static [function () {}]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[function () {}](),
+  1
+);
+assert.sameValue(
+  C[function () {}](),
+  1
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-generator-function-declaration.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-generator-function-declaration.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-generator-function-declaration.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from generator function (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function * g() { return 1; }
+
+
+class C {
+  [g()]() {
+    return 1;
+  }
+  static [g()]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[g()](),
+  1
+);
+assert.sameValue(
+  C[g()](),
+  1
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-identifier.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-identifier.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-identifier.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 1;
+
+
+
+class C {
+  [x]() {
+    return '2';
+  }
+  static [x]() {
+    return '2';
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x](),
+  '2'
+);
+assert.sameValue(
+  C[x](),
+  '2'
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-integer-e-notational-literal.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-integer-e-notational-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [1]() {
+    return 2;
+  }
+  static [1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1](),
+  2
+);
+assert.sameValue(
+  C[1](),
+  2
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-integer-separators.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-integer-separators.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-separators.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from integer with separators (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [1_2_3_4_5_6_7_8]() {
+    return 1_2_3_4_5_6_7_8;
+  }
+  static [1_2_3_4_5_6_7_8]() {
+    return 1_2_3_4_5_6_7_8;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1_2_3_4_5_6_7_8](),
+  1_2_3_4_5_6_7_8
+);
+assert.sameValue(
+  C[1_2_3_4_5_6_7_8](),
+  1_2_3_4_5_6_7_8
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-math.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-math.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-math.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from math (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [1 + 2 - 3 * 4 / 5 ** 6]() {
+    return 2.999232;
+  }
+  static [1 + 2 - 3 * 4 / 5 ** 6]() {
+    return 2.999232;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 2 - 3 * 4 / 5 ** 6](),
+  2.999232
+);
+assert.sameValue(
+  C[1 + 2 - 3 * 4 / 5 ** 6](),
+  2.999232
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-multiplicative-expression-div.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-multiplicative-expression-div.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-div.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from multiplicative expression "divide" (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [1 / 1]() {
+    return 1;
+  }
+  static [1 / 1]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 / 1](),
+  1
+);
+assert.sameValue(
+  C[1 / 1](),
+  1
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-multiplicative-expression-mult.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-multiplicative-expression-mult.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-mult.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from multiplicative expression "multiply" (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [1 * 1]() {
+    return 1;
+  }
+  static [1 * 1]() {
+    return 1;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 * 1](),
+  1
+);
+assert.sameValue(
+  C[1 * 1](),
+  1
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-numeric-literal.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-numeric-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-numeric-literal.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [1]() {
+    return 2;
+  }
+  static [1]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1](),
+  2
+);
+assert.sameValue(
+  C[1](),
+  2
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-string-literal.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-string-literal.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-string-literal.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  ['1']() {
+    return '2';
+  }
+  static ['1']() {
+    return '2';
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c['1'](),
+  '2'
+);
+assert.sameValue(
+  C['1'](),
+  '2'
+);

--- a/test/language/statements/class/cpn-computed-property-name-from-yield-expression.js
+++ b/test/language/statements/class/cpn-computed-property-name-from-yield-expression.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-yield-expression.case
+// - src/computed-property-names/evaluation/class-declaration.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassDeclaration)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+class C {
+  [true ? 1 : 2]() {
+    return 2;
+  }
+  static [true ? 1 : 2]() {
+    return 2;
+  }
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2](),
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2](),
+  2
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-additive-expression-add.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-additive-expression-add.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-add.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from additive expression "add" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 + 1] = 2;
+
+  static [1 + 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 1],
+  2
+);
+assert.sameValue(
+  C[1 + 1],
+  2
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-additive-expression-subtract.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-additive-expression-subtract.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-subtract.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from additive expression "subtract" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 - 1] = 0;
+
+  static [1 - 1] = 0;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 - 1],
+  0
+);
+assert.sameValue(
+  C[1 - 1],
+  0
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-arrow-function-expression.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-arrow-function-expression.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from arrow function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [() => { }] = 1;
+
+  static [() => { }] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[() => { }],
+  1
+);
+assert.sameValue(
+  C[() => { }],
+  1
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-assignment-expression-assignment.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-assignment-expression-assignment.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-assignment.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from assignment expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x = 1] = 2;
+
+  static [x = 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x = 1],
+  2
+);
+assert.sameValue(
+  C[x = 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-assignment-expression-bitwise-or.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-assignment-expression-bitwise-or.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-bitwise-or.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from assignment expression bitwise or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x |= 1] = 2;
+
+  static [x |= 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x |= 1],
+  2
+);
+assert.sameValue(
+  C[x |= 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-assignment-expression-coalesce.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-assignment-expression-coalesce.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from assignment expression coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = null;
+
+
+let C = class {
+  [x ??= 1] = 2;
+
+  static [x ??= 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ??= 1],
+  2
+);
+assert.sameValue(
+  C[x ??= 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-assignment-expression-logical-and.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-assignment-expression-logical-and.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from assignment expression logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x &&= 1] = 2;
+
+  static [x &&= 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x &&= 1],
+  2
+);
+assert.sameValue(
+  C[x &&= 1],
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-assignment-expression-logical-or.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-assignment-expression-logical-or.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from assignment expression logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x ||= 1] = 2;
+
+  static [x ||= 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ||= 1],
+  2
+);
+assert.sameValue(
+  C[x ||= 1],
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-async-arrow-function-expression.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-async-arrow-function-expression.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-async-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [async () => {}] = 1;
+
+  static [async () => {}] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[async () => {}],
+  1
+);
+assert.sameValue(
+  C[async () => {}],
+  1
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-condition-expression-false.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-condition-expression-false.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-false.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [false ? 1 : 2] = 1;
+
+  static [false ? 1 : 2] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[false ? 1 : 2],
+  1
+);
+assert.sameValue(
+  C[false ? 1 : 2],
+  1
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-condition-expression-true.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-condition-expression-true.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-true.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [true ? 1 : 2] = 2;
+
+  static [true ? 1 : 2] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2],
+  2
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-decimal-e-notational-literal.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-decimal-e-notational-literal.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from decimal e notational literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1.e1] = 2;
+
+  static [1.e1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.e1],
+  2
+);
+assert.sameValue(
+  C[1.e1],
+  2
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-decimal-literal.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-decimal-literal.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-literal.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from decimal literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1.1] = 2;
+
+  static [1.1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.1],
+  2
+);
+assert.sameValue(
+  C[1.1],
+  2
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-exponetiation-expression.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-exponetiation-expression.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [2 ** 2] = 4;
+
+  static [2 ** 2] = 4;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[2 ** 2],
+  4
+);
+assert.sameValue(
+  C[2 ** 2],
+  4
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-expression-coalesce.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-expression-coalesce.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x;
+
+
+let C = class {
+  [x ?? 1] = 2;
+
+  static [x ?? 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ?? 1],
+  2
+);
+assert.sameValue(
+  C[x ?? 1],
+  2
+);
+
+assert.sameValue(x, undefined);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-expression-logical-and.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-expression-logical-and.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x && 1] = 2;
+
+  static [x && 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x && 1],
+  2
+);
+assert.sameValue(
+  C[x && 1],
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-expression-logical-or.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-expression-logical-or.js
@@ -1,0 +1,56 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x || 1] = 2;
+
+  static [x || 1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x || 1],
+  2
+);
+assert.sameValue(
+  C[x || 1],
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-function-declaration.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-function-declaration.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-declaration.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function f() {}
+
+
+let C = class {
+  [f()] = 1;
+
+  static [f()] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[f()],
+  1
+);
+assert.sameValue(
+  C[f()],
+  1
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-function-expression.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-function-expression.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [function () {}] = 1;
+
+  static [function () {}] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[function () {}],
+  1
+);
+assert.sameValue(
+  C[function () {}],
+  1
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-generator-function-declaration.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-generator-function-declaration.js
@@ -1,0 +1,54 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-generator-function-declaration.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from generator function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function * g() { return 1; }
+
+
+let C = class {
+  [g()] = 1;
+
+  static [g()] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[g()],
+  1
+);
+assert.sameValue(
+  C[g()],
+  1
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-identifier.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-identifier.js
@@ -1,0 +1,55 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-identifier.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 1;
+
+
+
+let C = class {
+  [x] = '2';
+
+  static [x] = '2';
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x],
+  '2'
+);
+assert.sameValue(
+  C[x],
+  '2'
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-integer-e-notational-literal.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-integer-e-notational-literal.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1] = 2;
+
+  static [1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1],
+  2
+);
+assert.sameValue(
+  C[1],
+  2
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-integer-separators.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-integer-separators.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-separators.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from integer with separators (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1_2_3_4_5_6_7_8] = 1_2_3_4_5_6_7_8;
+
+  static [1_2_3_4_5_6_7_8] = 1_2_3_4_5_6_7_8;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1_2_3_4_5_6_7_8],
+  1_2_3_4_5_6_7_8
+);
+assert.sameValue(
+  C[1_2_3_4_5_6_7_8],
+  1_2_3_4_5_6_7_8
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-math.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-math.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-math.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from math (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 + 2 - 3 * 4 / 5 ** 6] = 2.999232;
+
+  static [1 + 2 - 3 * 4 / 5 ** 6] = 2.999232;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 2 - 3 * 4 / 5 ** 6],
+  2.999232
+);
+assert.sameValue(
+  C[1 + 2 - 3 * 4 / 5 ** 6],
+  2.999232
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-multiplicative-expression-div.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-multiplicative-expression-div.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-div.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from multiplicative expression "divide" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 / 1] = 1;
+
+  static [1 / 1] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 / 1],
+  1
+);
+assert.sameValue(
+  C[1 / 1],
+  1
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-multiplicative-expression-mult.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-multiplicative-expression-mult.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-mult.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from multiplicative expression "multiply" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 * 1] = 1;
+
+  static [1 * 1] = 1;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 * 1],
+  1
+);
+assert.sameValue(
+  C[1 * 1],
+  1
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-numeric-literal.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-numeric-literal.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-numeric-literal.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1] = 2;
+
+  static [1] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1],
+  2
+);
+assert.sameValue(
+  C[1],
+  2
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-string-literal.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-string-literal.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-string-literal.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  ['1'] = '2';
+
+  static ['1'] = '2';
+};
+
+let c = new C();
+
+assert.sameValue(
+  c['1'],
+  '2'
+);
+assert.sameValue(
+  C['1'],
+  '2'
+);

--- a/test/language/statements/class/cpn-fields-computed-property-name-from-yield-expression.js
+++ b/test/language/statements/class/cpn-fields-computed-property-name-from-yield-expression.js
@@ -1,0 +1,53 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-yield-expression.case
+// - src/computed-property-names/evaluation/class-declaration-fields.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [true ? 1 : 2] = 2;
+
+  static [true ? 1 : 2] = 2;
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2],
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2],
+  2
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-additive-expression-add.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-additive-expression-add.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-add.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from additive expression "add" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 + 1] = () => {
+    return 2;
+  };
+
+  static [1 + 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 1](),
+  2
+);
+assert.sameValue(
+  C[1 + 1](),
+  2
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-additive-expression-subtract.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-additive-expression-subtract.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-additive-expression-subtract.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from additive expression "subtract" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 - 1] = () => {
+    return 0;
+  };
+
+  static [1 - 1] = () => {
+    return 0;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 - 1](),
+  0
+);
+assert.sameValue(
+  C[1 - 1](),
+  0
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-arrow-function-expression.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-arrow-function-expression.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from arrow function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [() => { }] = () => {
+    return 1;
+  };
+
+  static [() => { }] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[() => { }](),
+  1
+);
+assert.sameValue(
+  C[() => { }](),
+  1
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-assignment-expression-assignment.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-assignment-expression-assignment.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-assignment.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from assignment expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x = 1] = () => {
+    return 2;
+  };
+
+  static [x = 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x = 1](),
+  2
+);
+assert.sameValue(
+  C[x = 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-assignment-expression-bitwise-or.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-assignment-expression-bitwise-or.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-bitwise-or.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from assignment expression bitwise or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x |= 1] = () => {
+    return 2;
+  };
+
+  static [x |= 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x |= 1](),
+  2
+);
+assert.sameValue(
+  C[x |= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-assignment-expression-coalesce.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-assignment-expression-coalesce.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from assignment expression coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = null;
+
+
+let C = class {
+  [x ??= 1] = () => {
+    return 2;
+  };
+
+  static [x ??= 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ??= 1](),
+  2
+);
+assert.sameValue(
+  C[x ??= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-assignment-expression-logical-and.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-assignment-expression-logical-and.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from assignment expression logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x &&= 1] = () => {
+    return 2;
+  };
+
+  static [x &&= 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x &&= 1](),
+  2
+);
+assert.sameValue(
+  C[x &&= 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-assignment-expression-logical-or.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-assignment-expression-logical-or.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-assignment-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from assignment expression logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x ||= 1] = () => {
+    return 2;
+  };
+
+  static [x ||= 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ||= 1](),
+  2
+);
+assert.sameValue(
+  C[x ||= 1](),
+  2
+);
+
+assert.sameValue(x, 1);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-async-arrow-function-expression.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-async-arrow-function-expression.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-async-arrow-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [async () => {}] = () => {
+    return 1;
+  };
+
+  static [async () => {}] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[async () => {}](),
+  1
+);
+assert.sameValue(
+  C[async () => {}](),
+  1
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-condition-expression-false.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-condition-expression-false.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-false.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [false ? 1 : 2] = () => {
+    return 1;
+  };
+
+  static [false ? 1 : 2] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[false ? 1 : 2](),
+  1
+);
+assert.sameValue(
+  C[false ? 1 : 2](),
+  1
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-condition-expression-true.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-condition-expression-true.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-condition-expression-true.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [true ? 1 : 2] = () => {
+    return 2;
+  };
+
+  static [true ? 1 : 2] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2](),
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2](),
+  2
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-decimal-e-notational-literal.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-decimal-e-notational-literal.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from decimal e notational literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1.e1] = () => {
+    return 2;
+  };
+
+  static [1.e1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.e1](),
+  2
+);
+assert.sameValue(
+  C[1.e1](),
+  2
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-decimal-literal.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-decimal-literal.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-decimal-literal.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from decimal literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1.1] = () => {
+    return 2;
+  };
+
+  static [1.1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1.1](),
+  2
+);
+assert.sameValue(
+  C[1.1](),
+  2
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-exponetiation-expression.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-exponetiation-expression.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [2 ** 2] = () => {
+    return 4;
+  };
+
+  static [2 ** 2] = () => {
+    return 4;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[2 ** 2](),
+  4
+);
+assert.sameValue(
+  C[2 ** 2](),
+  4
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-expression-coalesce.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-expression-coalesce.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-coalesce.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from coalesce (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x;
+
+
+let C = class {
+  [x ?? 1] = () => {
+    return 2;
+  };
+
+  static [x ?? 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x ?? 1](),
+  2
+);
+assert.sameValue(
+  C[x ?? 1](),
+  2
+);
+
+assert.sameValue(x, undefined);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-expression-logical-and.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-expression-logical-and.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-and.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from logical and (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x && 1] = () => {
+    return 2;
+  };
+
+  static [x && 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x && 1](),
+  2
+);
+assert.sameValue(
+  C[x && 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-expression-logical-or.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-expression-logical-or.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-expression-logical-or.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from logical or (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 0;
+
+
+let C = class {
+  [x || 1] = () => {
+    return 2;
+  };
+
+  static [x || 1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x || 1](),
+  2
+);
+assert.sameValue(
+  C[x || 1](),
+  2
+);
+
+assert.sameValue(x, 0);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-function-declaration.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-function-declaration.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-declaration.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function f() {}
+
+
+let C = class {
+  [f()] = () => {
+    return 1;
+  };
+
+  static [f()] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[f()](),
+  1
+);
+assert.sameValue(
+  C[f()](),
+  1
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-function-expression.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-function-expression.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-function-expression.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from function expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [function () {}] = () => {
+    return 1;
+  };
+
+  static [function () {}] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[function () {}](),
+  1
+);
+assert.sameValue(
+  C[function () {}](),
+  1
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-generator-function-declaration.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-generator-function-declaration.js
@@ -1,0 +1,58 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-generator-function-declaration.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from generator function (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+function * g() { return 1; }
+
+
+let C = class {
+  [g()] = () => {
+    return 1;
+  };
+
+  static [g()] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[g()](),
+  1
+);
+assert.sameValue(
+  C[g()](),
+  1
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-identifier.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-identifier.js
@@ -1,0 +1,59 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-identifier.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+let x = 1;
+
+
+
+let C = class {
+  [x] = () => {
+    return '2';
+  };
+
+  static [x] = () => {
+    return '2';
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[x](),
+  '2'
+);
+assert.sameValue(
+  C[x](),
+  '2'
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-integer-e-notational-literal.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-integer-e-notational-literal.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-e-notational-literal.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1] = () => {
+    return 2;
+  };
+
+  static [1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1](),
+  2
+);
+assert.sameValue(
+  C[1](),
+  2
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-integer-separators.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-integer-separators.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-integer-separators.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from integer with separators (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1_2_3_4_5_6_7_8] = () => {
+    return 1_2_3_4_5_6_7_8;
+  };
+
+  static [1_2_3_4_5_6_7_8] = () => {
+    return 1_2_3_4_5_6_7_8;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1_2_3_4_5_6_7_8](),
+  1_2_3_4_5_6_7_8
+);
+assert.sameValue(
+  C[1_2_3_4_5_6_7_8](),
+  1_2_3_4_5_6_7_8
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-math.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-math.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-math.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from math (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 + 2 - 3 * 4 / 5 ** 6] = () => {
+    return 2.999232;
+  };
+
+  static [1 + 2 - 3 * 4 / 5 ** 6] = () => {
+    return 2.999232;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 + 2 - 3 * 4 / 5 ** 6](),
+  2.999232
+);
+assert.sameValue(
+  C[1 + 2 - 3 * 4 / 5 ** 6](),
+  2.999232
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-multiplicative-expression-div.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-multiplicative-expression-div.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-div.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from multiplicative expression "divide" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 / 1] = () => {
+    return 1;
+  };
+
+  static [1 / 1] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 / 1](),
+  1
+);
+assert.sameValue(
+  C[1 / 1](),
+  1
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-multiplicative-expression-mult.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-multiplicative-expression-mult.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-multiplicative-expression-mult.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from multiplicative expression "multiply" (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1 * 1] = () => {
+    return 1;
+  };
+
+  static [1 * 1] = () => {
+    return 1;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1 * 1](),
+  1
+);
+assert.sameValue(
+  C[1 * 1](),
+  1
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-numeric-literal.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-numeric-literal.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-numeric-literal.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from numeric literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [1] = () => {
+    return 2;
+  };
+
+  static [1] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[1](),
+  2
+);
+assert.sameValue(
+  C[1](),
+  2
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-string-literal.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-string-literal.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-string-literal.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from string literal (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  ['1'] = () => {
+    return '2';
+  };
+
+  static ['1'] = () => {
+    return '2';
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c['1'](),
+  '2'
+);
+assert.sameValue(
+  C['1'](),
+  '2'
+);

--- a/test/language/statements/class/cpn-fields-methods-computed-property-name-from-yield-expression.js
+++ b/test/language/statements/class/cpn-fields-methods-computed-property-name-from-yield-expression.js
@@ -1,0 +1,57 @@
+// This file was procedurally generated from the following sources:
+// - src/computed-property-names/computed-property-name-from-yield-expression.case
+// - src/computed-property-names/evaluation/class-declaration-fields-methods.template
+/*---
+description: Computed property name from condition expression (ComputedPropertyName in ClassExpression)
+esid: prod-ComputedPropertyName
+features: [computed-property-names]
+flags: [generated]
+info: |
+    ClassExpression:
+      classBindingIdentifier opt ClassTail
+
+    ClassTail:
+      ClassHeritage opt { ClassBody opt }
+
+    ClassBody:
+      ClassElementList
+
+    ClassElementList:
+      ClassElement
+
+    ClassElement:
+      MethodDefinition
+
+    MethodDefinition:
+      PropertyName ...
+      get PropertyName ...
+      set PropertyName ...
+
+    PropertyName:
+      ComputedPropertyName
+
+    ComputedPropertyName:
+      [ AssignmentExpression ]
+---*/
+
+
+let C = class {
+  [true ? 1 : 2] = () => {
+    return 2;
+  };
+
+  static [true ? 1 : 2] = () => {
+    return 2;
+  };
+};
+
+let c = new C();
+
+assert.sameValue(
+  c[true ? 1 : 2](),
+  2
+);
+assert.sameValue(
+  C[true ? 1 : 2](),
+  2
+);


### PR DESCRIPTION
I think this sufficiently covers the cases linked in the original issue, plus additional cases. 