### PR TITLE
Add tests for Object.hasOwn

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -205,6 +205,10 @@ arbitrary-module-namespace-names
 # https://github.com/tc39/ecma262/pull/2164
 align-detached-buffer-semantics-with-web-reality
 
+# Object.hasOwn
+# https://github.com/tc39/proposal-accessible-object-hasownproperty
+Object.hasOwn
+
 ## Standard language features
 #
 # Language features that have been included in a published version of the

--- a/test/built-ins/Object/hasOwn/descriptor.js
+++ b/test/built-ins/Object/hasOwn/descriptor.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Testing descriptor property of Object.hasOwn
+includes:
+    - propertyHelper.js
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+verifyWritable(Object, "hasOwn");
+verifyNotEnumerable(Object, "hasOwn");
+verifyConfigurable(Object, "hasOwn");

--- a/test/built-ins/Object/hasOwn/hasown.js
+++ b/test/built-ins/Object/hasOwn/hasown.js
@@ -15,13 +15,5 @@ author: Jamie Kyle
 features: [Object.hasOwn]
 ---*/
 
-//CHECK#1
-if (typeof Object.hasOwn !== "function") {
-  $ERROR('#1: hasOwn method is defined');
-}
-
-//CHECK#2
-if (!(Object.hasOwn(Object, "hasOwn"))) {
-  $ERROR('#2: hasOwn method works properly');
-}
-//
+assert.sameValue(typeof Object.hasOwn, 'function');
+assert.sameValue(Object.hasOwn(Object, 'hasOwn'), false);

--- a/test/built-ins/Object/hasOwn/hasown.js
+++ b/test/built-ins/Object/hasOwn/hasown.js
@@ -1,0 +1,27 @@
+// Copyright 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+info: |
+    Object.hasOwn ( _O_, _P_ )
+
+    1. Let _obj_ be ? ToObject(_O_).
+    2. Let _key_ be ? ToPropertyKey(_P_).
+    3. Return ? HasOwnProperty(_obj_, _key_).
+description: >
+    Checking type of the Object.hasOwn and the returned result
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+//CHECK#1
+if (typeof Object.hasOwn !== "function") {
+  $ERROR('#1: hasOwn method is defined');
+}
+
+//CHECK#2
+if (!(Object.hasOwn(Object, "hasOwn"))) {
+  $ERROR('#2: hasOwn method works properly');
+}
+//

--- a/test/built-ins/Object/hasOwn/hasown.js
+++ b/test/built-ins/Object/hasOwn/hasown.js
@@ -16,4 +16,4 @@ features: [Object.hasOwn]
 ---*/
 
 assert.sameValue(typeof Object.hasOwn, 'function');
-assert.sameValue(Object.hasOwn(Object, 'hasOwn'), false);
+assert(Object.hasOwn(Object, 'hasOwn'));

