### PR TITLE
dft-currency-mnfd-range-check-mxfd.js should check maximumFractionDigits, not maximumSignificantDigits

### DIFF
--- a/test/intl402/NumberFormat/dft-currency-mnfd-range-check-mxfd.js
+++ b/test/intl402/NumberFormat/dft-currency-mnfd-range-check-mxfd.js
@@ -1,4 +1,5 @@
 // Copyright 2017 the V8 project authors. All rights reserved.
+// Copyright 2020 Apple Inc. All rights reserved.
 // This code is governed by the license found in the LICENSE file.
 
 /*---
@@ -18,4 +19,4 @@ assert.sameValue((new Intl.NumberFormat('en', {
     style: 'currency',
     currency: 'CLF',
     maximumFractionDigits: 3
-})).resolvedOptions().maximumSignificantDigits, 3);
+})).resolvedOptions().maximumFractionDigits, 3);


### PR DESCRIPTION
This test is checking maximumSignificantDigits, but this is wrong. We should check maximumFractionDigits.