### PR TITLE
Add NumberFormat and DateTimeFormat tests for OrdinaryHasInstance

### DIFF
--- a/test/intl402/DateTimeFormat/constructor-no-instanceof.js
+++ b/test/intl402/DateTimeFormat/constructor-no-instanceof.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2021 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DateTimeFormat.prototype.resolvedOptions
+description: >
+  Tests that Intl.DateTimeFormat.prototype.resolvedOptions calls
+  OrdinaryHasInstance instead of the instanceof operator which includes a
+  Symbol.hasInstance lookup and call among other things.
+---*/
+
+Object.defineProperty(Intl.DateTimeFormat, Symbol.hasInstance, {
+    get() { throw new Test262Error(); }
+});
+
+Intl.DateTimeFormat();

--- a/test/intl402/DateTimeFormat/prototype/format/no-instanceof.js
+++ b/test/intl402/DateTimeFormat/prototype/format/no-instanceof.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DateTimeFormat.prototype.resolvedOptions
+description: >
+  Tests that Intl.DateTimeFormat.prototype.resolvedOptions calls
+  OrdinaryHasInstance instead of the instanceof operator which includes a
+  Symbol.hasInstance lookup and call among other things.
+---*/
+
+const dtf = new Intl.DateTimeFormat();
+
+Object.defineProperty(Intl.DateTimeFormat, Symbol.hasInstance, {
+    get() { throw new Test262Error(); }
+});
+
+dtf.format;

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/no-instanceof.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/no-instanceof.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DateTimeFormat.prototype.resolvedOptions
+description: >
+  Tests that Intl.DateTimeFormat.prototype.resolvedOptions calls
+  OrdinaryHasInstance instead of the instanceof operator which includes a
+  Symbol.hasInstance lookup and call among other things.
+---*/
+
+const dtf = new Intl.DateTimeFormat();
+
+Object.defineProperty(Intl.DateTimeFormat, Symbol.hasInstance, {
+    get() { throw new Test262Error(); }
+});
+
+dtf.resolvedOptions();

--- a/test/intl402/NumberFormat/constructor-no-instanceof.js
+++ b/test/intl402/NumberFormat/constructor-no-instanceof.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2021 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.NumberFormat.prototype.resolvedOptions
+description: >
+  Tests that Intl.NumberFormat.prototype.resolvedOptions calls
+  OrdinaryHasInstance instead of the instanceof operator which includes a
+  Symbol.hasInstance lookup and call among other things.
+---*/
+
+Object.defineProperty(Intl.NumberFormat, Symbol.hasInstance, {
+    get() { throw new Test262Error(); }
+});
+
+Intl.NumberFormat();

--- a/test/intl402/NumberFormat/prototype/format/no-instanceof.js
+++ b/test/intl402/NumberFormat/prototype/format/no-instanceof.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.NumberFormat.prototype.resolvedOptions
+description: >
+  Tests that Intl.NumberFormat.prototype.resolvedOptions calls
+  OrdinaryHasInstance instead of the instanceof operator which includes a
+  Symbol.hasInstance lookup and call among other things.
+---*/
+
+const nf = new Intl.NumberFormat();
+
+Object.defineProperty(Intl.NumberFormat, Symbol.hasInstance, {
+    get() { throw new Test262Error(); }
+});
+
+nf.format;

--- a/test/intl402/NumberFormat/prototype/resolvedOptions/no-instanceof.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/no-instanceof.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.NumberFormat.prototype.resolvedOptions
+description: >
+  Tests that Intl.NumberFormat.prototype.resolvedOptions calls
+  OrdinaryHasInstance instead of the instanceof operator which includes a
+  Symbol.hasInstance lookup and call among other things.
+---*/
+
+const nf = new Intl.NumberFormat();
+
+Object.defineProperty(Intl.NumberFormat, Symbol.hasInstance, {
+    get() { throw new Test262Error(); }
+});
+
+nf.resolvedOptions();


### PR DESCRIPTION
Add tests to make sure `NumberFormat` and `DateTimeFormat` do not call the `instanceof` operator and call `OrdinaryHasInstance` instead.

Refs: https://github.com/tc39/ecma402/pull/500