### PR TITLE
Support normative change to Resizable ArrayBuffer

### DIFF
--- a/test/built-ins/TypedArray/prototype/byteLength/resizable-array-buffer-auto.js
+++ b/test/built-ins/TypedArray/prototype/byteLength/resizable-array-buffer-auto.js
@@ -42,5 +42,12 @@ testWithTypedArrayConstructors(function(TA) {
     expected = 0;
   } catch (_) {}
 
+  assert.sameValue(array.byteLength, expected, "following shrink (on boundary)");
+
+  try {
+    ab.resize(0);
+    expected = 0;
+  } catch (_) {}
+
   assert.sameValue(array.byteLength, expected, "following shrink (out of bounds)");
 });

--- a/test/built-ins/TypedArray/prototype/byteOffset/resizable-array-buffer-auto.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/resizable-array-buffer-auto.js
@@ -34,13 +34,18 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.sameValue(array.byteOffset, BPE, "following shrink (within bounds)");
 
-  var expected;
+  var expected = BPE;
   try {
     ab.resize(BPE);
     expected = 0;
-  } catch (_) {
-    expected = BPE;
-  }
+  } catch (_) {}
+
+  assert.sameValue(array.byteOffset, expected, "following shrink (on boundary)");
+
+  try {
+    ab.resize(0);
+    expected = 0;
+  } catch (_) {}
 
   assert.sameValue(array.byteOffset, expected, "following shrink (out of bounds)");
 });

--- a/test/built-ins/TypedArray/prototype/length/resizable-array-buffer-auto.js
+++ b/test/built-ins/TypedArray/prototype/length/resizable-array-buffer-auto.js
@@ -42,5 +42,12 @@ testWithTypedArrayConstructors(function(TA) {
     expected = 0;
   } catch (_) {}
 
+  assert.sameValue(array.length, expected, "following shrink (on boundary)");
+
+  try {
+    ab.resize(0);
+    expected = 0;
+  } catch (_) {}
+
   assert.sameValue(array.length, expected, "following shrink (out of bounds)");
 });

--- a/test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/out-of-bounds-when-species-retrieved-different-type.js
+++ b/test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/out-of-bounds-when-species-retrieved-different-type.js
@@ -57,13 +57,22 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert(compareArray(new TargetCtor(source), expected), 'following shrink (within bounds)');
 
+  onGetSpecies = function() {
+    try {
+      ab.resize(BPE);
+      expected = [];
+    } catch (_) {}
+  };
+
+  assert(compareArray(new TargetCtor(source), expected), 'following shrink (on boundary)');
+
   // `assert.throws` cannot be used in this case because the expected error
   // is derived only after the constructor is invoked.
   var expectedError;
   var actualError;
   onGetSpecies = function() {
     try {
-      ab.resize(BPE);
+      ab.resize(0);
       expectedError = TypeError;
     } catch (_) {
       expectedError = Test262Error;

--- a/test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/out-of-bounds-when-species-retrieved-same-type.js
+++ b/test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/out-of-bounds-when-species-retrieved-same-type.js
@@ -57,13 +57,22 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert(compareArray(new TA(source), expected), 'following shrink (within bounds)');
 
+  onGetSpecies = function() {
+    try {
+      ab.resize(BPE);
+      expected = [];
+    } catch (_) {}
+  };
+
+  assert(compareArray(new TA(source), expected), 'following shrink (on boundary)');
+
   // `assert.throws` cannot be used in this case because the expected error
   // is derived only after the constructor is invoked.
   var expectedError;
   var actualError;
   onGetSpecies = function() {
     try {
-      ab.resize(BPE);
+      ab.resize(0);
       expectedError = TypeError;
     } catch (_) {
       expectedError = Test262Error;

--- a/test/built-ins/TypedArrayConstructors/internals/HasProperty/resizable-array-buffer-auto.js
+++ b/test/built-ins/TypedArrayConstructors/internals/HasProperty/resizable-array-buffer-auto.js
@@ -50,5 +50,12 @@ testWithTypedArrayConstructors(function(TA) {
     expected = "false,false,false,false,false";
   } catch (_) {}
 
+  assert.sameValue(inspect(array), expected, "following shrink (on boundary)");
+
+  try {
+    ab.resize(0);
+    expected = "false,false,false,false,false";
+  } catch (_) {}
+
   assert.sameValue(inspect(array), expected, "following shrink (out of bounds)");
 });

--- a/test/built-ins/TypedArrayConstructors/internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-auto.js
+++ b/test/built-ins/TypedArrayConstructors/internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-auto.js
@@ -53,6 +53,15 @@ testWithTypedArrayConstructors(function(TA) {
   } catch (_) {}
 
   assert.sameValue(
+    Reflect.ownKeys(array).join(","), expected, "following shrink (on boundary)"
+  );
+
+  try {
+    ab.resize(0);
+    expected = "";
+  } catch (_) {}
+
+  assert.sameValue(
     Reflect.ownKeys(array).join(","), expected, "following shrink (out of bounds)"
   );
 });


### PR DESCRIPTION
A recent normative change to the Resizable ArrayBuffer modified the
criteria for a TypedArray becoming "out of bounds." Following the
change, TypedArrays which track the length of their underlying
ArrayBuffer instance are no longer considered "out of bounds" when the
ArrayBuffer is resized such that its size matches the TypedArray's
offset exactly.

https://github.com/tc39/proposal-resizablearraybuffer/pull/70

The majority of this patch's changes extend coverage to include cases
for both "on boundary" and "out of bounds" without reflecting any new
semantics. Two changes describe observable differences in the new
version of the algorithm:

- out-of-bounds-when-species-retrieved-different-type.js
- out-of-bounds-when-species-retrieved-same-type.js

/cc @marjakh