### PR TITLE
Add basic tests for proposal-intl-locale-info

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -84,6 +84,10 @@ Intl.ListFormat
 # https://github.com/tc39/proposal-intl-locale
 Intl.Locale
 
+# Intl.Locale Info
+# https://github.com/tc39/proposal-intl-locale-info
+Intl.Locale-info
+
 # Intl.RelativeTimeFormat
 # https://github.com/tc39/proposal-intl-relative-time
 Intl.RelativeTimeFormat

--- a/test/intl402/Locale/prototype/calendars/branding.js
+++ b/test/intl402/Locale/prototype/calendars/branding.js
@@ -10,7 +10,7 @@ info: |
 
     2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
         a. Throw a TypeError exception.
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "calendars");

--- a/test/intl402/Locale/prototype/calendars/branding.js
+++ b/test/intl402/Locale/prototype/calendars/branding.js
@@ -1,0 +1,30 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.calendars
+description: >
+    Verifies the branding check for the "calendars" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.calendars
+
+    2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
+        a. Throw a TypeError exception.
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "calendars");
+const invalidValues = [
+  undefined,
+  null,
+  true,
+  "",
+  Symbol(),
+  1,
+  {},
+  Intl.Locale.prototype,
+];
+
+for (const invalidValue of invalidValues) {
+  assert.throws(TypeError, () => propdesc.get.call(invalidValue));
+}

--- a/test/intl402/Locale/prototype/calendars/branding.js
+++ b/test/intl402/Locale/prototype/calendars/branding.js
@@ -14,6 +14,7 @@ features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "calendars");
+assert.sameValue(typeof propdesc.get, "function");
 const invalidValues = [
   undefined,
   null,

--- a/test/intl402/Locale/prototype/calendars/name.js
+++ b/test/intl402/Locale/prototype/calendars/name.js
@@ -1,0 +1,22 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.calendars
+description: >
+    Checks the "name" property of Intl.Locale.prototype.calendars.
+info: |
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 Language Specification, 10th edition, clause 17, or successor.
+    Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
+    Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "calendars").get;
+verifyProperty(getter, "name", {
+  value: "get calendars",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/calendars/name.js
+++ b/test/intl402/Locale/prototype/calendars/name.js
@@ -10,7 +10,7 @@ info: |
     Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
     Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "calendars").get;

--- a/test/intl402/Locale/prototype/calendars/prop-desc.js
+++ b/test/intl402/Locale/prototype/calendars/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale
+description: >
+    Checks the "calendars" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.calendars
+
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 script Specification, 10th edition, clause 17, or successor.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "calendars");
+assert.sameValue(propdesc.set, undefined);
+assert.sameValue(typeof propdesc.get, "function");
+
+verifyProperty(Intl.Locale.prototype, "calendars", {
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/calendars/prop-desc.js
+++ b/test/intl402/Locale/prototype/calendars/prop-desc.js
@@ -12,7 +12,7 @@ info: |
 
     Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "calendars");

--- a/test/intl402/Locale/prototype/collations/branding.js
+++ b/test/intl402/Locale/prototype/collations/branding.js
@@ -10,7 +10,7 @@ info: |
 
     2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
         a. Throw a TypeError exception.
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "collations");

--- a/test/intl402/Locale/prototype/collations/branding.js
+++ b/test/intl402/Locale/prototype/collations/branding.js
@@ -1,0 +1,30 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.collations
+description: >
+    Verifies the branding check for the "collations" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.collations
+
+    2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
+        a. Throw a TypeError exception.
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "collations");
+const invalidValues = [
+  undefined,
+  null,
+  true,
+  "",
+  Symbol(),
+  1,
+  {},
+  Intl.Locale.prototype,
+];
+
+for (const invalidValue of invalidValues) {
+  assert.throws(TypeError, () => propdesc.get.call(invalidValue));
+}

