### PR TITLE
Perl YAML parser cannot parse documents in options-granularity-abrupt-throws.js and options-granularity-toString-abrupt-throws.js

### DIFF
--- a/test/intl402/Segmenter/constructor/constructor/options-granularity-abrupt-throws.js
+++ b/test/intl402/Segmenter/constructor/constructor/options-granularity-abrupt-throws.js
@@ -3,8 +3,7 @@
 
 /*---
 esid: sec-intl.segmenter
-description:
-    Return abrupt completion from GetOption granularity
+description: Return abrupt completion from GetOption granularity
 info: |
     Intl.Segmenter ([ locales [ , options ]])
 

--- a/test/intl402/Segmenter/constructor/constructor/options-granularity-toString-abrupt-throws.js
+++ b/test/intl402/Segmenter/constructor/constructor/options-granularity-toString-abrupt-throws.js
@@ -3,8 +3,7 @@
 
 /*---
 esid: sec-intl.segmenter
-description:
-    Return abrupt completion from GetOption granularity
+description: Return abrupt completion from GetOption granularity
 
 info: |
     Intl.Segmenter ([ locales [ , options ]])


### PR DESCRIPTION
Remove line terminator.