### PR TITLE
Add more static class property ordering tests

### DIFF
--- a/test/language/statements/class/definition/fn-length-static-precedence.js
+++ b/test/language/statements/class/definition/fn-length-static-precedence.js
@@ -4,19 +4,22 @@
 /*---
 esid: sec-runtime-semantics-classdefinitionevaluation
 description: >
-    Function `name` attribute not inferred in presence of static `name` method
+    Function `length` attribute not inferred in presence of static `length` method
 info: |
     ClassTail : ClassHeritage_opt { ClassBody_opt }
 
     14. If constructor is empty, then [...]
       b. Let F be ! CreateBuiltinFunction(steps, 0, className, « [[ConstructorKind]], [[SourceText]] », empty, constructorParent).
-    15. Else, [...]
-      d. Perform ! SetFunctionName(F, className).
+    15. Else,
+      a. Let constructorInfo be ! DefineMethod of constructor with arguments proto and constructorParent.
+         [ This sets the length property on constructorInfo.[[Closure]]. ]
+      b. Let F be constructorInfo.[[Closure]].
+      [...]
     25. For each ClassElement e of elements, do
       a. If IsStatic of e is false, then [...]
       b. Else,
         i. Let field be ClassElementEvaluation of e with arguments F and false.
-           [ This overwrites the name property on F. ]
+           [ This overwrites the length property on F. ]
 includes: [compareArray.js]
 features: [generators]
 ---*/
@@ -25,15 +28,15 @@ class A {
   static method() {
     throw new Test262Error('Static method should not be executed during definition');
   }
-  static name() {
+  static length() {
     throw new Test262Error('Static method should not be executed during definition');
   }
 }
 
-assert.sameValue(typeof A.name, 'function');
+assert.sameValue(typeof A.length, 'function');
 assert(compareArray(Object.getOwnPropertyNames(A), ['length', 'name', 'prototype', 'method']))
 
-var attr = 'name';
+var attr = 'length';
 class B {
   static [attr]() {
     throw new Test262Error(
@@ -43,12 +46,12 @@ class B {
   }
 }
 
-assert.sameValue(typeof B.name, 'function');
+assert.sameValue(typeof B.length, 'function');
 assert(compareArray(Object.getOwnPropertyNames(B), ['length', 'name', 'prototype']))
 
 var isDefined = false;
 class C {
-  static get name() {
+  static get length() {
     if (isDefined) {
       return 'pass';
     }
@@ -57,23 +60,23 @@ class C {
 }
 
 isDefined = true;
-assert.sameValue(C.name, 'pass');
+assert.sameValue(C.length, 'pass');
 assert(compareArray(Object.getOwnPropertyNames(C), ['length', 'name', 'prototype']))
 
 class D {
-  static set name(_) {
+  static set length(_) {
     throw new Test262Error('Static `set` accessor should not be executed during definition');
   }
 }
 
-assert.sameValue(D.name, undefined);
+assert.sameValue(D.length, undefined);
 assert(compareArray(Object.getOwnPropertyNames(D), ['length', 'name', 'prototype']))
 
 class E {
-  static *name() {
+  static *length() {
     throw new Test262Error('Static GeneratorMethod should not be executed during definition');
   }
 }
 
-assert.sameValue(typeof E.name, 'function');
+assert.sameValue(typeof E.length, 'function');
 assert(compareArray(Object.getOwnPropertyNames(E), ['length', 'name', 'prototype']))


### PR DESCRIPTION
Since https://github.com/tc39/ecma262/pull/1490, the "length" and "name" properties of a class are defined before any static methods. This is tested by #2057, in test/language/computed-property-names of all places.

At the same time, static methods with "name" as the name would overwrite the original property, but retain the original property enumeration order. This was not previously tested. In fact, the overwriting behavior was not tested at all for the "length" property.

This commit mends both holes in test coverage.
