### PR TITLE
Fix error in test for Temporal.now.plainDateTime

### DIFF
--- a/test/built-ins/Temporal/Now/plainDateTime/calendar-object.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/calendar-object.js
@@ -9,7 +9,12 @@ features: [Proxy, Temporal]
 ---*/
 
 const actual = [];
-const expected = [
+const expectedWithout = [
+  'has calendar.calendar',
+  'get calendar.calendar',
+  'has nestedCalendar.calendar'
+];
+const expectedWith = [
   'has calendar.calendar',
   'get calendar.calendar',
   'has nestedCalendar.calendar',
@@ -58,4 +63,11 @@ Object.defineProperty(Temporal.Calendar, 'from', {
 
 Temporal.Now.plainDateTime(calendar);
 
-assert.compareArray(actual, expected, 'The value of actual is expected to equal the value of expected');
+assert.compareArray(actual, expectedWithout, 'Observable interactions without `calendar` property');
+
+actual.length = 0;
+nestedCalendar.calendar = null;
+
+Temporal.Now.plainDateTime(calendar);
+
+assert.compareArray(actual, expectedWith, 'Observable interactions with `calendar` property');


### PR DESCRIPTION
Resolves gh-3133. This change makes for a larger test than I'm accustomed to writing, but the amount of "set up" logic may warrant that. I'm happy to refactor into two files if anyone would prefer!