### PR TITLE
Cleanup: parseInt, migrate legacy tests to assert, update messages.

### DIFF
--- a/test/built-ins/parseInt/15.1.2.2-2-1.js
+++ b/test/built-ins/parseInt/15.1.2.2-2-1.js
@@ -8,4 +8,4 @@ description: >
     contain any such characters
 ---*/
 
-assert.sameValue(parseInt(""), NaN, 'parseInt("")');
+assert.sameValue(parseInt(""), NaN, 'parseInt("") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A1_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A1_T1.js
@@ -7,5 +7,5 @@ esid: sec-parseint-string-radix
 description: Checking for boolean primitive
 ---*/
 
-assert.sameValue(parseInt(true), NaN, "true");
-assert.sameValue(parseInt(false), NaN, "false");
+assert.sameValue(parseInt(true), NaN, 'parseInt(true) must return NaN');
+assert.sameValue(parseInt(false), NaN, 'parseInt(false) must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A1_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A1_T2.js
@@ -7,26 +7,7 @@ esid: sec-parseint-string-radix
 description: Checking for number primitive
 ---*/
 
-//CHECK#1
-if (parseInt(-1) !== parseInt("-1")) {
-  $ERROR('#1: parseInt(-1) === parseInt("-1"). Actual: ' + (parseInt(-1)));
-}
-
-//CHECK#2
-if (String(parseInt(Infinity)) !== "NaN") {
-  $ERROR('#2: String(parseInt(Infinity)) === "NaN". Actual: ' + (String(parseInt(Infinity))));
-}
-
-//CHECK#3
-if (String(parseInt(NaN)) !== "NaN") {
-  $ERROR('#3: String(parseInt(NaN)) === "NaN". Actual: ' + (String(parseInt(NaN))));
-}
-
-//CHECK#4
-if (parseInt(-0) !== 0) {
-  $ERROR('#4: parseInt(-0) === 0. Actual: ' + (parseInt(-0)));
-} else {
-  if (1 / parseInt(-0) !== Number.POSITIVE_INFINITY) {
-    $ERROR('#4: parseInt(-0) === +0. Actual: ' + (parseInt(-0)));
-  }
-}
+assert.sameValue(parseInt(-1), parseInt("-1"), 'parseInt(-1) must return the same value returned by parseInt("-1")');
+assert.sameValue(String(parseInt(Infinity)), "NaN", 'String(parseInt(Infinity)) must return "NaN"');
+assert.sameValue(String(parseInt(NaN)), "NaN", 'String(parseInt(NaN)) must return "NaN"');
+assert.sameValue(parseInt(-0), 0, 'parseInt(-0) must return 0');

--- a/test/built-ins/parseInt/S15.1.2.2_A1_T3.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A1_T3.js
@@ -7,5 +7,5 @@ esid: sec-parseint-string-radix
 description: Checking for undefined and null
 ---*/
 
-assert.sameValue(parseInt(undefined), NaN, "undefined");
-assert.sameValue(parseInt(null), NaN, "null");
+assert.sameValue(parseInt(undefined), NaN, 'parseInt(undefined) must return NaN');
+assert.sameValue(parseInt(null), NaN, 'parseInt(null) must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A1_T4.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A1_T4.js
@@ -7,5 +7,5 @@ esid: sec-parseint-string-radix
 description: Checking for Boolean object
 ---*/
 
-assert.sameValue(parseInt(new Boolean(true)), NaN, "new Boolean(true)");
-assert.sameValue(parseInt(new Boolean(false)), NaN, "new Boolean(false)");
+assert.sameValue(parseInt(new Boolean(true)), NaN, 'parseInt(new Boolean(true)) must return NaN');
+assert.sameValue(parseInt(new Boolean(false)), NaN, 'parseInt(new Boolean(false)) must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A1_T5.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A1_T5.js
@@ -7,17 +7,12 @@ esid: sec-parseint-string-radix
 description: Checking for Number object
 ---*/
 
-//CHECK#1
-if (parseInt(new Number(-1)) !== parseInt("-1")) {
-  $ERROR('#1: parseInt(new Number(-1)) === parseInt("-1"). Actual: ' + (parseInt(new Number(-1))));
-}
+assert.sameValue(parseInt(new Number(-1)), parseInt("-1"), 'parseInt(new Number(-1)) must return the same value returned by parseInt("-1")');
 
-//CHECK#2
-if (String(parseInt(new Number(Infinity))) !== "NaN") {
-  $ERROR('#2: String(parseInt(new Number(Infinity))) === "NaN". Actual: ' + (String(parseInt(new Number(Infinity)))));
-}
+assert.sameValue(
+  String(parseInt(new Number(Infinity))),
+  "NaN",
+  'String(parseInt(new Number(Infinity))) must return "NaN"'
+);
 
-//CHECK#3
-if (String(parseInt(new Number(NaN))) !== "NaN") {
-  $ERROR('#3: String(parseInt(new Number(NaN))) === "NaN". Actual: ' + (String(parseInt(new Number(NaN)))));
-}
+assert.sameValue(String(parseInt(new Number(NaN))), "NaN", 'String(parseInt(new Number(NaN))) must return "NaN"');

--- a/test/built-ins/parseInt/S15.1.2.2_A1_T6.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A1_T6.js
@@ -7,22 +7,13 @@ esid: sec-parseint-string-radix
 description: Checking for String object
 ---*/
 
-//CHECK#1
-if (parseInt(new String("-1")) !== parseInt("-1")) {
-  $ERROR('#1: parseInt(new String("-1")) === parseInt("-1"). Actual: ' + (parseInt(new String("-1"))));
-}
+assert.sameValue(parseInt(new String("-1")), parseInt("-1"), 'parseInt(new String("-1")) must return the same value returned by parseInt("-1")');
 
-//CHECK#2
-if (String(parseInt(new String("Infinity"))) !== "NaN") {
-  $ERROR('#2: String(parseInt(new String("Infinity"))) === "NaN". Actual: ' + (String(parseInt(new String("Infinity")))));
-}
+assert.sameValue(
+  String(parseInt(new String("Infinity"))),
+  "NaN",
+  'String(parseInt(new String("Infinity"))) must return "NaN"'
+);
 
-//CHECK#3
-if (String(parseInt(new String("NaN"))) !== "NaN") {
-  $ERROR('#3: String(parseInt(new String("NaN"))) === "NaN". Actual: ' + (String(parseInt(new String("NaN")))));
-}
-
-//CHECK#4
-if (String(parseInt(new String("false"))) !== "NaN") {
-  $ERROR('#4: String(parseInt(new String("false"))) === "NaN". Actual: ' + (String(parseInt(new String("false")))));
-}
+assert.sameValue(String(parseInt(new String("NaN"))), "NaN", 'String(parseInt(new String("NaN"))) must return "NaN"');
+assert.sameValue(String(parseInt(new String("false"))), "NaN", 'String(parseInt(new String("false"))) must return "NaN"');

--- a/test/built-ins/parseInt/S15.1.2.2_A1_T7.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A1_T7.js
@@ -13,7 +13,7 @@ var object = {
     return 1
   }
 };
-assert.sameValue(parseInt(object), NaN, "{valueOf: function() {return 1}}");
+assert.sameValue(parseInt(object), NaN, 'parseInt({valueOf: function() {return 1}}) must return NaN');
 
 //CHECK#2
 var object = {
@@ -24,9 +24,12 @@ var object = {
     return 0
   }
 };
-if (parseInt(object) !== 0) {
-  $ERROR('#2: var object = {valueOf: function() {return 1}, toString: function() {return 0}}; parseInt(object) === 0. Actual: ' + (parseInt(object)));
-}
+
+assert.sameValue(
+  parseInt(object),
+  0,
+  'parseInt({valueOf: function() {return 1}, toString: function() {return 0}}) must return 0'
+);
 
 //CHECK#3
 var object = {
@@ -37,9 +40,12 @@ var object = {
     return {}
   }
 };
-if (parseInt(object) !== 1) {
-  $ERROR('#3: var object = {valueOf: function() {return 1}, toString: function() {return {}}}; parseInt(object) === 1. Actual: ' + (parseInt(object)));
-}
+
+assert.sameValue(
+  parseInt(object),
+  1,
+  'parseInt({valueOf: function() {return 1}, toString: function() {return {}}}) must return 1'
+);
 
 //CHECK#4
 try {
@@ -51,16 +57,15 @@ try {
       return 1
     }
   };
-  if (parseInt(object) !== 1) {
-    $ERROR('#4.1: var object = {valueOf: function() {throw "error"}, toString: function() {return 1}}; parseInt(object) === 1. Actual: ' + (parseInt(object)));
-  }
+
+  assert.sameValue(
+    parseInt(object),
+    1,
+    'parseInt({valueOf: function() {throw \\"error\\"}, toString: function() {return 1}}) must return 1'
+  );
 }
 catch (e) {
-  if (e === "error") {
-    $ERROR('#4.2: var object = {valueOf: function() {throw "error"}, toString: function() {return 1}}; parseInt(object) not throw "error"');
-  } else {
-    $ERROR('#4.3: var object = {valueOf: function() {throw "error"}, toString: function() {return 1}}; parseInt(object) not throw Error. Actual: ' + (e));
-  }
+  assert.notSameValue(e, "error", 'The value of `e` is not "error"');
 }
 
 //CHECK#5
@@ -69,9 +74,7 @@ var object = {
     return 1
   }
 };
-if (parseInt(object) !== 1) {
-  $ERROR('#5: var object = {toString: function() {return 1}}; parseInt(object) === 1. Actual: ' + (parseInt(object)));
-}
+assert.sameValue(parseInt(object), 1, 'parseInt({toString: function() {return 1}}) must return 1');
 
 //CHECK#6
 var object = {
@@ -82,9 +85,12 @@ var object = {
     return 1
   }
 }
-if (parseInt(object) !== 1) {
-  $ERROR('#6: var object = {valueOf: function() {return {}}, toString: function() {return 1}}; parseInt(object) === 1. Actual: ' + (parseInt(object)));
-}
+
+assert.sameValue(
+  parseInt(object),
+  1,
+  'parseInt({valueOf: function() {return {}}, toString: function() {return 1}}) must return 1'
+);
 
 //CHECK#7
 try {
@@ -97,12 +103,10 @@ try {
     }
   };
   parseInt(object);
-  $ERROR('#7.1: var object = {valueOf: function() {return 1}, toString: function() {throw "error"}}; parseInt(object) throw "error". Actual: ' + (parseInt(object)));
+  Test262Error.thrower('#7.1: var object = {valueOf: function() {return 1}, toString: function() {throw "error"}}; parseInt(object) throw "error". Actual: ' + (parseInt(object)));
 }
 catch (e) {
-  if (e !== "error") {
-    $ERROR('#7.2: var object = {valueOf: function() {return 1}, toString: function() {throw "error"}}; parseInt(object) throw "error". Actual: ' + (e));
-  }
+  assert.sameValue(e, "error", 'The value of `e` is "error"');
 }
 
 //CHECK#8
@@ -116,10 +120,8 @@ try {
     }
   };
   parseInt(object);
