### PR TITLE
Remove test code between license and front matter

### DIFF
--- a/test/built-ins/parseInt/S15.1.2.2_A2_T2.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A2_T2.js
@@ -1,15 +1,16 @@
 // Copyright 2009 the Sputnik authors.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
-assert.sameValue(parseInt("\u00201"), parseInt("1"), 'parseInt("\\u00201") must return the same value returned by parseInt("1")');
-assert.sameValue(parseInt("\u0020\u0020-1"), parseInt("-1"), 'parseInt("\\u0020\\u0020-1") must return the same value returned by parseInt("-1")');
-assert.sameValue(parseInt(" 1"), parseInt("1"), 'parseInt(" 1") must return the same value returned by parseInt("1")');
-assert.sameValue(parseInt("       1"), parseInt("1"), 'parseInt(" 1") must return the same value returned by parseInt("1")');
 
 /*---
 info: Operator remove leading StrWhiteSpaceChar
 esid: sec-parseint-string-radix
 description: "StrWhiteSpaceChar :: SP (U+0020)"
 ---*/
+
+assert.sameValue(parseInt("\u00201"), parseInt("1"), 'parseInt("\\u00201") must return the same value returned by parseInt("1")');
+assert.sameValue(parseInt("\u0020\u0020-1"), parseInt("-1"), 'parseInt("\\u0020\\u0020-1") must return the same value returned by parseInt("-1")');
+assert.sameValue(parseInt(" 1"), parseInt("1"), 'parseInt(" 1") must return the same value returned by parseInt("1")');
+assert.sameValue(parseInt("       1"), parseInt("1"), 'parseInt(" 1") must return the same value returned by parseInt("1")');
 
 assert.sameValue(
   parseInt("       \u0020       \u0020-1"),


### PR DESCRIPTION
The script that we use for updating SpiderMonkey's copy of test262 doesn't like this.
@rwaldron r?