### PR TITLE
Throw distinctive errors for different failures

### DIFF
--- a/test/built-ins/decodeURI/S15.1.3.1_A2.1_T1.js
+++ b/test/built-ins/decodeURI/S15.1.3.1_A2.1_T1.js
@@ -12,11 +12,12 @@ for (var indexI = 0; indexI <= 65535; indexI++) {
   if (indexI !== 0x25) {
     try {
       var str = String.fromCharCode(indexI);
-      if (decodeURI(str) !== str) {
-        throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
-      }
+      var differs = decodeURI(str) !== str;
     } catch (e) {
-      throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
+      throw new Test262Error('#' + decimalToHexString(indexI) + ' throws');
+    }
+    if (differs) {
+      throw new Test262Error('#' + decimalToHexString(indexI) + ' differs');
     }
   }
 }

--- a/test/built-ins/decodeURIComponent/S15.1.3.2_A2.1_T1.js
+++ b/test/built-ins/decodeURIComponent/S15.1.3.2_A2.1_T1.js
@@ -12,11 +12,12 @@ for (var indexI = 0; indexI <= 65535; indexI++) {
   if (indexI !== 0x25) {
     try {
       var str = String.fromCharCode(indexI);
-      if (decodeURIComponent(str) !== str) {
-        throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
-      }
+      var differs = decodeURIComponent(str) !== str;
     } catch (e) {
-      throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
+      throw new Test262Error('#' + decimalToHexString(indexI) + ' throws');
+    }
+    if (differs) {
+      throw new Test262Error('#' + decimalToHexString(indexI) + ' differs');
     }
   }
 }

--- a/test/language/comments/S7.4_A6.js
+++ b/test/language/comments/S7.4_A6.js
@@ -14,10 +14,11 @@ for (var indexI = 0; indexI <= 65535; indexI++) {
   try {
     var xx = 0;
     eval("/*var " + String.fromCharCode(indexI) + "xx = 1*/");
-    if (xx !== 0) {
-      throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
-    }
+    var differs = xx !== 0;
   } catch (e){
-    throw new Test262Error('#' + decimalToHexString(indexI) + ' ');
+    throw new Test262Error('#' + decimalToHexString(indexI) + ' throws');
+  }
+  if (differs) {
+    throw new Test262Error('#' + decimalToHexString(indexI) + ' differs');
   }
 }


### PR DESCRIPTION
Prior to this patch, two distinct failure cases would produce the same
generic error message. Refactor the test logic to report the specific
condition which trigger failure.

---

Building on @lightmare's work in gh-3170.