--- a/test/intl402/Locale/prototype/collations/branding.js
+++ b/test/intl402/Locale/prototype/collations/branding.js
@@ -14,6 +14,7 @@ features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "collations");
+assert.sameValue(typeof propdesc.get, "function");
 const invalidValues = [
   undefined,
   null,

--- a/test/intl402/Locale/prototype/collations/name.js
+++ b/test/intl402/Locale/prototype/collations/name.js
@@ -10,7 +10,7 @@ info: |
     Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
     Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "collations").get;

--- a/test/intl402/Locale/prototype/collations/name.js
+++ b/test/intl402/Locale/prototype/collations/name.js
@@ -1,0 +1,22 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.collations
+description: >
+    Checks the "name" property of Intl.Locale.prototype.collations.
+info: |
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 Language Specification, 10th edition, clause 17, or successor.
+    Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
+    Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "collations").get;
+verifyProperty(getter, "name", {
+  value: "get collations",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/collations/prop-desc.js
+++ b/test/intl402/Locale/prototype/collations/prop-desc.js
@@ -12,7 +12,7 @@ info: |
 
     Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "collations");

--- a/test/intl402/Locale/prototype/collations/prop-desc.js
+++ b/test/intl402/Locale/prototype/collations/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale
+description: >
+    Checks the "collations" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.collations
+
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 script Specification, 10th edition, clause 17, or successor.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "collations");
+assert.sameValue(propdesc.set, undefined);
+assert.sameValue(typeof propdesc.get, "function");
+
+verifyProperty(Intl.Locale.prototype, "collations", {
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/hourCycles/branding.js
+++ b/test/intl402/Locale/prototype/hourCycles/branding.js
@@ -1,0 +1,30 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.hourCycles
+description: >
+    Verifies the branding check for the "hourCycles" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.hourCycles
+
+    2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
+        a. Throw a TypeError exception.
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "hourCycles");
+const invalidValues = [
+  undefined,
+  null,
+  true,
+  "",
+  Symbol(),
+  1,
+  {},
+  Intl.Locale.prototype,
+];
+
+for (const invalidValue of invalidValues) {
+  assert.throws(TypeError, () => propdesc.get.call(invalidValue));
+}

--- a/test/intl402/Locale/prototype/hourCycles/branding.js
+++ b/test/intl402/Locale/prototype/hourCycles/branding.js
@@ -14,6 +14,7 @@ features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "hourCycles");
+assert.sameValue(typeof propdesc.get, "function");
 const invalidValues = [
   undefined,
   null,

--- a/test/intl402/Locale/prototype/hourCycles/branding.js
+++ b/test/intl402/Locale/prototype/hourCycles/branding.js
@@ -10,7 +10,7 @@ info: |
 
     2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
         a. Throw a TypeError exception.
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "hourCycles");

--- a/test/intl402/Locale/prototype/hourCycles/name.js
+++ b/test/intl402/Locale/prototype/hourCycles/name.js
@@ -10,7 +10,7 @@ info: |
     Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
     Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "hourCycles").get;

--- a/test/intl402/Locale/prototype/hourCycles/name.js
+++ b/test/intl402/Locale/prototype/hourCycles/name.js
@@ -1,0 +1,22 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.hourCycles
+description: >
+    Checks the "name" property of Intl.Locale.prototype.hourCycles.
+info: |
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 Language Specification, 10th edition, clause 17, or successor.
+    Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
+    Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "hourCycles").get;
+verifyProperty(getter, "name", {
+  value: "get hourCycles",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/hourCycles/prop-desc.js
+++ b/test/intl402/Locale/prototype/hourCycles/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale
+description: >
+    Checks the "hourCycles" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.hourCycles
+
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 script Specification, 10th edition, clause 17, or successor.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "hourCycles");
+assert.sameValue(propdesc.set, undefined);
+assert.sameValue(typeof propdesc.get, "function");
+
+verifyProperty(Intl.Locale.prototype, "hourCycles", {
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/hourCycles/prop-desc.js
+++ b/test/intl402/Locale/prototype/hourCycles/prop-desc.js
@@ -12,7 +12,7 @@ info: |
 
     Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "hourCycles");

--- a/test/intl402/Locale/prototype/numberingSystems/branding.js
+++ b/test/intl402/Locale/prototype/numberingSystems/branding.js
@@ -1,0 +1,30 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.numberingSystems
+description: >
+    Verifies the branding check for the "numberingSystems" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.numberingSystems
+
+    2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
+        a. Throw a TypeError exception.
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "numberingSystems");
+const invalidValues = [
+  undefined,
+  null,
+  true,
+  "",
+  Symbol(),
+  1,
+  {},
+  Intl.Locale.prototype,
+];
+
+for (const invalidValue of invalidValues) {
+  assert.throws(TypeError, () => propdesc.get.call(invalidValue));
+}

--- a/test/intl402/Locale/prototype/numberingSystems/branding.js
+++ b/test/intl402/Locale/prototype/numberingSystems/branding.js
@@ -10,7 +10,7 @@ info: |
 
     2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
         a. Throw a TypeError exception.
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "numberingSystems");

