### PR TITLE
Test that Symbol / BigInt wrapper objects perform OrdinaryToPrimitive

### DIFF
--- a/test/built-ins/BigInt/wrapper-object-ordinary-toprimitive.js
+++ b/test/built-ins/BigInt/wrapper-object-ordinary-toprimitive.js
@@ -1,0 +1,72 @@
+// Copyright (C) 2021 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-toprimitive
+description: >
+    BigInt wrapper object is converted to primitive via OrdinaryToPrimitive.
+info: |
+    ToPrimitive ( input [ , preferredType ] )
+
+    [...]
+    2. If Type(input) is Object, then
+        a. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+        b. If exoticToPrim is not undefined, then
+            [...]
+        c. If preferredType is not present, let preferredType be number.
+        d. Return ? OrdinaryToPrimitive(input, preferredType).
+features: [BigInt]
+---*/
+
+const BigIntToString = BigInt.prototype.toString;
+let toStringGets = 0;
+let toStringCalls = 0;
+let toStringFunction = function() { ++toStringCalls; return `${BigIntToString.call(this)}foo`; };
+Object.defineProperty(BigInt.prototype, "toString", {
+    get: () => { ++toStringGets; return toStringFunction; },
+});
+
+assert.sameValue("" + Object(1n), "1", "hint: default");
+assert.throws(TypeError, () => { +Object(1n); }, "hint: number");
+assert.sameValue(`${Object(1n)}`, "1foo", "hint: string");
+
+assert.sameValue(toStringGets, 1);
+assert.sameValue(toStringCalls, 1);
+
+const BigIntValueOf = BigInt.prototype.valueOf;
+let valueOfGets = 0;
+let valueOfCalls = 0;
+let valueOfFunction = function() { ++valueOfCalls; return BigIntValueOf.call(this) * 2n; };
+Object.defineProperty(BigInt.prototype, "valueOf", {
+    get: () => { ++valueOfGets; return valueOfFunction; },
+});
+
+assert(Object(1n) == 2n, "hint: default");
+assert.sameValue(Object(1n) + 1n, 3n, "hint: number");
+assert.sameValue({ "1foo": 1, "2": 2 }[Object(1n)], 1, "hint: string");
+
+assert.sameValue(toStringGets, 2);
+assert.sameValue(toStringCalls, 2);
+assert.sameValue(valueOfGets, 2);
+assert.sameValue(valueOfCalls, 2);
+
+toStringFunction = undefined;
+
+assert.throws(TypeError, () => { 1 + Object(1n); }, "hint: default");
+assert.sameValue(Object(1n) * 1n, 2n, "hint: number");
+assert.sameValue("".concat(Object(1n)), "2", "hint: string");
+
+assert.sameValue(toStringGets, 3);
+assert.sameValue(toStringCalls, 2);
+assert.sameValue(valueOfGets, 5);
+assert.sameValue(valueOfCalls, 5);
+
+valueOfFunction = null;
+
+assert.throws(TypeError, () => { new Date(Object(1n)); }, "hint: default");
+assert.throws(TypeError, () => { Number(Object(1n)); }, "hint: number");
+assert.throws(TypeError, () => { String(Object(1n)); }, "hint: string");
+
+assert.sameValue(toStringGets, 6);
+assert.sameValue(toStringCalls, 2);
+assert.sameValue(valueOfGets, 8);
+assert.sameValue(valueOfCalls, 5);

--- a/test/built-ins/Symbol/prototype/Symbol.toPrimitive/redefined-symbol-wrapper-ordinary-toprimitive.js
+++ b/test/built-ins/Symbol/prototype/Symbol.toPrimitive/redefined-symbol-wrapper-ordinary-toprimitive.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2021 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.prototype-@@toprimitive
+description: >
+    If redefined to nullish value, Symbol wrapper object is converted to primitive
+    via OrdinaryToPrimitive.
+info: |
+    ToPrimitive ( input [ , preferredType ] )
+
+    [...]
+    2. If Type(input) is Object, then
+        a. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+        b. If exoticToPrim is not undefined, then
+            [...]
+        c. If preferredType is not present, let preferredType be number.
+        d. Return ? OrdinaryToPrimitive(input, preferredType).
+features: [Symbol.toPrimitive]
+---*/
+
+Object.defineProperty(Symbol.prototype, Symbol.toPrimitive, { value: null });
+
+assert.sameValue(Object(Symbol()) == "Symbol()", false, "hint: default");
+assert.throws(TypeError, () => { +Object(Symbol()); }, "hint: number");
+assert.sameValue(`${Object(Symbol())}`, "Symbol()", "hint: string");
+
+Object.defineProperty(Symbol.prototype, Symbol.toPrimitive, { value: undefined });
+
+assert(Object(Symbol.iterator) == Symbol.iterator, "hint: default");
+assert.throws(TypeError, () => { Object(Symbol()) <= ""; }, "hint: number");
+assert.sameValue({ "Symbol()": 1 }[Object(Symbol())], 1, "hint: string");

