### PR TITLE
Test Object.assign with non-extensible/sealed/frozen targets

### DIFF
--- a/test/built-ins/Object/assign/target-is-frozen-accessor-property-set-succeeds.js
+++ b/test/built-ins/Object/assign/target-is-frozen-accessor-property-set-succeeds.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2021 Alexey Shvayka. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-object.assign
+description: >
+  [[Set]] to accessor property of frozen `target` succeeds.
+info: |
+  SetIntegrityLevel ( O, level )
+
+  [...]
+  3. Let status be ? O.[[PreventExtensions]]().
+  [...]
+  7. Else,
+    a. Assert: level is frozen.
+    b. For each element k of keys, do
+      i. Let currentDesc be ? O.[[GetOwnProperty]](k).
+      ii. If currentDesc is not undefined, then
+        1. If IsAccessorDescriptor(currentDesc) is true, then
+          a. Let desc be the PropertyDescriptor { [[Configurable]]: false }.
+        [...]
+        3. Perform ? DefinePropertyOrThrow(O, k, desc).
+  8. Return true.
+
+  Object.assign ( target, ...sources )
+
+  [...]
+  3. For each element nextSource of sources, do
+    a. If nextSource is neither undefined nor null, then
+      [...]
+      iii. For each element nextKey of keys, do
+        1. Let desc be ? from.[[GetOwnProperty]](nextKey).
+        2. If desc is not undefined and desc.[[Enumerable]] is true, then
+          [...]
+          b. Perform ? Set(to, nextKey, propValue, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  7. Perform ? Call(setter, Receiver, « V »).
+  8. Return true.
+features: [Symbol]
+---*/
+
+var value1 = 1;
+var target1 = {
+  set foo(val) { value1 = val; },
+};
+
+Object.freeze(target1);
+Object.assign(target1, { foo: 2 });
+assert.sameValue(value1, 2);
+
+
+var sym = Symbol();
+var value2 = 1;
+var target2 = Object.freeze({
+  set [sym](val) { value2 = val; },
+});
+
+Object.freeze(target2);
+Object.assign(target2, { [sym]: 2 });
+assert.sameValue(value2, 2);

--- a/test/built-ins/Object/assign/target-is-frozen-data-property-set-throws.js
+++ b/test/built-ins/Object/assign/target-is-frozen-data-property-set-throws.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2021 Alexey Shvayka. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-object.assign
+description: >
+  [[Set]] to data property of frozen `target` fails with TypeError.
+info: |
+  SetIntegrityLevel ( O, level )
+
+  [...]
+  3. Let status be ? O.[[PreventExtensions]]().
+  [...]
+  7. Else,
+    a. Assert: level is frozen.
+    b. For each element k of keys, do
+      i. Let currentDesc be ? O.[[GetOwnProperty]](k).
+      ii. If currentDesc is not undefined, then
+        1. If IsAccessorDescriptor(currentDesc) is true, then
+          [...]
+        2. Else,
+          a. Let desc be the PropertyDescriptor { [[Configurable]]: false, [[Writable]]: false }.
+        3. Perform ? DefinePropertyOrThrow(O, k, desc).
+  8. Return true.
+
+  Object.assign ( target, ...sources )
+
+  [...]
+  3. For each element nextSource of sources, do
+    a. If nextSource is neither undefined nor null, then
+      [...]
+      iii. For each element nextKey of keys, do
+        1. Let desc be ? from.[[GetOwnProperty]](nextKey).
+        2. If desc is not undefined and desc.[[Enumerable]] is true, then
+          [...]
+          b. Perform ? Set(to, nextKey, propValue, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  3. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+features: [Symbol, Reflect]
+---*/
+
+var sym = Symbol();
+var target1 = { [sym]: 1 };
+
+Object.freeze(target1);
+assert.throws(TypeError, function() {
+  Object.assign(target1, { [sym]: 1 });
+});
+
+
+var target2 = Object.freeze({ foo: 1 });
+
+assert.throws(TypeError, function() {
+  Object.assign(target2, { foo: 1 });
+});

--- a/test/built-ins/Object/assign/target-is-non-extensible-existing-accessor-property.js
+++ b/test/built-ins/Object/assign/target-is-non-extensible-existing-accessor-property.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2021 Alexey Shvayka. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-object.assign
+description: >
+  [[Set]] to existing accessor property of non-extensible `target` is successful.
+info: |
+  OrdinaryPreventExtensions ( O )
+
+  1. Set O.[[Extensible]] to false.
+
+  Object.assign ( target, ...sources )
+
+  [...]
+  3. For each element nextSource of sources, do
+    a. If nextSource is neither undefined nor null, then
+      [...]
+      iii. For each element nextKey of keys, do
+        1. Let desc be ? from.[[GetOwnProperty]](nextKey).
+        2. If desc is not undefined and desc.[[Enumerable]] is true, then
+          [...]
+          b. Perform ? Set(to, nextKey, propValue, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  7. Perform ? Call(setter, Receiver, « V »).
+  8. Return true.
+features: [Symbol]
+---*/
+
+var value1 = 1;
+var target1 = Object.preventExtensions({
+  set foo(val) { value1 = val; },
+});
+
+Object.assign(target1, { foo: 2 });
+assert.sameValue(value1, 2);
+
+
+var sym = Symbol();
+var value2 = 1;
+var target2 = {
+  set [sym](val) { value2 = val; },
+};
+
+Object.preventExtensions(target2);
+Object.assign(target2, { [sym]: 2 });
+assert.sameValue(value2, 2);

--- a/test/built-ins/Object/assign/target-is-non-extensible-existing-data-property.js
+++ b/test/built-ins/Object/assign/target-is-non-extensible-existing-data-property.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2021 Alexey Shvayka. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-object.assign
+description: >
+  [[Set]] to existing data property of non-extensible `target` is successful.
+info: |
+  OrdinaryPreventExtensions ( O )
+
+  1. Set O.[[Extensible]] to false.
+
+  Object.assign ( target, ...sources )
+
+  [...]
+  3. For each element nextSource of sources, do
+    a. If nextSource is neither undefined nor null, then
+      [...]
+      iii. For each element nextKey of keys, do
+        1. Let desc be ? from.[[GetOwnProperty]](nextKey).
+        2. If desc is not undefined and desc.[[Enumerable]] is true, then
+          [...]
+          b. Perform ? Set(to, nextKey, propValue, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  3. If IsDataDescriptor(ownDesc) is true, then
+    [...]
+    c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
+    d. If existingDescriptor is not undefined, then
+      [...]
+      iii. Let valueDesc be the PropertyDescriptor { [[Value]]: V }.
+      iv. Return ? Receiver.[[DefineOwnProperty]](P, valueDesc).
+
+  ValidateAndApplyPropertyDescriptor ( O, P, extensible, Desc, current )
+
+  [...]
+  9. If O is not undefined, then
+    a. For each field of Desc that is present, set the corresponding attribute
+       of the property named P of object O to the value of the field.
+  10. Return true.
+features: [Symbol]
+---*/
+
+var target1 = Object.preventExtensions({ foo: 1 });
+
+Object.assign(target1, { foo: 2 });
+assert.sameValue(target1.foo, 2);
+
+
+var sym = Symbol();
+var target2 = { [sym]: 1 };
+
+Object.preventExtensions(target2);
+Object.assign(target2, { [sym]: 2 });
+assert.sameValue(target2[sym], 2);

--- a/test/built-ins/Object/assign/target-is-non-extensible-property-creation-throws.js
+++ b/test/built-ins/Object/assign/target-is-non-extensible-property-creation-throws.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2021 Alexey Shvayka. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-object.assign
+description: >
+  [[Set]] to non-existing property of non-extensible `target` fails with TypeError.
+info: |
+  Object.assign ( target, ...sources )
+
+  [...]
+  3. For each element nextSource of sources, do
+    a. If nextSource is neither undefined nor null, then
+      [...]
+      iii. For each element nextKey of keys, do
+        1. Let desc be ? from.[[GetOwnProperty]](nextKey).
+        2. If desc is not undefined and desc.[[Enumerable]] is true, then
+          [...]
+          b. Perform ? Set(to, nextKey, propValue, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  3. If IsDataDescriptor(ownDesc) is true, then
+    [...]
+    c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
+    d. If existingDescriptor is not undefined, then
+      [...]
+    e. Else,
+      i. Assert: Receiver does not currently have a property P.
+      ii. Return ? CreateDataProperty(Receiver, P, V).
+
+  ValidateAndApplyPropertyDescriptor ( O, P, extensible, Desc, current )
+
+  [...]
+  2. If current is undefined, then
+    a. If extensible is false, return false.
+features: [Symbol]
+---*/
+
+var target1 = Object.preventExtensions({ foo: 1 });
+
+assert.throws(TypeError, function() {
+  Object.assign(target1, { get bar() {} });
+});
+
+
+var target2 = {};
+
+Object.preventExtensions(target2);
+assert.throws(TypeError, function() {
+  Object.assign(target2, { [Symbol()]: 1 });
+});

--- a/test/built-ins/Object/assign/target-is-sealed-existing-accessor-property.js
+++ b/test/built-ins/Object/assign/target-is-sealed-existing-accessor-property.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2021 Alexey Shvayka. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-object.assign
+description: >
+  [[Set]] to existing accessor property of sealed `target` is successful.
+info: |
+  SetIntegrityLevel ( O, level )
+
+  [...]
+  3. Let status be ? O.[[PreventExtensions]]().
+  [...]
+
+  OrdinaryPreventExtensions ( O )
+
+  1. Set O.[[Extensible]] to false.
+
+  Object.assign ( target, ...sources )
+
+  [...]
+  3. For each element nextSource of sources, do
+    a. If nextSource is neither undefined nor null, then
+      [...]
+      iii. For each element nextKey of keys, do
+        1. Let desc be ? from.[[GetOwnProperty]](nextKey).
+        2. If desc is not undefined and desc.[[Enumerable]] is true, then
+          [...]
+          b. Perform ? Set(to, nextKey, propValue, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  7. Perform ? Call(setter, Receiver, « V »).
+  8. Return true.
+---*/
+
+var value1 = 1;
+var target1 = Object.seal({
+  set foo(val) { value1 = val; },
+});
+
+Object.assign(target1, { foo: 2 });
+assert.sameValue(value1, 2);
+
+
+var sym = Symbol();
+var value2 = 1;
+var target2 = {
+  set [sym](val) { value2 = val; },
+};
+
+Object.seal(target2);
+Object.assign(target2, { [sym]: 2 });
+assert.sameValue(value2, 2);

--- a/test/built-ins/Object/assign/target-is-sealed-existing-data-property.js
+++ b/test/built-ins/Object/assign/target-is-sealed-existing-data-property.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2021 Alexey Shvayka. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-object.assign
+description: >
+  [[Set]] to existing data property of sealed `target` is successful.
+info: |
+  SetIntegrityLevel ( O, level )
+
+  [...]
+  3. Let status be ? O.[[PreventExtensions]]().
+  [...]
+
+  OrdinaryPreventExtensions ( O )
+
+  1. Set O.[[Extensible]] to false.
+
+  Object.assign ( target, ...sources )
+
+  [...]
+  3. For each element nextSource of sources, do
+    a. If nextSource is neither undefined nor null, then
+      [...]
+      iii. For each element nextKey of keys, do
+        1. Let desc be ? from.[[GetOwnProperty]](nextKey).
+        2. If desc is not undefined and desc.[[Enumerable]] is true, then
+          [...]
+          b. Perform ? Set(to, nextKey, propValue, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  3. If IsDataDescriptor(ownDesc) is true, then
+    [...]
+    c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
+    d. If existingDescriptor is not undefined, then
+      [...]
+      iii. Let valueDesc be the PropertyDescriptor { [[Value]]: V }.
+      iv. Return ? Receiver.[[DefineOwnProperty]](P, valueDesc).
+
+  ValidateAndApplyPropertyDescriptor ( O, P, extensible, Desc, current )
+
+  [...]
+  9. If O is not undefined, then
+    a. For each field of Desc that is present, set the corresponding attribute
+       of the property named P of object O to the value of the field.
+  10. Return true.
+---*/
+
+var target1 = Object.seal({ foo: 1 });
+
+Object.assign(target1, { foo: 2 });
+assert.sameValue(target1.foo, 2);
+
+
+var sym = Symbol();
+var target2 = { [sym]: 1 };
+
+Object.seal(target2);
+Object.assign(target2, { [sym]: 2 });
+assert.sameValue(target2[sym], 2);

--- a/test/built-ins/Object/assign/target-is-sealed-property-creation-throws.js
+++ b/test/built-ins/Object/assign/target-is-sealed-property-creation-throws.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2021 Alexey Shvayka. All rights reserved.
+// This code is governed by the license found in the LICENSE file.
+
+/*---
+esid: sec-object.assign
+description: >
+  [[Set]] to non-existing property of sealed `target` fails with TypeError.
+info: |
+  SetIntegrityLevel ( O, level )
+
+  [...]
+  3. Let status be ? O.[[PreventExtensions]]().
+  [...]
+
+  Object.assign ( target, ...sources )
+
+  [...]
+  3. For each element nextSource of sources, do
+    a. If nextSource is neither undefined nor null, then
+      [...]
+      iii. For each element nextKey of keys, do
+        1. Let desc be ? from.[[GetOwnProperty]](nextKey).
+        2. If desc is not undefined and desc.[[Enumerable]] is true, then
+          [...]
+          b. Perform ? Set(to, nextKey, propValue, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  3. If IsDataDescriptor(ownDesc) is true, then
+    [...]
+    c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
+    d. If existingDescriptor is not undefined, then
+      [...]
+    e. Else,
+      i. Assert: Receiver does not currently have a property P.
+      ii. Return ? CreateDataProperty(Receiver, P, V).
+
+  ValidateAndApplyPropertyDescriptor ( O, P, extensible, Desc, current )
+
+  [...]
+  2. If current is undefined, then
+    a. If extensible is false, return false.
+features: [Symbol, Reflect]
+---*/
+
+var target1 = Object.seal({ foo: 1 });
+
+assert.throws(TypeError, function() {
+  Object.assign(target1, { get bar() {} });
+});
+
+
+var target2 = {};
+
+Object.seal(target2);
+assert.throws(TypeError, function() {
+  Object.assign(target2, { [Symbol()]: 1 });
+});


### PR DESCRIPTION
JSC bug: [`Object.assign` should throw for property creation on non-extensible `target`](https://bugs.webkit.org/show_bug.cgi?id=220712).