### PR TITLE
Remove mention of "phase: early", since it's never used

### DIFF
--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -179,8 +179,7 @@ attribute is a YAML dictonary with two keys:
 
 - `phase` - the stage of the test interpretation process that the error is
   expected to be produced; valid phases are:
-    - `parse`: occurs while parsing the source text.
-    - `early`: occurs prior to evaluation.
+    - `parse`: occurs while parsing the source text, or while checking it for early errors.
     - `resolution`: occurs during module resolution.
     - `runtime`: occurs during evaluation.
 - `type` - the name of the constructor of the expected error


### PR DESCRIPTION
(It was folded into "phase: parse" in PR #1366.)