### PR TITLE
Add test for [[Description]] from `Symbol.for`

### DIFF
--- a/test/built-ins/Symbol/for/description.js
+++ b/test/built-ins/Symbol/for/description.js
@@ -10,7 +10,7 @@ info: |
        is stringKey.
     [...]
     6. Return newSymbol.
-features: [Symbol]
+features: [Symbol, Symbol.prototype.description]
 ---*/
 
 var symbol = Symbol.for({toString: function() { return 'test262'; }});

--- a/test/built-ins/Symbol/for/description.js
+++ b/test/built-ins/Symbol/for/description.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.for
+description: Assigns the string value to the [[Description]] slot
+info: |
+    1. Let stringKey be ? ToString(key).
+    [...]
+    4. Let newSymbol be a new unique Symbol value whose [[Description]] value
+       is stringKey.
+    [...]
+    6. Return newSymbol.
+features: [Symbol]
+---*/
+
+var symbol = Symbol.for({toString: function() { return 'test262'; }});
+
+assert.sameValue(symbol.description, 'test262');


### PR DESCRIPTION
Resolves gh-2967. I reviewed the project's coverage for the rest of this algorithm, and it looks okay to me.