-  $ERROR('#8.1: var object = {valueOf: function() {return {}}, toString: function() {return {}}}; parseInt(object) throw TypeError. Actual: ' + (parseInt(object)));
+  Test262Error.thrower('#8.1: var object = {valueOf: function() {return {}}, toString: function() {return {}}}; parseInt(object) throw TypeError. Actual: ' + (parseInt(object)));
 }
 catch (e) {
-  if ((e instanceof TypeError) !== true) {
-    $ERROR('#8.2: var object = {valueOf: function() {return {}}, toString: function() {return {}}}; parseInt(object) throw TypeError. Actual: ' + (e));
-  }
+  assert.sameValue(e instanceof TypeError, true, 'The result of `(e instanceof TypeError)` is true');
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A2_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T1.js
@@ -7,30 +7,18 @@ esid: sec-parseint-string-radix
 description: "StrWhiteSpaceChar :: TAB (U+0009)"
 ---*/
 
-//CHECK#1
-if (parseInt("\u00091") !== parseInt("1")) {
-  $ERROR('#1: parseInt("\\u00091") === parseInt("1"). Actual: ' + (parseInt("\u00091")));
-}
+assert.sameValue(parseInt("\u00091"), parseInt("1"), 'parseInt("\\u00091") must return the same value returned by parseInt("1")');
 
-//CHECK#2
-if (parseInt("\u0009\u0009-1") !== parseInt("-1")) {
-  $ERROR('#2: parseInt("\\u0009\\u0009-1") === parseInt("-1"). Actual: ' + (parseInt("\u0009\u0009-1")));
-}
+assert.sameValue(parseInt("\u0009\u0009-1"), parseInt("-1"), 'parseInt("\\u0009\\u0009-1") must return the same value returned by parseInt("-1")');
 
-//CHECK#3
-if (parseInt("	1") !== parseInt("1")) {
-  $ERROR('#3: parseInt("	1") === parseInt("1"). Actual: ' + (parseInt("	1")));
-}
+assert.sameValue(parseInt("	1"), parseInt("1"), 'parseInt(" 1") must return the same value returned by parseInt("1")');
 
-//CHECK#4
-if (parseInt("			1") !== parseInt("1")) {
-  $ERROR('#4: parseInt("			1") === parseInt("1"). Actual: ' + (parseInt("			1")));
-}
+assert.sameValue(parseInt("			1"), parseInt("1"), 'parseInt(" 1") must return the same value returned by parseInt("1")');
 
-//CHECK#5
-if (parseInt("			\u0009			\u0009-1") !== parseInt("-1")) {
-  $ERROR('#5: parseInt("			\\u0009			\\u0009-1") === parseInt("-1"). Actual: ' + (parseInt("			\u0009			\u0009-1")));
-}
+assert.sameValue(
+  parseInt("			\u0009			\u0009-1"),
+  parseInt("-1"),
+  'parseInt(" \\u0009 \\u0009-1") must return the same value returned by parseInt("-1")'
+);
 
-//CHECK#6
-assert.sameValue(parseInt("\u0009"), NaN);
+assert.sameValue(parseInt("\u0009"), NaN, 'parseInt("\\u0009") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A2_T10.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T10.js
@@ -7,35 +7,22 @@ esid: sec-parseint-string-radix
 description: "StrWhiteSpaceChar :: USP"
 ---*/
 
-//CHECK#
-var n;
-var count = 0;
-var errorCount = 0;
 var uspU = ["\u1680", "\u2000", "\u2001", "\u2002", "\u2003", "\u2004", "\u2005", "\u2006", "\u2007", "\u2008", "\u2009", "\u200A", "\u202F", "\u205F", "\u3000"];
 var uspS = ["1680", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "200A", "202F", "205F", "3000"];
 
 for (var index = 0; index < uspU.length; index++) {
-  var result = true;
-  n = false;
-  if (parseInt(uspU[index] + "1") !== parseInt("1")) {
-    $ERROR('#1.' + uspS[index] + ' ');
-    result = false;
-  }
-  if (parseInt(uspU[index] + uspU[index] + uspU[index] + "1") !== parseInt("1")) {
-    $ERROR('#2.' + uspS[index] + ' ');
-    result = false;
-  }
-  n = parseInt(uspU[index]);
-  if (!(n !== n)) {
-    $ERROR('#3.' + uspS[index] + ' ');
-    result = false;
-  }
-  if (result !== true) {
-    errorCount++;
-  }
-  count++;
-}
+  assert.sameValue(
+    parseInt(uspU[index] + "1"),
+    parseInt("1"),
+    'parseInt(uspU[index] + "1") must return the same value returned by parseInt("1")'
+  );
 
-if (errorCount > 0) {
-  $ERROR('Total error: ' + errorCount + ' bad Unicode character in ' + count);
+  assert.sameValue(
+    parseInt(uspU[index] + uspU[index] + uspU[index] + "1"),
+    parseInt("1"),
+    'parseInt(uspU[index] + uspU[index] + uspU[index] + "1") must return the same value returned by parseInt("1")'
+  );
+
+  let n = parseInt(uspU[index]);
+  assert(n !== n, 'The result of `(n !== n)` is true');
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A2_T10_U180E.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T10_U180E.js
@@ -25,6 +25,6 @@ features: [u180e]
 
 var mongolianVowelSeparator = "\u180E";
 
-assert.sameValue(parseInt(mongolianVowelSeparator + "1"), NaN, "Single leading U+180E");
-assert.sameValue(parseInt(mongolianVowelSeparator + mongolianVowelSeparator + mongolianVowelSeparator + "1"), NaN, "Multiple leading U+180E");
-assert.sameValue(parseInt(mongolianVowelSeparator), NaN, "Only U+180E");
+assert.sameValue(parseInt(mongolianVowelSeparator + "1"), NaN, 'parseInt(mongolianVowelSeparator + "1") must return NaN');
+assert.sameValue(parseInt(mongolianVowelSeparator + mongolianVowelSeparator + mongolianVowelSeparator + "1"), NaN, 'parseInt( mongolianVowelSeparator + mongolianVowelSeparator + mongolianVowelSeparator + "1" ) must return NaN');
+assert.sameValue(parseInt(mongolianVowelSeparator), NaN, 'parseInt("\\"\\\\u180E\\"") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A2_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T2.js
@@ -1,5 +1,9 @@
 // Copyright 2009 the Sputnik authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
+assert.sameValue(parseInt("\u00201"), parseInt("1"), 'parseInt("\\u00201") must return the same value returned by parseInt("1")');
+assert.sameValue(parseInt("\u0020\u0020-1"), parseInt("-1"), 'parseInt("\\u0020\\u0020-1") must return the same value returned by parseInt("-1")');
+assert.sameValue(parseInt(" 1"), parseInt("1"), 'parseInt(" 1") must return the same value returned by parseInt("1")');
+assert.sameValue(parseInt("       1"), parseInt("1"), 'parseInt(" 1") must return the same value returned by parseInt("1")');
 
 /*---
 info: Operator remove leading StrWhiteSpaceChar
@@ -7,30 +11,11 @@ esid: sec-parseint-string-radix
 description: "StrWhiteSpaceChar :: SP (U+0020)"
 ---*/
 
-//CHECK#1
-if (parseInt("\u00201") !== parseInt("1")) {
-  $ERROR('#1: parseInt("\\u00201") === parseInt("1"). Actual: ' + (parseInt("\u00201")));
-}
-
-//CHECK#2
-if (parseInt("\u0020\u0020-1") !== parseInt("-1")) {
-  $ERROR('#2: parseInt("\\u0020\\u0020-1") === parseInt("-1"). Actual: ' + (parseInt("\u0020\u0020-1")));
-}
-
-//CHECK#3
-if (parseInt(" 1") !== parseInt("1")) {
-  $ERROR('#3: parseInt(" 1") === parseInt("1"). Actual: ' + (parseInt(" 1")));
-}
-
-//CHECK#4
-if (parseInt("       1") !== parseInt("1")) {
-  $ERROR('#4: parseInt("       1") === parseInt("1"). Actual: ' + (parseInt("       1")));
-}
-
-//CHECK#5
-if (parseInt("       \u0020       \u0020-1") !== parseInt("-1")) {
-  $ERROR('#5: parseInt("       \\u0020       \\u0020-1") === parseInt("-1"). Actual: ' + (parseInt("       \u0020       \u0020-1")));
-}
+assert.sameValue(
+  parseInt("       \u0020       \u0020-1"),
+  parseInt("-1"),
+  'parseInt(" \\u0020 \\u0020-1") must return the same value returned by parseInt("-1")'
+);
 
 //CHECK#6
-assert.sameValue(parseInt("\u0020"), NaN);
+assert.sameValue(parseInt("\u0020"), NaN, 'parseInt("\\u0020") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A2_T3.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T3.js
@@ -7,15 +7,8 @@ esid: sec-parseint-string-radix
 description: "StrWhiteSpaceChar :: NBSB (U+00A0)"
 ---*/
 
-//CHECK#1
-if (parseInt("\u00A01") !== parseInt("1")) {
-  $ERROR('#1: parseInt("\\u00A01") === parseInt("1"). Actual: ' + (parseInt("\u00A01")));
-}
-
-//CHECK#2
-if (parseInt("\u00A0\u00A0-1") !== parseInt("-1")) {
-  $ERROR('#2: parseInt("\\u00A0\\u00A0-1") === parseInt("-1"). Actual: ' + (parseInt("\u00A0\u00A0-1")));
-}
+assert.sameValue(parseInt("\u00A01"), parseInt("1"), 'parseInt("\\u00A01") must return the same value returned by parseInt("1")');
+assert.sameValue(parseInt("\u00A0\u00A0-1"), parseInt("-1"), 'parseInt("\\u00A0\\u00A0-1") must return the same value returned by parseInt("-1")');
 
 //CHECK#3
-assert.sameValue(parseInt("\u00A0"), NaN);
+assert.sameValue(parseInt("\u00A0"), NaN, 'parseInt("\\u00A0") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A2_T4.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T4.js
@@ -7,15 +7,8 @@ esid: sec-parseint-string-radix
 description: "StrWhiteSpaceChar :: FF (U+000C)"
 ---*/
 
-//CHECK#1
-if (parseInt("\u000C1") !== parseInt("1")) {
-  $ERROR('#1: parseInt("\\u000C1") === parseInt("1"). Actual: ' + (parseInt("\u000C1")));
-}
-
-//CHECK#2
-if (parseInt("\u000C\u000C-1") !== parseInt("-1")) {
-  $ERROR('#2: parseInt("\\u000C\\u000C-1") === parseInt("-1"). Actual: ' + (parseInt("\u000C\u000C-1")));
-}
+assert.sameValue(parseInt("\u000C1"), parseInt("1"), 'parseInt("\\u000C1") must return the same value returned by parseInt("1")');
+assert.sameValue(parseInt("\u000C\u000C-1"), parseInt("-1"), 'parseInt("\\u000C\\u000C-1") must return the same value returned by parseInt("-1")');
 
 //CHECK#3
-assert.sameValue(parseInt("\u000C"), NaN);
+assert.sameValue(parseInt("\u000C"), NaN, 'parseInt("\\u000C") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A2_T5.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T5.js
@@ -7,15 +7,8 @@ esid: sec-parseint-string-radix
 description: "StrWhiteSpaceChar :: VT (U+000B)"
 ---*/
 
-//CHECK#1
-if (parseInt("\u000B1") !== parseInt("1")) {
-  $ERROR('#1: parseInt("\\u000B1") === parseInt("1"). Actual: ' + (parseInt("\u000B1")));
-}
-
-//CHECK#2
-if (parseInt("\u000B\u000B-1") !== parseInt("-1")) {
-  $ERROR('#2: parseInt("\\u000B\\u000B-1") === parseInt("-1"). Actual: ' + (parseInt("\u000B\u000B-1")));
-}
+assert.sameValue(parseInt("\u000B1"), parseInt("1"), 'parseInt("\\u000B1") must return the same value returned by parseInt("1")');
+assert.sameValue(parseInt("\u000B\u000B-1"), parseInt("-1"), 'parseInt("\\u000B\\u000B-1") must return the same value returned by parseInt("-1")');
 
 //CHECK#3
-assert.sameValue(parseInt("\u000B"), NaN);
+assert.sameValue(parseInt("\u000B"), NaN, 'parseInt("\\u000B") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A2_T6.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T6.js
@@ -7,15 +7,8 @@ esid: sec-parseint-string-radix
 description: "StrWhiteSpaceChar :: CR (U+000D)"
 ---*/
 
-//CHECK#1
-if (parseInt("\u000D1") !== parseInt("1")) {
-  $ERROR('#1: parseInt("\\u000D1") === parseInt("1"). Actual: ' + (parseInt("\u000D1")));
-}
-
-//CHECK#2
-if (parseInt("\u000D\u000D-1") !== parseInt("-1")) {
-  $ERROR('#2: parseInt("\\u000D\\u000D-1") === parseInt("-1"). Actual: ' + (parseInt("\u000D\u000D-1")));
-}
+assert.sameValue(parseInt("\u000D1"), parseInt("1"), 'parseInt("\\u000D1") must return the same value returned by parseInt("1")');
+assert.sameValue(parseInt("\u000D\u000D-1"), parseInt("-1"), 'parseInt("\\u000D\\u000D-1") must return the same value returned by parseInt("-1")');
 
 //CHECK#3
-assert.sameValue(parseInt("\u000D"), NaN);
+assert.sameValue(parseInt("\u000D"), NaN, 'parseInt("\\u000D") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A2_T7.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T7.js
@@ -7,15 +7,8 @@ esid: sec-parseint-string-radix
 description: "StrWhiteSpaceChar :: LF (U+000A)"
 ---*/
 
-//CHECK#1
-if (parseInt("\u000A1") !== parseInt("1")) {
-  $ERROR('#1: parseInt("\\u000A1") === parseInt("1"). Actual: ' + (parseInt("\u000A1")));
-}
-
-//CHECK#2
-if (parseInt("\u000A\u000A-1") !== parseInt("-1")) {
-  $ERROR('#2: parseInt("\\u000A\\u000A-1") === parseInt("-1"). Actual: ' + (parseInt("\u000A\u000A-1")));
-}
+assert.sameValue(parseInt("\u000A1"), parseInt("1"), 'parseInt("\\u000A1") must return the same value returned by parseInt("1")');
+assert.sameValue(parseInt("\u000A\u000A-1"), parseInt("-1"), 'parseInt("\\u000A\\u000A-1") must return the same value returned by parseInt("-1")');
 
 //CHECK#3
-assert.sameValue(parseInt("\u000A"), NaN);
+assert.sameValue(parseInt("\u000A"), NaN, 'parseInt("\\u000A") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A2_T8.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T8.js
@@ -7,15 +7,8 @@ esid: sec-parseint-string-radix
 description: "StrWhiteSpaceChar :: LS (U+2028)"
 ---*/
 
-//CHECK#1
-if (parseInt("\u20281") !== parseInt("1")) {
-  $ERROR('#1: parseInt("\\u20281") === parseInt("1"). Actual: ' + (parseInt("\u20281")));
-}
-
-//CHECK#2
-if (parseInt("\u2028\u2028-1") !== parseInt("-1")) {
-  $ERROR('#2: parseInt("\\u2028\\u2028-1") === parseInt("-1"). Actual: ' + (parseInt("\u2028\u2028-1")));
-}
+assert.sameValue(parseInt("\u20281"), parseInt("1"), 'parseInt("\\u20281") must return the same value returned by parseInt("1")');
+assert.sameValue(parseInt("\u2028\u2028-1"), parseInt("-1"), 'parseInt("\\u2028\\u2028-1") must return the same value returned by parseInt("-1")');
 
 //CHECK#3
-assert.sameValue(parseInt("\u2028"), NaN);
+assert.sameValue(parseInt("\u2028"), NaN, 'parseInt("\\u2028") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A2_T9.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T9.js
@@ -7,15 +7,17 @@ esid: sec-parseint-string-radix
 description: "StrWhiteSpaceChar :: PS (U+2029)"
 ---*/
 
-//CHECK#1
-if (parseInt("\u20291") !== parseInt("1")) {
-  $ERROR('#1: parseInt("\\u20291") === parseInt("1"). Actual: ' + (parseInt("\u20291")));
-}
+assert.sameValue(
+  parseInt("\u20291"),
+  parseInt("1"),
+  'parseInt("\\u20291") must return the same value returned by parseInt("1")'
+);
 
-//CHECK#2
-if (parseInt("\u2029\u2029-1") !== parseInt("-1")) {
-  $ERROR('#2: parseInt("\\u2029\\u2029-1") === parseInt("-1"). Actual: ' + (parseInt("\u2029\u2029-1")));
-}
+assert.sameValue(
+  parseInt("\u2029\u2029-1"),
+  parseInt("-1"),
+  'parseInt("\\u2029\\u2029-1") must return the same value returned by parseInt("-1")'
+);
 
 //CHECK#3
-assert.sameValue(parseInt("\u2029"), NaN);
+assert.sameValue(parseInt("\u2029"), NaN, 'parseInt("\\u2029") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A3.1_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A3.1_T1.js
@@ -7,10 +7,7 @@ esid: sec-parseint-string-radix
 description: Checking for boolean primitive
 ---*/
 
-//CHECK#1
-if (parseInt("11", false) !== parseInt("11", 10)) {
-  $ERROR('#1: parseInt("11", false) === parseInt("11", 10). Actual: ' + (parseInt("11", false)));
-}
+assert.sameValue(parseInt("11", false), parseInt("11", 10), 'parseInt("11", false) must return the same value returned by parseInt("11", 10)');
 
 //CHECK#2
-assert.sameValue(parseInt("11", true), NaN);
+assert.sameValue(parseInt("11", true), NaN, 'parseInt("11", true) must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A3.1_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A3.1_T2.js
@@ -7,17 +7,6 @@ esid: sec-parseint-string-radix
 description: Checking for string primitive
 ---*/
 
-//CHECK#1
-if (parseInt("11", "2") !== parseInt("11", 2)) {
-  $ERROR('#1: parseInt("11", "2") === parseInt("11", 2). Actual: ' + (parseInt("11", "2")));
-}
-
-//CHECK#2
-if (parseInt("11", "0") !== parseInt("11", 10)) {
-  $ERROR('#2: parseInt("11", "0") === parseInt("11", 10). Actual: ' + (parseInt("11", "0")));
-}
-
-//CHECK#3
-if (parseInt("11", "") !== parseInt("11", 10)) {
-  $ERROR('#3: parseInt("11", "") === parseInt("11", 10). Actual: ' + (parseInt("11", "")));
-}
+assert.sameValue(parseInt("11", "2"), parseInt("11", 2), 'parseInt("11", "2") must return the same value returned by parseInt("11", 2)');
+assert.sameValue(parseInt("11", "0"), parseInt("11", 10), 'parseInt("11", "0") must return the same value returned by parseInt("11", 10)');
+assert.sameValue(parseInt("11", ""), parseInt("11", 10), 'parseInt("11", "") must return the same value returned by parseInt("11", 10)');

--- a/test/built-ins/parseInt/S15.1.2.2_A3.1_T3.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A3.1_T3.js
@@ -7,12 +7,9 @@ esid: sec-parseint-string-radix
 description: Checking for undefined and null
 ---*/
 
-//CHECK#1
-if (parseInt("11", undefined) !== parseInt("11", 10)) {
-  $ERROR('#1: parseInt("11", undefined) === parseInt("11", 10). Actual: ' + (parseInt("11", undefined)));
-}
-
-//CHECK#2
-if (parseInt("11", null) !== parseInt("11", 10)) {
-  $ERROR('#2: parseInt("11", null) === parseInt("11", 10). Actual: ' + (parseInt("11", null)));
-}
+assert.sameValue(
+  parseInt("11", undefined),
+  parseInt("11", 10),
+  'parseInt("11", undefined) must return the same value returned by parseInt("11", 10)'
+);
+assert.sameValue(parseInt("11", null), parseInt("11", 10), 'parseInt("11", null) must return the same value returned by parseInt("11", 10)');

--- a/test/built-ins/parseInt/S15.1.2.2_A3.1_T4.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A3.1_T4.js
@@ -7,10 +7,11 @@ esid: sec-parseint-string-radix
 description: Checking for Boolean object
 ---*/
 
-//CHECK#1
-if (parseInt("11", new Boolean(false)) !== parseInt("11", false)) {
-  $ERROR('#1: parseInt("11", new Boolean(false)) === parseInt("11", false). Actual: ' + (parseInt("11", new Boolean(false))));
-}
+assert.sameValue(
+  parseInt("11", new Boolean(false)),
+  parseInt("11", false),
+  'parseInt("11", new Boolean(false)) must return the same value returned by parseInt("11", false)'
+);
 
 //CHECK#2
-assert.sameValue(parseInt("11", new Boolean(true)), NaN);
+assert.sameValue(parseInt("11", new Boolean(true)), NaN, 'parseInt("11", new Boolean(true)) must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A3.1_T5.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A3.1_T5.js
@@ -1,18 +1,19 @@
 // Copyright 2009 the Sputnik authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-
 /*---
 info: Operator use ToNumber
 esid: sec-parseint-string-radix
 description: Checking for Number object
 ---*/
 
-//CHECK#1
-if (parseInt("11", new Number(2)) !== parseInt("11", 2)) {
-  $ERROR('#1: parseInt("11", new Number(2)) === parseInt("11", 2). Actual: ' + (parseInt("11", new Number(2))));
-}
+assert.sameValue(
+  parseInt("11", new Number(2)),
+  parseInt("11", 2),
+  'parseInt("11", new Number(2)) must return the same value returned by parseInt("11", 2)'
+);
 
-//CHECK#2
-if (parseInt("11", new Number(Infinity)) !== parseInt("11", Infinity)) {
-  $ERROR('#2: parseInt("11", new Number(Infinity)) === parseInt("11", Infinity). Actual: ' + (parseInt("11", new Number(Infinity))));
-}
+assert.sameValue(
+  parseInt("11", new Number(Infinity)),
+  parseInt("11", Infinity),
+  'parseInt("11", new Number(Infinity)) must return the same value returned by parseInt("11", Infinity)'
+);

--- a/test/built-ins/parseInt/S15.1.2.2_A3.1_T6.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A3.1_T6.js
@@ -8,12 +8,14 @@ description: Checking for String object
 esid: sec-parseint-string-radix
 ---*/
 
-//CHECK#1
-if (parseInt("11", new String("2")) !== parseInt("11", 2)) {
-  $ERROR('#1: parseInt("11", new String("2")) === parseInt("11", 2). Actual: ' + (parseInt("11", new String("2"))));
-}
+assert.sameValue(
+  parseInt("11", new String("2")),
+  parseInt("11", 2),
+  'parseInt("11", new String("2")) must return the same value returned by parseInt("11", 2)'
+);
 
-//CHECK#2
-if (parseInt("11", new String("Infinity")) !== parseInt("11", Infinity)) {
-  $ERROR('#2: parseInt("11", new String("Infinity")) === parseInt("11", Infinity). Actual: ' + (parseInt("11", new String("Infinity"))));
-}
+assert.sameValue(
+  parseInt("11", new String("Infinity")),
+  parseInt("11", Infinity),
+  'parseInt("11", new String("Infinity")) must return the same value returned by parseInt("11", Infinity)'
+);

--- a/test/built-ins/parseInt/S15.1.2.2_A3.1_T7.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A3.1_T7.js
@@ -13,9 +13,12 @@ var object = {
     return 2
   }
 };
-if (parseInt("11", object) !== parseInt("11", 2)) {
-  $ERROR('#1: var object = {valueOf: function() {return 2}}; parseInt("11", object) === parseInt("11", 2). Actual: ' + (parseInt("11", object)));
-}
+
+assert.sameValue(
+  parseInt("11", object),
+  parseInt("11", 2),
+  'parseInt("11", {valueOf: function() {return 2}}) must return the same value returned by parseInt("11", 2)'
+);
 
 //CHECK#2
 var object = {
@@ -26,9 +29,12 @@ var object = {
     return 1
   }
 };
-if (parseInt("11", object) !== parseInt("11", 2)) {
-  $ERROR('#2: var object = {valueOf: function() {return 2}, toString: function() {return 1}}; parseInt("11", object) === parseInt("11", 2). Actual: ' + (parseInt("11", object)));
-}
+
+assert.sameValue(
+  parseInt("11", object),
+  parseInt("11", 2),
+  'parseInt("11", {valueOf: function() {return 2}, toString: function() {return 1}}) must return the same value returned by parseInt("11", 2)'
+);
 
 //CHECK#3
 var object = {
@@ -39,9 +45,12 @@ var object = {
     return {}
   }
 };
-if (parseInt("11", object) !== parseInt("11", 2)) {
-  $ERROR('#3: var object = {valueOf: function() {return 2}, toString: function() {return {}}}; parseInt("11", object) === parseInt("11", 2). Actual: ' + (parseInt("11", object)));
-}
+
+assert.sameValue(
+  parseInt("11", object),
+  parseInt("11", 2),
+  'parseInt("11", {valueOf: function() {return 2}, toString: function() {return {}}}) must return the same value returned by parseInt("11", 2)'
+);
 
 //CHECK#4
 try {
@@ -53,16 +62,15 @@ try {
       throw "error"
     }
   };
-  if (parseInt("11", object) !== parseInt("11", 2)) {
-    $ERROR('#4.1: var object = {valueOf: function() {return 2}, toString: function() {throw "error"}}; parseInt("11", object) === parseInt("11", 2). Actual: ' + (parseInt("11", object)));
-  }
+
+  assert.sameValue(
+    parseInt("11", object),
+    parseInt("11", 2),
+    'parseInt( "11", {valueOf: function() {return 2}, toString: function() {throw \\"error\\"}} ) must return the same value returned by parseInt("11", 2)'
+  );
 }
 catch (e) {
-  if (e === "error") {
-    $ERROR('#4.2: var object = {valueOf: function() {return 2}, toString: function() {throw "error"}}; parseInt("11", object) not throw "error"');
-  } else {
-    $ERROR('#4.3: var object = {valueOf: function() {return 2}, toString: function() {throw "error"}}; parseInt("11", object) not throw Error. Actual: ' + (e));
-  }
+  assert.notSameValue(e, "error", 'The value of `e` is not "error"');
 }
 
 //CHECK#5
@@ -71,9 +79,12 @@ var object = {
     return 2
   }
 };
-if (parseInt("11", object) !== parseInt("11", 2)) {
-  $ERROR('#5: var object = {toString: function() {return 2}}; parseInt("11", object) === parseInt("11", 2). Actual: ' + (parseInt("11", object)));
-}
+
+assert.sameValue(
+  parseInt("11", object),
+  parseInt("11", 2),
+  'parseInt("11", {toString: function() {return 2}}) must return the same value returned by parseInt("11", 2)'
+);
 
 //CHECK#6
 var object = {
@@ -84,9 +95,12 @@ var object = {
     return 2
   }
 }
-if (parseInt("11", object) !== parseInt("11", 2)) {
-  $ERROR('#6: var object = {valueOf: function() {return {}}, toString: function() {return 2}}; parseInt("11", object) === parseInt("11", 2). Actual: ' + (parseInt("11", object)));
-}
+
+assert.sameValue(
+  parseInt("11", object),
+  parseInt("11", 2),
+  'parseInt("11", {valueOf: function() {return {}}, toString: function() {return 2}}) must return the same value returned by parseInt("11", 2)'
+);
 
 //CHECK#7
 try {
@@ -99,12 +113,10 @@ try {
     }
   };
   parseInt("11", object);
-  $ERROR('#7.1: var object = {valueOf: function() {throw "error"}, toString: function() {return 2}}; parseInt("11", object) throw "error". Actual: ' + (parseInt("11", object)));
+  Test262Error.thrower('#7.1: var object = {valueOf: function() {throw "error"}, toString: function() {return 2}}; parseInt("11", object) throw "error". Actual: ' + (parseInt("11", object)));
 }
 catch (e) {
-  if (e !== "error") {
-    $ERROR('#7.2: var object = {valueOf: function() {throw "error"}, toString: function() {return 2}}; parseInt("11", object) throw "error". Actual: ' + (e));
-  }
+  assert.sameValue(e, "error", 'The value of `e` is "error"');
 }
 
 //CHECK#8
@@ -118,10 +130,8 @@ try {
     }
   };
   parseInt("11", object);
-  $ERROR('#8.1: var object = {valueOf: function() {return {}}, toString: function() {return {}}}; parseInt("11", object) throw TypeError. Actual: ' + (parseInt("11", object)));
+  Test262Error.thrower('#8.1: var object = {valueOf: function() {return {}}, toString: function() {return {}}}; parseInt("11", object) throw TypeError. Actual: ' + (parseInt("11", object)));
 }
 catch (e) {
-  if ((e instanceof TypeError) !== true) {
-    $ERROR('#8.2: var object = {valueOf: function() {return {}}, toString: function() {return {}}}; parseInt("11", object) throw TypeError. Actual: ' + (e));
-  }
+  assert.sameValue(e instanceof TypeError, true, 'The result of `(e instanceof TypeError)` is true');
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A3.2_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A3.2_T1.js
@@ -7,27 +7,18 @@ esid: sec-parseint-string-radix
 description: If radix is NaN, +0, -0, +Infinity, -Infinity, return radix = +0
 ---*/
 
-//CHECK#1
-if (parseInt("11", NaN) !== parseInt("11", 10)) {
-  $ERROR('#1: parseInt("11", NaN) === parseInt("11", 10). Actual: ' + (parseInt("11", NaN)));
-}
+assert.sameValue(parseInt("11", NaN), parseInt("11", 10), 'parseInt("11", NaN) must return the same value returned by parseInt("11", 10)');
+assert.sameValue(parseInt("11", +0), parseInt("11", 10), 'parseInt("11", +0) must return the same value returned by parseInt("11", 10)');
+assert.sameValue(parseInt("11", -0), parseInt("11", 10), 'parseInt("11", -0) must return the same value returned by parseInt("11", 10)');
 
-//CHECK#2
-if (parseInt("11", +0) !== parseInt("11", 10)) {
-  $ERROR('#2: parseInt("11", +0) === parseInt("11", 10). Actual: ' + (parseInt("11", +0)));
-}
+assert.sameValue(
+  parseInt("11", Number.POSITIVE_INFINITY),
+  parseInt("11", 10),
+  'parseInt("11", Number.POSITIVE_INFINITY) must return the same value returned by parseInt("11", 10)'
+);
 
-//CHECK#3
-if (parseInt("11", -0) !== parseInt("11", 10)) {
-  $ERROR('#3: parseInt("11", -0) === parseInt("11", 10). Actual: ' + (parseInt("11", -0)));
-}
-
-//CHECK#4
-if (parseInt("11", Number.POSITIVE_INFINITY) !== parseInt("11", 10)) {
-  $ERROR('#4: parseInt("11", Number.POSITIVE_INFINITY) === parseInt("11", 10). Actual: ' + (parseInt("11", Number.POSITIVE_INFINITY)));
-}
-
-//CHECK#5
-if (parseInt("11", Number.NEGATIVE_INFINITY) !== parseInt("11", 10)) {
-  $ERROR('#5: parseInt("11", Number.NEGATIVE_INFINITY) === parseInt("11", 10). Actual: ' + (parseInt("11", Number.NEGATIVE_INFINITY)));
-}
+assert.sameValue(
+  parseInt("11", Number.NEGATIVE_INFINITY),
+  parseInt("11", 10),
+  'parseInt("11", Number.NEGATIVE_INFINITY) must return the same value returned by parseInt("11", 10)'
+);

--- a/test/built-ins/parseInt/S15.1.2.2_A3.2_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A3.2_T2.js
@@ -7,27 +7,18 @@ esid: sec-parseint-string-radix
 description: ToInt32 use floor
 ---*/
 
-//CHECK#1
-if (parseInt("11", 2.1) !== parseInt("11", 2)) {
-  $ERROR('#1: parseInt("11", 2.1) === parseInt("11", 2). Actual: ' + (parseInt("11", 2.1)));
-}
+assert.sameValue(parseInt("11", 2.1), parseInt("11", 2), 'parseInt("11", 2.1) must return the same value returned by parseInt("11", 2)');
+assert.sameValue(parseInt("11", 2.5), parseInt("11", 2), 'parseInt("11", 2.5) must return the same value returned by parseInt("11", 2)');
+assert.sameValue(parseInt("11", 2.9), parseInt("11", 2), 'parseInt("11", 2.9) must return the same value returned by parseInt("11", 2)');
 
-//CHECK#2
-if (parseInt("11", 2.5) !== parseInt("11", 2)) {
-  $ERROR('#2: parseInt("11", 2.5) === parseInt("11", 2). Actual: ' + (parseInt("11", 2.5)));
-}
+assert.sameValue(
+  parseInt("11", 2.000000000001),
+  parseInt("11", 2),
+  'parseInt("11", 2.000000000001) must return the same value returned by parseInt("11", 2)'
+);
 
-//CHECK#3
-if (parseInt("11", 2.9) !== parseInt("11", 2)) {
-  $ERROR('#3: parseInt("11", 2.9) === parseInt("11", 2). Actual: ' + (parseInt("11", 2.9)));
-}
-
-//CHECK#4
-if (parseInt("11", 2.000000000001) !== parseInt("11", 2)) {
-  $ERROR('#4: parseInt("11", 2.000000000001) === parseInt("11", 2). Actual: ' + (parseInt("11", 2.000000000001)));
-}
-
-//CHECK#5
-if (parseInt("11", 2.999999999999) !== parseInt("11", 2)) {
-  $ERROR('#5: parseInt("11", 2.999999999999) === parseInt("11", 2). Actual: ' + (parseInt("11", 2.999999999999)));
-}
+assert.sameValue(
+  parseInt("11", 2.999999999999),
+  parseInt("11", 2),
+  'parseInt("11", 2.999999999999) must return the same value returned by parseInt("11", 2)'
+);

--- a/test/built-ins/parseInt/S15.1.2.2_A3.2_T3.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A3.2_T3.js
@@ -7,20 +7,21 @@ esid: sec-parseint-string-radix
 description: ToInt32 use modulo
 ---*/
 
-//CHECK#1
-if (parseInt("11", 4294967298) !== parseInt("11", 2)) {
-  $ERROR('#1: parseInt("11", 4294967298) === parseInt("11", 2). Actual: ' + (parseInt("11", 4294967298)));
-}
+assert.sameValue(
+  parseInt("11", 4294967298),
+  parseInt("11", 2),
+  'parseInt("11", 4294967298) must return the same value returned by parseInt("11", 2)'
+);
+assert.sameValue(
+  parseInt("11", 4294967296),
+  parseInt("11", 10),
+  'parseInt("11", 4294967296) must return the same value returned by parseInt("11", 10)'
+);
 
-//CHECK#2
-if (parseInt("11", 4294967296) !== parseInt("11", 10)) {
-  $ERROR('#2: parseInt("11", 4294967296) === parseInt("11", 10). Actual: ' + (parseInt("11", 4294967296)));
-}
+assert.sameValue(parseInt("11", -2147483650), NaN, 'parseInt("11", -2147483650) must return NaN');
 
-//CHECK#3
-assert.sameValue(parseInt("11", -2147483650), NaN, "-2147483650");
-
-//CHECK#4
-if (parseInt("11", -4294967294) !== parseInt("11", 2)) {
-  $ERROR('#4: parseInt("11", -4294967294) === parseInt("11", 2). Actual: ' + (parseInt("11", -4294967294)));
-}
+assert.sameValue(
+  parseInt("11", -4294967294),
+  parseInt("11", 2),
+  'parseInt("11", -4294967294) must return the same value returned by parseInt("11", 2)'
+);

--- a/test/built-ins/parseInt/S15.1.2.2_A4.1_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A4.1_T1.js
@@ -7,67 +7,16 @@ esid: sec-parseint-string-radix
 description: R = 0
 ---*/
 
-//CHECK#0
-if (parseInt("0", 0) !== parseInt("0", 10)) {
-  $ERROR('#0: parseInt("0", 0) === parseInt("0", 10). Actual: ' + (parseInt("0", 0)));
-}
-
-//CHECK#1
-if (parseInt("1", 0) !== parseInt("1", 10)) {
-  $ERROR('#1: parseInt("1", 0) === parseInt("01", 10). Actual: ' + (parseInt("1", 0)));
-}
-
-//CHECK#2
-if (parseInt("2", 0) !== parseInt("2", 10)) {
-  $ERROR('#2: parseInt("2", 0) === parseInt("2", 10). Actual: ' + (parseInt("2", 0)));
-}
-
-//CHECK#3
-if (parseInt("3", 0) !== parseInt("3", 10)) {
-  $ERROR('#3: parseInt("3", 0) === parseInt("3", 10). Actual: ' + (parseInt("3", 0)));
-}
-
-//CHECK#4
-if (parseInt("4", 0) !== parseInt("4", 10)) {
-  $ERROR('#4: parseInt("4", 0) === parseInt(4", 10). Actual: ' + (parseInt("4", 0)));
-}
-
-//CHECK#5
-if (parseInt("5", 0) !== parseInt("5", 10)) {
-  $ERROR('#5: parseInt("5", 0) === parseInt("5", 10). Actual: ' + (parseInt("5", 0)));
-}
-
-//CHECK#6
-if (parseInt("6", 0) !== parseInt("6", 10)) {
-  $ERROR('#6: parseInt("6", 0) === parseInt("6", 10). Actual: ' + (parseInt("6", 0)));
-}
-
-//CHECK#7
-if (parseInt("7", 0) !== parseInt("7", 10)) {
-  $ERROR('#7: parseInt("7", 0) === parseInt("7", 10). Actual: ' + (parseInt("7", 0)));
-}
-
-//CHECK#8
-if (parseInt("8", 0) !== parseInt("8", 10)) {
-  $ERROR('#8: parseInt("8", 0) === parseInt("8", 10). Actual: ' + (parseInt("8", 0)));
-}
-
-//CHECK#9
-if (parseInt("9", 0) !== parseInt("9", 10)) {
-  $ERROR('#9: parseInt("9", 0) === parseInt("9", 10). Actual: ' + (parseInt("9", 0)));
-}
-
-//CHECK#10
-if (parseInt("10", 0) !== parseInt("10", 10)) {
-  $ERROR('#10: parseInt("10", 0) === parseInt("10", 10). Actual: ' + (parseInt("10", 0)));
-}
-
-//CHECK#11
-if (parseInt("11", 0) !== parseInt("11", 10)) {
-  $ERROR('#11: parseInt("11", 0) === parseInt("11", 10). Actual: ' + (parseInt("11", 0)));
-}
-
-//CHECK#12
-if (parseInt("9999", 0) !== parseInt("9999", 10)) {
-  $ERROR('#12: parseInt("9999", 0) === parseInt("9999", 10). Actual: ' + (parseInt("9999", 0)));
-}
+assert.sameValue(parseInt("0", 0), parseInt("0", 10), 'parseInt("0", 0) must return the same value returned by parseInt("0", 10)');
+assert.sameValue(parseInt("1", 0), parseInt("1", 10), 'parseInt("1", 0) must return the same value returned by parseInt("1", 10)');
+assert.sameValue(parseInt("2", 0), parseInt("2", 10), 'parseInt("2", 0) must return the same value returned by parseInt("2", 10)');
+assert.sameValue(parseInt("3", 0), parseInt("3", 10), 'parseInt("3", 0) must return the same value returned by parseInt("3", 10)');
+assert.sameValue(parseInt("4", 0), parseInt("4", 10), 'parseInt("4", 0) must return the same value returned by parseInt("4", 10)');
+assert.sameValue(parseInt("5", 0), parseInt("5", 10), 'parseInt("5", 0) must return the same value returned by parseInt("5", 10)');
+assert.sameValue(parseInt("6", 0), parseInt("6", 10), 'parseInt("6", 0) must return the same value returned by parseInt("6", 10)');
+assert.sameValue(parseInt("7", 0), parseInt("7", 10), 'parseInt("7", 0) must return the same value returned by parseInt("7", 10)');
+assert.sameValue(parseInt("8", 0), parseInt("8", 10), 'parseInt("8", 0) must return the same value returned by parseInt("8", 10)');
+assert.sameValue(parseInt("9", 0), parseInt("9", 10), 'parseInt("9", 0) must return the same value returned by parseInt("9", 10)');
+assert.sameValue(parseInt("10", 0), parseInt("10", 10), 'parseInt("10", 0) must return the same value returned by parseInt("10", 10)');
+assert.sameValue(parseInt("11", 0), parseInt("11", 10), 'parseInt("11", 0) must return the same value returned by parseInt("11", 10)');
+assert.sameValue(parseInt("9999", 0), parseInt("9999", 10), 'parseInt("9999", 0) must return the same value returned by parseInt("9999", 10)');

--- a/test/built-ins/parseInt/S15.1.2.2_A4.1_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A4.1_T2.js
@@ -7,67 +7,16 @@ esid: sec-parseint-string-radix
 description: R = undefined
 ---*/
 
-//CHECK#0
-if (parseInt("0") !== parseInt("0", 10)) {
-  $ERROR('#0: parseInt("0") === parseInt("0", 10). Actual: ' + (parseInt("0")));
-}
-
-//CHECK#1
-if (parseInt("1") !== parseInt("1", 10)) {
-  $ERROR('#1: parseInt("1") === parseInt("01", 10). Actual: ' + (parseInt("1")));
-}
-
-//CHECK#2
-if (parseInt("2") !== parseInt("2", 10)) {
-  $ERROR('#2: parseInt("2") === parseInt("2", 10). Actual: ' + (parseInt("2")));
-}
-
-//CHECK#3
-if (parseInt("3") !== parseInt("3", 10)) {
-  $ERROR('#3: parseInt("3") === parseInt("3", 10). Actual: ' + (parseInt("3")));
-}
-
-//CHECK#4
-if (parseInt("4") !== parseInt("4", 10)) {
-  $ERROR('#4: parseInt("4") === parseInt(4", 10). Actual: ' + (parseInt("4")));
-}
-
-//CHECK#5
-if (parseInt("5") !== parseInt("5", 10)) {
-  $ERROR('#5: parseInt("5") === parseInt("5", 10). Actual: ' + (parseInt("5")));
-}
-
-//CHECK#6
-if (parseInt("6") !== parseInt("6", 10)) {
-  $ERROR('#6: parseInt("6") === parseInt("6", 10). Actual: ' + (parseInt("6")));
-}
-
-//CHECK#7
-if (parseInt("7") !== parseInt("7", 10)) {
-  $ERROR('#7: parseInt("7") === parseInt("7", 10). Actual: ' + (parseInt("7")));
-}
-
-//CHECK#8
-if (parseInt("8") !== parseInt("8", 10)) {
-  $ERROR('#8: parseInt("8") === parseInt("8", 10). Actual: ' + (parseInt("8")));
-}
-
-//CHECK#9
-if (parseInt("9") !== parseInt("9", 10)) {
-  $ERROR('#9: parseInt("9") === parseInt("9", 10). Actual: ' + (parseInt("9")));
-}
-
-//CHECK#10
-if (parseInt("10") !== parseInt("10", 10)) {
-  $ERROR('#10: parseInt("10") === parseInt("10", 10). Actual: ' + (parseInt("10")));
-}
-
-//CHECK#11
-if (parseInt("11") !== parseInt("11", 10)) {
-  $ERROR('#11: parseInt("11") === parseInt("11", 10). Actual: ' + (parseInt("11")));
-}
-
-//CHECK#12
-if (parseInt("9999") !== parseInt("9999", 10)) {
-  $ERROR('#12: parseInt("9999") === parseInt("9999", 10). Actual: ' + (parseInt("9999")));
-}
+assert.sameValue(parseInt("0"), parseInt("0", 10), 'parseInt("0") must return the same value returned by parseInt("0", 10)');
+assert.sameValue(parseInt("1"), parseInt("1", 10), 'parseInt("1") must return the same value returned by parseInt("1", 10)');
+assert.sameValue(parseInt("2"), parseInt("2", 10), 'parseInt("2") must return the same value returned by parseInt("2", 10)');
+assert.sameValue(parseInt("3"), parseInt("3", 10), 'parseInt("3") must return the same value returned by parseInt("3", 10)');
+assert.sameValue(parseInt("4"), parseInt("4", 10), 'parseInt("4") must return the same value returned by parseInt("4", 10)');
+assert.sameValue(parseInt("5"), parseInt("5", 10), 'parseInt("5") must return the same value returned by parseInt("5", 10)');
+assert.sameValue(parseInt("6"), parseInt("6", 10), 'parseInt("6") must return the same value returned by parseInt("6", 10)');
+assert.sameValue(parseInt("7"), parseInt("7", 10), 'parseInt("7") must return the same value returned by parseInt("7", 10)');
+assert.sameValue(parseInt("8"), parseInt("8", 10), 'parseInt("8") must return the same value returned by parseInt("8", 10)');
+assert.sameValue(parseInt("9"), parseInt("9", 10), 'parseInt("9") must return the same value returned by parseInt("9", 10)');
+assert.sameValue(parseInt("10"), parseInt("10", 10), 'parseInt("10") must return the same value returned by parseInt("10", 10)');
+assert.sameValue(parseInt("11"), parseInt("11", 10), 'parseInt("11") must return the same value returned by parseInt("11", 10)');
+assert.sameValue(parseInt("9999"), parseInt("9999", 10), 'parseInt("9999") must return the same value returned by parseInt("9999", 10)');

--- a/test/built-ins/parseInt/S15.1.2.2_A4.2_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A4.2_T1.js
@@ -7,15 +7,15 @@ esid: sec-parseint-string-radix
 description: R = 1
 ---*/
 
-assert.sameValue(parseInt("0", 1), NaN, "0");
-assert.sameValue(parseInt("1", 1), NaN, "1");
-assert.sameValue(parseInt("2", 1), NaN, "2");
-assert.sameValue(parseInt("3", 1), NaN, "3");
-assert.sameValue(parseInt("4", 1), NaN, "4");
-assert.sameValue(parseInt("5", 1), NaN, "5");
-assert.sameValue(parseInt("6", 1), NaN, "6");
-assert.sameValue(parseInt("7", 1), NaN, "7");
-assert.sameValue(parseInt("8", 1), NaN, "8");
-assert.sameValue(parseInt("9", 1), NaN, "9");
-assert.sameValue(parseInt("10", 1), NaN, "10");
-assert.sameValue(parseInt("11", 1), NaN, "11");
+assert.sameValue(parseInt("0", 1), NaN, 'parseInt("0", 1) must return NaN');
+assert.sameValue(parseInt("1", 1), NaN, 'parseInt("1", 1) must return NaN');
+assert.sameValue(parseInt("2", 1), NaN, 'parseInt("2", 1) must return NaN');
+assert.sameValue(parseInt("3", 1), NaN, 'parseInt("3", 1) must return NaN');
+assert.sameValue(parseInt("4", 1), NaN, 'parseInt("4", 1) must return NaN');
+assert.sameValue(parseInt("5", 1), NaN, 'parseInt("5", 1) must return NaN');
+assert.sameValue(parseInt("6", 1), NaN, 'parseInt("6", 1) must return NaN');
+assert.sameValue(parseInt("7", 1), NaN, 'parseInt("7", 1) must return NaN');
+assert.sameValue(parseInt("8", 1), NaN, 'parseInt("8", 1) must return NaN');
+assert.sameValue(parseInt("9", 1), NaN, 'parseInt("9", 1) must return NaN');
+assert.sameValue(parseInt("10", 1), NaN, 'parseInt("10", 1) must return NaN');
+assert.sameValue(parseInt("11", 1), NaN, 'parseInt("11", 1) must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A4.2_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A4.2_T2.js
@@ -7,15 +7,15 @@ esid: sec-parseint-string-radix
 description: R = 37
 ---*/
 
-assert.sameValue(parseInt("0", 37), NaN, "0");
-assert.sameValue(parseInt("1", 37), NaN, "1");
-assert.sameValue(parseInt("2", 37), NaN, "2");
-assert.sameValue(parseInt("3", 37), NaN, "3");
-assert.sameValue(parseInt("4", 37), NaN, "4");
-assert.sameValue(parseInt("5", 37), NaN, "5");
-assert.sameValue(parseInt("6", 37), NaN, "6");
-assert.sameValue(parseInt("7", 37), NaN, "7");
-assert.sameValue(parseInt("8", 37), NaN, "8");
-assert.sameValue(parseInt("9", 37), NaN, "9");
-assert.sameValue(parseInt("10", 37), NaN, "10");
-assert.sameValue(parseInt("11", 37), NaN, "11");
+assert.sameValue(parseInt("0", 37), NaN, 'parseInt("0", 37) must return NaN');
+assert.sameValue(parseInt("1", 37), NaN, 'parseInt("1", 37) must return NaN');
+assert.sameValue(parseInt("2", 37), NaN, 'parseInt("2", 37) must return NaN');
+assert.sameValue(parseInt("3", 37), NaN, 'parseInt("3", 37) must return NaN');
+assert.sameValue(parseInt("4", 37), NaN, 'parseInt("4", 37) must return NaN');
+assert.sameValue(parseInt("5", 37), NaN, 'parseInt("5", 37) must return NaN');
+assert.sameValue(parseInt("6", 37), NaN, 'parseInt("6", 37) must return NaN');
+assert.sameValue(parseInt("7", 37), NaN, 'parseInt("7", 37) must return NaN');
+assert.sameValue(parseInt("8", 37), NaN, 'parseInt("8", 37) must return NaN');
+assert.sameValue(parseInt("9", 37), NaN, 'parseInt("9", 37) must return NaN');
+assert.sameValue(parseInt("10", 37), NaN, 'parseInt("10", 37) must return NaN');
+assert.sameValue(parseInt("11", 37), NaN, 'parseInt("11", 37) must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A5.1_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A5.1_T1.js
@@ -11,6 +11,4 @@ esid: sec-parseint-string-radix
 description: Check if parseInt still accepts octal
 ---*/
 
-if (parseInt('010') !== 10) {
-  $ERROR("parseInt should no longer accept octal");
-}
+assert.sameValue(parseInt('010'), 10, 'parseInt(\'010\') must return 10');

--- a/test/built-ins/parseInt/S15.1.2.2_A5.2_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A5.2_T1.js
@@ -9,92 +9,26 @@ esid: sec-parseint-string-radix
 description: ": 0x"
 ---*/
 
-//CHECK#0
-if (parseInt("0x0", 0) !== parseInt("0", 16)) {
-  $ERROR('#0: parseInt("0x0", 0) === parseInt("0", 16). Actual: ' + (parseInt("0x0", 0)));
-}
+assert.sameValue(parseInt("0x0", 0), parseInt("0", 16), 'parseInt("0x0", 0) must return the same value returned by parseInt("0", 16)');
+assert.sameValue(parseInt("0x1", 0), parseInt("1", 16), 'parseInt("0x1", 0) must return the same value returned by parseInt("1", 16)');
+assert.sameValue(parseInt("0x2", 0), parseInt("2", 16), 'parseInt("0x2", 0) must return the same value returned by parseInt("2", 16)');
+assert.sameValue(parseInt("0x3", 0), parseInt("3", 16), 'parseInt("0x3", 0) must return the same value returned by parseInt("3", 16)');
+assert.sameValue(parseInt("0x4", 0), parseInt("4", 16), 'parseInt("0x4", 0) must return the same value returned by parseInt("4", 16)');
+assert.sameValue(parseInt("0x5", 0), parseInt("5", 16), 'parseInt("0x5", 0) must return the same value returned by parseInt("5", 16)');
+assert.sameValue(parseInt("0x6", 0), parseInt("6", 16), 'parseInt("0x6", 0) must return the same value returned by parseInt("6", 16)');
+assert.sameValue(parseInt("0x7", 0), parseInt("7", 16), 'parseInt("0x7", 0) must return the same value returned by parseInt("7", 16)');
+assert.sameValue(parseInt("0x8", 0), parseInt("8", 16), 'parseInt("0x8", 0) must return the same value returned by parseInt("8", 16)');
+assert.sameValue(parseInt("0x9", 0), parseInt("9", 16), 'parseInt("0x9", 0) must return the same value returned by parseInt("9", 16)');
+assert.sameValue(parseInt("0xA", 0), parseInt("A", 16), 'parseInt("0xA", 0) must return the same value returned by parseInt("A", 16)');
+assert.sameValue(parseInt("0xB", 0), parseInt("B", 16), 'parseInt("0xB", 0) must return the same value returned by parseInt("B", 16)');
+assert.sameValue(parseInt("0xC", 0), parseInt("C", 16), 'parseInt("0xC", 0) must return the same value returned by parseInt("C", 16)');
+assert.sameValue(parseInt("0xD", 0), parseInt("D", 16), 'parseInt("0xD", 0) must return the same value returned by parseInt("D", 16)');
+assert.sameValue(parseInt("0xE", 0), parseInt("E", 16), 'parseInt("0xE", 0) must return the same value returned by parseInt("E", 16)');
+assert.sameValue(parseInt("0xF", 0), parseInt("F", 16), 'parseInt("0xF", 0) must return the same value returned by parseInt("F", 16)');
+assert.sameValue(parseInt("0xE", 0), parseInt("E", 16), 'parseInt("0xE", 0) must return the same value returned by parseInt("E", 16)');
 
-//CHECK#1
-if (parseInt("0x1", 0) !== parseInt("1", 16)) {
-  $ERROR('#1: parseInt("0x1", 0) === parseInt("1", 16). Actual: ' + (parseInt("0x1", 0)));
-}
-
-//CHECK#2
-if (parseInt("0x2", 0) !== parseInt("2", 16)) {
-  $ERROR('#2: parseInt("0x2", 0) === parseInt("2", 16). Actual: ' + (parseInt("0x2", 0)));
-}
-
-//CHECK#3
-if (parseInt("0x3", 0) !== parseInt("3", 16)) {
-  $ERROR('#3: parseInt("0x3", 0) === parseInt("3", 16). Actual: ' + (parseInt("0x3", 0)));
-}
-
-//CHECK#4
-if (parseInt("0x4", 0) !== parseInt("4", 16)) {
-  $ERROR('#4: parseInt("0x4", 0) === parseInt("4", 16). Actual: ' + (parseInt("0x4", 0)));
-}
-
-//CHECK#5
-if (parseInt("0x5", 0) !== parseInt("5", 16)) {
-  $ERROR('#5: parseInt("0x5", 0) === parseInt("5", 16). Actual: ' + (parseInt("0x5", 0)));
-}
-
-//CHECK#6
-if (parseInt("0x6", 0) !== parseInt("6", 16)) {
-  $ERROR('#6: parseInt("0x6", 0) === parseInt("6", 16). Actual: ' + (parseInt("0x6", 0)));
-}
-
-//CHECK#7
-if (parseInt("0x7", 0) !== parseInt("7", 16)) {
-  $ERROR('#7: parseInt("0x7", 0) === parseInt("7", 16). Actual: ' + (parseInt("0x7", 0)));
-}
-
-//CHECK#8
-if (parseInt("0x8", 0) !== parseInt("8", 16)) {
-  $ERROR('#8: parseInt("0x8", 0) === parseInt("8", 16). Actual: ' + (parseInt("0x8", 0)));
-}
-
-//CHECK#9
-if (parseInt("0x9", 0) !== parseInt("9", 16)) {
-  $ERROR('#9: parseInt("0x9", 0) === parseInt("9", 16). Actual: ' + (parseInt("0x9", 0)));
-}
-
-//CHECK#A
-if (parseInt("0xA", 0) !== parseInt("A", 16)) {
-  $ERROR('#A: parseInt("0xA", 0) === parseInt("A", 16). Actual: ' + (parseInt("0xA", 0)));
-}
-
-//CHECK#B
-if (parseInt("0xB", 0) !== parseInt("B", 16)) {
-  $ERROR('#B: parseInt("0xB", 0) === parseInt("B", 16). Actual: ' + (parseInt("0xB", 0)));
-}
-
-//CHECK#C
-if (parseInt("0xC", 0) !== parseInt("C", 16)) {
-  $ERROR('#C: parseInt("0xC", 0) === parseInt("C", 16). Actual: ' + (parseInt("0xC", 0)));
-}
-
-//CHECK#D
-if (parseInt("0xD", 0) !== parseInt("D", 16)) {
-  $ERROR('#D: parseInt("0xD", 0) === parseInt("D", 16). Actual: ' + (parseInt("0xD", 0)));
-}
-
-//CHECK#E
-if (parseInt("0xE", 0) !== parseInt("E", 16)) {
-  $ERROR('#E: parseInt("0xE", 0) === parseInt("E", 16). Actual: ' + (parseInt("0xE", 0)));
-}
-
-//CHECK#F
-if (parseInt("0xF", 0) !== parseInt("F", 16)) {
-  $ERROR('#F: parseInt("0xF", 0) === parseInt("F", 16). Actual: ' + (parseInt("0xF", 0)));
-}
-
-//CHECK#E
-if (parseInt("0xE", 0) !== parseInt("E", 16)) {
-  $ERROR('#E: parseInt("0xE", 0) === parseInt("E", 16). Actual: ' + (parseInt("0xE", 0)));
-}
-
-//CHECK#ABCDEF
-if (parseInt("0xABCDEF", 0) !== parseInt("ABCDEF", 16)) {
-  $ERROR('#ABCDEF: parseInt("0xABCDEF", 0) === parseInt("ABCDEF", 16). Actual: ' + (parseInt("0xABCDEF", 0)));
-}
+assert.sameValue(
+  parseInt("0xABCDEF", 0),
+  parseInt("ABCDEF", 16),
+  'parseInt("0xABCDEF", 0) must return the same value returned by parseInt("ABCDEF", 16)'
+);

--- a/test/built-ins/parseInt/S15.1.2.2_A5.2_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A5.2_T2.js
@@ -9,92 +9,21 @@ esid: sec-parseint-string-radix
 description: ": 0X"
 ---*/
 
-//CHECK#0
-if (parseInt("0X0", 0) !== parseInt("0", 16)) {
-  $ERROR('#0: parseInt("0X0", 0) === parseInt("0", 16). Actual: ' + (parseInt("0X0", 0)));
-}
-
-//CHECK#1
-if (parseInt("0X1") !== parseInt("1", 16)) {
-  $ERROR('#1: parseInt("0X1") === parseInt("1", 16). Actual: ' + (parseInt("0X1")));
-}
-
-//CHECK#2
-if (parseInt("0X2") !== parseInt("2", 16)) {
-  $ERROR('#2: parseInt("0X2") === parseInt("2", 16). Actual: ' + (parseInt("0X2")));
-}
-
-//CHECK#3
-if (parseInt("0X3") !== parseInt("3", 16)) {
-  $ERROR('#3: parseInt("0X3") === parseInt("3", 16). Actual: ' + (parseInt("0X3")));
-}
-
-//CHECK#4
-if (parseInt("0X4") !== parseInt("4", 16)) {
-  $ERROR('#4: parseInt("0X4") === parseInt("4", 16). Actual: ' + (parseInt("0X4")));
-}
-
-//CHECK#5
-if (parseInt("0X5") !== parseInt("5", 16)) {
-  $ERROR('#5: parseInt("0X5") === parseInt("5", 16). Actual: ' + (parseInt("0X5")));
-}
-
-//CHECK#6
-if (parseInt("0X6") !== parseInt("6", 16)) {
-  $ERROR('#6: parseInt("0X6") === parseInt("6", 16). Actual: ' + (parseInt("0X6")));
-}
-
-//CHECK#7
-if (parseInt("0X7") !== parseInt("7", 16)) {
-  $ERROR('#7: parseInt("0X7") === parseInt("7", 16). Actual: ' + (parseInt("0X7")));
-}
-
-//CHECK#8
-if (parseInt("0X8") !== parseInt("8", 16)) {
-  $ERROR('#8: parseInt("0X8") === parseInt("8", 16). Actual: ' + (parseInt("0X8")));
-}
-
-//CHECK#9
-if (parseInt("0X9") !== parseInt("9", 16)) {
-  $ERROR('#9: parseInt("0X9") === parseInt("9", 16). Actual: ' + (parseInt("0X9")));
-}
-
-//CHECK#A
-if (parseInt("0XA") !== parseInt("A", 16)) {
-  $ERROR('#A: parseInt("0XA") === parseInt("A", 16). Actual: ' + (parseInt("0XA")));
-}
-
-//CHECK#B
-if (parseInt("0XB") !== parseInt("B", 16)) {
-  $ERROR('#B: parseInt("0XB") === parseInt("B", 16). Actual: ' + (parseInt("0XB")));
-}
-
-//CHECK#C
-if (parseInt("0XC") !== parseInt("C", 16)) {
-  $ERROR('#C: parseInt("0XC") === parseInt("C", 16). Actual: ' + (parseInt("0XC")));
-}
-
-//CHECK#D
-if (parseInt("0XD") !== parseInt("D", 16)) {
-  $ERROR('#D: parseInt("0XD") === parseInt("D", 16). Actual: ' + (parseInt("0XD")));
-}
-
-//CHECK#E
-if (parseInt("0XE") !== parseInt("E", 16)) {
-  $ERROR('#E: parseInt("0XE") === parseInt("E", 16). Actual: ' + (parseInt("0XE")));
-}
-
-//CHECK#F
-if (parseInt("0XF") !== parseInt("F", 16)) {
-  $ERROR('#F: parseInt("0XF") === parseInt("F", 16). Actual: ' + (parseInt("0XF")));
-}
-
-//CHECK#E
-if (parseInt("0XE") !== parseInt("E", 16)) {
-  $ERROR('#E: parseInt("0XE") === parseInt("E", 16). Actual: ' + (parseInt("0XE")));
-}
-
-//CHECK#ABCDEF
-if (parseInt("0XABCDEF") !== parseInt("ABCDEF", 16)) {
-  $ERROR('#ABCDEF: parseInt("0XABCDEF") === parseInt("ABCDEF", 16). Actual: ' + (parseInt("0XABCDEF")));
-}
+assert.sameValue(parseInt("0X0", 0), parseInt("0", 16), 'parseInt("0X0", 0) must return the same value returned by parseInt("0", 16)');
+assert.sameValue(parseInt("0X1"), parseInt("1", 16), 'parseInt("0X1") must return the same value returned by parseInt("1", 16)');
+assert.sameValue(parseInt("0X2"), parseInt("2", 16), 'parseInt("0X2") must return the same value returned by parseInt("2", 16)');
+assert.sameValue(parseInt("0X3"), parseInt("3", 16), 'parseInt("0X3") must return the same value returned by parseInt("3", 16)');
+assert.sameValue(parseInt("0X4"), parseInt("4", 16), 'parseInt("0X4") must return the same value returned by parseInt("4", 16)');
+assert.sameValue(parseInt("0X5"), parseInt("5", 16), 'parseInt("0X5") must return the same value returned by parseInt("5", 16)');
+assert.sameValue(parseInt("0X6"), parseInt("6", 16), 'parseInt("0X6") must return the same value returned by parseInt("6", 16)');
+assert.sameValue(parseInt("0X7"), parseInt("7", 16), 'parseInt("0X7") must return the same value returned by parseInt("7", 16)');
+assert.sameValue(parseInt("0X8"), parseInt("8", 16), 'parseInt("0X8") must return the same value returned by parseInt("8", 16)');
+assert.sameValue(parseInt("0X9"), parseInt("9", 16), 'parseInt("0X9") must return the same value returned by parseInt("9", 16)');
+assert.sameValue(parseInt("0XA"), parseInt("A", 16), 'parseInt("0XA") must return the same value returned by parseInt("A", 16)');
+assert.sameValue(parseInt("0XB"), parseInt("B", 16), 'parseInt("0XB") must return the same value returned by parseInt("B", 16)');
+assert.sameValue(parseInt("0XC"), parseInt("C", 16), 'parseInt("0XC") must return the same value returned by parseInt("C", 16)');
+assert.sameValue(parseInt("0XD"), parseInt("D", 16), 'parseInt("0XD") must return the same value returned by parseInt("D", 16)');
+assert.sameValue(parseInt("0XE"), parseInt("E", 16), 'parseInt("0XE") must return the same value returned by parseInt("E", 16)');
+assert.sameValue(parseInt("0XF"), parseInt("F", 16), 'parseInt("0XF") must return the same value returned by parseInt("F", 16)');
+assert.sameValue(parseInt("0XE"), parseInt("E", 16), 'parseInt("0XE") must return the same value returned by parseInt("E", 16)');
+assert.sameValue(parseInt("0XABCDEF"), parseInt("ABCDEF", 16), 'parseInt("0XABCDEF") must return the same value returned by parseInt("ABCDEF", 16)');

--- a/test/built-ins/parseInt/S15.1.2.2_A6.1_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A6.1_T1.js
@@ -12,7 +12,5 @@ description: Complex test. R in [2, 36]
 
 //CHECK#
 for (var i = 2; i <= 36; i++) {
-  if (parseInt("10$1", i) !== i) {
-    $ERROR('#' + i + ': i = ' + i + 'parseInt("10$1", i) === i. Actual: ' + (parseInt("10$1", i)));
-  }
+  assert.sameValue(parseInt("10$1", i), i, 'parseInt("10$1", i) must return the value of i');
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A6.1_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A6.1_T2.js
@@ -13,7 +13,5 @@ description: Complex test. Radix-R notation in [0..9, A-Z]
 //CHECK#
 var R_digit = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"];
 for (var i = 2; i <= 36; i++) {
-  if (parseInt(R_digit[i - 2] + "$", i) !== i - 1) {
-    $ERROR('#' + i + ': ');
-  }
+  assert.sameValue(parseInt(R_digit[i - 2] + "$", i), i - 1, 'parseInt(R_digit[i - 2] + "$", 2) must return i - 1');
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A6.1_T3.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A6.1_T3.js
@@ -13,7 +13,5 @@ description: Complex test. Radix-R notation in [0..9, a-z]
 //CHECK#
 var R_digit = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"];
 for (var i = 2; i <= 36; i++) {
-  if (parseInt(R_digit[i - 2] + "$", i) !== i - 1) {
-    $ERROR('#' + i + ': ');
-  }
+  assert.sameValue(parseInt(R_digit[i - 2] + "$", i), i - 1, 'parseInt(R_digit[i - 2] + "$", i) must return i - 1');
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A6.1_T4.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A6.1_T4.js
@@ -13,7 +13,9 @@ description: Complex test. Radix-R notation in [0..9, A-Z]
 //CHECK#
 var R_digit = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"];
 for (var i = 2; i <= 35; i++) {
-  if (parseInt(R_digit[i - 2] + R_digit[i - 1], i) !== i - 1) {
-    $ERROR('#' + i + ': ');
-  }
+  assert.sameValue(
+    parseInt(R_digit[i - 2] + R_digit[i - 1], i),
+    i - 1,
+    'parseInt(R_digit[i - 2] + R_digit[i - 1], i) must return i - 1'
+  );
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A6.1_T5.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A6.1_T5.js
@@ -13,7 +13,9 @@ description: Complex test. Radix-R notation in [0..9, a-z]
 //CHECK#
 var R_digit = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"];
 for (var i = 2; i <= 35; i++) {
-  if (parseInt(R_digit[i - 2] + R_digit[i - 1], i) !== i - 1) {
-    $ERROR('#' + i + ': ');
-  }
+  assert.sameValue(
+    parseInt(R_digit[i - 2] + R_digit[i - 1], i),
+    i - 1,
+    'parseInt(R_digit[i - 2] + R_digit[i - 1], i) must return i - 1'
+  );
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A6.1_T6.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A6.1_T6.js
@@ -10,47 +10,17 @@ esid: sec-parseint-string-radix
 description: Complex test. Radix-R notation in [0..9]
 ---*/
 
-//CHECK#2
-if (parseInt("0123456789", 2) !== 1) {
-  $ERROR('#2: parseInt("0123456789", 2) === 1. Actual: ' + (parseInt("0123456789", 2)));
-}
+assert.sameValue(parseInt("0123456789", 2), 1, 'parseInt("0123456789", 2) must return 1');
+assert.sameValue(parseInt("01234567890", 3), 5, 'parseInt("01234567890", 3) must return 5');
+assert.sameValue(parseInt("01234567890", 4), 27, 'parseInt("01234567890", 4) must return 27');
+assert.sameValue(parseInt("01234567890", 5), 194, 'parseInt("01234567890", 5) must return 194');
+assert.sameValue(parseInt("01234567890", 6), 1865, 'parseInt("01234567890", 6) must return 1865');
+assert.sameValue(parseInt("01234567890", 7), 22875, 'parseInt("01234567890", 7) must return 22875');
+assert.sameValue(parseInt("01234567890", 8), 342391, 'parseInt("01234567890", 8) must return 342391');
+assert.sameValue(parseInt("01234567890", 9), 6053444, 'parseInt("01234567890", 9) must return 6053444');
 
-//CHECK#3
-if (parseInt("01234567890", 3) !== 5) {
-  $ERROR('#3: parseInt("01234567890", 3) === 5. Actual: ' + (parseInt("01234567890", 3)));
-}
-
-//CHECK#4
-if (parseInt("01234567890", 4) !== 27) {
-  $ERROR('#4: parseInt("01234567890", 4) === 27. Actual: ' + (parseInt("01234567890", 4)));
-}
-
-//CHECK#5
-if (parseInt("01234567890", 5) !== 194) {
-  $ERROR('#5: parseInt("01234567890", 5) === 194. Actual: ' + (parseInt("01234567890", 5)));
-}
-
-//CHECK#6
-if (parseInt("01234567890", 6) !== 1865) {
-  $ERROR('#6: parseInt("01234567890", 6) === 1865. Actual: ' + (parseInt("01234567890", 6)));
-}
-
-//CHECK#7
-if (parseInt("01234567890", 7) !== 22875) {
-  $ERROR('#7: parseInt("01234567890", 7) === 22875. Actual: ' + (parseInt("01234567890", 7)));
-}
-
-//CHECK#8
-if (parseInt("01234567890", 8) !== 342391) {
-  $ERROR('#8: parseInt("01234567890", 8) === 342391. Actual: ' + (parseInt("01234567890", 8)));
-}
-
-//CHECK#9
-if (parseInt("01234567890", 9) !== 6053444) {
-  $ERROR('#9: parseInt("01234567890", 9) === 6053444. Actual: ' + (parseInt("01234567890", 9)));
-}
-
-//CHECK#10
-if (parseInt("01234567890", 10) !== Number(1234567890)) {
-  $ERROR('#10: parseInt("01234567890", 10) === Number(1234567890). Actual: ' + (parseInt("01234567890", 10)));
-}
+assert.sameValue(
+  parseInt("01234567890", 10),
+  Number(1234567890),
+  'parseInt("01234567890", 10) must return the same value returned by Number(1234567890)'
+);

--- a/test/built-ins/parseInt/S15.1.2.2_A7.1_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A7.1_T1.js
@@ -9,5 +9,5 @@ description: Complex test. R in [2, 36]
 
 //CHECK#
 for (var i = 2; i <= 36; i++) {
-  assert.sameValue(parseInt("$string", i), NaN);
+  assert.sameValue(parseInt("$string", i), NaN, 'parseInt("$string", i) must return NaN');
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A7.1_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A7.1_T2.js
@@ -7,8 +7,8 @@ esid: sec-parseint-string-radix
 description: x is not a radix-R digit
 ---*/
 
-assert.sameValue(parseInt("$0x"), NaN, "$0x");
-assert.sameValue(parseInt("$0X"), NaN, "$0X");
-assert.sameValue(parseInt("$$$"), NaN, "$$$");
-assert.sameValue(parseInt(""), NaN, "the empty string");
-assert.sameValue(parseInt(" "), NaN, "a string with a single space");
+assert.sameValue(parseInt("$0x"), NaN, 'parseInt("$0x") must return NaN');
+assert.sameValue(parseInt("$0X"), NaN, 'parseInt("$0X") must return NaN');
+assert.sameValue(parseInt("$$$"), NaN, 'parseInt("$$$") must return NaN');
+assert.sameValue(parseInt(""), NaN, 'parseInt("") must return NaN');
+assert.sameValue(parseInt(" "), NaN, 'parseInt(" ") must return NaN');

--- a/test/built-ins/parseInt/S15.1.2.2_A7.2_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A7.2_T1.js
@@ -29,8 +29,6 @@ for (var i = 2; i <= 36; i++) {
       num = num + (i + (k0 - k) - 1) * pow;
       pow = pow * i;
     }
-    if (parseInt(str, i) !== num) {
-      $ERROR('#' + i + '.' + j + ' : ');
-    }
+    assert.sameValue(parseInt(str, i), num, 'parseInt("str + R_digit2[k - 2], i) must return the value of num');
   }
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A7.2_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A7.2_T2.js
@@ -11,102 +11,23 @@ esid: sec-parseint-string-radix
 description: Checking algorithm for R = 2
 ---*/
 
-//CHECK#1
-if (parseInt("1", 2) !== 1) {
-  $ERROR('#1: parseInt("1", 2) === 1. Actual: ' + (parseInt("1", 2)));
-}
-
-//CHECK#2
-if (parseInt("11", 2) !== 3) {
-  $ERROR('#2: parseInt("11", 2) === 3. Actual: ' + (parseInt("11", 2)));
-}
-
-//CHECK#3
-if (parseInt("111", 2) !== 7) {
-  $ERROR('#3: parseInt("111", 2) === 7. Actual: ' + (parseInt("111", 2)));
-}
-
-//CHECK#4
-if (parseInt("1111", 2) !== 15) {
-  $ERROR('#4: parseInt("1111", 2) === 15. Actual: ' + (parseInt("1111", 2)));
-}
-
-//CHECK#5
-if (parseInt("11111", 2) !== 31) {
-  $ERROR('#5: parseInt("11111", 2) === 31. Actual: ' + (parseInt("11111", 2)));
-}
-
-//CHECK#6
-if (parseInt("111111", 2) !== 63) {
-  $ERROR('#6: parseInt("111111", 2) === 63. Actual: ' + (parseInt("111111", 2)));
-}
-
-//CHECK#7
-if (parseInt("1111111", 2) !== 127) {
-  $ERROR('#7: parseInt("1111111", 2) === 127. Actual: ' + (parseInt("1111111", 2)));
-}
-
-//CHECK#8
-if (parseInt("11111111", 2) !== 255) {
-  $ERROR('#8: parseInt("11111111", 2) === 255. Actual: ' + (parseInt("11111111", 2)));
-}
-
-//CHECK#9
-if (parseInt("111111111", 2) !== 511) {
-  $ERROR('#9: parseInt("111111111", 2) === 511. Actual: ' + (parseInt("111111111", 2)));
-}
-
-//CHECK#10
-if (parseInt("1111111111", 2) !== 1023) {
-  $ERROR('#10: parseInt("1111111111", 2) === 1023. Actual: ' + (parseInt("1111111111", 2)));
-}
-
-//CHECK#11
-if (parseInt("11111111111", 2) !== 2047) {
-  $ERROR('#11: parseInt("11111111111", 2) === 2047. Actual: ' + (parseInt("11111111111", 2)));
-}
-
-//CHECK#12
-if (parseInt("111111111111", 2) !== 4095) {
-  $ERROR('#12: parseInt("111111111111", 2) === 4095. Actual: ' + (parseInt("111111111111", 2)));
-}
-
-//CHECK#13
-if (parseInt("1111111111111", 2) !== 8191) {
-  $ERROR('#13: parseInt("1111111111111", 2) === 8191. Actual: ' + (parseInt("1111111111111", 2)));
-}
-
-//CHECK#14
-if (parseInt("11111111111111", 2) !== 16383) {
-  $ERROR('#14: parseInt("11111111111111", 2) === 16383. Actual: ' + (parseInt("11111111111111", 2)));
-}
-
-//CHECK#15
-if (parseInt("111111111111111", 2) !== 32767) {
-  $ERROR('#15: parseInt("111111111111111", 2) === 32767. Actual: ' + (parseInt("111111111111111", 2)));
-}
-
-//CHECK#16
-if (parseInt("1111111111111111", 2) !== 65535) {
-  $ERROR('#16: parseInt("1111111111111111", 2) === 65535. Actual: ' + (parseInt("1111111111111111", 2)));
-}
-
-//CHECK#17
-if (parseInt("11111111111111111", 2) !== 131071) {
-  $ERROR('#17: parseInt("11111111111111111", 2) === 131071. Actual: ' + (parseInt("11111111111111111", 2)));
-}
-
-//CHECK#18
-if (parseInt("111111111111111111", 2) !== 262143) {
-  $ERROR('#18: parseInt("111111111111111111", 2) === 262143. Actual: ' + (parseInt("111111111111111111", 2)));
-}
-
-//CHECK#19
-if (parseInt("1111111111111111111", 2) !== 524287) {
-  $ERROR('#19: parseInt("1111111111111111111", 2) === 524287. Actual: ' + (parseInt("1111111111111111111", 2)));
-}
-
-//CHECK#20
-if (parseInt("11111111111111111111", 2) !== 1048575) {
-  $ERROR('#20: parseInt("11111111111111111111", 2) === 1048575. Actual: ' + (parseInt("11111111111111111111", 2)));
-}
+assert.sameValue(parseInt("1", 2), 1, 'parseInt("1", 2) must return 1');
+assert.sameValue(parseInt("11", 2), 3, 'parseInt("11", 2) must return 3');
+assert.sameValue(parseInt("111", 2), 7, 'parseInt("111", 2) must return 7');
+assert.sameValue(parseInt("1111", 2), 15, 'parseInt("1111", 2) must return 15');
+assert.sameValue(parseInt("11111", 2), 31, 'parseInt("11111", 2) must return 31');
+assert.sameValue(parseInt("111111", 2), 63, 'parseInt("111111", 2) must return 63');
+assert.sameValue(parseInt("1111111", 2), 127, 'parseInt("1111111", 2) must return 127');
+assert.sameValue(parseInt("11111111", 2), 255, 'parseInt("11111111", 2) must return 255');
+assert.sameValue(parseInt("111111111", 2), 511, 'parseInt("111111111", 2) must return 511');
+assert.sameValue(parseInt("1111111111", 2), 1023, 'parseInt("1111111111", 2) must return 1023');
+assert.sameValue(parseInt("11111111111", 2), 2047, 'parseInt("11111111111", 2) must return 2047');
+assert.sameValue(parseInt("111111111111", 2), 4095, 'parseInt("111111111111", 2) must return 4095');
+assert.sameValue(parseInt("1111111111111", 2), 8191, 'parseInt("1111111111111", 2) must return 8191');
+assert.sameValue(parseInt("11111111111111", 2), 16383, 'parseInt("11111111111111", 2) must return 16383');
+assert.sameValue(parseInt("111111111111111", 2), 32767, 'parseInt("111111111111111", 2) must return 32767');
+assert.sameValue(parseInt("1111111111111111", 2), 65535, 'parseInt("1111111111111111", 2) must return 65535');
+assert.sameValue(parseInt("11111111111111111", 2), 131071, 'parseInt("11111111111111111", 2) must return 131071');
+assert.sameValue(parseInt("111111111111111111", 2), 262143, 'parseInt("111111111111111111", 2) must return 262143');
+assert.sameValue(parseInt("1111111111111111111", 2), 524287, 'parseInt("1111111111111111111", 2) must return 524287');
+assert.sameValue(parseInt("11111111111111111111", 2), 1048575, 'parseInt("11111111111111111111", 2) must return 1048575');

--- a/test/built-ins/parseInt/S15.1.2.2_A7.2_T3.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A7.2_T3.js
@@ -11,102 +11,68 @@ esid: sec-parseint-string-radix
 description: Checking algorithm for R = 16
 ---*/
 
-//CHECK#1
-if (parseInt("0x1", 16) !== 1) {
-  $ERROR('#1: parseInt("0x1", 16) === 1. Actual: ' + (parseInt("0x1", 16)));
-}
+assert.sameValue(parseInt("0x1", 16), 1, 'parseInt("0x1", 16) must return 1');
+assert.sameValue(parseInt("0X10", 16), 16, 'parseInt("0X10", 16) must return 16');
+assert.sameValue(parseInt("0x100", 16), 256, 'parseInt("0x100", 16) must return 256');
+assert.sameValue(parseInt("0X1000", 16), 4096, 'parseInt("0X1000", 16) must return 4096');
+assert.sameValue(parseInt("0x10000", 16), 65536, 'parseInt("0x10000", 16) must return 65536');
+assert.sameValue(parseInt("0X100000", 16), 1048576, 'parseInt("0X100000", 16) must return 1048576');
+assert.sameValue(parseInt("0x1000000", 16), 16777216, 'parseInt("0x1000000", 16) must return 16777216');
+assert.sameValue(parseInt("0x10000000", 16), 268435456, 'parseInt("0x10000000", 16) must return 268435456');
+assert.sameValue(parseInt("0x100000000", 16), 4294967296, 'parseInt("0x100000000", 16) must return 4294967296');
+assert.sameValue(parseInt("0x1000000000", 16), 68719476736, 'parseInt("0x1000000000", 16) must return 68719476736');
+assert.sameValue(parseInt("0x10000000000", 16), 1099511627776, 'parseInt("0x10000000000", 16) must return 1099511627776');
 
-//CHECK#2
-if (parseInt("0X10", 16) !== 16) {
-  $ERROR('#2: parseInt("0X10", 16) === 16. Actual: ' + (parseInt("0X10", 16)));
-}
+assert.sameValue(
+  parseInt("0x100000000000", 16),
+  17592186044416,
+  'parseInt("0x100000000000", 16) must return 17592186044416'
+);
 
-//CHECK#3
-if (parseInt("0x100", 16) !== 256) {
-  $ERROR('#3: parseInt("0x100", 16) === 256. Actual: ' + (parseInt("0x100", 16)));
-}
+assert.sameValue(
+  parseInt("0x1000000000000", 16),
+  281474976710656,
+  'parseInt("0x1000000000000", 16) must return 281474976710656'
+);
 
-//CHECK#4
-if (parseInt("0X1000", 16) !== 4096) {
-  $ERROR('#4: parseInt("0X1000", 16) === 4096. Actual: ' + (parseInt("0X1000", 16)));
-}
+assert.sameValue(
+  parseInt("0x10000000000000", 16),
+  4503599627370496,
+  'parseInt("0x10000000000000", 16) must return 4503599627370496'
+);
 
-//CHECK#5
-if (parseInt("0x10000", 16) !== 65536) {
-  $ERROR('#5: parseInt("0x10000", 16) === 65536. Actual: ' + (parseInt("0x10000", 16)));
-}
+assert.sameValue(
+  parseInt("0x100000000000000", 16),
+  72057594037927936,
+  'parseInt("0x100000000000000", 16) must return 72057594037927936'
+);
 
-//CHECK#6
-if (parseInt("0X100000", 16) !== 1048576) {
-  $ERROR('#6: parseInt("x100000", 16) === 1048576. Actual: ' + (parseInt("x100000", 16)));
-}
+assert.sameValue(
+  parseInt("0x1000000000000000", 16),
+  1152921504606846976,
+  'parseInt("0x1000000000000000", 16) must return 1152921504606846976'
+);
 
-//CHECK#7
-if (parseInt("0x1000000", 16) !== 16777216) {
-  $ERROR('#7: parseInt("0x1000000", 16) === 16777216. Actual: ' + (parseInt("0x1000000", 16)));
-}
+assert.sameValue(
+  parseInt("0x10000000000000000", 16),
+  18446744073709551616,
+  'parseInt("0x10000000000000000", 16) must return 18446744073709551616'
+);
 
-//CHECK#8
-if (parseInt("0x10000000", 16) !== 268435456) {
-  $ERROR('#8: parseInt("0x10000000", 16) === 268435456. Actual: ' + (parseInt("0x10000000", 16)));
-}
+assert.sameValue(
+  parseInt("0x100000000000000000", 16),
+  295147905179352825856,
+  'parseInt("0x100000000000000000", 16) must return 295147905179352825856'
+);
 
-//CHECK#9
-if (parseInt("0x100000000", 16) !== 4294967296) {
-  $ERROR('#9: parseInt("0x100000000", 16) === 4294967296. Actual: ' + (parseInt("0x100000000", 16)));
-}
+assert.sameValue(
+  parseInt("0x1000000000000000000", 16),
+  4722366482869645213696,
+  'parseInt("0x1000000000000000000", 16) must return 4722366482869645213696'
+);
 
-//CHECK#10
-if (parseInt("0x1000000000", 16) !== 68719476736) {
-  $ERROR('#10: parseInt("0x1000000000", 16) === 68719476736. Actual: ' + (parseInt("0x1000000000", 16)));
-}
-
-//CHECK#10
-if (parseInt("0x10000000000", 16) !== 1099511627776) {
-  $ERROR('#10: parseInt("0x10000000000", 16) === 1099511627776. Actual: ' + (parseInt("0x10000000000", 16)));
-}
-
-//CHECK#12
-if (parseInt("0x100000000000", 16) !== 17592186044416) {
-  $ERROR('#12: parseInt("0x100000000000", 16) === 17592186044416. Actual: ' + (parseInt("0x100000000000", 16)));
-}
-
-//CHECK#13
-if (parseInt("0x1000000000000", 16) !== 281474976710656) {
-  $ERROR('#13: parseInt("0x1000000000000", 16) === 281474976710656. Actual: ' + (parseInt("0x1000000000000", 16)));
-}
-
-//CHECK#14
-if (parseInt("0x10000000000000", 16) !== 4503599627370496) {
-  $ERROR('#14: parseInt("0x10000000000000", 16) === 4503599627370496. Actual: ' + (parseInt("0x10000000000000", 16)));
-}
-
-//CHECK#15
-if (parseInt("0x100000000000000", 16) !== 72057594037927936) {
-  $ERROR('#15: parseInt("0x100000000000000", 16) === 72057594037927936. Actual: ' + (parseInt("0x100000000000000", 16)));
-}
-
-//CHECK#16
-if (parseInt("0x1000000000000000", 16) !== 1152921504606846976) {
-  $ERROR('#16: parseInt("0x1000000000000000", 16) === 1152921504606846976. Actual: ' + (parseInt("0x1000000000000000", 16)));
-}
-
-//CHECK#17
-if (parseInt("0x10000000000000000", 16) !== 18446744073709551616) {
-  $ERROR('#17: parseInt("0x10000000000000000", 16) === 18446744073709551616. Actual: ' + (parseInt("0x10000000000000000", 16)));
-}
-
-//CHECK#18
-if (parseInt("0x100000000000000000", 16) !== 295147905179352825856) {
-  $ERROR('#18: parseInt("0x100000000000000000", 16) === 295147905179352825856. Actual: ' + (parseInt("0x100000000000000000", 16)));
-}
-
-//CHECK#19
-if (parseInt("0x1000000000000000000", 16) !== 4722366482869645213696) {
-  $ERROR('#19: parseInt("0x1000000000000000000", 16) === 4722366482869645213696. Actual: ' + (parseInt("0x1000000000000000000", 16)));
-}
-
-//CHECK#20
-if (parseInt("0x10000000000000000000", 16) !== 75557863725914323419136) {
-  $ERROR('#20: parseInt("0x10000000000000000000", 16) === 75557863725914323419136. Actual: ' + (parseInt("0x10000000000000000000", 16)));
-}
+assert.sameValue(
+  parseInt("0x10000000000000000000", 16),
+  75557863725914323419136,
+  'parseInt("0x10000000000000000000", 16) must return 75557863725914323419136'
+);

--- a/test/built-ins/parseInt/S15.1.2.2_A7.3_T1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A7.3_T1.js
@@ -30,8 +30,6 @@ for (var i = 2; i <= 36; i++) {
       num = num + (i + (k0 - k) - 1) * pow;
       pow = pow * i;
     }
-    if (parseInt(str, i) !== num * sign) {
-      $ERROR('#' + i + '.' + j + ' : ');
-    }
+    assert.sameValue(parseInt(str, i), num * sign, 'parseInt("str + R_digit2[k - 2], i) must return num * sign');
   }
 }

--- a/test/built-ins/parseInt/S15.1.2.2_A7.3_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A7.3_T2.js
@@ -7,102 +7,28 @@ esid: sec-parseint-string-radix
 description: Checking algorithm for R = 2
 ---*/
 
-//CHECK#1
-if (parseInt("-1", 2) !== -1) {
-  $ERROR('#1: parseInt("-1", 2) === -1. Actual: ' + (parseInt("-1", 2)));
-}
+assert.sameValue(parseInt("-1", 2), -1, 'parseInt("-1", 2) must return -1');
+assert.sameValue(parseInt("-11", 2), -3, 'parseInt("-11", 2) must return -3');
+assert.sameValue(parseInt("-111", 2), -7, 'parseInt("-111", 2) must return -7');
+assert.sameValue(parseInt("-1111", 2), -15, 'parseInt("-1111", 2) must return -15');
+assert.sameValue(parseInt("-11111", 2), -31, 'parseInt("-11111", 2) must return -31');
+assert.sameValue(parseInt("-111111", 2), -63, 'parseInt("-111111", 2) must return -63');
+assert.sameValue(parseInt("-1111111", 2), -127, 'parseInt("-1111111", 2) must return -127');
+assert.sameValue(parseInt("-11111111", 2), -255, 'parseInt("-11111111", 2) must return -255');
+assert.sameValue(parseInt("-111111111", 2), -511, 'parseInt("-111111111", 2) must return -511');
+assert.sameValue(parseInt("-1111111111", 2), -1023, 'parseInt("-1111111111", 2) must return -1023');
+assert.sameValue(parseInt("-11111111111", 2), -2047, 'parseInt("-11111111111", 2) must return -2047');
+assert.sameValue(parseInt("-111111111111", 2), -4095, 'parseInt("-111111111111", 2) must return -4095');
+assert.sameValue(parseInt("-1111111111111", 2), -8191, 'parseInt("-1111111111111", 2) must return -8191');
+assert.sameValue(parseInt("-11111111111111", 2), -16383, 'parseInt("-11111111111111", 2) must return -16383');
+assert.sameValue(parseInt("-111111111111111", 2), -32767, 'parseInt("-111111111111111", 2) must return -32767');
+assert.sameValue(parseInt("-1111111111111111", 2), -65535, 'parseInt("-1111111111111111", 2) must return -65535');
+assert.sameValue(parseInt("-11111111111111111", 2), -131071, 'parseInt("-11111111111111111", 2) must return -131071');
+assert.sameValue(parseInt("-111111111111111111", 2), -262143, 'parseInt("-111111111111111111", 2) must return -262143');
+assert.sameValue(parseInt("-1111111111111111111", 2), -524287, 'parseInt("-1111111111111111111", 2) must return -524287');
 
-//CHECK#2
-if (parseInt("-11", 2) !== -3) {
-  $ERROR('#2: parseInt("-11", 2) === -3. Actual: ' + (parseInt("-11", 2)));
-}
-
-//CHECK#3
-if (parseInt("-111", 2) !== -7) {
-  $ERROR('#3: parseInt("-111", 2) === -7. Actual: ' + (parseInt("-111", 2)));
-}
-
-//CHECK#4
-if (parseInt("-1111", 2) !== -15) {
-  $ERROR('#4: parseInt("-1111", 2) === -15. Actual: ' + (parseInt("-1111", 2)));
-}
-
-//CHECK#5
-if (parseInt("-11111", 2) !== -31) {
-  $ERROR('#5: parseInt("-11111", 2) === -31. Actual: ' + (parseInt("-11111", 2)));
-}
-
-//CHECK#6
-if (parseInt("-111111", 2) !== -63) {
-  $ERROR('#6: parseInt("-111111", 2) === -63. Actual: ' + (parseInt("-111111", 2)));
-}
-
-//CHECK#7
-if (parseInt("-1111111", 2) !== -127) {
-  $ERROR('#7: parseInt("-1111111", 2) === -127. Actual: ' + (parseInt("-1111111", 2)));
-}
-
-//CHECK#8
-if (parseInt("-11111111", 2) !== -255) {
-  $ERROR('#8: parseInt("-11111111", 2) === -255. Actual: ' + (parseInt("-11111111", 2)));
-}
-
-//CHECK#9
-if (parseInt("-111111111", 2) !== -511) {
-  $ERROR('#9: parseInt("-111111111", 2) === -511. Actual: ' + (parseInt("-111111111", 2)));
-}
-
-//CHECK#10
-if (parseInt("-1111111111", 2) !== -1023) {
-  $ERROR('#10: parseInt("-1111111111", 2) === -1023. Actual: ' + (parseInt("-1111111111", 2)));
-}
-
-//CHECK#11
-if (parseInt("-11111111111", 2) !== -2047) {
-  $ERROR('#11: parseInt("-11111111111", 2) === -2047. Actual: ' + (parseInt("-11111111111", 2)));
-}
-
-//CHECK#12
-if (parseInt("-111111111111", 2) !== -4095) {
-  $ERROR('#12: parseInt("-111111111111", 2) === -4095. Actual: ' + (parseInt("-111111111111", 2)));
-}
-
-//CHECK#13
-if (parseInt("-1111111111111", 2) !== -8191) {
-  $ERROR('#13: parseInt("-1111111111111", 2) === -8191. Actual: ' + (parseInt("-1111111111111", 2)));
-}
-
-//CHECK#14
-if (parseInt("-11111111111111", 2) !== -16383) {
-  $ERROR('#14: parseInt("-11111111111111", 2) === -16383. Actual: ' + (parseInt("-11111111111111", 2)));
-}
-
-//CHECK#15
-if (parseInt("-111111111111111", 2) !== -32767) {
-  $ERROR('#15: parseInt("-111111111111111", 2) === -32767. Actual: ' + (parseInt("-111111111111111", 2)));
-}
-
-//CHECK#16
-if (parseInt("-1111111111111111", 2) !== -65535) {
-  $ERROR('#16: parseInt("-1111111111111111", 2) === -65535. Actual: ' + (parseInt("-1111111111111111", 2)));
-}
-
-//CHECK#17
-if (parseInt("-11111111111111111", 2) !== -131071) {
-  $ERROR('#17: parseInt("-11111111111111111", 2) === -131071. Actual: ' + (parseInt("-11111111111111111", 2)));
-}
-
-//CHECK#18
-if (parseInt("-111111111111111111", 2) !== -262143) {
-  $ERROR('#18: parseInt("-111111111111111111", 2) === -262143. Actual: ' + (parseInt("-111111111111111111", 2)));
-}
-
-//CHECK#19
-if (parseInt("-1111111111111111111", 2) !== -524287) {
-  $ERROR('#19: parseInt("-1111111111111111111", 2) === -524287. Actual: ' + (parseInt("-1111111111111111111", 2)));
-}
-
-//CHECK#20
-if (parseInt("-11111111111111111111", 2) !== -1048575) {
-  $ERROR('#20: parseInt("-11111111111111111111", 2) === -1048575. Actual: ' + (parseInt("-11111111111111111111", 2)));
-}
+assert.sameValue(
+  parseInt("-11111111111111111111", 2),
+  -1048575,
+  'parseInt("-11111111111111111111", 2) must return -1048575'
+);

--- a/test/built-ins/parseInt/S15.1.2.2_A7.3_T3.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A7.3_T3.js
@@ -7,102 +7,63 @@ esid: sec-parseint-string-radix
 description: Checking algorithm for R = 10
 ---*/
 
-//CHECK#1
-if (parseInt("-1", 10) !== -1) {
-  $ERROR('#1: parseInt("-1", 10) === -1. Actual: ' + (parseInt("-1", 10)));
-}
+assert.sameValue(parseInt("-1", 10), -1, 'parseInt("-1", 10) must return -1');
+assert.sameValue(parseInt("-10", 10), -10, 'parseInt("-10", 10) must return -10');
+assert.sameValue(parseInt("-100", 10), -100, 'parseInt("-100", 10) must return -100');
+assert.sameValue(parseInt("-1000", 10), -1000, 'parseInt("-1000", 10) must return -1000');
+assert.sameValue(parseInt("-10000", 10), -10000, 'parseInt("-10000", 10) must return -10000');
+assert.sameValue(parseInt("-100000", 10), -100000, 'parseInt("-100000", 10) must return -100000');
+assert.sameValue(parseInt("-1000000", 10), -1000000, 'parseInt("-1000000", 10) must return -1000000');
+assert.sameValue(parseInt("-10000000", 10), -10000000, 'parseInt("-10000000", 10) must return -10000000');
+assert.sameValue(parseInt("-100000000", 10), -100000000, 'parseInt("-100000000", 10) must return -100000000');
+assert.sameValue(parseInt("-1000000000", 10), -1000000000, 'parseInt("-1000000000", 10) must return -1000000000');
+assert.sameValue(parseInt("-10000000000", 10), -10000000000, 'parseInt("-10000000000", 10) must return -10000000000');
+assert.sameValue(parseInt("-100000000000", 10), -100000000000, 'parseInt("-100000000000", 10) must return -100000000000');
 
-//CHECK#2
-if (parseInt("-10", 10) !== -10) {
-  $ERROR('#2: parseInt("-10", 10) === -10. Actual: ' + (parseInt("-10", 10)));
-}
+assert.sameValue(
+  parseInt("-1000000000000", 10),
+  -1000000000000,
+  'parseInt("-1000000000000", 10) must return -1000000000000'
+);
 
-//CHECK#3
-if (parseInt("-100", 10) !== -100) {
-  $ERROR('#3: parseInt("-100", 10) === -100. Actual: ' + (parseInt("-100", 10)));
-}
+assert.sameValue(
+  parseInt("-10000000000000", 10),
+  -10000000000000,
+  'parseInt("-10000000000000", 10) must return -10000000000000'
+);
 
-//CHECK#4
-if (parseInt("-1000", 10) !== -1000) {
-  $ERROR('#4: parseInt("-1000", 10) === -1000. Actual: ' + (parseInt("-1000", 10)));
-}
+assert.sameValue(
+  parseInt("-100000000000000", 10),
+  -100000000000000,
+  'parseInt("-100000000000000", 10) must return -100000000000000'
+);
 
-//CHECK#5
-if (parseInt("-10000", 10) !== -10000) {
-  $ERROR('#5: parseInt("-10000", 10) === -10000. Actual: ' + (parseInt("-10000", 10)));
-}
+assert.sameValue(
+  parseInt("-1000000000000000", 10),
+  -1000000000000000,
+  'parseInt("-1000000000000000", 10) must return -1000000000000000'
+);
 
-//CHECK#6
-if (parseInt("-100000", 10) !== -100000) {
-  $ERROR('#6: parseInt("-100000", 10) === -100000. Actual: ' + (parseInt("-100000", 10)));
-}
+assert.sameValue(
+  parseInt("-10000000000000000", 10),
+  -10000000000000000,
+  'parseInt("-10000000000000000", 10) must return -10000000000000000'
+);
 
-//CHECK#7
-if (parseInt("-1000000", 10) !== -1000000) {
-  $ERROR('#7: parseInt("-1000000", 10) === -1000000. Actual: ' + (parseInt("-1000000", 10)));
-}
+assert.sameValue(
+  parseInt("-100000000000000000", 10),
+  -100000000000000000,
+  'parseInt("-100000000000000000", 10) must return -100000000000000000'
+);
 
-//CHECK#8
-if (parseInt("-10000000", 10) !== -10000000) {
-  $ERROR('#8: parseInt("-10000000", 10) === -10000000. Actual: ' + (parseInt("-10000000", 10)));
-}
+assert.sameValue(
+  parseInt("-1000000000000000000", 10),
+  -1000000000000000000,
+  'parseInt("-1000000000000000000", 10) must return -1000000000000000000'
+);
 
-//CHECK#9
-if (parseInt("-100000000", 10) !== -100000000) {
-  $ERROR('#9: parseInt("-100000000", 10) === -100000000. Actual: ' + (parseInt("-100000000", 10)));
-}
-
-//CHECK#10
-if (parseInt("-1000000000", 10) !== -1000000000) {
-  $ERROR('#10: parseInt("-1000000000", 10) === -1000000000. Actual: ' + (parseInt("-1000000000", 10)));
-}
-
-//CHECK#10
-if (parseInt("-10000000000", 10) !== -10000000000) {
-  $ERROR('#10: parseInt("-10000000000", 10) === -10000000000. Actual: ' + (parseInt("-10000000000", 10)));
-}
-
-//CHECK#12
-if (parseInt("-100000000000", 10) !== -100000000000) {
-  $ERROR('#12: parseInt("-100000000000", 10) === -100000000000. Actual: ' + (parseInt("-100000000000", 10)));
-}
-
-//CHECK#13
-if (parseInt("-1000000000000", 10) !== -1000000000000) {
-  $ERROR('#13: parseInt("-1000000000000", 10) === -1000000000000. Actual: ' + (parseInt("-1000000000000", 10)));
-}
-
-//CHECK#14
-if (parseInt("-10000000000000", 10) !== -10000000000000) {
-  $ERROR('#14: parseInt("-10000000000000", 10) === -10000000000000. Actual: ' + (parseInt("-10000000000000", 10)));
-}
-
-//CHECK#15
-if (parseInt("-100000000000000", 10) !== -100000000000000) {
-  $ERROR('#15: parseInt("-100000000000000", 10) === -100000000000000. Actual: ' + (parseInt("-100000000000000", 10)));
-}
-
-//CHECK#10
-if (parseInt("-1000000000000000", 10) !== -1000000000000000) {
-  $ERROR('#10: parseInt("-1000000000000000", 10) === -1000000000000000. Actual: ' + (parseInt("-1000000000000000", 10)));
-}
-
-//CHECK#17
-if (parseInt("-10000000000000000", 10) !== -10000000000000000) {
-  $ERROR('#17: parseInt("-10000000000000000", 10) === -10000000000000000. Actual: ' + (parseInt("-10000000000000000", 10)));
-}
-
-//CHECK#18
-if (parseInt("-100000000000000000", 10) !== -100000000000000000) {
-  $ERROR('#18: parseInt("-100000000000000000", 10) === -100000000000000000. Actual: ' + (parseInt("-100000000000000000", 10)));
-}
-
-//CHECK#19
-if (parseInt("-1000000000000000000", 10) !== -1000000000000000000) {
-  $ERROR('#19: parseInt("-1000000000000000000", 10) === -1000000000000000000. Actual: ' + (parseInt("-1000000000000000000", 10)));
-}
-
-//CHECK#20
-if (parseInt("-10000000000000000000", 10) !== -10000000000000000000) {
-  $ERROR('#20: parseInt("-10000000000000000000", 10) === -10000000000000000000. Actual: ' + (parseInt("-10000000000000000000", 10)));
-}
+assert.sameValue(
+  parseInt("-10000000000000000000", 10),
+  -10000000000000000000,
+  'parseInt("-10000000000000000000", 10) must return -10000000000000000000'
+);

--- a/test/built-ins/parseInt/S15.1.2.2_A9.1.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A9.1.js
@@ -7,10 +7,11 @@ esid: sec-parseint-string-radix
 description: Checking use propertyIsEnumerable, for-in
 ---*/
 
-//CHECK#1
-if (parseInt.propertyIsEnumerable('length') !== false) {
-  $ERROR('#1: parseInt.propertyIsEnumerable(\'length\') === false. Actual: ' + (parseInt.propertyIsEnumerable('length')));
-}
+assert.sameValue(
+  parseInt.propertyIsEnumerable('length'),
+  false,
+  'parseInt.propertyIsEnumerable(\'length\') must return false'
+);
 
 //CHECK#2
 var result = true;
@@ -20,6 +21,4 @@ for (var p in parseInt) {
   }
 }
 
-if (result !== true) {
-  $ERROR('#2: result = true; for (p in parseInt) { if (p === "length") result = false; }  result === true;');
-}
+assert.sameValue(result, true, 'The value of `result` is true');

--- a/test/built-ins/parseInt/S15.1.2.2_A9.2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A9.2.js
@@ -7,19 +7,9 @@ esid: sec-parseint-string-radix
 description: Checking use hasOwnProperty, delete
 ---*/
 
-//CHECK#1
-if (parseInt.hasOwnProperty('length') !== true) {
-  $ERROR('#1: parseInt.hasOwnProperty(\'length\') === true. Actual: ' + (parseInt.hasOwnProperty('length')));
-}
+assert.sameValue(parseInt.hasOwnProperty('length'), true, 'parseInt.hasOwnProperty(\'length\') must return true');
 
 delete parseInt.length;
 
-//CHECK#2
-if (parseInt.hasOwnProperty('length') !== false) {
-  $ERROR('#2: delete parseInt.length; parseInt.hasOwnProperty(\'length\') === false. Actual: ' + (parseInt.hasOwnProperty('length')));
-}
-
-//CHECK#3
-if (parseInt.length === undefined) {
-  $ERROR('#3: delete parseInt.length; parseInt.length !== undefined');
-}
+assert.sameValue(parseInt.hasOwnProperty('length'), false, 'parseInt.hasOwnProperty(\'length\') must return false');
+assert.notSameValue(parseInt.length, undefined, 'The value of parseInt.length is expected to not equal ``undefined``');

--- a/test/built-ins/parseInt/S15.1.2.2_A9.3.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A9.3.js
@@ -8,9 +8,5 @@ description: Checking if varying the length property fails
 includes: [propertyHelper.js]
 ---*/
 
-//CHECK#1
-var x = parseInt.length;
+assert.sameValue(parseInt.length, 2, 'The value of parseInt.length is 2');
 verifyNotWritable(parseInt, "length", null, Infinity);
-if (parseInt.length !== x) {
-  $ERROR('#1: x = parseInt.length; parseInt.length = Infinity; parseInt.length === x. Actual: ' + (parseInt.length));
-}

--- a/test/built-ins/parseInt/S15.1.2.2_A9.4.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A9.4.js
@@ -7,7 +7,4 @@ esid: sec-parseint-string-radix
 description: parseInt.length === 2
 ---*/
 
-//CHECK#1
-if (parseInt.length !== 2) {
-  $ERROR('#1: parseInt.length === 2. Actual: ' + (parseInt.length));
-}
+assert.sameValue(parseInt.length, 2, 'The value of parseInt.length is 2');

--- a/test/built-ins/parseInt/S15.1.2.2_A9.5.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A9.5.js
@@ -7,10 +7,11 @@ esid: sec-parseint-string-radix
 description: Checking use propertyIsEnumerable, for-in
 ---*/
 
-//CHECK#1
-if (this.propertyIsEnumerable('parseInt') !== false) {
-  $ERROR('#1: this.propertyIsEnumerable(\'parseInt\') === false. Actual: ' + (this.propertyIsEnumerable('parseInt')));
-}
+assert.sameValue(
+  this.propertyIsEnumerable('parseInt'),
+  false,
+  'this.propertyIsEnumerable(\'parseInt\') must return false'
+);
 
 //CHECK#2
 var result = true;
@@ -20,6 +21,4 @@ for (var p in this) {
   }
 }
 
-if (result !== true) {
-  $ERROR('#2: result = true; for (p in this) { if (p === "parseInt") result = false; }  result === true;');
-}
+assert.sameValue(result, true, 'The value of `result` is true');

--- a/test/built-ins/parseInt/S15.1.2.2_A9.6.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A9.6.js
@@ -7,7 +7,4 @@ esid: sec-parseint-string-radix
 description: Checking parseInt.prototype
 ---*/
 
-//CHECK#1
-if (parseInt.prototype !== undefined) {
-  $ERROR('#1: parseInt.prototype === undefined. Actual: ' + (parseInt.prototype));
-}
+assert.sameValue(Object.prototype.hasOwnProperty.call(parseInt, "prototype"), false, 'Object.prototype.hasOwnProperty.call(parseInt, "prototype") must return false');

--- a/test/built-ins/parseInt/name.js
+++ b/test/built-ins/parseInt/name.js
@@ -19,7 +19,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(parseInt.name, "parseInt");
+assert.sameValue(parseInt.name, "parseInt", 'The value of parseInt.name is "parseInt"');
 
 verifyNotEnumerable(parseInt, "name");
 verifyNotWritable(parseInt, "name");

--- a/test/built-ins/parseInt/not-a-constructor.js
+++ b/test/built-ins/parseInt/not-a-constructor.js
@@ -9,13 +9,6 @@ description: >
     throw a TypeError exception
 ---*/
 
-//CHECK#1
-
-try {
+assert.throws(TypeError, () => {
   new parseInt();
-  $ERROR('#1.1: new parseInt() throw TypeError. Actual: ' + (new parseInt()));
-} catch (e) {
-  if ((e instanceof TypeError) !== true) {
-    $ERROR('#1.2: new parseInt() throw TypeError. Actual: ' + (e));
-  }
-}
+}, '`new parseInt()` throws TypeError');


### PR DESCRIPTION
@leobalter another run with my experimental migration tool. This required very little manual intervention. 