### PR TITLE
Normalize some YAML

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/dateFromFields/throws-range-error.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateFromFields/throws-range-error.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.datefromfields
-description: Temporal.Calendar.prototype.dateFromFields should throw RangeError for
+description: >
+  Temporal.Calendar.prototype.dateFromFields should throw RangeError for
   input not in valid range.
 info: |
   1. Let calendar be the this value.

--- a/test/built-ins/Temporal/Calendar/prototype/day/date-time.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/date-time.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.day
-description: Temporal.Calendar.prototype.day will take PlainDateTime and return
+description: >
+  Temporal.Calendar.prototype.day will take PlainDateTime and return
   the value of the day.
 info: |
   5. Return ! ISODay(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/day/date.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/date.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.day
-description: Temporal.Calendar.prototype.day will take PlainDate and return
+description: >
+  Temporal.Calendar.prototype.day will take PlainDate and return
   the value of the day.
 info: |
   5. Return ! ISODay(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/day/month-day.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/month-day.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.day
-description: Temporal.Calendar.prototype.day will take PlainMonthDay and return
+description: >
+  Temporal.Calendar.prototype.day will take PlainMonthDay and return
   the value of the day.
 info: |
   4. If Type(temporalDateLike) is not Object or temporalDateLike does not have

--- a/test/built-ins/Temporal/Calendar/prototype/day/string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/string.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.day
-description: Temporal.Calendar.prototype.day will take ISO8601 string and return
+description: >
+  Temporal.Calendar.prototype.day will take ISO8601 string and return
   the value of the day.
 info: |
   4. If Type(temporalDateLike) is not Object or temporalDateLike does not have

--- a/test/built-ins/Temporal/Calendar/prototype/day/throw-range-error-ToTemporalDate.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/throw-range-error-ToTemporalDate.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.day
-description: Temporal.Calendar.prototype.day throws RangeError on
+description: >
+  Temporal.Calendar.prototype.day throws RangeError on
   ToTemporalDate when temporalDateLike is invalid string.
 info: |
   4. If Type(temporalDateLike) is not Object or temporalDateLike

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/plain-date-time.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/plain-date-time.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.dayofweek
-description: Temporal.Calendar.prototype.dayOfWeek will take Temporal.PlainDateTime objects
+description: >
+  Temporal.Calendar.prototype.dayOfWeek will take Temporal.PlainDateTime objects
   and return the day of week.
 info: |
   5. Return 𝔽(! ToISODayOfWeek(temporalDate.[[ISOYear]], temporalDate.[[ISOMonth]], temporalDate.[[ISODay]])).

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/plain-date.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/plain-date.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.dayofweek
-description: Temporal.Calendar.prototype.dayOfWeek will take Temporal.PlainDate objects
+description: >
+  Temporal.Calendar.prototype.dayOfWeek will take Temporal.PlainDate objects
   and return the day of week.
 info: |
   5. Return 𝔽(! ToISODayOfWeek(temporalDate.[[ISOYear]], temporalDate.[[ISOMonth]], temporalDate.[[ISODay]])).

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/string.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.dayofweek
-description: Temporal.Calendar.prototype.dayOfWeek will take ISO8601 string
+description: >
+  Temporal.Calendar.prototype.dayOfWeek will take ISO8601 string
   and return the day of week.
 info: |
   4. Let temporalDate be ? ToTemporalDate(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/throw-range-error-ToTemporalDate.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/throw-range-error-ToTemporalDate.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.dayOfWeek
-description: Temporal.Calendar.prototype.dayOfWeek throws RangeError on
+description: >
+  Temporal.Calendar.prototype.dayOfWeek throws RangeError on
   ToTemporalDate when temporalDateLike is invalid string.
 info: |
   4. Let temporalDate be ? ToTemporalDate(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/throw-type-error-RequireInternalSlot.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/throw-type-error-RequireInternalSlot.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.dayOfWeek
-description: Temporal.Calendar.prototype.dayOfWeek throws TypeError
+description: >
+  Temporal.Calendar.prototype.dayOfWeek throws TypeError
   when the internal lot is not presented.
 info: |
   2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/plain-date-time.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/plain-date-time.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.dayofyear
-description: Temporal.Calendar.prototype.dayOfYear will take PlainDateTime object and
+description: >
+  Temporal.Calendar.prototype.dayOfYear will take PlainDateTime object and
   return the day of year.
 info: |
   4. Let temporalDate be ? ToTemporalDate(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/plain-date.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/plain-date.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.dayofyear
-description: Temporal.Calendar.prototype.dayOfYear will take PlainDate object and
+description: >
+  Temporal.Calendar.prototype.dayOfYear will take PlainDate object and
   return the day of year.
 info: |
   5. Return 𝔽(! ToISODayOfYear(temporalDate.[[ISOYear]], temporalDate.[[ISOMonth]], temporalDate.[[ISODay]])).

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/string.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.dayofyear
-description: Temporal.Calendar.prototype.dayOfYear will take ISO8601 string and
+description: >
+  Temporal.Calendar.prototype.dayOfYear will take ISO8601 string and
   return the day of year.
 info: |
   4. Let temporalDate be ? ToTemporalDate(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/throw-range-error-ToTemporalDate.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/throw-range-error-ToTemporalDate.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.dayOfYear
-description: Temporal.Calendar.prototype.dayOfYear throws RangeError on
+description: >
+  Temporal.Calendar.prototype.dayOfYear throws RangeError on
   ToTemporalDate when temporalDateLike is invalid string.
 info: |
   4. Let temporalDate be ? ToTemporalDate(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/throw-type-error-RequireInternalSlot.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/throw-type-error-RequireInternalSlot.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.dayOfYear
-description: Temporal.Calendar.prototype.dayOfYear throws TypeError
+description: >
+  Temporal.Calendar.prototype.dayOfYear throws TypeError
   when the internal lot is not presented.
 info: |
   2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/plain-date-time.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/plain-date-time.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysinmonth
-description: Temporal.Calendar.prototype.daysInMonth will take Temporal.PlainDateTime object
+description: >
+  Temporal.Calendar.prototype.daysInMonth will take Temporal.PlainDateTime object
   and return the number of days in that month.
 info: |
   4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalYearMonth]] internal slots, then

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/plain-date.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/plain-date.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysinmonth
-description: Temporal.Calendar.prototype.daysInMonth will take Temporal.PlainDate object
+description: >
+  Temporal.Calendar.prototype.daysInMonth will take Temporal.PlainDate object
   and return the number of days in that month.
 info: |
   5. Return 𝔽(! ISODaysInMonth(temporalDateLike.[[ISOYear]], temporalDateLike.[[ISOMonth]])).

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/string.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysinmonth
-description: Temporal.Calendar.prototype.daysInMonth will take ISO8601 string
+description: >
+  Temporal.Calendar.prototype.daysInMonth will take ISO8601 string
   and return the number of days in that month.
 info: |
   4. If Type(temporalDateLike) is not Object or temporalDateLike does not have

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/throw-range-error-ToTemporalDate.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/throw-range-error-ToTemporalDate.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysInMonth
-description: Temporal.Calendar.prototype.daysInMonth throws RangeError on
+description: >
+  Temporal.Calendar.prototype.daysInMonth throws RangeError on
   ToTemporalDate when temporalDateLike is invalid string.
 info: |
   4. If Type(temporalDateLike) is not Object or temporalDateLike does not have

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/throw-type-error-RequireInternalSlot.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/throw-type-error-RequireInternalSlot.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysInMonth
-description: Temporal.Calendar.prototype.daysInMonth throws TypeError
+description: >
+  Temporal.Calendar.prototype.daysInMonth throws TypeError
   when the internal lot is not presented.
 info: |
   2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/string.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysinweeks
-description: Temporal.Calendar.prototype.daysInWeek will take valid ISO8601 string
+description: >
+  Temporal.Calendar.prototype.daysInWeek will take valid ISO8601 string
   and return 7.
 info: |
   4. Perform ? ToTemporalDate(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/throw-range-error-ToTemporalDate.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/throw-range-error-ToTemporalDate.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysInWeek
-description: Temporal.Calendar.prototype.daysInWeek throws RangeError on
+description: >
+  Temporal.Calendar.prototype.daysInWeek throws RangeError on
   ToTemporalDate when temporalDateLike is invalid string.
 info: |
   4. Let temporalDate be ? ToTemporalDate(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/throw-type-error-RequireInternalSlot.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/throw-type-error-RequireInternalSlot.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysInWeek
-description: Temporal.Calendar.prototype.daysInWeek throws TypeError
+description: >
+  Temporal.Calendar.prototype.daysInWeek throws TypeError
   when the internal lot is not presented.
 info: |
   2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/plain-date-time.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/plain-date-time.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysinyear
-description: Temporal.Calendar.prototype.daysInYear will take PlainDateTime and return
+description: >
+  Temporal.Calendar.prototype.daysInYear will take PlainDateTime and return
   the number of days in a year.
 info: |
   4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalYearMonth]] internal slot, then

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/plain-date.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/plain-date.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysinyear
-description: Temporal.Calendar.prototype.daysInYear will take PlainDate and return
+description: >
+  Temporal.Calendar.prototype.daysInYear will take PlainDate and return
   the number of days in a year.
 info: |
   5. Return 𝔽(! ISODaysInYear(temporalDateLike.[[ISOYear]])).

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/string.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysinyear
-description: Temporal.Calendar.prototype.daysInYear will take PlainDate and return
+description: >
+  Temporal.Calendar.prototype.daysInYear will take PlainDate and return
   the number of days in a year.
 info: |
   4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalYearMonth]] internal slot, then

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/throw-range-error-ToTemporalDate.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/throw-range-error-ToTemporalDate.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysInYear
-description: Temporal.Calendar.prototype.daysInYear throws RangeError on
+description: >
+  Temporal.Calendar.prototype.daysInYear throws RangeError on
   ToTemporalDate when temporalDateLike is invalid string.
 info: |
   4. If Type(temporalDateLike) is not Object or temporalDateLike does

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/throw-type-error-RequireInternalSlot.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/throw-type-error-RequireInternalSlot.js
@@ -2,7 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
 esid: sec-temporal.calendar.prototype.daysInYear
-description: Temporal.Calendar.prototype.daysInYear throws TypeError
+description: >
+  Temporal.Calendar.prototype.daysInYear throws TypeError
   when the internal lot is not presented.
 info: |
   2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).

--- a/test/built-ins/Temporal/Calendar/prototype/month/date-time.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/date-time.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.month
-description: Temporal.Calendar.prototype.month will take PlainDateTime and return
+description: >
+  Temporal.Calendar.prototype.month will take PlainDateTime and return
   the value of the month.
 info: |
   5. If Type(temporalDateLike) is not Object or temporalDateLike does not have

--- a/test/built-ins/Temporal/Calendar/prototype/month/date.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/date.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.month
-description: Temporal.Calendar.prototype.month will take PlainDate and return
+description: >
+  Temporal.Calendar.prototype.month will take PlainDate and return
   the value of the month.
 info: |
   1. Let calendar be the this value.

--- a/test/built-ins/Temporal/Calendar/prototype/month/month-day-throw-type-error.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/month-day-throw-type-error.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.month
-description: Temporal.Calendar.prototype.month throws TypeError if temporalDateLike
+description: >
+  Temporal.Calendar.prototype.month throws TypeError if temporalDateLike
   is a PlainMonthDay object.
   ToTemporalDate when temporalDateLike is invalid string.
 info: |

--- a/test/built-ins/Temporal/Calendar/prototype/month/string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/string.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.month
-description: Temporal.Calendar.prototype.month will take ISO8601 string and return
+description: >
+  Temporal.Calendar.prototype.month will take ISO8601 string and return
   the value of the month.
 info: |
   5. If Type(temporalDateLike) is not Object or temporalDateLike does not have

--- a/test/built-ins/Temporal/Calendar/prototype/month/throw-range-error-ToTemporalDate.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/throw-range-error-ToTemporalDate.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.month
-description: Temporal.Calendar.prototype.month throws RangeError on
+description: >
+  Temporal.Calendar.prototype.month throws RangeError on
   ToTemporalDate when temporalDateLike is invalid string.
 info: |
   5. If Type(temporalDateLike) is not Object or temporalDateLike

--- a/test/built-ins/Temporal/Calendar/prototype/month/year-month.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/year-month.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.month
-description: Temporal.Calendar.prototype.month will take PlainYearMonth and return
+description: >
+  Temporal.Calendar.prototype.month will take PlainYearMonth and return
   the value of the month.
 info: |
   6. Return ! ISOMonth(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/date-time.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/date-time.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.monthCode
-description: Temporal.Calendar.prototype.month will take PlainDateTime and return
+description: >
+  Temporal.Calendar.prototype.month will take PlainDateTime and return
   the value of the monthCode.
 info: |
   6. Return ! ISOMonthCode(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/date.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/date.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.monthCode
-description: Temporal.Calendar.prototype.monthCode will take PlainDate and return
+description: >
+  Temporal.Calendar.prototype.monthCode will take PlainDate and return
   the value of the monthCode.
 info: |
   5. Return ! ISOMonthCode(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/month-day.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/month-day.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.monthCode
-description: Temporal.Calendar.prototype.monthCode will take PlainMonthDay and return
+description: >
+  Temporal.Calendar.prototype.monthCode will take PlainMonthDay and return
   the value of the monthCode.
 info: |
   6. Return ! ISOMonthCode(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/string.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.monthCode
-description: Temporal.Calendar.prototype.monthCode will take ISO8601 string and return
+description: >
+  Temporal.Calendar.prototype.monthCode will take ISO8601 string and return
   the value of the monthCode.
 info: |
   5. If Type(temporalDateLike) is not Object or temporalDateLike does not have

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/throw-range-error-ToTemporalDate.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/throw-range-error-ToTemporalDate.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.monthCode
-description: Temporal.Calendar.prototype.monthCode throws RangeError on
+description: >
+  Temporal.Calendar.prototype.monthCode throws RangeError on
   ToTemporalDate when temporalDateLike is invalid string.
 info: |
   4. If Type(temporalDateLike) is not Object or temporalDateLike

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/year-month.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/year-month.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.monthCode
-description: Temporal.Calendar.prototype.monthCode will take PlainYearMonth and return
+description: >
+  Temporal.Calendar.prototype.monthCode will take PlainYearMonth and return
   the value of the monthCode.
 info: |
   6. Return ! ISOMonthCode(temporalDateLike).

--- a/test/built-ins/Temporal/Calendar/prototype/year/date-time.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/date-time.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.year
-description: Temporal.Calendar.prototype.year will take PlainDateTime and return
+description: >
+  Temporal.Calendar.prototype.year will take PlainDateTime and return
   the value of the year.
 info: |
   1. Let calendar be the this value.

--- a/test/built-ins/Temporal/Calendar/prototype/year/date.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/date.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.year
-description: Temporal.Calendar.prototype.year will take PlainDate and return
+description: >
+  Temporal.Calendar.prototype.year will take PlainDate and return
   the value of the year.
 info: |
   1. Let calendar be the this value.

--- a/test/built-ins/Temporal/Calendar/prototype/year/string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/string.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.year
-description: Temporal.Calendar.prototype.year will take ISO8601 string and return
+description: >
+  Temporal.Calendar.prototype.year will take ISO8601 string and return
   the value of the year.
 info: |
   1. Let calendar be the this value.

--- a/test/built-ins/Temporal/Calendar/prototype/year/throw-range-error-ToTemporalDate.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/throw-range-error-ToTemporalDate.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.year
-description: Temporal.Calendar.prototype.year throws RangeError on
+description: >
+  Temporal.Calendar.prototype.year throws RangeError on
   ToTemporalDate when temporalDateLike is invalid string.
 info: |
   4. If Type(temporalDateLike) is not Object or temporalDateLike

--- a/test/built-ins/Temporal/Calendar/prototype/year/throw-type-error-RequireInternalSlot.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/throw-type-error-RequireInternalSlot.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.year
-description: Temporal.Calendar.prototype.year throws TypeError on
+description: >
+  Temporal.Calendar.prototype.year throws TypeError on
   RequireInternalSlot if object has no internal slot.
 info: |
   2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).

--- a/test/built-ins/Temporal/Calendar/prototype/year/year-month.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/year-month.js
@@ -3,7 +3,8 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.year
-description: Temporal.Calendar.prototype.year will take PlainYearMonth and return
+description: >
+  Temporal.Calendar.prototype.year will take PlainYearMonth and return
   the value of the year.
 info: |
   1. Let calendar be the this value.


### PR DESCRIPTION
In some recently added tests, the `description` is a multi-line scalar in flow notation. Change it to block notation.

Resolves #3171.