### PR TITLE
Define policy for Promise rejections in sync tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,9 @@ single line comment syntax.
 #### negative
 `negative: [dictionary containing "phase" and "type" keys]`
 
-This means the test is expected to throw an error of the given type.  If no error is thrown, a test failure is reported.
+This means the test is expected to throw an error of the given type or produce
+an unhandled Promise rejection of the given type. If neither of these events
+occur, a test failure is reported.
 
 - **type** - If an error is thrown, it is implicitly converted to a string. In order for the test to pass, this value must match the name of the error constructor.
 - **phase** - Negative tests whose **phase** value is "parse" must produce the specified error prior to executing code. The value "resolution" indicates that the error is expected to result while performing ES2015 module resolution. The value "runtime" dictates that the error is expected to be produced as a result of executing the test code.

--- a/INTERPRETING.md
+++ b/INTERPRETING.md
@@ -159,9 +159,10 @@ located at `test/language/import/nested/dep.js`.
 
 ## Test Results
 
-By default, tests signal failure by generating an uncaught exception. If
-execution completes without generating an exception, the test must be
-interpreted as "passing." Any uncaught exception must be interpreted as test
+By default, tests signal failure by generating an uncaught exception or failing
+to handle a Promise rejection. If execution completes without generating an
+exception or unhandled rejection, the test must be interpreted as "passing."
+Any uncaught exception or unhandled rejection must be interpreted as test
 failure. These semantics may be modified by any test according to the metadata
 declared within the test itself (via the `negative` attribute and the `async`
 flag, described below).

--- a/test/harness/synchronous-rejection.js
+++ b/test/harness/synchronous-rejection.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2021 the V8 project authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Synchronous tests should fail if they include unhandled Promise rejections.
+negative:
+  phase: runtime
+  type: Test262Error
+---*/
+
+Promise.reject(new Test262Error('This rejection should cause the test to fail.'));


### PR DESCRIPTION
Although the semantics being verified by a synchronous test may be
observable during the initial evaluation, subsequently-rejected jobs may
indicate errors in test design or anomalies in the implementation under
test.

A more relaxed policy would instruct implementations to ignore any
unhandled rejections in synchronous tests. Compared to the policy
introduced by this patch, such a policy would impose fewer constraints
on test authors. However, it would also make their tests more
susceptible to mistakes, and it would also reduce Test262's ability to
identify implementation defects.

Since test authors are in full control of the Promise values created in
their tests, they can consistently handle rejections. This requirement
will help surface mistakes (whether in test design or in the
implementation under test).

---

This change introduces a policy where historically there has been no policy, and there are certainly other alternatives. Starting with a concrete proposal seemed like the best way to inspire productive discussion.

Today, V8 satisfies this policy when tested using [the test262-harness utility](https://github.com/bterlson/test262-harness). SpiderMonkey interprets unhandled rejections similarly to uncaught exceptions, but it does not recognize the "name" of the error constructor.

Chakra, JavaScriptCore, QuickJS, GraalJS, Engine262, and XS all ignore unhandled rejections in synchronous tests.

Simply following the majority would dictate a different policy than what I'm suggesting in this patch. As the commit message explains, I think the more strict policy is beneficial for both test authors and for the implementations themselves.

As far as I'm aware, no synchronous tests intentionally produce uncaught exceptions today. This change will help us consistently vet future contributions, and it has the potential to surface implementation bugs which have been ignored.

To Test262's consumers: would you mind sharing how difficult it would be to adhere to this policy?

Whatever policy we choose will impact (at least) ease of contribution, test expressiveness, and ease of consumption. Does this patch strike a good balance?