### PR TITLE
add test that delete early error is recursive

### DIFF
--- a/test/language/expressions/delete/identifier-strict-recursive.js
+++ b/test/language/expressions/delete/identifier-strict-recursive.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2018 Mike Pennisi.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-delete-operator-static-semantics-early-errors
+description: Parsing error when operand is an IdentifierReference
+info: |
+  It is a Syntax Error if the UnaryExpression is contained in strict mode code
+  and the derived UnaryExpression is PrimaryExpression:IdentifierReference.
+negative:
+  phase: parse
+  type: SyntaxError
+flags: [onlyStrict]
+---*/
+
+$DONOTEVALUATE();
+
+delete ((identifier));

--- a/test/language/expressions/delete/identifier-strict-recursive.js
+++ b/test/language/expressions/delete/identifier-strict-recursive.js
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Mike Pennisi.  All rights reserved.
+// Copyright (c) 2021 Gus Caplan. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-delete-operator-static-semantics-early-errors


### PR DESCRIPTION
i noticed this was missing after seeing all the tests for `delete ((this.#field))`