### PR TITLE
Add tests for [[Description]] of Intl [[FallbackSymbol]]

### DIFF
--- a/test/intl402/DateTimeFormat/intl-legacy-constructed-symbol-on-unwrap.js
+++ b/test/intl402/DateTimeFormat/intl-legacy-constructed-symbol-on-unwrap.js
@@ -1,0 +1,31 @@
+// Copyright 2020 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-unwrapdatetimeformat
+description: >
+    Tests that [[FallbackSymbol]]'s [[Description]] is "IntlLegacyConstructedSymbol" if normative optional is implemented.
+author: Yusuke Suzuki
+---*/
+
+let object = new Intl.DateTimeFormat();
+let newObject = Intl.DateTimeFormat.call(object);
+let symbol = null;
+let error = null;
+try {
+    let proxy = new Proxy(newObject, {
+        get(target, property) {
+            symbol = property;
+            return target[property];
+        }
+    });
+    Intl.DateTimeFormat.prototype.resolvedOptions.call(proxy);
+} catch (e) {
+    // If normative optional is not implemented, an error will be thrown.
+    error = e;
+    assert(error instanceof TypeError);
+}
+if (error === null) {
+      assert.sameValue(typeof symbol, "symbol");
+      assert.sameValue(symbol.description, "IntlLegacyConstructedSymbol");
+}

--- a/test/intl402/DateTimeFormat/intl-legacy-constructed-symbol.js
+++ b/test/intl402/DateTimeFormat/intl-legacy-constructed-symbol.js
@@ -1,0 +1,17 @@
+// Copyright 2020 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.datetimeformat
+description: >
+    Tests that [[FallbackSymbol]]'s [[Description]] is "IntlLegacyConstructedSymbol" if normative optional is implemented.
+author: Yusuke Suzuki
+---*/
+
+let object = new Intl.DateTimeFormat();
+let newObject = Intl.DateTimeFormat.call(object);
+let symbols = Object.getOwnPropertySymbols(newObject);
+if (symbols.length !== 0) {
+    assert.sameValue(symbols.length, 1);
+    assert.sameValue(symbols[0].description, "IntlLegacyConstructedSymbol");
+}

--- a/test/intl402/NumberFormat/intl-legacy-constructed-symbol-on-unwrap.js
+++ b/test/intl402/NumberFormat/intl-legacy-constructed-symbol-on-unwrap.js
@@ -1,0 +1,31 @@
+// Copyright 2020 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-unwrapnumberformat
+description: >
+    Tests that [[FallbackSymbol]]'s [[Description]] is "IntlLegacyConstructedSymbol" if normative optional is implemented.
+author: Yusuke Suzuki
+---*/
+
+let object = new Intl.NumberFormat();
+let newObject = Intl.NumberFormat.call(object);
+let symbol = null;
+let error = null;
+try {
+    let proxy = new Proxy(newObject, {
+        get(target, property) {
+            symbol = property;
+            return target[property];
+        }
+    });
+    Intl.NumberFormat.prototype.resolvedOptions.call(proxy);
+} catch (e) {
+    // If normative optional is not implemented, an error will be thrown.
+    error = e;
+    assert(error instanceof TypeError);
+}
+if (error === null) {
+      assert.sameValue(typeof symbol, "symbol");
+      assert.sameValue(symbol.description, "IntlLegacyConstructedSymbol");
+}

--- a/test/intl402/NumberFormat/intl-legacy-constructed-symbol.js
+++ b/test/intl402/NumberFormat/intl-legacy-constructed-symbol.js
@@ -1,0 +1,17 @@
+// Copyright 2020 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat
+description: >
+    Tests that [[FallbackSymbol]]'s [[Description]] is "IntlLegacyConstructedSymbol" if normative optional is implemented.
+author: Yusuke Suzuki
+---*/
+
+let object = new Intl.NumberFormat();
+let newObject = Intl.NumberFormat.call(object);
+let symbols = Object.getOwnPropertySymbols(newObject);
+if (symbols.length !== 0) {
+    assert.sameValue(symbols.length, 1);
+    assert.sameValue(symbols[0].description, "IntlLegacyConstructedSymbol");
+}


### PR DESCRIPTION
If normative optional is implemented and [[FallbackSymbol]] is used, its description should be "IntlLegacyConstructedSymbol"

https://tc39.es/ecma402/#intl-object
> The Intl object has an internal slot, [[FallbackSymbol]], which is a new %Symbol% in the current realm with the [[Description]] "IntlLegacyConstructedSymbol".

Tests for https://trac.webkit.org/changeset/266655/webkit change.