### PR TITLE
simplify test/language/comments/S7.4_A5

### DIFF
--- a/test/language/comments/S7.4_A5.js
+++ b/test/language/comments/S7.4_A5.js
@@ -7,34 +7,21 @@ info: |
     Terminators
 es5id: 7.4_A5
 description: >
-    //var " + xx + "yy = -1", insert instead of xx all Unicode
-    characters
+    "//var " + xx + "yy = true",
+    replace xx with each Unicode BMP character or surrogate
+includes: [decimalToHexString.js]
 ---*/
 
-var hex = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"];
-for (var i1 = 0; i1 < 16; i1++) {
-  for (var i2 = 0; i2 < 16; i2++) {
-    for (var i3 = 0; i3 < 16; i3++) {
-      for (var i4 = 0; i4 < 16; i4++) {
-        try {
-          var uu = hex[i1] + hex[i2] + hex[i3] + hex[i4];
-          var xx = String.fromCharCode("0x" + uu);
-          var LineTerminators = ((uu === "000A") || (uu === "000D") || (uu === "2028") || (uu === "2029"));
-          var yy = 0;
-          eval("//var " + xx + "yy = -1");
-          if (LineTerminators !== true) {
-            if (yy !== 0) {
-              throw new Test262Error('#' + uu + ' ');
-            }
-          } else {
-            if (yy !== -1) {
-              throw new Test262Error('#' + uu + ' ');
-            }
-          }
-        } catch (e){
-          throw new Test262Error('#' + uu + ' ');
-        }
-      }
+for (var uu = 0; uu <= 0xFFFF; ++uu) {
+  try {
+    var isLineTerminator = (uu === 0x0A || uu === 0x0D || uu === 0x2028 || uu === 0x2029);
+    var xx = String.fromCharCode(uu);
+    var yy = false;
+    eval("//var " + xx + "yy = true");
+    if (yy !== isLineTerminator) {
+      throw new Test262Error('#' + decimalToHexString(uu) + ' ');
     }
+  } catch (e) {
+    throw new Test262Error('#' + decimalToHexString(uu) + ' ');
   }
 }


### PR DESCRIPTION
I believe this version with a single loop conveys more clearly that it loops over the whole Unicode BMP. Although that's a side-effect of why I was rewriting it in the first place.

On engine262 this runs much faster (12s versus 20s) than the original four nested loops.
On node it's marginally faster:
```sh
pnpx benchmark S7.4_A5.*.js
```
```
✔ S7.4_A5.new x 16.25 ops/sec ±30.87% (36 runs sampled)
✔ S7.4_A5.old x 13.02 ops/sec ±17.89% (39 runs sampled)
```
