### PR TITLE
Don't use function argument destructuring in regExpUtils.js

### DIFF
--- a/harness/regExpUtils.js
+++ b/harness/regExpUtils.js
@@ -6,7 +6,12 @@ description: |
 defines: [buildString, testPropertyEscapes, matchValidator]
 ---*/
 
-function buildString({ loneCodePoints, ranges }) {
+function buildString(args) {
+  // Use member expressions rather than destructuring `args` for improved
+  // compatibility with engines that only implement assignment patterns
+  // partially or not at all.
+  const loneCodePoints = args.loneCodePoints;
+  const ranges = args.ranges;
   const CHUNK_SIZE = 10000;
   let result = Reflect.apply(String.fromCodePoint, null, loneCodePoints);
   for (let i = 0; i < ranges.length; i++) {


### PR DESCRIPTION
This increases compatibility with less advanced engines that only have partial support for recent language features like assignment patterns.