### PR TITLE
Correct tests and improve documentation

### DIFF
--- a/test/built-ins/TypedArray/prototype/findLast/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/findLast/return-abrupt-from-this-out-of-bounds.js
@@ -40,7 +40,10 @@ testWithTypedArrayConstructors(TA => {
 
   var expectedError;
   try {
-    ab.resize(BPE * 3);
+    ab.resize(BPE * 2);
+    // If the preceding "resize" operation is successful, the typed array will
+    // be out out of bounds, so the subsequent prototype method should produce
+    // a TypeError due to the semantics of ValidateTypedArray.
     expectedError = TypeError;
   } catch (_) {
     // The host is permitted to fail any "resize" operation at its own

--- a/test/built-ins/TypedArray/prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js
@@ -40,7 +40,10 @@ testWithTypedArrayConstructors(TA => {
 
   var expectedError;
   try {
-    ab.resize(BPE * 3);
+    ab.resize(BPE * 2);
+    // If the preceding "resize" operation is successful, the typed array will
+    // be out out of bounds, so the subsequent prototype method should produce
+    // a TypeError due to the semantics of ValidateTypedArray.
     expectedError = TypeError;
   } catch (_) {
     // The host is permitted to fail any "resize" operation at its own


### PR DESCRIPTION
The tests for the "Array findFromLast" proposal were originally authored
based on related tests that had already been merged to the repository's
`main` branch [1]. While those new tests were under review, a number of
tests for the Resizable ArrayBuffer proposal were found to be incorrect
[2]. The problem was fixed for the tests in `main`, but because the
corresponding tests for "Array findFromLast" were not yet merged, the
error persisted there [3].

Apply the same correction to the new tests.

[1] https://github.com/tc39/test262/issues/3111
[2] https://github.com/tc39/test262/pull/3113
[3] https://github.com/tc39/test262/pull/3045