--- a/test/intl402/Locale/prototype/numberingSystems/branding.js
+++ b/test/intl402/Locale/prototype/numberingSystems/branding.js
@@ -14,6 +14,7 @@ features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "numberingSystems");
+assert.sameValue(typeof propdesc.get, "function");
 const invalidValues = [
   undefined,
   null,

--- a/test/intl402/Locale/prototype/numberingSystems/name.js
+++ b/test/intl402/Locale/prototype/numberingSystems/name.js
@@ -10,7 +10,7 @@ info: |
     Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
     Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "numberingSystems").get;

--- a/test/intl402/Locale/prototype/numberingSystems/name.js
+++ b/test/intl402/Locale/prototype/numberingSystems/name.js
@@ -1,0 +1,22 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.numberingSystems
+description: >
+    Checks the "name" property of Intl.Locale.prototype.numberingSystems.
+info: |
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 Language Specification, 10th edition, clause 17, or successor.
+    Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
+    Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "numberingSystems").get;
+verifyProperty(getter, "name", {
+  value: "get numberingSystems",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/numberingSystems/prop-desc.js
+++ b/test/intl402/Locale/prototype/numberingSystems/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale
+description: >
+    Checks the "numberingSystems" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.numberingSystems
+
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 script Specification, 10th edition, clause 17, or successor.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "numberingSystems");
+assert.sameValue(propdesc.set, undefined);
+assert.sameValue(typeof propdesc.get, "function");
+
+verifyProperty(Intl.Locale.prototype, "numberingSystems", {
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/numberingSystems/prop-desc.js
+++ b/test/intl402/Locale/prototype/numberingSystems/prop-desc.js
@@ -12,7 +12,7 @@ info: |
 
     Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "numberingSystems");

--- a/test/intl402/Locale/prototype/textInfo/branding.js
+++ b/test/intl402/Locale/prototype/textInfo/branding.js
@@ -10,7 +10,7 @@ info: |
 
     2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
         a. Throw a TypeError exception.
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "textInfo");

--- a/test/intl402/Locale/prototype/textInfo/branding.js
+++ b/test/intl402/Locale/prototype/textInfo/branding.js
@@ -14,6 +14,7 @@ features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "textInfo");
+assert.sameValue(typeof propdesc.get, "function");
 const invalidValues = [
   undefined,
   null,

--- a/test/intl402/Locale/prototype/textInfo/branding.js
+++ b/test/intl402/Locale/prototype/textInfo/branding.js
@@ -1,0 +1,30 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.textInfo
+description: >
+    Verifies the branding check for the "textInfo" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.textInfo
+
+    2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
+        a. Throw a TypeError exception.
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "textInfo");
+const invalidValues = [
+  undefined,
+  null,
+  true,
+  "",
+  Symbol(),
+  1,
+  {},
+  Intl.Locale.prototype,
+];
+
+for (const invalidValue of invalidValues) {
+  assert.throws(TypeError, () => propdesc.get.call(invalidValue));
+}