--- a/test/built-ins/Object/hasOwn/hasown_inherited_exists.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_exists.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Properties - [[HasOwnProperty]] (old style inherited property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {
+  foo: 42
+};
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_getter.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_getter.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Properties - [[HasOwnProperty]] (literal inherited getter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {
+  get foo() {
+    return 42;
+  }
+};
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter.js
@@ -14,7 +14,7 @@ var base = {
   get foo() {
     return 42;
   },
-  set foo(x) {;
+  set foo(x) {
   }
 };
 var o = Object.create(base);

--- a/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (literal inherited getter/setter
+    property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {
+  get foo() {
+    return 42;
+  },
+  set foo(x) {;
+  }
+};
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter_configurable_enumerable.js
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, enumerable
+    inherited getter/setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  get: function() {
+    return 42;
+  },
+  set: function() {;
+  },
+  enumerable: true,
+  configurable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter_configurable_nonenumerable.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, non-enumerable
+    inherited getter/setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  get: function() {
+    return 42;
+  },
+  set: function() {;
+  },
+  configurable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter_nonconfigurable_enumerable.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, enumerable
+    inherited getter/setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  get: function() {
+    return 42;
+  },
+  set: function() {;
+  },
+  enumerable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_getter_and_setter_nonconfigurable_nonenumerable.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, non-enumerable
+    inherited getter/setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  get: function() {
+    return 42;
+  },
+  set: function() {;
+  }
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_getter_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_getter_configurable_enumerable.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, enumerable
+    inherited getter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  get: function() {
+    return 42;
+  },
+  enumerable: true,
+  configurable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_getter_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_getter_configurable_nonenumerable.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, non-enumerable
+    inherited getter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  get: function() {
+    return 42;
+  },
+  configurable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_getter_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_getter_nonconfigurable_enumerable.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, enumerable
+    inherited getter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  get: function() {
+    return 42;
+  },
+  enumerable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_getter_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_getter_nonconfigurable_nonenumerable.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, non-enumerable
+    inherited getter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  get: function() {
+    return 42;
+  }
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_nonwritable_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_nonwritable_configurable_enumerable.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-writable, configurable,
+    enumerable inherited value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  value: 42,
+  configurable: true,
+  enumerable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_nonwritable_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_nonwritable_configurable_nonenumerable.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-writable, configurable,
+    non-enumerable inherited value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  value: 42,
+  configurable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_nonwritable_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_nonwritable_nonconfigurable_enumerable.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-writable, non-configurable,
+    enumerable inherited value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  value: 42,
+  enumerable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_nonwritable_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_nonwritable_nonconfigurable_nonenumerable.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-writable, non-configurable,
+    non-enumerable inherited value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  value: 42
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_setter.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_setter.js
@@ -9,7 +9,7 @@ features: [Object.hasOwn]
 ---*/
 
 var base = {
-  set foo(x) {;
+  set foo(x) {
   }
 };
 var o = Object.create(base);

--- a/test/built-ins/Object/hasOwn/hasown_inherited_setter.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_setter.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Properties - [[HasOwnProperty]] (literal inherited setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {
+  set foo(x) {;
+  }
+};
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_setter_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_setter_configurable_enumerable.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, enumerable
+    inherited setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  set: function() {;
+  },
+  enumerable: true,
+  configurable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_setter_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_setter_configurable_nonenumerable.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, non-enumerable
+    inherited setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  set: function() {;
+  },
+  configurable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_setter_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_setter_nonconfigurable_enumerable.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, enumerable
+    inherited setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  set: function() {;
+  },
+  enumerable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_setter_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_setter_nonconfigurable_nonenumerable.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, non-enumerable
+    inherited setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  set: function() {;
+  }
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_writable_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_writable_configurable_enumerable.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (writable, configurable,
+    enumerable inherited value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  value: 42,
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_writable_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_writable_configurable_nonenumerable.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (writable, configurable,
+    non-enumerable inherited value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  value: 42,
+  writable: true,
+  configurable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_writable_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_writable_nonconfigurable_enumerable.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (writable, non-configurable,
+    enumerable inherited value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  value: 42,
+  writable: true,
+  enumerable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_inherited_writable_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_inherited_writable_nonconfigurable_nonenumerable.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (writable, non-configurable,
+    non-enumerable inherited value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var base = {};
+Object.defineProperty(base, "foo", {
+  value: 42,
+  writable: true
+});
+var o = Object.create(base);
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_nonexistent.js
+++ b/test/built-ins/Object/hasOwn/hasown_nonexistent.js
@@ -1,0 +1,13 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Properties - [[HasOwnProperty]] (property does not exist)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+
+assert.sameValue(Object.hasOwn(o, "foo"), false, 'Object.hasOwn(o, "foo")');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Properties - [[HasOwnProperty]] (literal own getter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {
+  get foo() {
+    return 42;
+  }
+};
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter.js
@@ -14,4 +14,4 @@ var o = {
   }
 };
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter.js
@@ -14,7 +14,7 @@ var o = {
   get foo() {
     return 42;
   },
-  set foo(x) {;
+  set foo(x) {
   }
 };
 

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (literal own getter/setter
+    property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {
+  get foo() {
+    return 42;
+  },
+  set foo(x) {;
+  }
+};
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter.js
@@ -18,4 +18,4 @@ var o = {
   }
 };
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_configurable_enumerable.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, enumerable own
+    getter/setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  get: function() {
+    return 42;
+  },
+  set: function() {;
+  },
+  enumerable: true,
+  configurable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_configurable_enumerable.js
@@ -21,4 +21,4 @@ Object.defineProperty(o, "foo", {
   configurable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_configurable_nonenumerable.js
@@ -20,4 +20,4 @@ Object.defineProperty(o, "foo", {
   configurable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_configurable_nonenumerable.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, non-enumerable own
+    getter/setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  get: function() {
+    return 42;
+  },
+  set: function() {;
+  },
+  configurable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_nonconfigurable_enumerable.js
@@ -20,4 +20,4 @@ Object.defineProperty(o, "foo", {
   enumerable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_nonconfigurable_enumerable.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, enumerable own
+    getter/setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  get: function() {
+    return 42;
+  },
+  set: function() {;
+  },
+  enumerable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_nonconfigurable_nonenumerable.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, non-enumerable
+    own getter/setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  get: function() {
+    return 42;
+  },
+  set: function() {;
+  }
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_and_setter_nonconfigurable_nonenumerable.js
@@ -19,4 +19,4 @@ Object.defineProperty(o, "foo", {
   }
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_configurable_enumerable.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, enumerable own
+    getter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  get: function() {
+    return 42;
+  },
+  enumerable: true,
+  configurable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_configurable_enumerable.js
@@ -19,4 +19,4 @@ Object.defineProperty(o, "foo", {
   configurable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_configurable_nonenumerable.js
@@ -18,4 +18,4 @@ Object.defineProperty(o, "foo", {
   configurable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_configurable_nonenumerable.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, non-enumerable own
+    getter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  get: function() {
+    return 42;
+  },
+  configurable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_nonconfigurable_enumerable.js
@@ -18,4 +18,4 @@ Object.defineProperty(o, "foo", {
   enumerable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_nonconfigurable_enumerable.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, enumerable own
+    getter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  get: function() {
+    return 42;
+  },
+  enumerable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_nonconfigurable_nonenumerable.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, non-enumerable
+    own getter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  get: function() {
+    return 42;
+  }
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_getter_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_getter_nonconfigurable_nonenumerable.js
@@ -17,4 +17,4 @@ Object.defineProperty(o, "foo", {
   }
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_nonwritable_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_nonwritable_configurable_enumerable.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-writable, configurable,
+    enumerable own value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  value: 42,
+  configurable: true,
+  enumerable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_nonwritable_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_nonwritable_configurable_enumerable.js
@@ -17,4 +17,4 @@ Object.defineProperty(o, "foo", {
   enumerable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_nonwritable_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_nonwritable_nonconfigurable_enumerable.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-writable, non-configurable,
+    enumerable own value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  value: 42,
+  enumerable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_nonwritable_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_nonwritable_nonconfigurable_enumerable.js
@@ -16,4 +16,4 @@ Object.defineProperty(o, "foo", {
   enumerable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_nonwriteable_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_nonwriteable_configurable_nonenumerable.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-writable, configurable,
+    non-enumerable own value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  value: 42,
+  configurable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_nonwriteable_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_nonwriteable_configurable_nonenumerable.js
@@ -16,4 +16,4 @@ Object.defineProperty(o, "foo", {
   configurable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_nonwriteable_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_nonwriteable_nonconfigurable_nonenumerable.js
@@ -15,4 +15,4 @@ Object.defineProperty(o, "foo", {
   value: 42
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_nonwriteable_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_nonwriteable_nonconfigurable_nonenumerable.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-writable, non-configurable,
+    non-enumerable own value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  value: 42
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_property_exists.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_property_exists.js
@@ -12,4 +12,4 @@ var o = {
   foo: 42
 };
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_property_exists.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_property_exists.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Properties - [[HasOwnProperty]] (old style own property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {
+  foo: 42
+};
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_setter.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_setter.js
@@ -13,4 +13,4 @@ var o = {
   }
 };
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_setter.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_setter.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Properties - [[HasOwnProperty]] (literal own setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {
+  set foo(x) {;
+  }
+};
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_setter.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_setter.js
@@ -9,7 +9,7 @@ features: [Object.hasOwn]
 ---*/
 
 var o = {
-  set foo(x) {;
+  set foo(x) {
   }
 };
 

--- a/test/built-ins/Object/hasOwn/hasown_own_setter_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_setter_configurable_enumerable.js
@@ -18,4 +18,4 @@ Object.defineProperty(o, "foo", {
   configurable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_setter_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_setter_configurable_enumerable.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, enumerable own
+    setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  set: function() {;
+  },
+  enumerable: true,
+  configurable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_setter_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_setter_configurable_nonenumerable.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (configurable, non-enumerable own
+    setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  set: function() {;
+  },
+  configurable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_setter_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_setter_configurable_nonenumerable.js
@@ -17,4 +17,4 @@ Object.defineProperty(o, "foo", {
   configurable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_setter_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_setter_nonconfigurable_enumerable.js
@@ -17,4 +17,4 @@ Object.defineProperty(o, "foo", {
   enumerable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_setter_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_setter_nonconfigurable_enumerable.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, enumerable own
+    setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  set: function() {;
+  },
+  enumerable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_setter_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_setter_nonconfigurable_nonenumerable.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (non-configurable, non-enumerable
+    own setter property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  set: function() {;
+  }
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_setter_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_setter_nonconfigurable_nonenumerable.js
@@ -16,4 +16,4 @@ Object.defineProperty(o, "foo", {
   }
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_writable_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_writable_configurable_enumerable.js
@@ -18,4 +18,4 @@ Object.defineProperty(o, "foo", {
   configurable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_writable_configurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_writable_configurable_enumerable.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (writable, configurable,
+    enumerable own value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  value: 42,
+  writable: true,
+  enumerable: true,
+  configurable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_writable_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_writable_configurable_nonenumerable.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (writable, configurable,
+    non-enumerable own value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  value: 42,
+  writable: true,
+  configurable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_writable_configurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_writable_configurable_nonenumerable.js
@@ -17,4 +17,4 @@ Object.defineProperty(o, "foo", {
   configurable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_writable_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_writable_nonconfigurable_enumerable.js
@@ -17,4 +17,4 @@ Object.defineProperty(o, "foo", {
   enumerable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_writable_nonconfigurable_enumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_writable_nonconfigurable_enumerable.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (writable, non-configurable,
+    enumerable own value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  value: 42,
+  writable: true,
+  enumerable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_writable_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_writable_nonconfigurable_nonenumerable.js
@@ -16,4 +16,4 @@ Object.defineProperty(o, "foo", {
   writable: true
 });
 
-assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');
+assert.sameValue(Object.hasOwn(o, "foo"), true, 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/hasown_own_writable_nonconfigurable_nonenumerable.js
+++ b/test/built-ins/Object/hasOwn/hasown_own_writable_nonconfigurable_nonenumerable.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Properties - [[HasOwnProperty]] (writable, non-configurable,
+    non-enumerable own value property)
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+var o = {};
+Object.defineProperty(o, "foo", {
+  value: 42,
+  writable: true
+});
+
+assert(Object.hasOwn(o, "foo"), 'Object.hasOwn(o, "foo") !== true');

--- a/test/built-ins/Object/hasOwn/length.js
+++ b/test/built-ins/Object/hasOwn/length.js
@@ -24,7 +24,7 @@ features: [Object.hasOwn]
 ---*/
 
 verifyProperty(Object.hasOwn, "length", {
-  value: 1,
+  value: 2,
   writable: false,
   enumerable: false,
   configurable: true,

--- a/test/built-ins/Object/hasOwn/length.js
+++ b/test/built-ins/Object/hasOwn/length.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+  Object.prototype.hasOwnProperty.length is 1.
+info: |
+  Object.prototype.hasOwnProperty ( V )
+
+  ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a "length"
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description.
+
+  Unless otherwise specified, the "length" property of a built-in Function
+  object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+verifyProperty(Object.hasOwn, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Object/hasOwn/length.js
+++ b/test/built-ins/Object/hasOwn/length.js
@@ -4,9 +4,9 @@
 /*---
 esid: sec-object.hasown
 description: >
-  Object.prototype.hasOwnProperty.length is 1.
+  Object.hasOwn.length is 2.
 info: |
-  Object.prototype.hasOwnProperty ( V )
+  Object.hasOwn ( _O_, _P_ )
 
   ECMAScript Standard Built-in Objects
 

--- a/test/built-ins/Object/hasOwn/name.js
+++ b/test/built-ins/Object/hasOwn/name.js
@@ -21,7 +21,7 @@ author: Jamie Kyle
 features: [Object.hasOwn]
 ---*/
 
-assert.sameValue(Object.hasOwn.name, "hasOwnProperty");
+assert.sameValue(Object.hasOwn.name, "hasOwn");
 
 verifyNotEnumerable(Object.hasOwn, "name");
 verifyNotWritable(Object.hasOwn, "name");

--- a/test/built-ins/Object/hasOwn/name.js
+++ b/test/built-ins/Object/hasOwn/name.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+  Object.prototype.hasOwnProperty.name is "hasOwnProperty".
+info: |
+  Object.hasOwn ( _O_, _P_ )
+
+  17 ECMAScript Standard Built-in Objects:
+    Every built-in Function object, including constructors, that is not
+    identified as an anonymous function has a name property whose value
+    is a String.
+
+    Unless otherwise specified, the name property of a built-in Function
+    object, if it exists, has the attributes { [[Writable]]: false,
+    [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+assert.sameValue(Object.hasOwn.name, "hasOwnProperty");
+
+verifyNotEnumerable(Object.hasOwn, "name");
+verifyNotWritable(Object.hasOwn, "name");
+verifyConfigurable(Object.hasOwn, "name");

--- a/test/built-ins/Object/hasOwn/name.js
+++ b/test/built-ins/Object/hasOwn/name.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-object.hasown
 description: >
-  Object.prototype.hasOwnProperty.name is "hasOwnProperty".
+  Object.hasOwn.name is "hasOwn".
 info: |
   Object.hasOwn ( _O_, _P_ )
 

--- a/test/built-ins/Object/hasOwn/not-a-constructor.js
+++ b/test/built-ins/Object/hasOwn/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  Object.hasOwn does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+author: Jamie Kyle
+features: [Reflect.construct, arrow-function, Object.hasOwn]
+---*/
+
+assert.sameValue(
+  isConstructor(Object.hasOwn),
+  false,
+  'isConstructor(Object.hasOwn) must return false'
+);
+
+assert.throws(TypeError, () => {
+  new Object.hasOwn('');
+}, '`new Object.hasOwn(\'\')` throws TypeError');

--- a/test/built-ins/Object/hasOwn/prototype.js
+++ b/test/built-ins/Object/hasOwn/prototype.js
@@ -1,0 +1,17 @@
+// Copyright 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+info: Object.hasOwn has not prototype property
+description: >
+    Checking if obtaining the prototype property of Object.hasOwn fails
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+//CHECK#1
+if (Object.hasOwn.prototype !== undefined) {
+  $ERROR('#1: Object.hasOwn has not prototype property' + Object.hasOwn.prototype);
+}
+//

--- a/test/built-ins/Object/hasOwn/prototype.js
+++ b/test/built-ins/Object/hasOwn/prototype.js
@@ -10,8 +10,4 @@ author: Jamie Kyle
 features: [Object.hasOwn]
 ---*/
 
-//CHECK#1
-if (Object.hasOwn.prototype !== undefined) {
-  $ERROR('#1: Object.hasOwn has not prototype property' + Object.hasOwn.prototype);
-}
-//
+assert.sameValue(Object.hasOwn.prototype !== undefined, true);

--- a/test/built-ins/Object/hasOwn/prototype.js
+++ b/test/built-ins/Object/hasOwn/prototype.js
@@ -10,4 +10,4 @@ author: Jamie Kyle
 features: [Object.hasOwn]
 ---*/
 
-assert.sameValue(Object.hasOwn.prototype !== undefined, true);
+assert.sameValue(Object.hasOwn.prototype, undefined);

--- a/test/built-ins/Object/hasOwn/symbol_own_property.js
+++ b/test/built-ins/Object/hasOwn/symbol_own_property.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Object.hasOwn called with symbol property key
+info: |
+  Object.hasOwn ( _O_, _P_ )
+
+  1. Let _obj_ be ? ToObject(_O_).
+  1. Let _key_ be ? ToPropertyKey(_P_).
+  ...
+author: Jamie Kyle
+features: [Symbol, Object.hasOwn]
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+assert.sameValue(
+  Object.hasOwn(obj, sym),
+  false,
+  "Returns false if symbol own property not found"
+);
+
+obj[sym] = 0;
+
+assert.sameValue(
+  Object.hasOwn(obj, sym),
+  true,
+  "Returns true if symbol own property found"
+);

--- a/test/built-ins/Object/hasOwn/symbol_property_toPrimitive.js
+++ b/test/built-ins/Object/hasOwn/symbol_property_toPrimitive.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Object.hasOwn with symbol and @@toPrimitive conversion
+info: |
+  Object.hasOwn ( _O_, _P_ )
+
+  1. Let _obj_ be ? ToObject(_O_).
+  1. Let _key_ be ? ToPropertyKey(_P_).
+  ...
+author: Jamie Kyle
+features: [Symbol.toPrimitive, Object.hasOwn]
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+var callCount = 0;
+var wrapper = {};
+wrapper[Symbol.toPrimitive] = function() {
+  callCount += 1;
+  return sym;
+};
+
+obj[sym] = 0;
+
+assert.sameValue(
+  Object.hasOwn(obj, wrapper),
+  true,
+  "Returns true if symbol own property found"
+);
+
+assert.sameValue(callCount, 1, "toPrimitive method called exactly once");

--- a/test/built-ins/Object/hasOwn/symbol_property_toString.js
+++ b/test/built-ins/Object/hasOwn/symbol_property_toString.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Object.hasOwn with symbol and toString conversion
+info: |
+  Object.hasOwn ( _O_, _P_ )
+
+  1. Let _obj_ be ? ToObject(_O_).
+  1. Let _key_ be ? ToPropertyKey(_P_).
+  ...
+author: Jamie Kyle
+features: [Symbol, Object.hasOwn]
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+var callCount = 0;
+var wrapper = {
+  toString: function() {
+    callCount += 1;
+    return sym;
+  },
+  valueOf: function() {
+    $ERROR("valueOf() called");
+  }
+};
+
+obj[sym] = 0;
+
+assert.sameValue(
+  Object.hasOwn(obj, wrapper),
+  true,
+  "Returns true if symbol own property found"
+);
+
+assert.sameValue(callCount, 1, "toString method called exactly once");

--- a/test/built-ins/Object/hasOwn/symbol_property_toString.js
+++ b/test/built-ins/Object/hasOwn/symbol_property_toString.js
@@ -23,8 +23,8 @@ var wrapper = {
     callCount += 1;
     return sym;
   },
-  valueOf: function() {
-    $ERROR("valueOf() called");
+  valueOf: function () {
+    throw new Test262Error("valueOf() called")
   }
 };
 

--- a/test/built-ins/Object/hasOwn/symbol_property_valueOf.js
+++ b/test/built-ins/Object/hasOwn/symbol_property_valueOf.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: Object.hasOwn with symbol and valueOf conversion
+info: |
+  Object.hasOwn ( _O_, _P_ )
+
+  1. Let _obj_ be ? ToObject(_O_).
+  2. Let _key_ be ? ToPropertyKey(_P_).
+  ...
+author: Jamie Kyle
+features: [Symbol, Object.hasOwn]
+---*/
+
+var obj = {};
+var sym = Symbol();
+
+var callCount = 0;
+var wrapper = {
+  valueOf: function() {
+    callCount += 1;
+    return sym;
+  },
+  toString: null
+};
+
+obj[sym] = 0;
+
+assert.sameValue(
+  Object.hasOwn(obj, wrapper),
+  true,
+  "Returns true if symbol own property found"
+);
+
+assert.sameValue(callCount, 1, "valueOf method called exactly once");

--- a/test/built-ins/Object/hasOwn/toobject_before_topropertykey.js
+++ b/test/built-ins/Object/hasOwn/toobject_before_topropertykey.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-object.hasown
+description: >
+  ToObject is performed before ToPropertyKey.
+info: |
+  Object.hasOwn ( _O_, _P_ )
+
+  1. Let _obj_ be ? ToObject(_O_).
+  2. Let _key_ be ? ToPropertyKey(_P_).
+
+  ToPropertyKey ( argument )
+
+  1. Let key be ? ToPrimitive(argument, hint String).
+author: Jamie Kyle
+features: [Symbol.toPrimitive, Object.hasOwn]
+---*/
+
+var callCount1 = 0;
+var coercibleKey1 = {
+  get toString() {
+    callCount1++;
+    throw new Test262Error();
+  },
+  get valueOf() {
+    callCount1++;
+    throw new Test262Error();
+  },
+};
+
+assert.throws(Test262Error, function() {
+  Object.hasOwn(null, coercibleKey1);
+});
+assert.sameValue(callCount1, 0, "toString and valueOf must not be called");
+
+
+var callCount2 = 0;
+var coercibleKey2 = {};
+coercibleKey2[Symbol.toPrimitive] = function() {
+  callCount2++;
+  throw new Test262Error();
+};
+
+assert.throws(Test262Error, function() {
+  Object.hasOwn(undefined, coercibleKey2);
+});
+assert.sameValue(callCount2, 0, "Symbol.toPrimitive must not be called");

--- a/test/built-ins/Object/hasOwn/toobject_before_topropertykey.js
+++ b/test/built-ins/Object/hasOwn/toobject_before_topropertykey.js
@@ -29,7 +29,7 @@ var coercibleKey1 = {
   },
 };
 
-assert.throws(Test262Error, function() {
+assert.throws(TypeError, function() {
   Object.hasOwn(null, coercibleKey1);
 });
 assert.sameValue(callCount1, 0, "toString and valueOf must not be called");
@@ -42,7 +42,7 @@ coercibleKey2[Symbol.toPrimitive] = function() {
   throw new Test262Error();
 };
 
-assert.throws(Test262Error, function() {
+assert.throws(TypeError, function() {
   Object.hasOwn(undefined, coercibleKey2);
 });
 assert.sameValue(callCount2, 0, "Symbol.toPrimitive must not be called");

--- a/test/built-ins/Object/hasOwn/toobject_null.js
+++ b/test/built-ins/Object/hasOwn/toobject_null.js
@@ -1,0 +1,15 @@
+// Copyright 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Let O be the result of calling ToObject passing the this value as
+    the argument.
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+assert.throws(TypeError, function() {
+  Object.hasOwn(null, 'foo');
+});

--- a/test/built-ins/Object/hasOwn/toobject_undefined.js
+++ b/test/built-ins/Object/hasOwn/toobject_undefined.js
@@ -1,0 +1,15 @@
+// Copyright 2021 Jamie Kyle.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.hasown
+description: >
+    Let O be the result of calling ToObject passing the this value as
+    the argument.
+author: Jamie Kyle
+features: [Object.hasOwn]
+---*/
+
+assert.throws(TypeError, function() {
+  Object.hasOwn(undefined, 'foo');
+});


### PR DESCRIPTION
Proposal: https://github.com/tc39/proposal-accessible-object-hasownproperty

This proposal just reached stage 3, its not currently published in the draft but I've used `esid: sec-object.hasown` since that's what it's very likely going to end up being.

This PR is largely a copy-and-paste job from the old `Object.prototype.hasOwnProperty` tests, but I've tried to modernize anything I can.