### PR TITLE
Fix 'asserts.throws()' typo in two tests

### DIFF
--- a/test/built-ins/Error/prototype/S15.11.4_A3.js
+++ b/test/built-ins/Error/prototype/S15.11.4_A3.js
@@ -7,7 +7,7 @@ es5id: 15.11.4_A3
 description: Checking if call of Error prototype as a function fails
 ---*/
 
-asserts.throws(TypeError, () => {
+assert.throws(TypeError, () => {
   Error.prototype();
   throw new Test262Error();
 });

--- a/test/built-ins/Error/prototype/S15.11.4_A4.js
+++ b/test/built-ins/Error/prototype/S15.11.4_A4.js
@@ -7,7 +7,7 @@ es5id: 15.11.4_A4
 description: Checking if creating "new Error.prototype" fails
 ---*/
 
-asserts.throws(TypeError, () => {
+assert.throws(TypeError, () => {
   new Error.prototype();
   throw new Test262Error();
 });


### PR DESCRIPTION
This should be 'assert.throws()', otherwise these fail unexpectedly.

Fixes #3184.