### PR TITLE
Fix tests on {localeMatcher: "lookup"}

### DIFF
--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -128,12 +128,13 @@ function taintArray() {
  * Gets locale support info for the given constructor object, which must be one
  * of Intl constructors.
  * @param {object} Constructor the constructor for which to get locale support info
+ * @param {object} options the options while calling the constructor
  * @return {object} locale support info with the following properties:
  *   supported: array of fully supported language tags
  *   byFallback: array of language tags that are supported through fallbacks
  *   unsupported: array of unsupported language tags
  */
-function getLocaleSupportInfo(Constructor) {
+function getLocaleSupportInfo(Constructor, options) {
   var languages = ["zh", "es", "en", "hi", "ur", "ar", "ja", "pa"];
   var scripts = ["Latn", "Hans", "Deva", "Arab", "Jpan", "Hant", "Guru"];
   var countries = ["CN", "IN", "US", "PK", "JP", "TW", "HK", "SG", "419"];
@@ -163,7 +164,7 @@ function getLocaleSupportInfo(Constructor) {
   var unsupported = [];
   for (i = 0; i < allTags.length; i++) {
     var request = allTags[i];
-    var result = new Constructor([request], {localeMatcher: "lookup"}).resolvedOptions().locale;
+    var result = new Constructor([request], options).resolvedOptions().locale;
     if (request === result) {
       supported.push(request);
     } else if (request.indexOf(result) === 0) {

--- a/test/intl402/Segmenter/constructor/supportedLocalesOf/locales-specific.js
+++ b/test/intl402/Segmenter/constructor/supportedLocalesOf/locales-specific.js
@@ -19,4 +19,4 @@ assert.sameValue(typeof Intl.Segmenter.supportedLocalesOf, "function",
 assert.compareArray(Intl.Segmenter.supportedLocalesOf("sr"), ["sr"]);
 
 const multiLocale = ["sr-Thai-RS", "de", "zh-CN"];
-assert.compareArray(Intl.Segmenter.supportedLocalesOf(multiLocale), multiLocale);
+assert.compareArray(Intl.Segmenter.supportedLocalesOf(multiLocale, {localeMatcher: "lookup"}), multiLocale);

--- a/test/intl402/fallback-locales-are-supported.js
+++ b/test/intl402/fallback-locales-are-supported.js
@@ -11,7 +11,8 @@ includes: [testIntl.js]
 ---*/
 
 testWithIntlConstructors(function (Constructor) {
-    var info = getLocaleSupportInfo(Constructor);
+    // The test is only valid under "lookup" localeMatcher
+    var info = getLocaleSupportInfo(Constructor, {localeMatcher: "lookup"});
     for (var locale of info.supported) {
         var match = /^([a-z]{2,3})(-[A-Z][a-z]{3})?(-(?:[A-Z]{2}|[0-9]{3}))?$/.exec(locale);
         assert.notSameValue(match, null, "Locale " + locale + " is supported, but can't be parsed.")

--- a/test/intl402/supportedLocalesOf-consistent-with-resolvedOptions.js
+++ b/test/intl402/supportedLocalesOf-consistent-with-resolvedOptions.js
@@ -11,9 +11,9 @@ includes: [testIntl.js]
 ---*/
 
 testWithIntlConstructors(function (Constructor) {
-    var info = getLocaleSupportInfo(Constructor);
     // this test should work equally for both matching algorithms
     ["lookup", "best fit"].forEach(function (matcher) {
+        var info = getLocaleSupportInfo(Constructor, {localeMatcher: matcher});
         var supportedByConstructor = info.supported.concat(info.byFallback);
         var supported = Constructor.supportedLocalesOf(supportedByConstructor,
             {localeMatcher: matcher});
@@ -28,6 +28,7 @@ testWithIntlConstructors(function (Constructor) {
     });
     
     // this test is only valid for lookup - best fit may find additional locales supported
+    var info = getLocaleSupportInfo(Constructor, {localeMatcher: "lookup"});
     var unsupportedByConstructor = info.unsupported;
     var supported = Constructor.supportedLocalesOf(unsupportedByConstructor,
             {localeMatcher: "lookup"});

--- a/test/intl402/supportedLocalesOf-unicode-extensions-ignored.js
+++ b/test/intl402/supportedLocalesOf-unicode-extensions-ignored.js
@@ -11,20 +11,18 @@ includes: [testIntl.js]
 ---*/
 
 testWithIntlConstructors(function (Constructor) {
-    var info = getLocaleSupportInfo(Constructor);
 
     // this test should work equally for both matching algorithms
     ["lookup", "best fit"].forEach(function (matcher) {
+        var opt = {localeMatcher: matcher};
+        var info = getLocaleSupportInfo(Constructor, opt);
         var allLocales = info.supported.concat(info.byFallback, info.unsupported);
         allLocales.forEach(function (locale) {
             var validExtension = "-u-co-phonebk-nu-latn";
             var invalidExtension = "-u-nu-invalid";
-            var supported1 = Constructor.supportedLocalesOf([locale],
-                {localeMatcher: matcher});
-            var supported2 = Constructor.supportedLocalesOf([locale + validExtension],
-                {localeMatcher: matcher});
-            var supported3 = Constructor.supportedLocalesOf([locale + invalidExtension],
-                {localeMatcher: matcher});
+            var supported1 = Constructor.supportedLocalesOf([locale], opt);
+            var supported2 = Constructor.supportedLocalesOf([locale + validExtension], opt));
+            var supported3 = Constructor.supportedLocalesOf([locale + invalidExtension], opt));
             if (supported1.length === 1) {
                 assert.sameValue(supported2.length, 1, "#1.1: Presence of Unicode locale extension sequence affects whether locale " + locale + " is considered supported with matcher " + matcher + ".");
                 assert.sameValue(supported3.length, 1, "#1.2: Presence of Unicode locale extension sequence affects whether locale " + locale + " is considered supported with matcher " + matcher + ".");


### PR DESCRIPTION
This PR fix the harness by passing the option for getLocaleSupportInfo instead of an internal hard coded {localeMatcher:  "lookup"} . It also fix 3 tests which have strong assumption based on only "lookup" localeMatcher
1. intl402/Segmenter/constructor/supportedLocalesOf/locales-specific.js

The expectation that "sr-Thai-RS" would be returned is only true with the 
9.2.2 BestAvailableLocale ( availableLocales, locale )
https://tc39.es/ecma402/#sec-bestavailablelocale
algorithm used by 9.2.3 LookupMatcher ( availableLocales, requestedLocales )
https://tc39.es/ecma402/#sec-lookupmatcher

The default for localeMatcher is "best fit" but not "lookup" for all Intl objects.

And for 9.2.4 BestFitMatcher ( availableLocales, requestedLocales )
https://tc39.es/ecma402/#sec-bestfitmatcher
It may not match "sr-Thai-RS" for "sr"  and return ["de", "zh-CN"] instead. Therefore, we need to change this test to only test on {localeMatcher: "lookup"}

2. The intl402/fallback-locales-are-supported.js is only valid for "lookup" localeMatcher since the "best fit" algorithm does not guarantee of the fallback assumption
3. The intl402/supportedLocalesOf-consistent-with-resolvedOptions.js and  supportedLocalesOf-unicode-extensions-ignored.js
Passing the localeMatcher to get the correct expectation. 