--- a/test/intl402/Locale/prototype/textInfo/name.js
+++ b/test/intl402/Locale/prototype/textInfo/name.js
@@ -10,7 +10,7 @@ info: |
     Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
     Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "textInfo").get;

--- a/test/intl402/Locale/prototype/textInfo/name.js
+++ b/test/intl402/Locale/prototype/textInfo/name.js
@@ -1,0 +1,22 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.textInfo
+description: >
+    Checks the "name" property of Intl.Locale.prototype.textInfo.
+info: |
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 Language Specification, 10th edition, clause 17, or successor.
+    Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
+    Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "textInfo").get;
+verifyProperty(getter, "name", {
+  value: "get textInfo",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/textInfo/prop-desc.js
+++ b/test/intl402/Locale/prototype/textInfo/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale
+description: >
+    Checks the "textInfo" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.textInfo
+
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 script Specification, 10th edition, clause 17, or successor.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "textInfo");
+assert.sameValue(propdesc.set, undefined);
+assert.sameValue(typeof propdesc.get, "function");
+
+verifyProperty(Intl.Locale.prototype, "textInfo", {
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/textInfo/prop-desc.js
+++ b/test/intl402/Locale/prototype/textInfo/prop-desc.js
@@ -12,7 +12,7 @@ info: |
 
     Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "textInfo");

--- a/test/intl402/Locale/prototype/timeZones/branding.js
+++ b/test/intl402/Locale/prototype/timeZones/branding.js
@@ -14,6 +14,7 @@ features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "timeZones");
+assert.sameValue(typeof propdesc.get, "function");
 const invalidValues = [
   undefined,
   null,

--- a/test/intl402/Locale/prototype/timeZones/branding.js
+++ b/test/intl402/Locale/prototype/timeZones/branding.js
@@ -10,7 +10,7 @@ info: |
 
     2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
         a. Throw a TypeError exception.
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "timeZones");

--- a/test/intl402/Locale/prototype/timeZones/branding.js
+++ b/test/intl402/Locale/prototype/timeZones/branding.js
@@ -1,0 +1,30 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.timeZones
+description: >
+    Verifies the branding check for the "timeZones" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.timeZones
+
+    2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
+        a. Throw a TypeError exception.
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "timeZones");
+const invalidValues = [
+  undefined,
+  null,
+  true,
+  "",
+  Symbol(),
+  1,
+  {},
+  Intl.Locale.prototype,
+];
+
+for (const invalidValue of invalidValues) {
+  assert.throws(TypeError, () => propdesc.get.call(invalidValue));
+}

--- a/test/intl402/Locale/prototype/timeZones/name.js
+++ b/test/intl402/Locale/prototype/timeZones/name.js
@@ -10,7 +10,7 @@ info: |
     Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
     Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "timeZones").get;

--- a/test/intl402/Locale/prototype/timeZones/name.js
+++ b/test/intl402/Locale/prototype/timeZones/name.js
@@ -1,0 +1,22 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.timeZones
+description: >
+    Checks the "name" property of Intl.Locale.prototype.timeZones.
+info: |
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 Language Specification, 10th edition, clause 17, or successor.
+    Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
+    Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "timeZones").get;
+verifyProperty(getter, "name", {
+  value: "get timeZones",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/timeZones/prop-desc.js
+++ b/test/intl402/Locale/prototype/timeZones/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale
+description: >
+    Checks the "timeZones" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.timeZones
+
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 script Specification, 10th edition, clause 17, or successor.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "timeZones");
+assert.sameValue(propdesc.set, undefined);
+assert.sameValue(typeof propdesc.get, "function");
+
+verifyProperty(Intl.Locale.prototype, "timeZones", {
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/timeZones/prop-desc.js
+++ b/test/intl402/Locale/prototype/timeZones/prop-desc.js
@@ -12,7 +12,7 @@ info: |
 
     Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "timeZones");

--- a/test/intl402/Locale/prototype/weekInfo/branding.js
+++ b/test/intl402/Locale/prototype/weekInfo/branding.js
@@ -14,6 +14,7 @@ features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "weekInfo");
+assert.sameValue(typeof propdesc.get, "function");
 const invalidValues = [
   undefined,
   null,

--- a/test/intl402/Locale/prototype/weekInfo/branding.js
+++ b/test/intl402/Locale/prototype/weekInfo/branding.js
@@ -10,7 +10,7 @@ info: |
 
     2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
         a. Throw a TypeError exception.
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "weekInfo");

--- a/test/intl402/Locale/prototype/weekInfo/branding.js
+++ b/test/intl402/Locale/prototype/weekInfo/branding.js
@@ -1,0 +1,30 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.Locale.prototype.weekInfo
+description: >
+    Verifies the branding check for the "weekInfo" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.weekInfo
+
+    2. If Type(loc) is not Object or loc does not have an [[InitializedLocale]] internal slot, then
+        a. Throw a TypeError exception.
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "weekInfo");
+const invalidValues = [
+  undefined,
+  null,
+  true,
+  "",
+  Symbol(),
+  1,
+  {},
+  Intl.Locale.prototype,
+];
+
+for (const invalidValue of invalidValues) {
+  assert.throws(TypeError, () => propdesc.get.call(invalidValue));
+}

