### PR TITLE
avoid unnecessary calls to decimalToHexString()

### DIFF
--- a/test/built-ins/decodeURI/S15.1.3.1_A2.1_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.1_T1.js
@@ -10,14 +10,13 @@ includes: [decimalToHexString.js]
 
 for (var indexI = 0; indexI <= 65535; indexI++) {
   if (indexI !== 0x25) {
-    var hex = decimalToHexString(indexI);
     try {
       var str = String.fromCharCode(indexI);
       if (decodeURI(str) !== str) {
-        throw new Test262Error('#' + hex + ' ');
+        throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
       }
     } catch (e) {
-      throw new Test262Error('#' + hex + ' ');
+      throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
     }
   }
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.1_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.1_T1.js
@@ -10,14 +10,13 @@ includes: [decimalToHexString.js]
 
 for (var indexI = 0; indexI <= 65535; indexI++) {
   if (indexI !== 0x25) {
-    var hex = decimalToHexString(indexI);
     try {
       var str = String.fromCharCode(indexI);
       if (decodeURIComponent(str) !== str) {
-        throw new Test262Error('#' + hex + ' ');
+        throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
       }
     } catch (e) {
-      throw new Test262Error('#' + hex + ' ');
+      throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
     }
   }
 }

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.1_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.1_T1.js
@@ -15,7 +15,6 @@ var indexO = 0;
 
 for (var index = 0xDC00; index <= 0xDFFF; index++) {
   count++;
-  var hex = decimalToHexString(index);
   try {
     encodeURI(String.fromCharCode(index));
   } catch (e) {

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.1_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.1_T2.js
@@ -15,7 +15,6 @@ var indexO = 0;
 
 for (var index = 0xDC00; index <= 0xDFFF; index++) {
   count++;
-  var hex = decimalToHexString(index);
   try {
     encodeURI(String.fromCharCode(index, 0x0041));
   } catch (e) {

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.2_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.2_T1.js
@@ -17,7 +17,6 @@ var indexO = 0;
 
 for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++;
-  var hex = decimalToHexString(index);
   try {
     encodeURI(String.fromCharCode(index));
   } catch (e) {

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.2_T2.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.2_T2.js
@@ -17,7 +17,6 @@ var indexO = 0;
 
 for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++;
-  var hex = decimalToHexString(index);
   try {
     encodeURI(String.fromCharCode(0x0041, index));
   } catch (e) {

--- a/test/built-ins/encodeURI/S15.1.3.3_A1.3_T1.js
+++ b/test/built-ins/encodeURI/S15.1.3.3_A1.3_T1.js
@@ -22,7 +22,6 @@ for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++;
   var res = true;
   for (var indexC = 0; indexC < chars.length; indexC++) {
-    var hex = decimalToHexString(index);
     try {
       encodeURI(String.fromCharCode(index, chars[indexC]));
     } catch (e) {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T1.js
@@ -15,7 +15,6 @@ var indexO = 0;
 
 for (var index = 0xDC00; index <= 0xDFFF; index++) {
   count++;
-  var hex = decimalToHexString(index);
   try {
     encodeURIComponent(String.fromCharCode(index));
   } catch (e) {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.1_T2.js
@@ -15,7 +15,6 @@ var indexO = 0;
 
 for (var index = 0xDC00; index <= 0xDFFF; index++) {
   count++;
-  var hex = decimalToHexString(index);
   try {
     encodeURIComponent(String.fromCharCode(index, 0x0041));
   } catch (e) {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T1.js
@@ -17,7 +17,6 @@ var indexO = 0;
 
 for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++;
-  var hex = decimalToHexString(index);
   try {
     encodeURIComponent(String.fromCharCode(index));
   } catch (e) {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T2.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.2_T2.js
@@ -17,7 +17,6 @@ var indexO = 0;
 
 for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++;
-  var hex = decimalToHexString(index);
   try {
     encodeURIComponent(String.fromCharCode(0x0041, index));
   } catch (e) {

--- a/test/built-ins/encodeURIComponent/S15.1.3.4_A1.3_T1.js
+++ b/test/built-ins/encodeURIComponent/S15.1.3.4_A1.3_T1.js
@@ -22,7 +22,6 @@ for (var index = 0xD800; index <= 0xDBFF; index++) {
   count++;
   var res = true;
   for (var indexC = 0; indexC < chars.length; indexC++) {
-    var hex = decimalToHexString(index);
     try {
       encodeURIComponent(String.fromCharCode(index, chars[indexC]));
     } catch (e) {

--- a/test/built-ins/parseFloat/S15.1.2.3_A6.js
+++ b/test/built-ins/parseFloat/S15.1.2.3_A6.js
@@ -19,7 +19,6 @@ var indexP;
 var indexO = 0;
 for (var index = 0; index <= 65535; index++) {
   if ((index < 0x0030) || (index > 0x0039)) {
-    var hex = decimalToHexString(index);
     if (parseFloat("0.1e1" + String.fromCharCode(index)) !== 1) {
       if (indexO === 0) {
         indexO = index;

--- a/test/built-ins/parseInt/S15.1.2.2_A8.js
+++ b/test/built-ins/parseInt/S15.1.2.2_A8.js
@@ -21,7 +21,6 @@ for (var index = 0; index <= 65535; index++) {
   if ((index < 0x0030) || (index > 0x0039) &&
     (index < 0x0041) || (index > 0x005A) &&
     (index < 0x0061) || (index > 0x007A)) {
-    var hex = decimalToHexString(index);
     if (parseInt("1Z" + String.fromCharCode(index), 36) !== 71) {
       if (indexO === 0) {
         indexO = index;

--- a/test/language/comments/S7.4_A6.js
+++ b/test/language/comments/S7.4_A6.js
@@ -7,41 +7,17 @@ info: |
     character
 es5id: 7.4_A6
 description: "\"var\"+ yy+ \"xx = 1\", insert instead of yy all Unicode characters"
+includes: [decimalToHexString.js]
 ---*/
 
 for (var indexI = 0; indexI <= 65535; indexI++) {
   try {
     var xx = 0;
     eval("/*var " + String.fromCharCode(indexI) + "xx = 1*/");
-    var hex = decimalToHexString(indexI);
     if (xx !== 0) {
-      throw new Test262Error('#' + hex + ' ');
+      throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
     }
   } catch (e){
-    throw new Test262Error('#' + hex + ' ');
+    throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
   }
-}
-
-function decimalToHexString(n) {
-  n = Number(n);
-  var h = "";
-  for (var i = 3; i >= 0; i--) {
-    if (n >= Math.pow(16, i)) {
-      var t = Math.floor(n / Math.pow(16, i));
-      n -= t * Math.pow(16, i);
-      if ( t >= 10 ) {
-        if ( t == 10 ) { h += "A"; }
-        if ( t == 11 ) { h += "B"; }
-        if ( t == 12 ) { h += "C"; }
-        if ( t == 13 ) { h += "D"; }
-        if ( t == 14 ) { h += "E"; }
-        if ( t == 15 ) { h += "F"; }
-      } else {
-        h += String(t);
-      }
-    } else {
-      h += "0";
-    }
-  }
-  return h;
 }


### PR DESCRIPTION
This removes calls to `decimalToHexString()` whose result was never used; and moves calls whose result was only used to construct error message, into the error-handling branch.
