### PR TITLE
Correct tests for Unicode Language Identifier

### DIFF
--- a/test/intl402/DisplayNames/prototype/of/type-calendar-invalid.js
+++ b/test/intl402/DisplayNames/prototype/of/type-calendar-invalid.js
@@ -43,3 +43,19 @@ assert.throws(RangeError, function() {
 assert.throws(RangeError, function() {
   displayNames.of('abc def');
 }, 'interstitial space');
+
+assert.throws(RangeError, function() {
+  displayNames.of('123_abc');
+}, '2 segments, minimum length, underscore');
+
+assert.throws(RangeError, function() {
+  displayNames.of('12345678_abcdefgh');
+}, '2 segments, maximum length, underscore');
+
+assert.throws(RangeError, function() {
+  displayNames.of('123_abc_ABC');
+}, '3 segments, minimum length, underscore');
+
+assert.throws(RangeError, function() {
+  displayNames.of('12345678_abcdefgh_ABCDEFGH');
+}, '3 segments, maximum length, underscore');

--- a/test/intl402/DisplayNames/prototype/of/type-calendar-valid.js
+++ b/test/intl402/DisplayNames/prototype/of/type-calendar-valid.js
@@ -25,8 +25,3 @@ assert.sameValue(typeof displayNames.of('123-abc'), 'string', '2 segments, minim
 assert.sameValue(typeof displayNames.of('12345678-abcdefgh'), 'string', '2 segments, maximum length, dash');
 assert.sameValue(typeof displayNames.of('123-abc-ABC'), 'string', '3 segments, minimum length, dash');
 assert.sameValue(typeof displayNames.of('12345678-abcdefgh-ABCDEFGH'), 'string', '3 segments, maximum length, dash');
-
-assert.sameValue(typeof displayNames.of('123_abc'), 'string', '2 segments, minimum length, underscore');
-assert.sameValue(typeof displayNames.of('12345678_abcdefgh'), 'string', '2 segments, maximum length, underscore');
-assert.sameValue(typeof displayNames.of('123_abc_ABC'), 'string', '3 segments, minimum length, underscore');
-assert.sameValue(typeof displayNames.of('12345678_abcdefgh_ABCDEFGH'), 'string', '3 segments, maximum length, underscore');


### PR DESCRIPTION
The underscore character "_" is only accepted for the sep production [1]
when the backwards-compatibility extensions [2] are enabled. However,
ECMA-402 only accepts Unicode BCP 47 locale identifiers [3], meaning
identifiers *without* the backwards-compatibility extensions.

[1] https://unicode.org/reports/tr35/#Unicode_language_identifier
[2] https://unicode.org/reports/tr35/#BCP_47_Conformance
[3] https://tc39.es/ecma402/#sec-language-tags

---

Resolves gh-3139. /cc @anba