### PR TITLE
Strengthen sloppy-mode tests for future reserved words.

### DIFF
--- a/test/language/future-reserved-words/implements.js
+++ b/test/language/future-reserved-words/implements.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+esid: sec-identifiers-static-semantics-early-errors
 info: The "implements" token can be used as identifier in non-strict code
 es5id: 7.6.1.2_A1.15ns
 description: Checking if execution of "implements=1" succeeds in non-strict code
@@ -9,3 +10,10 @@ flags: [noStrict]
 ---*/
 
 var implements = 1;
+var impl\u0065ments = 2;
+
+{ let implements = 3; }
+{ let impl\u0065ments = 4; }
+
+{ const implements = 5; }
+{ const impl\u0065ments = 6; }

--- a/test/language/future-reserved-words/interface.js
+++ b/test/language/future-reserved-words/interface.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+esid: sec-identifiers-static-semantics-early-errors
 info: |
     The "interface" token can be used as identifier in
     non-strict code
@@ -13,3 +14,10 @@ flags: [noStrict]
 ---*/
 
 var interface = 1;
+var int\u0065rface = 2;
+
+{ let interface = 3; }
+{ let int\u0065rface = 4; }
+
+{ const interface = 5; }
+{ const int\u0065rface = 6; }

--- a/test/language/future-reserved-words/package.js
+++ b/test/language/future-reserved-words/package.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+esid: sec-identifiers-static-semantics-early-errors
 info: The "package" token can be used as identifier in non-strict code
 es5id: 7.6.1.2_A1.21ns
 description: Checking if execution of "package=1" succeeds in non-strict code
@@ -9,3 +10,10 @@ flags: [noStrict]
 ---*/
 
 var package = 1;
+var pack\u0061ge = 2;
+
+{ let package = 3; }
+{ let pack\u0061ge = 4; }
+
+{ const package = 5; }
+{ const pack\u0061ge = 6; }

--- a/test/language/future-reserved-words/private.js
+++ b/test/language/future-reserved-words/private.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+esid: sec-identifiers-static-semantics-early-errors
 info: The "private" token can be used as identifier in non-strict code
 es5id: 7.6.1.2_A1.22ns
 description: Checking if execution of "private=1" succeeds in non-strict code
@@ -9,3 +10,10 @@ flags: [noStrict]
 ---*/
 
 var private = 1;
+var priv\u0061te = 2;
+
+{ let private = 3; }
+{ let priv\u0061te = 4; }
+
+{ const private = 5; }
+{ const priv\u0061te = 6; }

--- a/test/language/future-reserved-words/protected.js
+++ b/test/language/future-reserved-words/protected.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+esid: sec-identifiers-static-semantics-early-errors
 info: The "protected" token can be used as identifier in non-strict code
 es5id: 7.6.1.2_A1.23ns
 description: Checking if execution of "protected=1" succeeds in non-strict code
@@ -9,3 +10,10 @@ flags: [noStrict]
 ---*/
 
 var protected = 1;
+var prot\u0065cted = 2;
+
+{ let protected = 3; }
+{ let prot\u0065cted = 4; }
+
+{ const protected = 5; }
+{ const prot\u0065cted = 6; }

--- a/test/language/future-reserved-words/public.js
+++ b/test/language/future-reserved-words/public.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+esid: sec-identifiers-static-semantics-early-errors
 info: The "public" token can be used as identifier in non-strict code
 es5id: 7.6.1.2_A1.24ns
 description: Checking if execution of "public=1" succeeds in non-strict code
@@ -9,3 +10,10 @@ flags: [noStrict]
 ---*/
 
 var public = 1;
+var publi\u0063 = 2;
+
+{ let public = 3; }
+{ let publi\u0063 = 4; }
+
+{ const public = 5; }
+{ const publi\u0063 = 6; }

--- a/test/language/future-reserved-words/static.js
+++ b/test/language/future-reserved-words/static.js
@@ -2,6 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
+esid: sec-identifiers-static-semantics-early-errors
 info: The "static" token can be used as identifier in non-strict code
 es5id: 7.6.1.2_A1.26ns
 description: Checking if execution of "static=1" succeeds in non-strict code
@@ -9,3 +10,10 @@ flags: [noStrict]
 ---*/
 
 var static = 1;
+var st\u0061tic = 2;
+
+{ let static = 3; }
+{ let st\u0061tic = 4; }
+
+{ const static = 5; }
+{ const st\u0061tic = 6; }


### PR DESCRIPTION
I noticed while fixing test failures in JSC that V8 exhibits the following surprising behavior in sloppy mode:
```js
// OK
var st\u0061tic = 3;

// should be OK but throws
let st\u0061tic = 3;

// OK
const st\u0061tic = 3;
```
This PR adds coverage such that the issue can be detected.