--- a/test/built-ins/Symbol/prototype/Symbol.toPrimitive/removed-symbol-wrapper-ordinary-toprimitive.js
+++ b/test/built-ins/Symbol/prototype/Symbol.toPrimitive/removed-symbol-wrapper-ordinary-toprimitive.js
@@ -1,0 +1,83 @@
+// Copyright (C) 2021 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-symbol.prototype-@@toprimitive
+description: >
+    If deleted, Symbol wrapper objects is converted to primitive via OrdinaryToPrimitive.
+info: |
+    ToPrimitive ( input [ , preferredType ] )
+
+    [...]
+    2. If Type(input) is Object, then
+        a. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+        b. If exoticToPrim is not undefined, then
+            [...]
+        c. If preferredType is not present, let preferredType be number.
+        d. Return ? OrdinaryToPrimitive(input, preferredType).
+features: [Symbol.toPrimitive]
+---*/
+
+assert(delete Symbol.prototype[Symbol.toPrimitive]);
+
+let valueOfGets = 0;
+let valueOfCalls = 0;
+let valueOfFunction = () => { ++valueOfCalls; return 123; };
+Object.defineProperty(Symbol.prototype, "valueOf", {
+    get: () => { ++valueOfGets; return valueOfFunction; },
+});
+
+assert(Object(Symbol()) == 123, "hint: default");
+assert.sameValue(Object(Symbol()) - 0, 123, "hint: number");
+assert.sameValue("".concat(Object(Symbol())), "Symbol()", "hint: string");
+
+assert.sameValue(valueOfGets, 2);
+assert.sameValue(valueOfCalls, 2);
+
+let toStringGets = 0;
+let toStringCalls = 0;
+let toStringFunction = () => { ++toStringCalls; return "foo"; };
+Object.defineProperty(Symbol.prototype, "toString", {
+    get: () => { ++toStringGets; return toStringFunction; },
+});
+
+assert.sameValue("" + Object(Symbol()), "123", "hint: default");
+assert.sameValue(Object(Symbol()) * 1, 123, "hint: number");
+assert.sameValue({ "123": 1, "Symbol()": 2, "foo": 3 }[Object(Symbol())], 3, "hint: string");
+
+assert.sameValue(valueOfGets, 4);
+assert.sameValue(valueOfCalls, 4);
+assert.sameValue(toStringGets, 1);
+assert.sameValue(toStringCalls, 1);
+
+valueOfFunction = null;
+
+assert.sameValue(new Date(Object(Symbol())).getTime(), NaN, "hint: default");
+assert.sameValue(+Object(Symbol()), NaN, "hint: number");
+assert.sameValue(`${Object(Symbol())}`, "foo", "hint: string");
+
+assert.sameValue(valueOfGets, 6);
+assert.sameValue(valueOfCalls, 4);
+assert.sameValue(toStringGets, 4);
+assert.sameValue(toStringCalls, 4);
+
+toStringFunction = function() { throw new Test262Error(); };
+
+assert.throws(Test262Error, () => { Object(Symbol()) != 123; }, "hint: default");
+assert.throws(Test262Error, () => { Object(Symbol()) / 0; }, "hint: number");
+assert.throws(Test262Error, () => { "".concat(Object(Symbol())); }, "hint: string");
+
+assert.sameValue(valueOfGets, 8);
+assert.sameValue(valueOfCalls, 4);
+assert.sameValue(toStringGets, 7);
+assert.sameValue(toStringCalls, 4);
+
+toStringFunction = undefined;
+
+assert.throws(TypeError, () => { 1 + Object(Symbol()); }, "hint: default");
+assert.throws(TypeError, () => { Number(Object(Symbol())); }, "hint: number");
+assert.throws(TypeError, () => { String(Object(Symbol())); }, "hint: string");
+
+assert.sameValue(valueOfGets, 11);
+assert.sameValue(valueOfCalls, 4);
+assert.sameValue(toStringGets, 10);
+assert.sameValue(toStringCalls, 4);


### PR DESCRIPTION
JSC bug: [`Symbol` and `BigInt` wrapper objects should perform `OrdinaryToPrimitive`](https://bugs.webkit.org/show_bug.cgi?id=224208).

`BigInt` test is passing on V8 7.5.288.22.