### PR TITLE
Add test for duplicated top level function declarations in modules

### DIFF
--- a/test/language/module-code/early-dup-lex.js
+++ b/test/language/module-code/early-dup-lex.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-es6id: 10.2.1
+esid: sec-module-semantics-static-semantics-early-errors
 description: >
     It is a Syntax Error if the LexicallyDeclaredNames of ModuleItemList
     contains any duplicate entries.

--- a/test/language/module-code/early-dup-top-function-async-generator.js
+++ b/test/language/module-code/early-dup-top-function-async-generator.js
@@ -17,4 +17,4 @@ negative:
 $DONOTEVALUATE();
 
 function x() {}
-function x() {}
+async function* x() {}

--- a/test/language/module-code/early-dup-top-function-async.js
+++ b/test/language/module-code/early-dup-top-function-async.js
@@ -17,4 +17,4 @@ negative:
 $DONOTEVALUATE();
 
 function x() {}
-function x() {}
+async function x() {}

--- a/test/language/module-code/early-dup-top-function-generator.js
+++ b/test/language/module-code/early-dup-top-function-generator.js
@@ -17,4 +17,4 @@ negative:
 $DONOTEVALUATE();
 
 function x() {}
-function x() {}
+function* x() {}

--- a/test/language/module-code/early-dup-top-function.js
+++ b/test/language/module-code/early-dup-top-function.js
@@ -1,0 +1,25 @@
+// Copyright 2021 Chengzhong Wu. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 10.2.1
+description: >
+    It is a Syntax Error if the LexicallyDeclaredNames of ModuleItemList
+    contains any duplicate entries.
+    At the top level of a Module, function declarations are treated like
+    lexical declarations rather than like var declarations.
+flags: [module]
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+function x() {
+
+}
+
+async function x() {
+
+}

--- a/test/language/module-code/early-dup-top-function.js
+++ b/test/language/module-code/early-dup-top-function.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-es6id: 10.2.1
+esid: sec-module-semantics-static-semantics-early-errors
 description: >
     It is a Syntax Error if the LexicallyDeclaredNames of ModuleItemList
     contains any duplicate entries.
@@ -16,10 +16,5 @@ negative:
 
 $DONOTEVALUATE();
 
-function x() {
-
-}
-
-async function x() {
-
-}
+function x() {}
+async function x() {}


### PR DESCRIPTION
In https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames 

>  ModuleItem : StatementListItem
> > Note 3 At the top level of a Module, function declarations are treated like lexical declarations rather than like var declarations.

Static Early Errors for Modules (https://tc39.es/ecma262/#sec-module-semantics-static-semantics-early-errors):
> It is a Syntax Error if the LexicallyDeclaredNames of ModuleItemList contains any duplicate entries. 

v8:  ✅
SpiderMonkey: ✅
JSC: ❌
Hermes:  ❌