--- a/test/intl402/Locale/prototype/weekInfo/name.js
+++ b/test/intl402/Locale/prototype/weekInfo/name.js
@@ -1,0 +1,22 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale.prototype.weekInfo
+description: >
+    Checks the "name" property of Intl.Locale.prototype.weekInfo.
+info: |
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 Language Specification, 10th edition, clause 17, or successor.
+    Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
+    Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "weekInfo").get;
+verifyProperty(getter, "name", {
+  value: "get weekInfo",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Locale/prototype/weekInfo/name.js
+++ b/test/intl402/Locale/prototype/weekInfo/name.js
@@ -10,7 +10,7 @@ info: |
     Every built-in function object, including constructors, that is not identified as an anonymous function has a name property whose value is a String. Unless otherwise specified, this value is the name that is given to the function in this specification. Functions that are specified as get or set accessor functions of built-in properties have "get " or "set " prepended to the property name string.
     Unless otherwise specified, the name property of a built-in function object, if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const getter = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "weekInfo").get;

--- a/test/intl402/Locale/prototype/weekInfo/prop-desc.js
+++ b/test/intl402/Locale/prototype/weekInfo/prop-desc.js
@@ -12,7 +12,7 @@ info: |
 
     Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
 includes: [propertyHelper.js]
-features: [Intl.Locale]
+features: [Intl.Locale,Intl.Locale-info]
 ---*/
 
 const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "weekInfo");

--- a/test/intl402/Locale/prototype/weekInfo/prop-desc.js
+++ b/test/intl402/Locale/prototype/weekInfo/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.locale
+description: >
+    Checks the "weekInfo" property of the Locale prototype object.
+info: |
+    Intl.Locale.prototype.weekInfo
+
+    Unless specified otherwise in this document, the objects, functions, and constructors described in this standard are subject to the generic requirements and restrictions specified for standard built-in ECMAScript objects in the ECMAScript 2019 script Specification, 10th edition, clause 17, or successor.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified. If only a get accessor function is described, the set accessor function is the default value, undefined.
+includes: [propertyHelper.js]
+features: [Intl.Locale]
+---*/
+
+const propdesc = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, "weekInfo");
+assert.sameValue(propdesc.set, undefined);
+assert.sameValue(typeof propdesc.get, "function");
+
+verifyProperty(Intl.Locale.prototype, "weekInfo", {
+  enumerable: false,
+  configurable: true,
+});


### PR DESCRIPTION
Add the basic tests (`name.js`, `branding.js` and `prop-desc.js`) for the Intl LocaleInfo proposal.

The existing getters on the `Intl.Locale` prototype only have these basic tests as well, so I think this should be sufficient for unblocking implementations. That said, I will try to add more comprehensive tests for these getters.

/cc @FrankYFTang

Fixes: #2984 