### PR TITLE
Increase precision of assertions for Error Cause

### DIFF
--- a/test/built-ins/Error/cause_abrupt.js
+++ b/test/built-ins/Error/cause_abrupt.js
@@ -21,29 +21,31 @@ esid: sec-error-message
 ---*/
 
 var message = "my-message";
+var options;
+
 //////////////////////////////////////////////////////////////////////////////
 // CHECK#0
+options = new Proxy({}, {
+  has(target, prop) {
+    if (prop === "cause") {
+      throw new Test262Error("HasProperty");
+    }
+    return prop in target;
+  },
+});
 assert.throws(Test262Error, function () {
-  var options = new Proxy({}, {
-    has(target, prop) {
-      if (prop === "cause") {
-        throw new Test262Error("HasProperty");
-      }
-      return prop in target;
-    },
-  });
-  var error = new Error(message, options);
+  new Error(message, options);
 }, "HasProperty");
 //////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////
 // CHECK#1
+options = {
+  get cause() {
+    throw new Test262Error("Get Cause");
+  },
+};
 assert.throws(Test262Error, function () {
-  var options = {
-    get cause() {
-      throw new Test262Error("Get Cause");
-    },
-  };
-  var error = new Error(message, options);
+  new Error(message, options);
 }, "Get Cause");
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Minimize the code provided to the `assert.throws` utility in order to
reduce the possibility of false positives and to improve failure
messages in non-conforming runtimes.

---

@legendecas here's the improvement that [I mentioned earlier](https://github.com/tc39/test262/pull/2965#pullrequestreview-643575028).