### PR TITLE
Fix typo in private getter/setter tests

### DIFF
--- a/test/language/statements/class/private-non-static-getter-static-setter-early-error.js
+++ b/test/language/statements/class/private-non-static-getter-static-setter-early-error.js
@@ -13,7 +13,7 @@ negative:
 $DONOTEVALUATE();
 
 class C {
-  get #f();
+  get #f() {}
   static set #f(v) {}
 }
 

--- a/test/language/statements/class/private-non-static-setter-static-getter-early-error.js
+++ b/test/language/statements/class/private-non-static-setter-static-getter-early-error.js
@@ -14,6 +14,6 @@ $DONOTEVALUATE();
 
 class C {
   set #f(v) {}
-  static get #f();
+  static get #f() {}
 }
 

--- a/test/language/statements/class/private-static-getter-non-static-setter-early-error.js
+++ b/test/language/statements/class/private-static-getter-non-static-setter-early-error.js
@@ -13,7 +13,7 @@ negative:
 $DONOTEVALUATE();
 
 class C {
-  static get #f();
+  static get #f() {}
   set #f(v) {}
 }
 

--- a/test/language/statements/class/private-static-setter-non-static-getter-early-error.js
+++ b/test/language/statements/class/private-static-setter-non-static-getter-early-error.js
@@ -14,6 +14,6 @@ $DONOTEVALUATE();
 
 class C {
   static set #f(v) {}
-  get #f();
+  get #f() {}
 }
 


### PR DESCRIPTION
Several tests for getters and setters claim to check for an early
SyntaxError regarding mixing static and non-static propeties with the
same name. However, the tests trigger another issue: the getters have no
method body; they're missing curlies.

Fix the tests to test only the intended SyntaxError, not unrelated
SyntaxError-s.