### PR TITLE
Fix typos for at/prop-desc tests.

### DIFF
--- a/test/built-ins/String/prototype/at/prop-desc.js
+++ b/test/built-ins/String/prototype/at/prop-desc.js
@@ -19,7 +19,7 @@ assert.sameValue(
   'The value of `typeof String.prototype.at` is "function"'
 );
 
-verifyProperty(String.prototype.at, 'name', {
+verifyProperty(String.prototype, 'at', {
   enumerable: false,
   writable: true,
   configurable: true

--- a/test/built-ins/TypedArray/prototype/at/prop-desc.js
+++ b/test/built-ins/TypedArray/prototype/at/prop-desc.js
@@ -17,7 +17,7 @@ assert.sameValue(
   'The value of `typeof TypedArray.prototype.at` is "function"'
 );
 
-verifyProperty(TypedArray.prototype.at, 'name', {
+verifyProperty(TypedArray.prototype, 'at', {
   enumerable: false,
   writable: true,
   configurable: true


### PR DESCRIPTION
Fix for copy-paste errors in the verifyProperty change of #2907.

@leobalter @rwaldron 