### PR TITLE
Update "info" field

### DIFF
--- a/test/language/export/escaped-as-export-specifier.js
+++ b/test/language/export/escaped-as-export-specifier.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `as` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/export/escaped-default.js
+++ b/test/language/export/escaped-default.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `default` keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/export/escaped-from.js
+++ b/test/language/export/escaped-from.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `from` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/expressions/async-arrow-function/escaped-async-line-terminator.js
+++ b/test/language/expressions/async-arrow-function/escaped-async-line-terminator.js
@@ -12,7 +12,7 @@ info: |
 
   5.1.5 Grammar Notation
 
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/expressions/async-arrow-function/escaped-async.js
+++ b/test/language/expressions/async-arrow-function/escaped-async.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `async` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/expressions/async-function/escaped-async.js
+++ b/test/language/expressions/async-function/escaped-async.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `async` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/expressions/async-generator/escaped-async.js
+++ b/test/language/expressions/async-generator/escaped-async.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `async` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/expressions/dynamic-import/escape-sequence-import.js
+++ b/test/language/expressions/dynamic-import/escape-sequence-import.js
@@ -8,7 +8,7 @@ description: >
 info: |
   5.1.5 Grammar Notation
 
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown in fixed width
+  Terminal symbols are shown in fixed width
   font, both in the productions of the grammars and throughout this specification whenever the
   text directly refers to such a terminal symbol. These are to appear in a script exactly as
   written. All terminal symbol code points specified in this way are to be understood as the

--- a/test/language/expressions/import.meta/syntax/escape-sequence-import.js
+++ b/test/language/expressions/import.meta/syntax/escape-sequence-import.js
@@ -8,7 +8,7 @@ description: >
 info: |
   5.1.5 Grammar Notation
 
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown in fixed width
+  Terminal symbols are shown in fixed width
   font, both in the productions of the grammars and throughout this specification whenever the
   text directly refers to such a terminal symbol. These are to appear in a script exactly as
   written. All terminal symbol code points specified in this way are to be understood as the

--- a/test/language/expressions/import.meta/syntax/escape-sequence-meta.js
+++ b/test/language/expressions/import.meta/syntax/escape-sequence-meta.js
@@ -8,7 +8,7 @@ description: >
 info: |
   5.1.5 Grammar Notation
 
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown in fixed width
+  Terminal symbols are shown in fixed width
   font, both in the productions of the grammars and throughout this specification whenever the
   text directly refers to such a terminal symbol. These are to appear in a script exactly as
   written. All terminal symbol code points specified in this way are to be understood as the

--- a/test/language/expressions/new.target/escaped-new.js
+++ b/test/language/expressions/new.target/escaped-new.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `new` keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/expressions/new.target/escaped-target.js
+++ b/test/language/expressions/new.target/escaped-target.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `target` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/expressions/object/method-definition/async-gen-meth-escaped-async.js
+++ b/test/language/expressions/object/method-definition/async-gen-meth-escaped-async.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `async` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/expressions/object/method-definition/async-meth-escaped-async.js
+++ b/test/language/expressions/object/method-definition/async-meth-escaped-async.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `async` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/expressions/object/method-definition/escaped-get.js
+++ b/test/language/expressions/object/method-definition/escaped-get.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `get` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/expressions/object/method-definition/escaped-set.js
+++ b/test/language/expressions/object/method-definition/escaped-set.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `set` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/import/escaped-as-import-specifier.js
+++ b/test/language/import/escaped-as-import-specifier.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `as` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/import/escaped-as-namespace-import.js
+++ b/test/language/import/escaped-as-namespace-import.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `as` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/import/escaped-from.js
+++ b/test/language/import/escaped-from.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `from` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/statements/async-function/escaped-async.js
+++ b/test/language/statements/async-function/escaped-async.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `async` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/statements/async-generator/escaped-async.js
+++ b/test/language/statements/async-generator/escaped-async.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `async` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/statements/class/async-gen-meth-escaped-async.js
+++ b/test/language/statements/class/async-gen-meth-escaped-async.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `async` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/statements/class/async-meth-escaped-async.js
+++ b/test/language/statements/class/async-meth-escaped-async.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `async` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/statements/class/syntax/escaped-static.js
+++ b/test/language/statements/class/syntax/escaped-static.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `static` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/statements/for-await-of/escaped-of.js
+++ b/test/language/statements/for-await-of/escaped-of.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `of` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/statements/for-of/escaped-of.js
+++ b/test/language/statements/for-of/escaped-of.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `of` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points

--- a/test/language/statements/let/syntax/escaped-let.js
+++ b/test/language/statements/let/syntax/escaped-let.js
@@ -6,7 +6,7 @@ esid: sec-grammar-notation
 description: >
   The `let` contextual keyword must not contain Unicode escape sequences.
 info: |
-  Terminal symbols of the lexical, RegExp, and numeric string grammars are shown
+  Terminal symbols are shown
   in fixed width font, both in the productions of the grammars and throughout this
   specification whenever the text directly refers to such a terminal symbol. These
   are to appear in a script exactly as written. All terminal symbol code points


### PR DESCRIPTION
The quoted spec wording changed in tc39/ecma262#1694.

(Note that the former wording, referring to "terminal symbols of the lexical, RegExp, and numeric string grammars" wasn't actually relevant to these tests, because each test hinges on a terminal symbol of the *syntactic* grammar.)