### PR TITLE
remove redundant throw from assert.throws() test functions

### DIFF
--- a/test/built-ins/Array/prototype/join/S15.4.4.5_A2_T4.js
+++ b/test/built-ins/Array/prototype/join/S15.4.4.5_A2_T4.js
@@ -90,5 +90,4 @@ assert.throws(TypeError, () => {
     }
   };
   obj.join();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/join/S15.4.4.5_A6.7.js
+++ b/test/built-ins/Array/prototype/join/S15.4.4.5_A6.7.js
@@ -11,5 +11,4 @@ description: >
 
 assert.throws(TypeError, () => {
   new Array.prototype.join();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/pop/S15.4.4.6_A5.7.js
+++ b/test/built-ins/Array/prototype/pop/S15.4.4.6_A5.7.js
@@ -11,5 +11,4 @@ description: >
 
 assert.throws(TypeError, () => {
   new Array.prototype.pop();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/push/S15.4.4.7_A6.7.js
+++ b/test/built-ins/Array/prototype/push/S15.4.4.7_A6.7.js
@@ -11,5 +11,4 @@ description: >
 
 assert.throws(TypeError, () => {
   new Array.prototype.push();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/reverse/S15.4.4.8_A5.7.js
+++ b/test/built-ins/Array/prototype/reverse/S15.4.4.8_A5.7.js
@@ -11,5 +11,4 @@ description: >
 
 assert.throws(TypeError, () => {
   new Array.prototype.reverse();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/shift/S15.4.4.9_A5.7.js
+++ b/test/built-ins/Array/prototype/shift/S15.4.4.9_A5.7.js
@@ -11,5 +11,4 @@ description: >
 
 assert.throws(TypeError, () => {
   new Array.prototype.shift();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/slice/S15.4.4.10_A3_T1.js
+++ b/test/built-ins/Array/prototype/slice/S15.4.4.10_A3_T1.js
@@ -14,6 +14,4 @@ assert.throws(RangeError, () => {
   obj[4294967295] = "y";
   obj.length = 4294967296;
   obj.slice(0, 4294967296);
-  new Array.prototype.toLocaleString();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/slice/S15.4.4.10_A3_T2.js
+++ b/test/built-ins/Array/prototype/slice/S15.4.4.10_A3_T2.js
@@ -14,5 +14,4 @@ assert.throws(RangeError, () => {
   obj[4294967296] = "y";
   obj.length = 4294967297;
   obj.slice(0, 4294967297);
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/slice/S15.4.4.10_A5.7.js
+++ b/test/built-ins/Array/prototype/slice/S15.4.4.10_A5.7.js
@@ -11,5 +11,4 @@ description: >
 
 assert.throws(TypeError, () => {
   new Array.prototype.slice();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/sort/S15.4.4.11_A7.7.js
+++ b/test/built-ins/Array/prototype/sort/S15.4.4.11_A7.7.js
@@ -11,5 +11,4 @@ description: >
 
 assert.throws(TypeError, () => {
   new Array.prototype.sort();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/splice/S15.4.4.12_A5.7.js
+++ b/test/built-ins/Array/prototype/splice/S15.4.4.12_A5.7.js
@@ -11,5 +11,4 @@ description: >
 
 assert.throws(TypeError, () => {
   new Array.prototype.splice();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/toLocaleString/S15.4.4.3_A4.7.js
+++ b/test/built-ins/Array/prototype/toLocaleString/S15.4.4.3_A4.7.js
@@ -12,5 +12,4 @@ description: >
 
 assert.throws(TypeError, () => {
   new Array.prototype.toLocaleString();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/toString/S15.4.4.2_A1_T4.js
+++ b/test/built-ins/Array/prototype/toString/S15.4.4.2_A1_T4.js
@@ -95,5 +95,4 @@ assert.throws(TypeError, () => {
   };
   var x = new Array(object);
   x.toString();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/toString/S15.4.4.2_A4.7.js
+++ b/test/built-ins/Array/prototype/toString/S15.4.4.2_A4.7.js
@@ -12,5 +12,4 @@ description: >
 
 assert.throws(TypeError, () => {
   new Array.prototype.toString();
-  throw new Test262Error();
 });

--- a/test/built-ins/Array/prototype/unshift/S15.4.4.13_A5.7.js
+++ b/test/built-ins/Array/prototype/unshift/S15.4.4.13_A5.7.js
@@ -11,5 +11,4 @@ description: >
 
 assert.throws(TypeError, () => {
   new Array.prototype.unshift();
-  throw new Test262Error();
 });

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T1.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T1.js
@@ -15,12 +15,10 @@ assert.throws(TypeError, () => {
   var s1 = new String();
   s1.toString = Boolean.prototype.toString;
   var v1 = s1.toString();
-  throw new Test262Error();
 });
 
 assert.throws(TypeError, () => {
   var s2 = new String();
   s2.myToString = Boolean.prototype.toString;
   var v2 = s2.myToString();
-  throw new Test262Error();
 });

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T2.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T2.js
@@ -15,12 +15,10 @@ assert.throws(TypeError, () => {
   var s1 = new Number();
   s1.toString = Boolean.prototype.toString;
   s1.toString();
-  throw new Test262Error();
 });
 
 assert.throws(TypeError, () => {
   var s2 = new Number();
   s2.myToString = Boolean.prototype.toString;
   s2.myToString();
-  throw new Test262Error();
 });

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T3.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T3.js
@@ -15,12 +15,10 @@ assert.throws(TypeError, () => {
   var s1 = new Date();
   s1.toString = Boolean.prototype.toString;
   s1.toString();
-  throw new Test262Error();
 });
 
 assert.throws(TypeError, () => {
   var s2 = new Date();
   s2.myToString = Boolean.prototype.toString;
   s2.myToString();
-  throw new Test262Error();
 });

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T4.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T4.js
@@ -16,12 +16,10 @@ assert.throws(TypeError, () => {
   var s1 = new Object();
   s1.toString = Boolean.prototype.toString;
   s1.toString();
-  throw new Test262Error();
 });
 
 assert.throws(TypeError, () => {
   var s2 = new Object();
   s2.myToString = Boolean.prototype.toString;
   s2.myToString();
-  throw new Test262Error();
 });

--- a/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T5.js
+++ b/test/built-ins/Boolean/prototype/toString/S15.6.4.2_A2_T5.js
@@ -17,7 +17,6 @@ assert.throws(TypeError, () => {
   };
   s1.toString = Boolean.prototype.toString;
   s1.toString();
-  throw new Test262Error();
 });
 
 assert.throws(TypeError, () => {
@@ -26,5 +25,4 @@ assert.throws(TypeError, () => {
   };
   s2.myToString = Boolean.prototype.toString;
   s2.myToString();
-  throw new Test262Error();
 });

--- a/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T1.js
+++ b/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T1.js
@@ -14,12 +14,10 @@ assert.throws(TypeError, () => {
   var s1 = new String();
   s1.valueOf = Boolean.prototype.valueOf;
   s1.valueOf();
-  throw new Test262Error();
 });
 
 assert.throws(TypeError, () => {
   var s2 = new String();
   s2.myvalueOf = Boolean.prototype.valueOf;
   s2.myvalueOf();
-  throw new Test262Error();
 });

--- a/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T2.js
+++ b/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T2.js
@@ -14,12 +14,10 @@ assert.throws(TypeError, () => {
   var s1 = new Number();
   s1.valueOf = Boolean.prototype.valueOf;
   s1.valueOf();
-  throw new Test262Error();
 });
 
 assert.throws(TypeError, () => {
   var s2 = new Number();
   s2.myvalueOf = Boolean.prototype.valueOf;
   s2.myvalueOf();
-  throw new Test262Error();
 });

--- a/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T3.js
+++ b/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T3.js
@@ -14,12 +14,10 @@ assert.throws(TypeError, () => {
   var s1 = new Date();
   s1.valueOf = Boolean.prototype.valueOf;
   s1.valueOf();
-  throw new Test262Error();
 });
 
 assert.throws(TypeError, () => {
   var s2 = new Date();
   s2.myvalueOf = Boolean.prototype.valueOf;
   s2.myvalueOf();
-  throw new Test262Error();
 });

--- a/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T4.js
+++ b/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T4.js
@@ -14,12 +14,10 @@ assert.throws(TypeError, () => {
   var s1 = new Object();
   s1.valueOf = Boolean.prototype.valueOf;
   s1.valueOf();
-  throw new Test262Error();
 });
 
 assert.throws(TypeError, () => {
   var s2 = new Object();
   s2.myvalueOf = Boolean.prototype.valueOf;
   s2.myvalueOf();
-  throw new Test262Error();
 });

--- a/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T5.js
+++ b/test/built-ins/Boolean/prototype/valueOf/S15.6.4.3_A2_T5.js
@@ -16,7 +16,6 @@ assert.throws(TypeError, () => {
   };
   s1.valueOf = Boolean.prototype.valueOf;
   s1.valueOf();
-  throw new Test262Error();
 });
 
 assert.throws(TypeError, () => {
@@ -25,5 +24,4 @@ assert.throws(TypeError, () => {
   };
   s2.myvalueOf = Boolean.prototype.valueOf;
   s2.myvalueOf();
-  throw new Test262Error();
 });


### PR DESCRIPTION
`assert.throws()` already handles the case — and gives a useful message — when the function under scrutiny fails to throw anything.
