### PR TITLE
"Normalize" some YAML

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/fields/long-input.js
+++ b/test/built-ins/Temporal/Calendar/prototype/fields/long-input.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.fields
-description: Temporal.Calendar.prototype.fields will take iterable of any size and any string
+description: >
+  Temporal.Calendar.prototype.fields will take iterable of any size and any string
   and return Array of the same content.
 info: |
   ## 12.4.21 Temporal.Calendar.prototype.fields ( fields )

--- a/test/intl402/DateTimeFormat/constructor-options-timeZoneName-invalid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-timeZoneName-invalid.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-initializedatetimeformat
-description:
+description: >
   Invalid values for the `timeZoneName` option of the DateTimeFormat constructor
 features: [Intl.DateTimeFormat-extend-timezonename]
 ---*/

--- a/test/intl402/DateTimeFormat/constructor-options-timeZoneName-valid.js
+++ b/test/intl402/DateTimeFormat/constructor-options-timeZoneName-valid.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-initializedatetimeformat
-description:
+description: >
   Valid values for the `timeZoneName` option of the DateTimeFormat constructor
 features: [Intl.DateTimeFormat-extend-timezonename]
 ---*/


### PR DESCRIPTION
In each case, it's the scalar value associated with the "description" key.
Normally in test262, this is written in either:
- block notation (indicated by '>' or '|'), or
- flow notation, single-line, on the same line as the key.

In the cases addressed by this PR, the value is instead written in:
- (1x) flow notation, *multi*-line, or
- (2x) flow notation, single-line, on the line *after* the key.

These are valid YAML, but they're styles that test262 doesn't otherwise use,
so could conceivably confuse people or harnesses.

This PR changes them to block notation.