### PR TITLE
Fix formatRangeToParts/date-same-returns-single-date.js and add tests using practically-equal two dates

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/formatRange/date-same-returns-single-date.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRange/date-same-returns-single-date.js
@@ -1,4 +1,5 @@
 // Copyright 2021 Google Inc. All rights reserved.
+// Copyright 2021 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -27,16 +28,34 @@ features: [Intl.DateTimeFormat-formatRange]
 locale: [en-US]
 ---*/
 
-const date = new Date(2019, 7, 10,  1, 2, 3, 234);
+{
+  const date = new Date(2019, 7, 10,  1, 2, 3, 234);
 
-let dtf = new Intl.DateTimeFormat("en", { year: "numeric", month: "short", day: "numeric" });
-assert.sameValue(dtf.formatRange(date, date), dtf.format(date), "same output with date options");
+  let dtf = new Intl.DateTimeFormat("en", { year: "numeric", month: "short", day: "numeric" });
+  assert.sameValue(dtf.formatRange(date, date), dtf.format(date), "same output with date options");
 
-dtf = new Intl.DateTimeFormat("en", { minute: "numeric", second: "numeric" });
-assert.sameValue(dtf.formatRange(date, date), dtf.format(date), "same output with time options");
+  dtf = new Intl.DateTimeFormat("en", { minute: "numeric", second: "numeric" });
+  assert.sameValue(dtf.formatRange(date, date), dtf.format(date), "same output with time options");
 
-dtf = new Intl.DateTimeFormat("en", { month: "short", day: "numeric", minute: "numeric" });
-assert.sameValue(dtf.formatRange(date, date), dtf.format(date), "same output with date-time options");
+  dtf = new Intl.DateTimeFormat("en", { month: "short", day: "numeric", minute: "numeric" });
+  assert.sameValue(dtf.formatRange(date, date), dtf.format(date), "same output with date-time options");
 
-dtf = new Intl.DateTimeFormat("en", { dateStyle: "long", timeStyle: "short" });
-assert.sameValue(dtf.formatRange(date, date), dtf.format(date), "same output with dateStyle/timeStyle");
+  dtf = new Intl.DateTimeFormat("en", { dateStyle: "long", timeStyle: "short" });
+  assert.sameValue(dtf.formatRange(date, date), dtf.format(date), "same output with dateStyle/timeStyle");
+}
+{
+  const date1 = new Date(2019, 7, 10,  1, 2, 3, 234);
+  const date2 = new Date(2019, 7, 10,  1, 2, 3, 235);
+
+  let dtf = new Intl.DateTimeFormat("en", { year: "numeric", month: "short", day: "numeric" });
+  assert.sameValue(dtf.formatRange(date1, date2), dtf.format(date1), "same output with date options");
+
+  dtf = new Intl.DateTimeFormat("en", { minute: "numeric", second: "numeric" });
+  assert.sameValue(dtf.formatRange(date1, date2), dtf.format(date1), "same output with time options");
+
+  dtf = new Intl.DateTimeFormat("en", { month: "short", day: "numeric", minute: "numeric" });
+  assert.sameValue(dtf.formatRange(date1, date2), dtf.format(date1), "same output with date-time options");
+
+  dtf = new Intl.DateTimeFormat("en", { dateStyle: "long", timeStyle: "short" });
+  assert.sameValue(dtf.formatRange(date1, date2), dtf.format(date1), "same output with dateStyle/timeStyle");
+}

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/date-same-returns-single-date.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/date-same-returns-single-date.js
@@ -1,4 +1,5 @@
 // Copyright 2021 Google Inc. All rights reserved.
+// Copyright 2021 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -42,16 +43,34 @@ function compare(actual, expected) {
   }
 }
 
-const date = new Date(2019, 7, 10,  1, 2, 3, 234);
+{
+  const date = new Date(2019, 7, 10,  1, 2, 3, 234);
 
-let dtf = new Intl.DateTimeFormat("en", { year: "numeric", month: "short", day: "numeric" });
-compare(dtf.formatRange(date, date), dtf.format(date), "same output with date options");
+  let dtf = new Intl.DateTimeFormat("en", { year: "numeric", month: "short", day: "numeric" });
+  compare(dtf.formatRangeToParts(date, date), dtf.formatToParts(date), "same output with date options");
 
-dtf = new Intl.DateTimeFormat("en", { minute: "numeric", second: "numeric" });
-compare(dtf.formatRange(date, date), dtf.format(date), "same output with time options");
+  dtf = new Intl.DateTimeFormat("en", { minute: "numeric", second: "numeric" });
+  compare(dtf.formatRangeToParts(date, date), dtf.formatToParts(date), "same output with time options");
 
-dtf = new Intl.DateTimeFormat("en", { month: "short", day: "numeric", minute: "numeric" });
-compare(dtf.formatRange(date, date), dtf.format(date), "same output with date-time options");
+  dtf = new Intl.DateTimeFormat("en", { month: "short", day: "numeric", minute: "numeric" });
+  compare(dtf.formatRangeToParts(date, date), dtf.formatToParts(date), "same output with date-time options");
 
-dtf = new Intl.DateTimeFormat("en", { dateStyle: "long", timeStyle: "short" });
-compare(dtf.formatRange(date, date), dtf.format(date), "same output with dateStyle/timeStyle");
+  dtf = new Intl.DateTimeFormat("en", { dateStyle: "long", timeStyle: "short" });
+  compare(dtf.formatRangeToParts(date, date), dtf.formatToParts(date), "same output with dateStyle/timeStyle");
+}
+{
+  const date1 = new Date(2019, 7, 10,  1, 2, 3, 234);
+  const date2 = new Date(2019, 7, 10,  1, 2, 3, 235);
+
+  let dtf = new Intl.DateTimeFormat("en", { year: "numeric", month: "short", day: "numeric" });
+  compare(dtf.formatRangeToParts(date1, date2), dtf.formatToParts(date1), "same output with date options");
+
+  dtf = new Intl.DateTimeFormat("en", { minute: "numeric", second: "numeric" });
+  compare(dtf.formatRangeToParts(date1, date2), dtf.formatToParts(date1), "same output with time options");
+
+  dtf = new Intl.DateTimeFormat("en", { month: "short", day: "numeric", minute: "numeric" });
+  compare(dtf.formatRangeToParts(date1, date2), dtf.formatToParts(date1), "same output with date-time options");
+
+  dtf = new Intl.DateTimeFormat("en", { dateStyle: "long", timeStyle: "short" });
+  compare(dtf.formatRangeToParts(date1, date2), dtf.formatToParts(date1), "same output with dateStyle/timeStyle");
+}


### PR DESCRIPTION
intl402/DateTimeFormat/prototype/formatRangeToParts/date-same-returns-single-date.js is using `formatRange` and `format`.
Fix this test to use `formatRangeToParts` and `formatToParts` since it is the intention of this test.

This patch adds additional tests to intl402/DateTimeFormat/prototype/formatRangeToParts/date-same-returns-single-date.js and
intl402/DateTimeFormat/prototype/formatRange/date-same-returns-single-date.js. The new test uses two dates that are practially-equal,
and ensures the implementation uses `format` or `formatToParts` by detecting they are practically-equal.