### PR TITLE
Fix BigInt TypedArrays tests

### DIFF
--- a/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-detachbuffer.js
+++ b/test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-detachbuffer.js
@@ -1,4 +1,5 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
+// Copyright (C) 2021 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%typedarray%.prototype.filter
@@ -22,11 +23,14 @@ testWithBigIntTypedArrayConstructors(function(TA) {
   var sample = new TA(2);
 
   sample.filter(function() {
+    var flag = true;
     if (loops === 0) {
       $DETACHBUFFER(sample.buffer);
+    } else {
+      flag = false;
     }
     loops++;
-    return true;
+    return flag;
   });
 
   assert.sameValue(loops, 2);

--- a/test/built-ins/TypedArray/prototype/findIndex/BigInt/predicate-may-detach-buffer.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/BigInt/predicate-may-detach-buffer.js
@@ -1,4 +1,5 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
+// Copyright (C) 2021 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-%typedarray%.prototype.findindex
@@ -36,16 +37,12 @@ features: [BigInt, TypedArray]
 testWithBigIntTypedArrayConstructors(function(TA) {
   var sample = new TA(2);
   var loops = 0;
-  var completion = false;
 
-  assert.throws(TypeError, function() {
-    sample.findIndex(function() {
-      loops++;
+  sample.findIndex(function() {
+    if (loops === 0) {
       $DETACHBUFFER(sample.buffer);
-      completion = true;
-    });
-  }, "throws a TypeError getting a value from the detached buffer");
-
-  assert.sameValue(loops, 1, "predicated is called once");
-  assert(completion, "abrupt completion does not come from DETACHBUFFER");
+    }
+    loops++;
+  });
+  assert.sameValue(loops, 2, "predicate is called once");
 });


### PR DESCRIPTION
WebKit implemented `BigInt64Array` and `BigUint64Array` in https://github.com/WebKit/WebKit/commit/5a13e56ddd882124c0803939f4ba08f1c1f16a18 and found two test262 issues.

1. test/built-ins/TypedArray/prototype/findIndex/BigInt/predicate-may-detach-buffer.js
It is not updated when a60a67ea880bb4b5de849ee8f7676a475f60c85f is landed. This patch fixes it.

2. test/built-ins/TypedArray/prototype/filter/BigInt/callbackfn-detachbuffer.js
After detaching, BigInt64Array/BigUint64Array will produce undefined for indexed access. And
if `filter`'s callback says `true` for these results, we need to store `ToBigInt(undefined)`
to a newly resulted BigInt64Array/BigUint64Array and this will throw an error. But this test
assumed it does not throw. This patch fixes flag so that we do not throw that error while keeping
detached typed arrays tested.