### PR TITLE
Resizable ArrayBuffer: DataView methods

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -331,3 +331,7 @@ import-assertions
 # JSON modules
 # https://github.com/tc39/proposal-json-modules
 json-modules
+
+# Resizable Arraybuffer
+# https://github.com/tc39/proposal-resizablearraybuffer
+resizable-arraybuffer

--- a/test/built-ins/DataView/prototype/getBigInt64/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/getBigInt64/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.getbigint64
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.getBigInt64(0), 0n, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.getBigInt64(0), 0n, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.getBigInt64(0);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/getBigUint64/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/getBigUint64/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.getbiguint64
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.getBigUint64(0), 0n, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.getBigUint64(0), 0n, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.getBigUint64(0);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/getFloat32/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/getFloat32/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.getfloat32
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.getFloat32(0), 0, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.getFloat32(0), 0, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.getFloat32(0);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/getFloat64/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/getFloat64/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.getfloat64
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.getFloat64(0), 0, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.getFloat64(0), 0, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.getFloat64(0);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/getInt16/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/getInt16/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.getint16
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.getInt16(0), 0, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.getInt16(0), 0, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.getInt16(0);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/getInt32/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/getInt32/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.getint32
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.getInt32(0), 0, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.getInt32(0), 0, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.getInt32(0);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/getInt8/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/getInt8/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.getint8
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.getInt8(0), 0, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.getInt8(0), 0, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.getInt8(0);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/getUint16/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/getUint16/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.getuint16
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.getUint16(0), 0, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.getUint16(0), 0, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.getUint16(0);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/getUint32/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/getUint32/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.getuint32
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.getUint32(0), 0, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.getUint32(0), 0, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.getUint32(0);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/getUint8/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/getUint8/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.getuint8
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.getUint8(0), 0, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.getUint8(0), 0, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.getUint8(0);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/setBigInt64/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/setBigInt64/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.setbigint64
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.setBigInt64(0, 10n), undefined, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.setBigInt64(0, 20n), undefined, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.setBigInt64(0, 30n);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/setBigUint64/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/setBigUint64/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.setbiguint64
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.setBigUint64(0, 10n), undefined, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.setBigUint64(0, 20n), undefined, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.setBigUint64(0, 30n);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/setFloat32/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/setFloat32/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.setfloat32
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.setFloat32(0, 10), undefined, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.setFloat32(0, 20), undefined, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.setFloat32(0, 30);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/setFloat64/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/setFloat64/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.setfloat64
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.setFloat64(0, 10), undefined, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.setFloat64(0, 20), undefined, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.setFloat64(0, 30);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/setInt16/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/setInt16/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.setint16
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.setInt16(0, 10), undefined, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.setInt16(0, 20), undefined, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.setInt16(0, 30);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/setInt32/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/setInt32/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.setint32
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.setInt32(0, 10), undefined, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.setInt32(0, 20), undefined, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.setInt32(0, 30);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/setInt8/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/setInt8/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.setint8
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.setInt8(0, 10), undefined, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.setInt8(0, 20), undefined, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.setInt8(0, 30);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/setUint16/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/setUint16/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.setuint16
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.setUint16(0, 10), undefined, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.setUint16(0, 20), undefined, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.setUint16(0, 30);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/setUint32/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/setUint32/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.setuint32
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.setUint32(0, 10), undefined, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.setUint32(0, 20), undefined, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.setUint32(0, 30);
+  throw new Test262Error('the operation completed successfully');
+});

--- a/test/built-ins/DataView/prototype/setUint8/resizable-buffer.js
+++ b/test/built-ins/DataView/prototype/setUint8/resizable-buffer.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype.setuint8
+description: Throws a TypeError if buffer is out-of-bounds
+features: [DataView, ArrayBuffer, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+var buffer = new ArrayBuffer(24, {maxByteLength: 32});
+var sample = new DataView(buffer, 0, 16);
+
+try {
+  buffer.resize(32);
+} catch (_) {}
+
+assert.sameValue(sample.setUint8(0, 10), undefined, 'following grow');
+
+try {
+  buffer.resize(16);
+} catch (_) {}
+
+assert.sameValue(sample.setUint8(0, 20), undefined, 'following shrink (within bounds)');
+
+var expectedError;
+try {
+  buffer.resize(8);
+  expectedError = TypeError;
+} catch (_) {
+  expectedError = Test262Error;
+}
+
+assert.throws(expectedError, function() {
+  sample.setUint8(0, 30);
+  throw new Test262Error('the operation completed successfully');
+});


### PR DESCRIPTION
The files in this patch are highly similar. Only the test for
`DataView.prototype.getBigInt64` and `DataView.prototype.setBigInt64`
were written manually. The others were generated from those files via
the following script:

    #!/bin/bash

    set -eu

    names='
    BigUint64
    Float32
    Float64
    Int16
    Int32
    Int8
    Uint16
    Uint32
    Uint8
    '

    for name in ${names}; do
      lower=$(echo ${name} | tr '[:upper:]' '[:lower:]')
      if [ ${name} == 'BigUint64' ]; then
        replace_bigints=''
      else
        replace_bigints='-e s/\b\([0-9]\+\)n\b/\1/g'
      fi

      sed \
        -e "s/getbigint64/get${lower}/g" \
        -e "s/getBigInt64/get${name}/g" \
        ${replace_bigints} \
        ./test/built-ins/DataView/prototype/getBigInt64/resizable-buffer.js \
        > ./test/built-ins/DataView/prototype/get${name}/resizable-buffer.js

      sed \
        -e "s/setbigint64/set${lower}/g" \
        -e "s/setBigInt64/set${name}/g" \
        ${replace_bigints} \
        ./test/built-ins/DataView/prototype/setBigInt64/resizable-buffer.js \
        > ./test/built-ins/DataView/prototype/set${name}/resizable-buffer.js
    done