### PR TITLE
Move some AnnexB tests per proposed spec change

### DIFF
--- a/test/annexB/language/literals/regexp/legacy-octal-escape.js
+++ b/test/annexB/language/literals/regexp/legacy-octal-escape.js
@@ -20,8 +20,8 @@ info: |
         ZeroToThree OctalDigit OctalDigit
 
     The production CharacterEscape :: LegacyOctalEscapeSequence evaluates by
-    evaluating the SV of the LegacyOctalEscapeSequence (see B.1.2) and
-    returning its character result.
+    evaluating the SV of the LegacyOctalEscapeSequence and returning its
+    character result.
 ---*/
 
 assert.sameValue(/\1/.exec('\x01')[0], '\x01', '\\1');

--- a/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence-8.js
+++ b/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence-8.js
@@ -5,8 +5,18 @@ esid: sec-template-literal-lexical-components
 description: >
     Invalid octal escape sequence (regardless of the presence of Annex B)
 info: |
-    A conforming implementation must not use the extended definition of
-    EscapeSequence described in B.1.2 when parsing a TemplateCharacter.
+  TemplateCharacter ::
+    $ [lookahead ≠ {]
+    \ TemplateEscapeSequence
+    \ NotEscapeSequence
+    LineContinuation
+    LineTerminatorSequence
+    SourceCharacter but not one of ` or \ or $ or LineTerminator
+  TemplateEscapeSequence ::
+    CharacterEscapeSequence
+    0 [lookahead ∉ DecimalDigit]
+    HexEscapeSequence
+    UnicodeEscapeSequence
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence-9.js
+++ b/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence-9.js
@@ -5,8 +5,18 @@ esid: sec-template-literal-lexical-components
 description: >
     Invalid octal escape sequence (regardless of the presence of Annex B)
 info: |
-    A conforming implementation must not use the extended definition of
-    EscapeSequence described in B.1.2 when parsing a TemplateCharacter.
+  TemplateCharacter ::
+    $ [lookahead ≠ {]
+    \ TemplateEscapeSequence
+    \ NotEscapeSequence
+    LineContinuation
+    LineTerminatorSequence
+    SourceCharacter but not one of ` or \ or $ or LineTerminator
+  TemplateEscapeSequence ::
+    CharacterEscapeSequence
+    0 [lookahead ∉ DecimalDigit]
+    HexEscapeSequence
+    UnicodeEscapeSequence
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence.js
+++ b/test/language/expressions/template-literal/invalid-legacy-octal-escape-sequence.js
@@ -4,8 +4,18 @@
 es6id: 16.1
 description: Invalid octal escape sequence
 info: |
-    TemplateCharacter (11.8.6) must not be extended to include
-    LegacyOctalEscapeSequence as defined in B.1.2.
+  TemplateCharacter ::
+    $ [lookahead ≠ {]
+    \ TemplateEscapeSequence
+    \ NotEscapeSequence
+    LineContinuation
+    LineTerminatorSequence
+    SourceCharacter but not one of ` or \ or $ or LineTerminator
+  TemplateEscapeSequence ::
+    CharacterEscapeSequence
+    0 [lookahead ∉ DecimalDigit]
+    HexEscapeSequence
+    UnicodeEscapeSequence
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/literals/numeric/legacy-octal-integer-strict.js
+++ b/test/language/literals/numeric/legacy-octal-integer-strict.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-numeric-literals
+esid: sec-literals-numeric-literals
 description: LegacyOctalIntegerLiteral is not enabled in strict mode code
 info: |
     NumericLiteral ::
@@ -11,9 +11,17 @@ info: |
       HexIntegerLiteral
       LegacyOctalIntegerLiteral
 
-     LegacyOctalIntegerLiteral ::
-       0 OctalDigit
-       LegacyOctalIntegerLiteral OctalDigit
+    LegacyOctalIntegerLiteral ::
+      0 OctalDigit
+      LegacyOctalIntegerLiteral OctalDigit
+
+    ## 12.8.3.1 Static Semantics: Early Errors
+
+    NumericLiteral :: LegacyOctalIntegerLiteral
+    DecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral
+
+    - It is a Syntax Error if the source code matching this production is
+      strict mode code.
 flags: [onlyStrict]
 negative:
   phase: parse

--- a/test/language/literals/numeric/legacy-octal-integer.js
+++ b/test/language/literals/numeric/legacy-octal-integer.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-numeric-literals
+esid: sec-literals-numeric-literals
 description: Mathematical value for LegacyOctalIntegerLiteral
 info: |
     NumericLiteral ::

--- a/test/language/literals/numeric/non-octal-decimal-integer-strict.js
+++ b/test/language/literals/numeric/non-octal-decimal-integer-strict.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-numeric-literals
+esid: sec-literals-numeric-literals
 description: NonOctalDecimalIntegerLiteral is not enabled in strict mode code
 info: |
      DecimalIntegerLiteral ::
@@ -20,6 +20,14 @@ info: |
 
      NonOctalDigit :: one of
        8 9
+
+     ## 12.8.3.1 Static Semantics: Early Errors
+
+     NumericLiteral :: LegacyOctalIntegerLiteral
+     DecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral
+
+     - It is a Syntax Error if the source code matching this production is
+       strict mode code.
 flags: [onlyStrict]
 negative:
   phase: parse

--- a/test/language/literals/numeric/non-octal-decimal-integer.js
+++ b/test/language/literals/numeric/non-octal-decimal-integer.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-numeric-literals
+esid: sec-literals-numeric-literals
 description: Mathematical value for NonOctalDecimalIntegerLiteral
 info: |
      DecimalIntegerLiteral ::

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-1-strict-explicit-pragma.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-1-strict-explicit-pragma.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 Rick Waldron Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
+esid: sec-literals-string-literals
 description: >
   String Literals extensions disallowed in strict mode; ZeroToThree 1
 info: |

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-2-strict-explicit-pragma.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-2-strict-explicit-pragma.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 Rick Waldron Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
+esid: sec-literals-string-literals
 description: >
   String Literals extensions disallowed in strict mode; ZeroToThree 2
 info: |

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-3-strict-explicit-pragma.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-3-strict-explicit-pragma.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 Rick Waldron Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
+esid: sec-literals-string-literals
 description: >
   String Literals extensions disallowed in strict mode; ZeroToThree 3
 info: |

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-4-strict-explicit-pragma.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-4-strict-explicit-pragma.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 Rick Waldron Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
+esid: sec-literals-string-literals
 description: >
   String Literals extensions disallowed in strict mode; FourToSeven 4
 info: |

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-5-strict-explicit-pragma.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-5-strict-explicit-pragma.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 Rick Waldron Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
+esid: sec-literals-string-literals
 description: >
   String Literals extensions disallowed in strict mode; FourToSeven 5
 info: |

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-6-strict-explicit-pragma.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-6-strict-explicit-pragma.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 Rick Waldron Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
+esid: sec-literals-string-literals
 description: >
   String Literals extensions disallowed in strict mode; FourToSeven 6
 info: |

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-7-strict-explicit-pragma.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-7-strict-explicit-pragma.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 Rick Waldron Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
+esid: sec-literals-string-literals
 description: >
   String Literals extensions disallowed in strict mode; FourToSeven 7
 info: |

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-8-non-strict.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-8-non-strict.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-literals-string-literals
+description: LegacyOctalEscapeSequence is not available in non-strict code - 8
+info: |
+    EscapeSequence ::
+      CharacterEscapeSequence
+      LegacyOctalEscapeSequence
+      NonOctalDecimalEscapeSequence
+      HexEscapeSequence
+      UnicodeEscapeSequence
+
+    NonOctalDecimalEscapeSequence :: one of
+      8 9
+flags: [noStrict]
+---*/
+
+assert.sameValue('\8', '8');

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-8-strict-explicit-pragma.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-8-strict-explicit-pragma.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 Rick Waldron Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
+esid: sec-literals-string-literals
 description: >
   String Literals extensions disallowed in strict mode; NonOctalDecimalEscapeSequence 8
 info: |

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-8-strict.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-8-strict.js
@@ -2,12 +2,24 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-literals-string-literals
-description: >
-    LegacyOctalEscapeSequence is not enabled in strict mode code
-    (regardless of the presence of Annex B)
+description: LegacyOctalEscapeSequence is not enabled in strict mode code - 8
 info: |
-    A conforming implementation, when processing strict mode code, must not extend the
-    syntax of EscapeSequence to include LegacyOctalEscapeSequence as described in B.1.2.
+  EscapeSequence ::
+    CharacterEscapeSequence
+    LegacyOctalEscapeSequence
+    NonOctalDecimalEscapeSequence
+    HexEscapeSequence
+    UnicodeEscapeSequence
+
+  NonOctalDecimalEscapeSequence :: one of
+    8 9
+
+  ## 12.8.4.1 Static Semantics: Early Errors
+
+  EscapeSequence :: NonOctalDecimalEscapeSequence
+
+  - It is a Syntax Error if the source code matching this production is strict
+    mode code.
 flags: [onlyStrict]
 negative:
   phase: parse

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-9-non-strict.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-9-non-strict.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-literals-string-literals
+description: LegacyOctalEscapeSequence is not available in non-strict code - 9
+info: |
+    EscapeSequence ::
+      CharacterEscapeSequence
+      LegacyOctalEscapeSequence
+      NonOctalDecimalEscapeSequence
+      HexEscapeSequence
+      UnicodeEscapeSequence
+
+    NonOctalDecimalEscapeSequence :: one of
+      8 9
+flags: [noStrict]
+---*/
+
+assert.sameValue('\9', '9');

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-9-strict-explicit-pragma.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-9-strict-explicit-pragma.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 Rick Waldron Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
+esid: sec-literals-string-literals
 description: >
   String Literals extensions disallowed in strict mode; NonOctalDecimalEscapeSequence 9
 info: |

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-9-strict.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-9-strict.js
@@ -2,12 +2,24 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-literals-string-literals
-description: >
-    LegacyOctalEscapeSequence is not enabled in strict mode code
-    (regardless of the presence of Annex B)
+description: LegacyOctalEscapeSequence is not enabled in strict mode code - 9
 info: |
-    A conforming implementation, when processing strict mode code, must not extend the
-    syntax of EscapeSequence to include LegacyOctalEscapeSequence as described in B.1.2.
+  EscapeSequence ::
+    CharacterEscapeSequence
+    LegacyOctalEscapeSequence
+    NonOctalDecimalEscapeSequence
+    HexEscapeSequence
+    UnicodeEscapeSequence
+
+  NonOctalDecimalEscapeSequence :: one of
+    8 9
+
+  ## 12.8.4.1 Static Semantics: Early Errors
+
+  EscapeSequence :: NonOctalDecimalEscapeSequence
+
+  - It is a Syntax Error if the source code matching this production is strict
+    mode code.
 flags: [onlyStrict]
 negative:
   phase: parse

--- a/test/language/literals/string/legacy-non-octal-escape-sequence-strict.js
+++ b/test/language/literals/string/legacy-non-octal-escape-sequence-strict.js
@@ -1,32 +1,21 @@
 // Copyright (C) 2017 Kevin Gibbons. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
-es6id: B.1.2
-description: >
-    LegacyOctalEscapeSequence is not enabled in strict mode code (regardless of
-    the presence of Annex B)
+esid: sec-template-literal-lexical-components
+description: LegacyOctalEscapeSequence is not available in template literals
 info: |
-    EscapeSequence ::
-      CharacterEscapeSequence
-      LegacyOctalEscapeSequence
-      HexEscapeSequence
-      UnicodeEscapeSequence
-
-    LegacyOctalEscapeSequence ::
-      OctalDigit [lookahead ∉ OctalDigit]
-      ZeroToThree OctalDigit [lookahead ∉ OctalDigit]
-      FourToSeven OctalDigit
-      ZeroToThree OctalDigit OctalDigit
-
-    ZeroToThree :: one of
-      0 1 2 3
-
-    FourToSeven :: one of
-      4 5 6 7
-
-    This definition of EscapeSequence is not used in strict mode or when
-    parsing TemplateCharacter.
+  TemplateCharacter ::
+    $ [lookahead ≠ {]
+    \ TemplateEscapeSequence
+    \ NotEscapeSequence
+    LineContinuation
+    LineTerminatorSequence
+    SourceCharacter but not one of ` or \ or $ or LineTerminator
+  TemplateEscapeSequence ::
+    CharacterEscapeSequence
+    0 [lookahead ∉ DecimalDigit]
+    HexEscapeSequence
+    UnicodeEscapeSequence
 flags: [onlyStrict]
 negative:
   phase: parse

--- a/test/language/literals/string/legacy-octal-escape-sequence-strict.js
+++ b/test/language/literals/string/legacy-octal-escape-sequence-strict.js
@@ -1,32 +1,21 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
-es6id: B.1.2
-description: >
-    LegacyOctalEscapeSequence is not enabled in strict mode code (regardless of
-    the presence of Annex B)
+esid: sec-template-literal-lexical-components
+description: LegacyOctalEscapeSequence is not available in template literals
 info: |
-    EscapeSequence ::
-      CharacterEscapeSequence
-      LegacyOctalEscapeSequence
-      HexEscapeSequence
-      UnicodeEscapeSequence
-
-    LegacyOctalEscapeSequence ::
-      OctalDigit [lookahead ∉ OctalDigit]
-      ZeroToThree OctalDigit [lookahead ∉ OctalDigit]
-      FourToSeven OctalDigit
-      ZeroToThree OctalDigit OctalDigit
-
-    ZeroToThree :: one of
-      0 1 2 3
-
-    FourToSeven :: one of
-      4 5 6 7
-
-    This definition of EscapeSequence is not used in strict mode or when
-    parsing TemplateCharacter.
+  TemplateCharacter ::
+    $ [lookahead ≠ {]
+    \ TemplateEscapeSequence
+    \ NotEscapeSequence
+    LineContinuation
+    LineTerminatorSequence
+    SourceCharacter but not one of ` or \ or $ or LineTerminator
+  TemplateEscapeSequence ::
+    CharacterEscapeSequence
+    0 [lookahead ∉ DecimalDigit]
+    HexEscapeSequence
+    UnicodeEscapeSequence
 flags: [onlyStrict]
 negative:
   phase: parse

--- a/test/language/literals/string/legacy-octal-escape-sequence.js
+++ b/test/language/literals/string/legacy-octal-escape-sequence.js
@@ -1,13 +1,13 @@
 // Copyright (C) 2016 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-additional-syntax-string-literals
-es6id: B.1.2
+esid: sec-literals-string-literals
 description: String value for LegacyOctalEscapeSequence
 info: |
     EscapeSequence ::
       CharacterEscapeSequence
       LegacyOctalEscapeSequence
+      NonOctalDecimalEscapeSequence
       HexEscapeSequence
       UnicodeEscapeSequence
 


### PR DESCRIPTION
Additionally, update test metadata and introduce two new tests to
complete coverage.

Reference: "Normative: Make B.1.{1,2} normative"
https://github.com/tc39/ecma262/pull/1867