### PR TITLE
Revert "Intl.NumberFormat + currency will throw an error if maximumFractionDigits is less than currencyDigits"

### DIFF
--- a/test/intl402/NumberFormat/dft-currency-mnfd-range-check-mxfd.js
+++ b/test/intl402/NumberFormat/dft-currency-mnfd-range-check-mxfd.js
@@ -1,79 +1,21 @@
 // Copyright 2017 the V8 project authors. All rights reserved.
-// Copyright 2020 Apple Inc. All rights reserved.
 // This code is governed by the license found in the LICENSE file.
 
 /*---
 esid: sec-setnfdigitoptions
 description: >
     When a currency is used in Intl.NumberFormat and minimumFractionDigits is
-    not provided, maximumFractionDigits should be set as provided if it is larger
-    than currencyDigits.
+    not provided, maximumFractionDigits should be set as provided.
 ---*/
 
-assert.throws(RangeError, () => {
-    new Intl.NumberFormat('en', {
-        style: 'currency',
-        currency: 'USD',
-        maximumFractionDigits: 1
-    });
-});
-
 assert.sameValue((new Intl.NumberFormat('en', {
     style: 'currency',
     currency: 'USD',
-    maximumFractionDigits: 2
-})).resolvedOptions().maximumFractionDigits, 2);
+    maximumFractionDigits: 1
+})).resolvedOptions().maximumFractionDigits, 1);
 
 assert.sameValue((new Intl.NumberFormat('en', {
     style: 'currency',
-    currency: 'USD',
+    currency: 'CLF',
     maximumFractionDigits: 3
-})).resolvedOptions().maximumFractionDigits, 3);
-
-assert.sameValue((new Intl.NumberFormat('en', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: 20
-})).resolvedOptions().maximumFractionDigits, 20);
-
-assert.throws(RangeError, () => {
-    new Intl.NumberFormat('en', {
-        style: 'currency',
-        currency: 'USD',
-        maximumFractionDigits: 21
-    })
-});
-
-assert.throws(RangeError, () => {
-    new Intl.NumberFormat('en', {
-        style: 'currency',
-        currency: 'CLF',
-        maximumFractionDigits: 3
-    })
-});
-
-assert.sameValue((new Intl.NumberFormat('en', {
-    style: 'currency',
-    currency: 'CLF',
-    maximumFractionDigits: 4
-})).resolvedOptions().maximumFractionDigits, 4);
-
-assert.sameValue((new Intl.NumberFormat('en', {
-    style: 'currency',
-    currency: 'CLF',
-    maximumFractionDigits: 5
-})).resolvedOptions().maximumFractionDigits, 5);
-
-assert.sameValue((new Intl.NumberFormat('en', {
-    style: 'currency',
-    currency: 'CLF',
-    maximumFractionDigits: 20
-})).resolvedOptions().maximumFractionDigits, 20);
-
-assert.throws(RangeError, () => {
-    new Intl.NumberFormat('en', {
-        style: 'currency',
-        currency: 'CLF',
-        maximumFractionDigits: 21
-    })
-});
+})).resolvedOptions().maximumSignificantDigits, 3);


### PR DESCRIPTION
This reverts commit a7b9067fe129b8ded01a4b86f8295ed40fe2d9e5.
I fixed the test with a7b9067fe129b8ded01a4b86f8295ed40fe2d9e5 based on the current spec, but this test was based on WIP spec change.