### PR TITLE
Derived class constructor checks are executed after leaving the function body

### DIFF
--- a/test/language/statements/class/subclass/derived-class-return-override-catch-finally-arrow.js
+++ b/test/language/statements/class/subclass/derived-class-return-override-catch-finally-arrow.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+description: >
+  `super()` in finally block is executed before checking for missing `super()`
+  call when `return` is in a catch block. The `super()` call is performed
+  through an arrow function.
+---*/
+
+class C extends class {} {
+  constructor() {
+    var f = () => super();
+
+    try {
+      throw null;
+    } catch(e) {
+      return;
+    } finally {
+      f();
+    }
+  }
+}
+
+var o = new C();
+assert.sameValue(typeof o, "object");

--- a/test/language/statements/class/subclass/derived-class-return-override-catch-finally.js
+++ b/test/language/statements/class/subclass/derived-class-return-override-catch-finally.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+description: >
+  `super()` in finally block is executed before checking for missing `super()`
+  call when `return` is in a catch block.
+---*/
+
+class C extends class {} {
+  constructor() {
+    try {
+      throw null;
+    } catch(e) {
+      return;
+    } finally {
+      super();
+    }
+  }
+}
+
+var o = new C();
+assert.sameValue(typeof o, "object");

--- a/test/language/statements/class/subclass/derived-class-return-override-catch-super-arrow.js
+++ b/test/language/statements/class/subclass/derived-class-return-override-catch-super-arrow.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+description: >
+  TypeError from `return 0` is not catchable with `super` called in catch block
+  from an arrow function.
+---*/
+
+class C extends class {} {
+  constructor() {
+    var f = () => super();
+
+    try {
+      return 0;
+    } catch(e) {
+      f();
+    }
+  }
+}
+
+assert.throws(TypeError, function() {
+  new C();
+});

--- a/test/language/statements/class/subclass/derived-class-return-override-catch-super.js
+++ b/test/language/statements/class/subclass/derived-class-return-override-catch-super.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+description: >
+  TypeError from `return 0` is not catchable with `super` in catch block.
+---*/
+
+class C extends class {} {
+  constructor() {
+    try {
+      return 0;
+    } catch(e) {
+      super();
+    }
+  }
+}
+
+assert.throws(TypeError, function() {
+  new C();
+});

--- a/test/language/statements/class/subclass/derived-class-return-override-catch.js
+++ b/test/language/statements/class/subclass/derived-class-return-override-catch.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+description: >
+  TypeError from `return 0` is not catchable.
+---*/
+
+class C extends class {} {
+  constructor() {
+    super();
+
+    try {
+      return 0;
+    } catch(e) {
+      return;
+    }
+  }
+}
+
+assert.throws(TypeError, function() {
+  new C();
+});

--- a/test/language/statements/class/subclass/derived-class-return-override-finally-super-arrow.js
+++ b/test/language/statements/class/subclass/derived-class-return-override-finally-super-arrow.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+description: >
+  `super()` in finally block is executed before checking for missing `super()`
+  call when `return` is in a try block. The `super()` call is performed
+  through an arrow function.
+---*/
+
+class C extends class {} {
+  constructor() {
+    var f = () => super();
+
+    try {
+      return;
+    } finally {
+      f();
+    }
+  }
+}
+
+var o = new C();
+assert.sameValue(typeof o, "object");

--- a/test/language/statements/class/subclass/derived-class-return-override-finally-super.js
+++ b/test/language/statements/class/subclass/derived-class-return-override-finally-super.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+description: >
+  `super()` in finally block is executed before checking for missing `super()`
+  call when `return` is in a try block.
+---*/
+
+class C extends class {} {
+  constructor() {
+    try {
+      return;
+    } finally {
+      super();
+    }
+  }
+}
+
+var o = new C();
+assert.sameValue(typeof o, "object");

--- a/test/language/statements/class/subclass/derived-class-return-override-for-of-arrow.js
+++ b/test/language/statements/class/subclass/derived-class-return-override-for-of-arrow.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+description: >
+  ReferenceError when returning from a derived class constructor without calling
+  `super()` is thrown after the function body has been left, so an iterator
+  return handler can still call `super()`.
+---*/
+
+var iter = {
+  [Symbol.iterator]() {
+    return this;
+  },
+  next() {
+    return {done: false};
+  },
+  return() {
+    // Calls |super()|.
+    this.f();
+
+    return {done: true};
+  },
+};
+
+class C extends class {} {
+  constructor() {
+    iter.f = () => super();
+
+    for (var k of iter) {
+      return;
+    }
+  }
+}
+
+var o = new C();
+assert.sameValue(typeof o, "object");

--- a/test/language/statements/class/subclass/derived-class-return-override-for-of.js
+++ b/test/language/statements/class/subclass/derived-class-return-override-for-of.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-function-objects-construct-argumentslist-newtarget
+description: >
+  TypeError from `return 0` is thrown after the function body has been left, so
+  an error thrown from an iterator has precedence.
+---*/
+
+var error = new Test262Error();
+
+var iter = {
+  [Symbol.iterator]() {
+    return this;
+  },
+  next() {
+    return {done: false};
+  },
+  return() {
+    throw error;
+  },
+};
+
+class C extends class {} {
+  constructor() {
+    super();
+
+    for (var k of iter) {
+      return 0;
+    }
+  }
+}
+
+assert.throws(Test262Error, function() {
+  new C();
+});


### PR DESCRIPTION
Upstreams the tests for <https://bugzilla.mozilla.org/show_bug.cgi?id=1722269>, because some of the tests also fail in JSC and V8.