### PR TITLE
lint: disallow extra fields in "negative" metadata

### DIFF
--- a/tools/lint/lib/checks/negative.py
+++ b/tools/lint/lib/checks/negative.py
@@ -27,6 +27,9 @@ class CheckNegative(Check):
         if not 'phase' in negative:
             return '"negative" must specify a "phase" field'
 
+        if len(negative.keys()) > 2:
+            return '"negative" must specify only "type" and "phase" fields'
+
         if negative["phase"] not in ["parse", "resolution", "runtime"]:
             return '"phase" must be one of ["parse", "resolution", "runtime"]'
 

--- a/tools/lint/test/fixtures/test/negative_extra_fields.js
+++ b/tools/lint/test/fixtures/test/negative_extra_fields.js
@@ -1,0 +1,15 @@
+NEGATIVE
+^ expected errors | v input
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-assignment-operators-static-semantics-early-errors
+description: Extraneous field in "negative" frontmatter
+negative:
+  flags: strict
+  type: ReferenceError
+  phase: runtime
+---*/
+
+x;
+let x;


### PR DESCRIPTION
As highlighted by gh-3006. cc @jmdyck