### PR TITLE
Default to not regenerate test files that are already newer than their case and template

### DIFF
--- a/tools/generation/generator.py
+++ b/tools/generation/generator.py
@@ -49,8 +49,8 @@ def create(args):
         for test in exp.expand('utf-8', caseFile):
             if args.out:
                 try:
-                    existing = Test(test.file_name)
-                    existing.load(args.out)
+                    test_file = os.path.join(args.out, test.file_name)
+                    test_mtime = os.path.getmtime(test_file)
 
                     if args.no_clobber:
                         print_error(
@@ -58,18 +58,18 @@ def create(args):
                         exit(1)
 
                     if not args.regenerate:
-                        test_file = os.path.join(args.out, test.file_name)
-                        test_mtime = os.path.getmtime(test_file)
                         source_files = test.source_file_names
                         if all(test_mtime > os.path.getmtime(f) for f in source_files):
                             continue
 
+                    existing = Test(test_file)
+                    existing.load()
                     if not existing.is_generated():
                         print_error(
                             'Refusing to overwrite non-generated file: ' +
                             test.file_name)
                         exit(1)
-                except IOError:
+                except (OSError, IOError):
                     pass
 
                 test.write(args.out, parents=args.parents)

--- a/tools/generation/generator.py
+++ b/tools/generation/generator.py
@@ -57,6 +57,13 @@ def create(args):
                             'Refusing to overwrite file: ' + test.file_name)
                         exit(1)
 
+                    if not args.regenerate:
+                        test_file = os.path.join(args.out, test.file_name)
+                        test_mtime = os.path.getmtime(test_file)
+                        source_files = test.source_file_names
+                        if all(test_mtime > os.path.getmtime(f) for f in source_files):
+                            continue
+
                     if not existing.is_generated():
                         print_error(
                             'Refusing to overwrite non-generated file: ' +
@@ -80,6 +87,8 @@ create_parser.add_argument('-p', '--parents', action='store_true',
     help='''Create non-existent directories as necessary.''')
 create_parser.add_argument('-n', '--no-clobber', action='store_true',
     help='''Abort if any test file already exists.''')
+create_parser.add_argument('-r', '--regenerate', action='store_true',
+    help='''Regenerate test files that are already newer than their source data.''')
 create_parser.add_argument('cases',
     help='''Test cases to generate. May be a file or a directory.''')
 create_parser.set_defaults(func=create)

--- a/tools/generation/lib/expander.py
+++ b/tools/generation/lib/expander.py
@@ -14,8 +14,8 @@ class Expander:
         self.templates = dict()
         self.case_dir = case_dir
 
-    def _load_templates(self, template_class, encoding):
-        directory = os.path.join(self.case_dir, template_class)
+    def _load_templates(self, template_group, encoding):
+        directory = os.path.join(self.case_dir, template_group)
         file_names = []
 
         for expanded_directory in glob.glob(directory):
@@ -29,15 +29,15 @@ class Expander:
             except:
                 file_names.append(expanded_directory)
 
-        self.templates[template_class] = [
+        self.templates[template_group] = [
             Template(x, encoding) for x in file_names
         ]
 
-    def _get_templates(self, template_class, encoding):
-        if not template_class in self.templates:
-            self._load_templates(template_class, encoding)
+    def _get_templates(self, template_group, encoding):
+        if not template_group in self.templates:
+            self._load_templates(template_group, encoding)
 
-        return self.templates[template_class]
+        return self.templates[template_group]
 
     def is_template_file(self, filename):
         return re.match(templateFilenamePattern, filename)
@@ -69,8 +69,8 @@ class Expander:
             localtemplates.extend(case.attribs['meta']['templates'])
 
         for t in localtemplates:
-            template_class = t
-            templates = self.templates.get(template_class)
+            template_group = t
+            templates = self.templates.get(template_group)
 
-            for template in self._get_templates(template_class, encoding):
+            for template in self._get_templates(template_group, encoding):
                 yield template.expand(file_name, os.path.basename(file_name[:-5]), case.attribs, encoding)

--- a/tools/generation/lib/template.py
+++ b/tools/generation/lib/template.py
@@ -214,9 +214,10 @@ class Template:
         return '\n'.join(lines)
 
     def expand(self, case_filename, case_name, case_values, encoding):
-        frontmatter = self._frontmatter(case_filename, case_values)
-        body = self.expand_regions(self.source, case_values)
-
         assert encoding == 'utf-8'
+        def get_source():
+            frontmatter = self._frontmatter(case_filename, case_values)
+            body = self.expand_regions(self.source, case_values)
+            return codecs.encode(frontmatter + '\n' + body, encoding)
         return Test(self.attribs['meta']['path'] + case_name + '.js',
-            source=codecs.encode(frontmatter + '\n' + body, encoding))
+            dynamic_source=get_source)

--- a/tools/generation/lib/template.py
+++ b/tools/generation/lib/template.py
@@ -220,4 +220,5 @@ class Template:
             body = self.expand_regions(self.source, case_values)
             return codecs.encode(frontmatter + '\n' + body, encoding)
         return Test(self.attribs['meta']['path'] + case_name + '.js',
-            dynamic_source=get_source)
+            dynamic_source=get_source,
+            source_file_names=(self.filename, case_filename))

--- a/tools/generation/lib/test.py
+++ b/tools/generation/lib/test.py
@@ -17,9 +17,10 @@ def after_parse(fn):
 class Test:
     """Representation of a generated test. Specifies a file location which may
     or may not exist."""
-    def __init__(self, file_name, dynamic_source=None):
+    def __init__(self, file_name, dynamic_source=None, source_file_names=None):
         self.file_name = file_name
         self.dynamic_source = dynamic_source
+        self.source_file_names = source_file_names
         self.source = None
         self.attribs = dict(meta=None)
 

--- a/tools/generation/lib/test.py
+++ b/tools/generation/lib/test.py
@@ -24,9 +24,8 @@ class Test:
         self.source = None
         self.attribs = dict(meta=None)
 
-    def load(self, prefix = None):
-        location = os.path.join(prefix or '', self.file_name)
-        with open(location, 'r') as handle:
+    def load(self):
+        with open(self.file_name, 'r') as handle:
             self.source = handle.read()
         self._parse()
 


### PR DESCRIPTION
This reduces the time of `./make.py` by  an order of magnitude for me, from 110 seconds to 6.