### PR TITLE
Resizable ArrayBuffer: TypedArray methods

### DIFF
--- a/test/built-ins/TypedArray/prototype/at/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/at/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.at
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, TypedArray.prototype.at, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.at,
+  'function',
+  'implements TypedArray.prototype.at'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.at(0);
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.at(0);
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the at operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.at(0);
+    throw new Test262Error('at completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.copywithin
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.copyWithin,
+  'function',
+  'implements TypedArray.prototype.copyWithin'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.copyWithin(new TA(), 0);
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.copyWithin(new TA(), 0);
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the copyWithin operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.copyWithin(new TA(), 0);
+    throw new Test262Error('copyWithin completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/entries/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/entries/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.entries
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.entries,
+  'function',
+  'implements TypedArray.prototype.entries'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.entries();
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.entries();
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the entries operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.entries();
+    throw new Test262Error('entries completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/every/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/every/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.every
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.every,
+  'function',
+  'implements TypedArray.prototype.every'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.every(() => {});
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.every(() => {});
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the every operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.every(() => {});
+    throw new Test262Error('every completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/fill/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.fill
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.fill,
+  'function',
+  'implements TypedArray.prototype.fill'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.fill(0);
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.fill(0);
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the fill operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.fill(0);
+    throw new Test262Error('fill completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/filter/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/filter/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.filter
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.filter,
+  'function',
+  'implements TypedArray.prototype.filter'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.filter(() => {});
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.filter(() => {});
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the filter operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.filter(() => {});
+    throw new Test262Error('filter completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/find/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/find/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.find
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.find,
+  'function',
+  'implements TypedArray.prototype.find'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.find(() => {});
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.find(() => {});
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the find operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.find(() => {});
+    throw new Test262Error('find completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/findIndex/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.findindex
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.findIndex,
+  'function',
+  'implements TypedArray.prototype.findIndex'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.findIndex(() => {});
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.findIndex(() => {});
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the findIndex operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.findIndex(() => {});
+    throw new Test262Error('findIndex completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/forEach/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/forEach/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.foreach
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.forEach,
+  'function',
+  'implements TypedArray.prototype.forEach'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.forEach(() => {});
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.forEach(() => {});
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the forEach operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.forEach(() => {});
+    throw new Test262Error('forEach completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/includes/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/includes/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.includes
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.includes,
+  'function',
+  'implements TypedArray.prototype.includes'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.includes(0);
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.includes(0);
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the includes operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.includes(0);
+    throw new Test262Error('includes completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/indexOf/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.indexof
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.indexOf,
+  'function',
+  'implements TypedArray.prototype.indexOf'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.indexOf(0);
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.indexOf(0);
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the indexOf operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.indexOf(0);
+    throw new Test262Error('indexOf completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/join/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/join/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.join
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.join,
+  'function',
+  'implements TypedArray.prototype.join'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.join(0);
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.join(0);
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the join operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.join(0);
+    throw new Test262Error('join completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/keys/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/keys/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.keys
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.keys,
+  'function',
+  'implements TypedArray.prototype.keys'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.keys();
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.keys();
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the keys operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.keys();
+    throw new Test262Error('keys completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.lastindexof
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.lastIndexOf,
+  'function',
+  'implements TypedArray.prototype.lastIndexOf'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.lastIndexOf(0);
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.lastIndexOf(0);
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the lastIndexOf operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.lastIndexOf(0);
+    throw new Test262Error('lastIndexOf completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/map/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/map/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.map,
+  'function',
+  'implements TypedArray.prototype.map'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.map(() => {});
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.map(() => {});
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the map operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.map(() => {});
+    throw new Test262Error('map completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/reduce/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/reduce/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.reduce
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.reduce,
+  'function',
+  'implements TypedArray.prototype.reduce'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.reduce(() => {});
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.reduce(() => {});
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the reduce operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.reduce(() => {});
+    throw new Test262Error('reduce completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.reduceright
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.reduceRight,
+  'function',
+  'implements TypedArray.prototype.reduceRight'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.reduceRight(() => {});
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.reduceRight(() => {});
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the reduceRight operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.reduceRight(() => {});
+    throw new Test262Error('reduceRight completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/reverse/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/reverse/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.reverse
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.reverse,
+  'function',
+  'implements TypedArray.prototype.reverse'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.reverse();
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.reverse();
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the reverse operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.reverse();
+    throw new Test262Error('reverse completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.set-typedarray-offset
+description: >
+  Set values from different instances using the same buffer and same
+  constructor when underlying ArrayBuffer has been resized
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var source = new TA(ab);
+  var target = new TA(ab);
+  var expected = [10, 20, 30, 40];
+
+  source[0] = 10;
+  source[1] = 20;
+  source[2] = 30;
+  source[3] = 40;
+
+  try {
+    ab.resize(BPE * 5);
+    expected = [10, 20, 30, 40, 0];
+  } catch (_) {}
+
+  target.set(source);
+  assert(compareArray(target, expected), 'following grow');
+
+  try {
+    ab.resize(BPE * 3);
+    expected = [10, 20, 30];
+  } catch (_) {}
+
+  target.set(source);
+  assert(compareArray(target, expected), 'following shrink');
+});

--- a/test/built-ins/TypedArray/prototype/set/typedarray-arg-target-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/set/typedarray-arg-target-out-of-bounds.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.set-typedarray-offset
+description: Error when target TypedArray fails boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.set,
+  'function',
+  'implements TypedArray.prototype.set'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 4});
+  var target = new TA(ab, 0, 4);
+  var source = new TA(new ArrayBuffer(BPE * 4));
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the reverse operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    target.set(source, 0);
+    throw new Test262Error('The `set` operation completed successfully.');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/slice/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/slice/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.slice
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.slice,
+  'function',
+  'implements TypedArray.prototype.slice'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.slice(0);
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.slice(0);
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the slice operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.slice(0);
+    throw new Test262Error('slice completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/some/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/some/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.some
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.some,
+  'function',
+  'implements TypedArray.prototype.some'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.some(() => {});
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.some(() => {});
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the some operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.some(() => {});
+    throw new Test262Error('some completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/sort/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/sort/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.sort
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.sort,
+  'function',
+  'implements TypedArray.prototype.sort'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.sort();
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.sort();
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the sort operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.sort();
+    throw new Test262Error('sort completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.tolocalestring
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.toLocaleString,
+  'function',
+  'implements TypedArray.prototype.toLocaleString'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.toLocaleString();
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.toLocaleString();
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the toLocaleString operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.toLocaleString();
+    throw new Test262Error('toLocaleString completed successfully');
+  });
+});

--- a/test/built-ins/TypedArray/prototype/values/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/values/return-abrupt-from-this-out-of-bounds.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.values
+description: Return abrupt when "this" value fails buffer boundary checks
+includes: [testTypedArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+assert.sameValue(
+  typeof TypedArray.prototype.values,
+  'function',
+  'implements TypedArray.prototype.values'
+);
+
+assert.sameValue(
+  typeof ArrayBuffer.prototype.resize,
+  'function',
+  'implements ArrayBuffer.prototype.resize'
+);
+
+testWithTypedArrayConstructors(TA => {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var ab = new ArrayBuffer(BPE * 4, {maxByteLength: BPE * 5});
+  var array = new TA(ab, BPE, 2);
+
+  try {
+    ab.resize(BPE * 5);
+  } catch (_) {}
+
+  // no error following grow:
+  array.values();
+
+  try {
+    ab.resize(BPE * 3);
+  } catch (_) {}
+
+  // no error following shrink (within bounds):
+  array.values();
+
+  var expectedError;
+  try {
+    ab.resize(BPE * 3);
+    expectedError = TypeError;
+  } catch (_) {
+    // The host is permitted to fail any "resize" operation at its own
+    // discretion. If that occurs, the values operation should complete
+    // successfully.
+    expectedError = Test262Error;
+  }
+
+  assert.throws(expectedError, () => {
+    array.values();
+    throw new Test262Error('values completed successfully');
+  });
+});


### PR DESCRIPTION
This is in service of gh-3003.

The files in the second commit are highly similar. Only the test for
`TypedArray.prototype.copyWithin` was written manually. The others were
generated from that test via the following script:

    #!/bin/bash

    set -eu

    names_cb='
    every
    filter
    find
    findIndex
    forEach
    map
    reduce
    reduceRight
    some
    '
    names_num='
    at
    fill
    includes
    indexOf
    join
    lastIndexOf
    slice
    '
    names_none='
    entries
    values
    keys
    reverse
    sort
    toLocaleString
    values
    '

    for name in $(printf "${names_cb} ${names_num} ${names_none}"); do
      lower=$(echo ${name} | tr '[:upper:]' '[:lower:]')
      if echo "$names_cb" | grep -xq $name; then
        value='() => {}'
      elif echo "$names_num" | grep -xq $name; then
        value='0'
      else
        value=''
      fi

      sed \
        -e "s/copywithin/${lower}/g" \
        -e "s/copyWithin/${name}/g" \
        -e "s/${name}(.*);/${name}(${value});/g" \
        ./test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-this-oob.js \
        > ./test/built-ins/TypedArray/prototype/${name}/return-abrupt-from-this-oob.js
    done