### PR TITLE
Add more tests for `for (async of` edge-cases

### DIFF
--- a/test/language/statements/for-of/head-lhs-async-escaped.js
+++ b/test/language/statements/for-of/head-lhs-async-escaped.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Stuart Cook. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-for-in-and-for-of-statements
+description: >
+  The left-hand-side of a for-of loop may be the identifier `async` written
+  with an escape sequence.
+info: |
+  ForInOfStatement[Yield, Await, Return] :
+    for ( [lookahead ∉ { let, async of }] LeftHandSideExpression[?Yield, ?Await] of AssignmentExpression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return]
+---*/
+
+let async;
+
+for (\u0061sync of [7]);
+
+assert.sameValue(async, 7);

--- a/test/language/statements/for-of/head-lhs-async-parens.js
+++ b/test/language/statements/for-of/head-lhs-async-parens.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Stuart Cook. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-for-in-and-for-of-statements
+description: >
+  The left-hand-side of a for-of loop may be the identifier `async`
+  surrounded by parentheses.
+info: |
+  ForInOfStatement[Yield, Await, Return] :
+    for ( [lookahead ∉ { let, async of }] LeftHandSideExpression[?Yield, ?Await] of AssignmentExpression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return]
+---*/
+
+let async;
+
+for ((async) of [7]);
+
+assert.sameValue(async, 7);


### PR DESCRIPTION
This adds tests for two more edge-cases related to the `for (async of` restriction (https://github.com/tc39/ecma262/pull/2256):

```js
for (\u0061sync of [7]);
```

In this case, the identifier `async` is written with an escape sequence. This avoids the `async of` lookahead, which only considers non-escaped words.

This detects implementations that check for an `async` token without considering whether it was escaped.

Recently fixed in V8: https://bugs.chromium.org/p/v8/issues/detail?id=11722

```js
for ((async) of [7]);
```

In this case, the identifier token `async` is preceded by a `(` token, which avoids the `async of` lookahead because `async` is no longer the first token in the head.

This detects implementations that check whether the LHS is an identifier at the AST level, without considering parentheses.

Motivated by https://github.com/babel/babel/pull/13244#pullrequestreview-649786288.