### PR TITLE
Add 'import-assertions' feature tag to json modules tests

### DIFF
--- a/test/language/import/json-extensibility-array.js
+++ b/test/language/import/json-extensibility-array.js
@@ -5,7 +5,7 @@ esid: sec-parse-json-module
 description: Creates extensible arrays
 flags: [module]
 includes: [propertyHelper.js]
-features: [json-modules]
+features: [import-assertions, json-modules]
 ---*/
 
 import value from './json-value-array_FIXTURE.json' assert { type: 'json' };

--- a/test/language/import/json-extensibility-object.js
+++ b/test/language/import/json-extensibility-object.js
@@ -5,7 +5,7 @@ esid: sec-parse-json-module
 description: Creates extensible objects
 flags: [module]
 includes: [propertyHelper.js]
-features: [json-modules]
+features: [import-assertions, json-modules]
 ---*/
 
 import value from './json-value-object_FIXTURE.json' assert { type: 'json' };

--- a/test/language/import/json-idempotency.js
+++ b/test/language/import/json-idempotency.js
@@ -4,7 +4,7 @@
 esid: sec-parse-json-module
 description: The same object representation is returned to all import sites
 flags: [module, async]
-features: [json-modules, globalThis, dynamic-import]
+features: [import-assertions, json-modules, globalThis, dynamic-import]
 ---*/
 
 import viaStaticImport1 from './json-idempotency_FIXTURE.json' assert { type: 'json' };

--- a/test/language/import/json-invalid.js
+++ b/test/language/import/json-invalid.js
@@ -12,7 +12,7 @@ info: |
   1. Let json be ? Call(%JSON.parse%, undefined, « source »).
   2. Return CreateDefaultExportSyntheticModule(json).
 flags: [module]
-features: [json-modules]
+features: [import-assertions, json-modules]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/import/json-named-bindings.js
+++ b/test/language/import/json-named-bindings.js
@@ -9,7 +9,7 @@ info: |
   This was ultimately rejected, so attempting to import in this way should
   produce a SyntaxError.
 flags: [module]
-features: [json-modules]
+features: [import-assertions, json-modules]
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/import/json-value-array.js
+++ b/test/language/import/json-value-array.js
@@ -16,7 +16,7 @@ info: |
   module record includes non-printable characters (specifically, all four forms
   of JSON's so-called "whitespace" token) both before and after the "value."
 flags: [module]
-features: [json-modules]
+features: [import-assertions, json-modules]
 ---*/
 
 import value from './json-value-array_FIXTURE.json' assert { type: 'json' };

--- a/test/language/import/json-value-boolean.js
+++ b/test/language/import/json-value-boolean.js
@@ -12,7 +12,7 @@ info: |
   1. Let json be ? Call(%JSON.parse%, undefined, « source »).
   2. Return CreateDefaultExportSyntheticModule(json).
 flags: [module]
-features: [json-modules]
+features: [import-assertions, json-modules]
 ---*/
 
 import value from './json-value-boolean_FIXTURE.json' assert { type: 'json' };

--- a/test/language/import/json-value-null.js
+++ b/test/language/import/json-value-null.js
@@ -12,7 +12,7 @@ info: |
   1. Let json be ? Call(%JSON.parse%, undefined, « source »).
   2. Return CreateDefaultExportSyntheticModule(json).
 flags: [module]
-features: [json-modules]
+features: [import-assertions, json-modules]
 ---*/
 
 import value from './json-value-null_FIXTURE.json' assert { type: 'json' };

--- a/test/language/import/json-value-number.js
+++ b/test/language/import/json-value-number.js
@@ -12,7 +12,7 @@ info: |
   1. Let json be ? Call(%JSON.parse%, undefined, « source »).
   2. Return CreateDefaultExportSyntheticModule(json).
 flags: [module]
-features: [json-modules]
+features: [import-assertions, json-modules]
 ---*/
 
 import value from './json-value-number_FIXTURE.json' assert { type: 'json' };

--- a/test/language/import/json-value-object.js
+++ b/test/language/import/json-value-object.js
@@ -17,7 +17,7 @@ info: |
   of JSON's so-called "whitespace" token) both before and after the "value."
 flags: [module]
 includes: [propertyHelper.js]
-features: [json-modules]
+features: [import-assertions, json-modules]
 ---*/
 
 import value from './json-value-object_FIXTURE.json' assert { type: 'json' };

--- a/test/language/import/json-value-string.js
+++ b/test/language/import/json-value-string.js
@@ -12,7 +12,7 @@ info: |
   1. Let json be ? Call(%JSON.parse%, undefined, « source »).
   2. Return CreateDefaultExportSyntheticModule(json).
 flags: [module]
-features: [json-modules]
+features: [import-assertions, json-modules]
 ---*/
 
 import value from './json-value-string_FIXTURE.json' assert { type: 'json' };

--- a/test/language/import/json-via-namespace.js
+++ b/test/language/import/json-via-namespace.js
@@ -4,7 +4,7 @@
 esid: sec-parse-json-module
 description: May be imported via a module namespace object
 flags: [module]
-features: [json-modules]
+features: [import-assertions, json-modules]
 ---*/
 
 import * as ns from './json-via-namespace_FIXTURE.json' assert { type: 'json' };


### PR DESCRIPTION
The language/import/json-* tests depend on syntax from the Stage 3 import assertions proposal, so these tests should have the import-assertions feature tag.

Add it to the tests where it was missing.