### PR TITLE
Coverage: String.prototype.replace method calls toString on replaceValue (regexp object). Fixes gh-2797

### DIFF
--- a/test/built-ins/String/prototype/replace/replaceValue-evaluation-order-regexp-object.js
+++ b/test/built-ins/String/prototype/replace/replaceValue-evaluation-order-regexp-object.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-string.prototype.replace
+description: >
+  Non-callable replaceValue is evaluated via toString
+info: |
+  String.prototype.replace ( searchValue, replaceValue )
+
+  If functionalReplace is false, then
+    Set replaceValue to ? ToString(replaceValue).
+---*/
+
+let calls = 0;
+let replaceValue = /$/;
+let oldToString = replaceValue.toString.bind(replaceValue);
+
+replaceValue.toString = () => {
+  calls += 1;
+  return oldToString();
+};
+
+let newString = "".replace("a", replaceValue);
+assert.sameValue(newString, "");
+assert.sameValue(calls, 1);
+assert.sameValue("dollar".replace("dollar", /$/), "/$/");


### PR DESCRIPTION
New test that ensures a regexp object that appears as the replaceValue of String.prototype.replace has its toString method called. 