### PR TITLE
Correct formatting in INTERPRETING.md

### DIFF
--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -358,7 +358,7 @@ following strings:
 
 - **`CanBlockIsFalse`** The test file should only be run when the [[CanBlock]] property of the [Agent Record](https://tc39.github.io/ecma262/#sec-agents) executing the file is `false`.
 
- *Example*
+  *Example*
 
   ```js
   /*---
@@ -370,7 +370,7 @@ following strings:
 
 - **`CanBlockIsTrue`** The test file should only be run when the [[CanBlock]] property of the [Agent Record](https://tc39.github.io/ecma262/#sec-agents) executing the file is `true`.
 
- *Example*
+  *Example*
 
   ```js
   /*---


### PR DESCRIPTION
Prior to this commit, the implementation of Markdown on GitHub.com
caused the contents of two list items to be rendered outside of their
containing list. Update the indentation so that the structure of the
rendered output matches the structure implied by the text.