### PR TITLE
Add tests for Intl Enumeration API

### DIFF
--- a/harness/testIntl.js
+++ b/harness/testIntl.js
@@ -19,7 +19,12 @@ defines:
   - getInvalidLocaleArguments
   - testOption
   - testForUnwantedRegExpChanges
+  - allCalendars
+  - allCollations
+  - allNumberingSystems
   - isValidNumberingSystem
+  - numberingSystemDigits
+  - allSimpleSanctionedUnits
   - testNumberFormat
   - getDateTimeComponents
   - getDateTimeComponentValues
@@ -2029,17 +2034,71 @@ function testForUnwantedRegExpChanges(testFunc) {
 
 
 /**
- * Tests whether name is a valid BCP 47 numbering system name
- * and not excluded from use in the ECMAScript Internationalization API.
- * @param {string} name the name to be tested.
- * @return {boolean} whether name is a valid BCP 47 numbering system name and
- *   allowed for use in the ECMAScript Internationalization API.
+ * Returns an array of all known calendars.
  */
+function allCalendars() {
+  // source: CLDR file common/bcp47/number.xml; version CLDR 39.
+  // https://github.com/unicode-org/cldr/blob/master/common/bcp47/calendar.xml
+  return [
+    "buddhist",
+    "chinese",
+    "coptic",
+    "dangi",
+    "ethioaa",
+    "ethiopic",
+    "gregory",
+    "hebrew",
+    "indian",
+    "islamic",
+    "islamic-umalqura",
+    "islamic-tbla",
+    "islamic-civil",
+    "islamic-rgsa",
+    "iso8601",
+    "japanese",
+    "persian",
+    "roc",
+  ];
+}
 
-function isValidNumberingSystem(name) {
 
-  // source: CLDR file common/bcp47/number.xml; version CLDR 36.1.
-  var numberingSystems = [
+/**
+ * Returns an array of all known collations.
+ */
+function allCollations() {
+  // source: CLDR file common/bcp47/collation.xml; version CLDR 39.
+  // https://github.com/unicode-org/cldr/blob/master/common/bcp47/collation.xml
+  return [
+    "big5han",
+    "compat",
+    "dict",
+    "direct",
+    "ducet",
+    "emoji",
+    "eor",
+    "gb2312",
+    "phonebk",
+    "phonetic",
+    "pinyin",
+    "reformed",
+    "search",
+    "searchjl",
+    "standard",
+    "stroke",
+    "trad",
+    "unihan",
+    "zhuyin",
+  ];
+}
+
+
+/**
+ * Returns an array of all known numbering systems.
+ */
+function allNumberingSystems() {
+  // source: CLDR file common/bcp47/number.xml; version CLDR 39.
+  // https://github.com/unicode-org/cldr/blob/master/common/bcp47/number.xml
+  return [
     "adlm",
     "ahom",
     "arab",
@@ -2128,6 +2187,20 @@ function isValidNumberingSystem(name) {
     "wara",
     "wcho",
   ];
+}
+
+
+/**
+ * Tests whether name is a valid BCP 47 numbering system name
+ * and not excluded from use in the ECMAScript Internationalization API.
+ * @param {string} name the name to be tested.
+ * @return {boolean} whether name is a valid BCP 47 numbering system name and
+ *   allowed for use in the ECMAScript Internationalization API.
+ */
+
+function isValidNumberingSystem(name) {
+
+  var numberingSystems = allNumberingSystems();
 
   var excluded = [
     "finance",
@@ -2213,6 +2286,59 @@ var numberingSystemDigits = {
   wara: "𑣠𑣡𑣢𑣣𑣤𑣥𑣦𑣧𑣨𑣩",
   wcho: "𞋰𞋱𞋲𞋳𞋴𞋵𞋶𞋷𞋸𞋹",
 };
+
+
+/**
+ * Returns an array of all simple, sanctioned unit identifiers.
+ */
+function allSimpleSanctionedUnits() {
+  // https://tc39.es/ecma402/#table-sanctioned-simple-unit-identifiers
+  return [
+    "acre",
+    "bit",
+    "byte",
+    "celsius",
+    "centimeter",
+    "day",
+    "degree",
+    "fahrenheit",
+    "fluid-ounce",
+    "foot",
+    "gallon",
+    "gigabit",
+    "gigabyte",
+    "gram",
+    "hectare",
+    "hour",
+    "inch",
+    "kilobit",
+    "kilobyte",
+    "kilogram",
+    "kilometer",
+    "liter",
+    "megabit",
+    "megabyte",
+    "meter",
+    "mile",
+    "mile-scandinavian",
+    "milliliter",
+    "millimeter",
+    "millisecond",
+    "minute",
+    "month",
+    "ounce",
+    "percent",
+    "petabyte",
+    "pound",
+    "second",
+    "stone",
+    "terabit",
+    "terabyte",
+    "week",
+    "yard",
+    "year",
+  ];
+}
 
 
 /**

--- a/test/intl402/Collator/prototype/resolvedOptions/basic.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/basic.js
@@ -15,29 +15,7 @@ var actual = new Intl.Collator().resolvedOptions();
 var actual2 = new Intl.Collator().resolvedOptions();
 assert.notSameValue(actual2, actual, "resolvedOptions returned the same object twice.");
 
-// source: CLDR file common/bcp47/collation.xml; version CLDR 32.
-var collations = [
-    "default", // added
-    "big5han",
-    "compat",
-    "dict",
-    "direct",
-    "ducet",
-    "emoji",
-    "eor",
-    "gb2312",
-    "phonebk",
-    "phonetic",
-    "pinyin",
-    "reformed",
-    // "search", // excluded
-    "searchjl",
-    // "standard", // excluded
-    "stroke",
-    "trad",
-    "unihan",
-    "zhuyin",
-];
+var collations = ["default", ...allCollations()];
 
 // this assumes the default values where the specification provides them
 assert(isCanonicalizedStructurallyValidLanguageTag(actual.locale),
@@ -45,6 +23,8 @@ assert(isCanonicalizedStructurallyValidLanguageTag(actual.locale),
 assert.sameValue(actual.usage, "sort");
 assert.sameValue(actual.sensitivity, "variant");
 assert.sameValue(actual.ignorePunctuation, false);
+assert.notSameValue(actual.collation, "search");
+assert.notSameValue(actual.collation, "standard");
 assert.notSameValue(collations.indexOf(actual.collation), -1,
                     "Invalid collation: " + actual.collation);
 

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/pattern-on-calendar.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/pattern-on-calendar.js
@@ -6,29 +6,12 @@ esid: sec-initializedatetimeformat
 description: >
   Checks the DateTimeFormat choose different patterns based
   on calendar.
+includes: [testIntl.js]
 features: [Intl.DateTimeFormat-formatRange]
 locale: [en]
 ---*/
 
-let calendars = [
-  "buddhist",
-  "chinese",
-  "coptic",
-  "dangi",
-  "ethiopic",
-  "ethioaa",
-  "gregory",
-  "hebrew",
-  "indian",
-  "islamic",
-  "islamic-civil",
-  "islamic-rgsa",
-  "islamic-tbla",
-  "islamic-umalqura",
-  "japanese",
-  "persian",
-  "roc"
-];
+let calendars = allCalendars();
 let date1 = new Date(2017, 3, 12);
 let date2 = new Date();
 

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/pattern-on-calendar.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/pattern-on-calendar.js
@@ -6,28 +6,11 @@ esid: sec-initializedatetimeformat
 description: >
   Checks the DateTimeFormat choose different patterns based
   on calendar.
+includes: [testIntl.js]
 locale: [en]
 ---*/
 
-let calendars = [
-  "buddhist",
-  "chinese",
-  "coptic",
-  "dangi",
-  "ethiopic",
-  "ethioaa",
-  "gregory",
-  "hebrew",
-  "indian",
-  "islamic",
-  "islamic-civil",
-  "islamic-rgsa",
-  "islamic-tbla",
-  "islamic-umalqura",
-  "japanese",
-  "persian",
-  "roc"
-];
+let calendars = allCalendars();
 let date = new Date();
 
 // serialize parts to a string by considering only the type and literal.

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/basic.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/basic.js
@@ -16,29 +16,7 @@ var actual = new Intl.DateTimeFormat().resolvedOptions();
 var actual2 = new Intl.DateTimeFormat().resolvedOptions();
 assert.notSameValue(actual2, actual, "resolvedOptions returned the same object twice.");
 
-// source: CLDR file common/bcp47/calendar.xml; version CLDR 32.
-var calendars = [
-    "buddhist",
-    "chinese",
-    "coptic",
-    "dangi",
-    "ethioaa",
-    "ethiopic-amete-alem",
-    "ethiopic",
-    "gregory",
-    "hebrew",
-    "indian",
-    "islamic",
-    "islamic-umalqura",
-    "islamic-tbla",
-    "islamic-civil",
-    "islamic-rgsa",
-    "iso8601",
-    "japanese",
-    "persian",
-    "roc",
-    "islamicc",
-];
+var calendars = allCalendars();
 
 // this assumes the default values where the specification provides them
 assert(isCanonicalizedStructurallyValidLanguageTag(actual.locale),

--- a/test/intl402/Intl/supportedValuesOf/builtin.js
+++ b/test/intl402/Intl/supportedValuesOf/builtin.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  Intl.supportedValuesOf is a built-in function object..
+info: |
+  Intl.supportedValuesOf ( key )
+
+  18 ECMAScript Standard Built-in Objects:
+    Unless specified otherwise, a built-in object that is callable as a function
+    is a built-in function object with the characteristics described in 10.3.
+    Unless specified otherwise, the [[Extensible]] internal slot of a built-in
+    object initially has the value true.
+
+    Unless otherwise specified every built-in function and every built-in
+    constructor has the Function prototype object, which is the initial value
+    of the expression Function.prototype (20.2.3), as the value of its
+    [[Prototype]] internal slot.
+
+    Built-in function objects that are not identified as constructors do not
+    implement the [[Construct]] internal method unless otherwise specified in
+    the description of a particular function.
+includes: [isConstructor.js]
+features: [Intl-enumeration, Reflect.construct]
+---*/
+
+assert.sameValue(typeof Intl.supportedValuesOf, "function",
+                 "Intl.supportedValuesOf is a function");
+
+assert(!Object.prototype.hasOwnProperty.call(Intl.supportedValuesOf, "prototype"),
+       "Intl.supportedValuesOf doesn't have an own 'prototype' property");
+
+assert(Object.isExtensible(Intl.supportedValuesOf),
+       "Built-in objects must be extensible");
+
+assert.sameValue(Object.getPrototypeOf(Intl.supportedValuesOf), Function.prototype,
+                 "[[Prototype]] of Intl.supportedValuesOf is Function.prototype");
+
+assert(!isConstructor(Intl.supportedValuesOf),
+       "Intl.supportedValuesOf not a constructor function");

--- a/test/intl402/Intl/supportedValuesOf/calendars-accepted-by-DateTimeFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/calendars-accepted-by-DateTimeFormat.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "calendar" values can be used with DateTimeFormat.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  2. If key is "calendar", then
+    a. Let list be ! AvailableCalendars( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableCalendars ( )
+    The AvailableCalendars abstract operation returns a List, ordered as if an
+    Array of the same values had been sorted using %Array.prototype.sort% using
+    undefined as comparefn, that contains unique calendar types identifying the
+    calendars for which the implementation provides the functionality of
+    Intl.DateTimeFormat objects. The list must include "gregory".
+includes: [testIntl.js]
+locale: [en]
+features: [Intl-enumeration]
+---*/
+
+const calendars = Intl.supportedValuesOf("calendar");
+
+for (let calendar of calendars) {
+  let obj = new Intl.DateTimeFormat("en", {calendar});
+  assert.sameValue(obj.resolvedOptions().calendar, calendar,
+                   `${calendar} is supported by DateTimeFormat`);
+}
+
+for (let calendar of allCalendars()) {
+  let obj = new Intl.DateTimeFormat("en", {calendar});
+  if (obj.resolvedOptions().calendar === calendar) {
+    assert(calendars.includes(calendar),
+           `${calendar} supported but not returned by supportedValuesOf`);
+  } else {
+    assert(!calendars.includes(calendar),
+           `${calendar} not supported but returned by supportedValuesOf`);
+  }
+}

--- a/test/intl402/Intl/supportedValuesOf/calendars-accepted-by-DisplayNames.js
+++ b/test/intl402/Intl/supportedValuesOf/calendars-accepted-by-DisplayNames.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "calendar" values can be used with DisplayNames.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  2. If key is "calendar", then
+    a. Let list be ! AvailableCalendars( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableCalendars ( )
+    The AvailableCalendars abstract operation returns a List, ordered as if an
+    Array of the same values had been sorted using %Array.prototype.sort% using
+    undefined as comparefn, that contains unique calendar types identifying the
+    calendars for which the implementation provides the functionality of
+    Intl.DateTimeFormat objects. The list must include "gregory".
+includes: [testIntl.js]
+locale: [en]
+features: [Intl-enumeration, Intl.DisplayNames-v2]
+---*/
+
+const calendars = Intl.supportedValuesOf("calendar");
+
+const obj = new Intl.DisplayNames("en", {type: "calendar", fallback: "none"});
+
+for (let calendar of calendars) {
+  assert.sameValue(typeof obj.of(calendar), "string",
+                   `${calendar} is supported by DisplayNames`);
+}
+
+for (let calendar of allCalendars()) {
+  if (typeof obj.of(calendar) === "string") {
+    assert(calendars.includes(calendar),
+           `${calendar} supported but not returned by supportedValuesOf`);
+  } else {
+    assert(!calendars.includes(calendar),
+           `${calendar} not supported but returned by supportedValuesOf`);
+  }
+}

--- a/test/intl402/Intl/supportedValuesOf/calendars.js
+++ b/test/intl402/Intl/supportedValuesOf/calendars.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "calendar" values are sorted, unique, and match the type production.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  2. If key is "calendar", then
+    a. Let list be ! AvailableCalendars( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableCalendars ( )
+    The AvailableCalendars abstract operation returns a List, ordered as if an
+    Array of the same values had been sorted using %Array.prototype.sort% using
+    undefined as comparefn, that contains unique calendar types identifying the
+    calendars for which the implementation provides the functionality of
+    Intl.DateTimeFormat objects. The list must include "gregory".
+includes: [compareArray.js]
+features: [Intl-enumeration, Intl.Locale]
+---*/
+
+const calendars = Intl.supportedValuesOf("calendar");
+
+assert(Array.isArray(calendars), "Returns an Array object.");
+assert.sameValue(Object.getPrototypeOf(calendars), Array.prototype,
+                 "The array prototype is Array.prototype");
+
+const otherCalendars = Intl.supportedValuesOf("calendar");
+assert.notSameValue(otherCalendars, calendars,
+                    "Returns a new array object for each call.");
+
+assert.compareArray(calendars, otherCalendars.sort(),
+                    "The array is sorted.");
+
+assert.sameValue(new Set(calendars).size, calendars.length,
+                 "The array doesn't contain duplicates.");
+
+// https://unicode.org/reports/tr35/tr35.html#Unicode_locale_identifier
+const typeRE = /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/;
+for (let calendar of calendars) {
+  assert(typeRE.test(calendar), `${calendar} matches the 'type' production`);
+}
+
+for (let calendar of calendars) {
+  assert.sameValue(new Intl.Locale("und", {calendar}).calendar, calendar,
+                   `${calendar} is canonicalised`);
+}
+
+assert(calendars.includes("gregory"), "Includes the Gregorian calendar.");

--- a/test/intl402/Intl/supportedValuesOf/coerced-to-string.js
+++ b/test/intl402/Intl/supportedValuesOf/coerced-to-string.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  Input key is coerced with ToString.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  2. If key is "calendar", then
+    a. Let list be ! AvailableCalendars( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+includes: [compareArray.js]
+features: [Intl-enumeration]
+---*/
+
+const calendars = Intl.supportedValuesOf("calendar");
+
+// ToString on a String object.
+assert.compareArray(Intl.supportedValuesOf(new String("calendar")), calendars);
+
+// ToString on a plain object.
+let obj = {
+  toString() {
+    return "calendar";
+  }
+};
+assert.compareArray(Intl.supportedValuesOf(obj), calendars);
+
+// ToString() of a symbol throws a TypeError.
+assert.throws(TypeError, function() {
+  Intl.supportedValuesOf(Symbol());
+});

--- a/test/intl402/Intl/supportedValuesOf/collations-accepted-by-Collator.js
+++ b/test/intl402/Intl/supportedValuesOf/collations-accepted-by-Collator.js
@@ -1,0 +1,81 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "collation" values can be used with Collator.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  3. Else if key is "collation", then
+    a. Let list be ! AvailableCollations( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableCollations ( )
+    The AvailableCollations abstract operation returns a List, ordered as if an
+    Array of the same values had been sorted using %Array.prototype.sort% using
+    undefined as comparefn, that contains unique collation types identifying the
+    collations for which the implementation provides the functionality of
+    Intl.Collator objects.
+includes: [testIntl.js]
+locale: [en, ar, de, es, ko, ln, si, sv, zh]
+features: [Intl-enumeration]
+---*/
+
+const collations = Intl.supportedValuesOf("collation");
+
+// Not all locales support all possible collations, so test the minimal set to
+// cover all supported collations.
+//
+// The list of all collations can be derived from
+// <https://github.com/unicode-org/cldr/blob/master/common/bcp47/collation.xml>.
+//
+// Note: "standard" and "search" are explicitly disallowed by Intl.Collator.
+const locales = [
+  "en", // ducet, emoji, eor
+  "ar", // compat
+  "de", // phonebk
+  "es", // trad
+  "hi", // direct
+  "ko", // searchjl
+  "ln", // phonetic
+  "si", // dict
+  "sv", // reformed
+  "zh", // big5han, gb2312, pinyin, stroke, unihan, zhuyin
+];
+
+for (let collation of collations) {
+  let supported = false;
+  for (let locale of locales) {
+    let obj = new Intl.Collator(locale, {collation});
+    if (obj.resolvedOptions().collation === collation) {
+      supported = true;
+      break;
+    }
+  }
+
+  assert(supported, `${collation} is supported by Collator`);
+}
+
+for (let collation of allCollations()) {
+  let supported = false;
+  for (let locale of locales) {
+    let obj = new Intl.Collator(locale, {collation});
+    if (obj.resolvedOptions().collation === collation) {
+      supported = true;
+      break;
+    }
+  }
+
+  if (supported) {
+    assert(collations.includes(collation),
+           `${collation} supported but not returned by supportedValuesOf`);
+  } else {
+    assert(!collations.includes(collation),
+           `${collation} not supported but returned by supportedValuesOf`);
+  }
+}

--- a/test/intl402/Intl/supportedValuesOf/collations.js
+++ b/test/intl402/Intl/supportedValuesOf/collations.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "collation" values are sorted, unique, and match the type production.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  3. Else if key is "collation", then
+    a. Let list be ! AvailableCollations( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableCollations ( )
+    The AvailableCollations abstract operation returns a List, ordered as if an
+    Array of the same values had been sorted using %Array.prototype.sort% using
+    undefined as comparefn, that contains unique collation types identifying the
+    collations for which the implementation provides the functionality of
+    Intl.Collator objects.
+includes: [compareArray.js]
+features: [Intl-enumeration, Intl.Locale]
+---*/
+
+const collations = Intl.supportedValuesOf("collation");
+
+assert(Array.isArray(collations), "Returns an Array object.");
+assert.sameValue(Object.getPrototypeOf(collations), Array.prototype,
+                 "The array prototype is Array.prototype");
+
+const otherCollations = Intl.supportedValuesOf("collation");
+assert.notSameValue(otherCollations, collations,
+                    "Returns a new array object for each call.");
+
+assert.compareArray(collations, otherCollations.sort(),
+                    "The array is sorted.");
+
+assert.sameValue(new Set(collations).size, collations.length,
+                 "The array doesn't contain duplicates.");
+
+// https://unicode.org/reports/tr35/tr35.html#Unicode_locale_identifier
+const typeRE = /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/;
+for (let collation of collations) {
+  assert(typeRE.test(collation), `${collation} matches the 'type' production`);
+}
+
+for (let collation of collations) {
+  assert.sameValue(new Intl.Locale("und", {collation}).collation, collation,
+                   `${collation} is canonicalised`);
+}
+
+assert(!collations.includes("standard"), "Mustn't include the 'standard' collation type.");
+assert(!collations.includes("search"), "Mustn't include the 'search' collation type.");

--- a/test/intl402/Intl/supportedValuesOf/currencies-accepted-by-DisplayNames.js
+++ b/test/intl402/Intl/supportedValuesOf/currencies-accepted-by-DisplayNames.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "currency" values can be used with DisplayNames.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  4. Else if key is "currency", then
+    a. Let list be ! AvailableCurrencies( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableCurrencies ( )
+    The AvailableCurrencies abstract operation returns a List, ordered as if an
+    Array of the same values had been sorted using %Array.prototype.sort% using
+    undefined as comparefn, that contains unique, well-formed, and upper case
+    canonicalized 3-letter ISO 4217 currency codes, identifying the currencies
+    for which the implementation provides the functionality of Intl.DisplayNames
+    and Intl.NumberFormat objects.
+locale: [en]
+features: [Intl-enumeration, Intl.DisplayNames]
+---*/
+
+const currencies = Intl.supportedValuesOf("currency");
+
+const obj = new Intl.DisplayNames("en", {type: "currency", fallback: "none"});
+
+for (let currency of currencies) {
+  assert.sameValue(typeof obj.of(currency), "string",
+                   `${currency} is supported by DisplayNames`);
+}
+
+for (let i = 0x41; i <= 0x5A; ++i) {
+  for (let j = 0x41; j <= 0x5A; ++j) {
+    for (let k = 0x41; k <= 0x5A; ++k) {
+      let currency = String.fromCharCode(i, j, k);
+      if (typeof obj.of(currency) === "string") {
+        assert(currencies.includes(currency),
+               `${currency} supported but not returned by supportedValuesOf`);
+      } else {
+        assert(!currencies.includes(currency),
+               `${currency} not supported but returned by supportedValuesOf`);
+      }
+    }
+  }
+}

--- a/test/intl402/Intl/supportedValuesOf/currencies-accepted-by-NumberFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/currencies-accepted-by-NumberFormat.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "currency" values can be used with NumberFormat.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  4. Else if key is "currency", then
+    a. Let list be ! AvailableCurrencies( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableCurrencies ( )
+    The AvailableCurrencies abstract operation returns a List, ordered as if an
+    Array of the same values had been sorted using %Array.prototype.sort% using
+    undefined as comparefn, that contains unique, well-formed, and upper case
+    canonicalized 3-letter ISO 4217 currency codes, identifying the currencies
+    for which the implementation provides the functionality of Intl.DisplayNames
+    and Intl.NumberFormat objects.
+locale: [en]
+features: [Intl-enumeration]
+---*/
+
+const currencies = Intl.supportedValuesOf("currency");
+
+for (let currency of currencies) {
+  let obj = new Intl.NumberFormat("en", {style: "currency", currency});
+  assert.sameValue(obj.resolvedOptions().currency, currency,
+                   `${currency} is supported by NumberFormat`);
+}
+
+// Note: We can't test that additional currency values not present in |currencies|
+// aren't supported by Intl.NumberFormat, because PartitionNumberPattern defaults
+// to using the currency code itself when the currency is unsupported:
+//
+// PartitionNumberPattern, step 8.k.iii:
+// Let cd be an ILD String value representing currency after x in currencyDisplay form,
+// which may depend on x in languages having different plural forms. If the
+// implementation does not have such a representation of currency, use currency itself.

--- a/test/intl402/Intl/supportedValuesOf/currencies.js
+++ b/test/intl402/Intl/supportedValuesOf/currencies.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "currency" values are sorted, unique, and upper-case canonicalised.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  4. Else if key is "currency", then
+    a. Let list be ! AvailableCurrencies( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableCurrencies ( )
+    The AvailableCurrencies abstract operation returns a List, ordered as if an
+    Array of the same values had been sorted using %Array.prototype.sort% using
+    undefined as comparefn, that contains unique, well-formed, and upper case
+    canonicalized 3-letter ISO 4217 currency codes, identifying the currencies
+    for which the implementation provides the functionality of Intl.DisplayNames
+    and Intl.NumberFormat objects.
+includes: [compareArray.js]
+features: [Intl-enumeration]
+---*/
+
+const currencies = Intl.supportedValuesOf("currency");
+
+assert(Array.isArray(currencies), "Returns an Array object.");
+assert.sameValue(Object.getPrototypeOf(currencies), Array.prototype,
+                 "The array prototype is Array.prototype");
+
+const otherCurrencies = Intl.supportedValuesOf("currency");
+assert.notSameValue(otherCurrencies, currencies,
+                    "Returns a new array object for each call.");
+
+assert.compareArray(currencies, otherCurrencies.sort(),
+                    "The array is sorted.");
+
+assert.sameValue(new Set(currencies).size, currencies.length,
+                 "The array doesn't contain duplicates.");
+
+const codeRE = /^[A-Z]{3}$/;
+for (let currency of currencies) {
+  assert(codeRE.test(currency), `${currency} is a 3-letter ISO 4217 currency code`);
+}

--- a/test/intl402/Intl/supportedValuesOf/invalid-key.js
+++ b/test/intl402/Intl/supportedValuesOf/invalid-key.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  Intl.supportedValuesOf throws a RangeError if the key is invalid.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  8. Else,
+    a. Throw a RangeError exception.
+  ...
+features: [Intl-enumeration]
+---*/
+
+const invalidKeys = [
+  // Empty string is invalid.
+  "",
+
+  // Various unsupported keys.
+  "hourCycle", "locale", "language", "script", "region",
+
+  // Plural form of supported keys not valid.
+  "calendars", "collations", "currencies", "numberingSystems", "timeZones", "units",
+
+  // Wrong case for supported keys.
+  "CALENDAR", "Collation", "Currency", "numberingsystem", "timezone", "UNIT",
+
+  // NUL character must be handled correctly.
+  "calendar\0",
+
+  // Non-string cases.
+  undefined, null, false, true, NaN, 0, Math.PI, 123n, {}, [],
+];
+
+for (let key of invalidKeys) {
+  assert.throws(RangeError, function() {
+    Intl.supportedValuesOf(key);
+  }, "key: " + key);
+}

--- a/test/intl402/Intl/supportedValuesOf/length.js
+++ b/test/intl402/Intl/supportedValuesOf/length.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  Intl.supportedValuesOf.length value and descriptor.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  18 ECMAScript Standard Built-in Objects:
+    Every built-in function object, including constructors, has a "length"
+    property whose value is a non-negative integral Number. Unless otherwise
+    specified, this value is equal to the number of required parameters shown in
+    the subclause heading for the function description. Optional parameters and
+    rest parameters are not included in the parameter count.
+
+    Unless otherwise specified, the "length" property of a built-in function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl-enumeration]
+---*/
+
+verifyProperty(Intl.supportedValuesOf, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Intl/supportedValuesOf/name.js
+++ b/test/intl402/Intl/supportedValuesOf/name.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  Intl.supportedValuesOf.name value and descriptor.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  18 ECMAScript Standard Built-in Objects:
+    Every built-in function object, including constructors, has a "name"
+    property whose value is a String. Unless otherwise specified, this value is
+    the name that is given to the function in this specification. Functions that
+    are identified as anonymous functions use the empty String as the value of
+    the "name" property. For functions that are specified as properties of
+    objects, the name value is the property name string used to access the
+    function.
+
+    Unless otherwise specified, the "name" property of a built-in function object
+    has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Intl-enumeration]
+---*/
+
+verifyProperty(Intl.supportedValuesOf, "name", {
+  value: "supportedValuesOf",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-DateTimeFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-DateTimeFormat.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "numberingSystem" values can be used with DateTimeFormat.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  5. Else if key is "numberingSystem", then
+    a. Let list be ! AvailableNumberingSystems( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableNumberingSystems ( )
+    The AvailableNumberingSystems abstract operation returns a List, ordered as
+    if an Array of the same values had been sorted using %Array.prototype.sort%
+    using undefined as comparefn, that contains unique numbering systems
+    identifiers identifying the numbering systems for which the implementation
+    provides the functionality of Intl.DateTimeFormat, Intl.NumberFormat, and
+    Intl.RelativeTimeFormat objects. The list must include the Numbering System
+    value of every row of Table 4, except the header row.
+includes: [testIntl.js]
+locale: [en]
+features: [Intl-enumeration]
+---*/
+
+const numberingSystems = Intl.supportedValuesOf("numberingSystem");
+
+for (let numberingSystem of numberingSystems) {
+  let obj = new Intl.DateTimeFormat("en", {numberingSystem});
+  assert.sameValue(obj.resolvedOptions().numberingSystem, numberingSystem,
+                   `${numberingSystem} is supported by DateTimeFormat`);
+}
+
+for (let numberingSystem of allNumberingSystems()) {
+  let obj = new Intl.DateTimeFormat("en", {numberingSystem});
+  if (obj.resolvedOptions().numberingSystem === numberingSystem) {
+    assert(numberingSystems.includes(numberingSystem),
+           `${numberingSystem} supported but not returned by supportedValuesOf`);
+  } else {
+    assert(!numberingSystems.includes(numberingSystem),
+           `${numberingSystem} not supported but returned by supportedValuesOf`);
+  }
+}

--- a/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-NumberFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-NumberFormat.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "numberingSystem" values can be used with NumberFormat.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  5. Else if key is "numberingSystem", then
+    a. Let list be ! AvailableNumberingSystems( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableNumberingSystems ( )
+    The AvailableNumberingSystems abstract operation returns a List, ordered as
+    if an Array of the same values had been sorted using %Array.prototype.sort%
+    using undefined as comparefn, that contains unique numbering systems
+    identifiers identifying the numbering systems for which the implementation
+    provides the functionality of Intl.DateTimeFormat, Intl.NumberFormat, and
+    Intl.RelativeTimeFormat objects. The list must include the Numbering System
+    value of every row of Table 4, except the header row.
+includes: [testIntl.js]
+locale: [en]
+features: [Intl-enumeration]
+---*/
+
+const numberingSystems = Intl.supportedValuesOf("numberingSystem");
+
+for (let numberingSystem of numberingSystems) {
+  let obj = new Intl.NumberFormat("en", {numberingSystem});
+  assert.sameValue(obj.resolvedOptions().numberingSystem, numberingSystem,
+                   `${numberingSystem} is supported by NumberFormat`);
+}
+
+for (let numberingSystem of allNumberingSystems()) {
+  let obj = new Intl.NumberFormat("en", {numberingSystem});
+  if (obj.resolvedOptions().numberingSystem === numberingSystem) {
+    assert(numberingSystems.includes(numberingSystem),
+           `${numberingSystem} supported but not returned by supportedValuesOf`);
+  } else {
+    assert(!numberingSystems.includes(numberingSystem),
+           `${numberingSystem} not supported but returned by supportedValuesOf`);
+  }
+}

--- a/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-RelativeTimeFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-RelativeTimeFormat.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "numberingSystem" values can be used with RelativeTimeFormat.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  5. Else if key is "numberingSystem", then
+    a. Let list be ! AvailableNumberingSystems( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableNumberingSystems ( )
+    The AvailableNumberingSystems abstract operation returns a List, ordered as
+    if an Array of the same values had been sorted using %Array.prototype.sort%
+    using undefined as comparefn, that contains unique numbering systems
+    identifiers identifying the numbering systems for which the implementation
+    provides the functionality of Intl.DateTimeFormat, Intl.NumberFormat, and
+    Intl.RelativeTimeFormat objects. The list must include the Numbering System
+    value of every row of Table 4, except the header row.
+includes: [testIntl.js]
+locale: [en]
+features: [Intl-enumeration, Intl.RelativeTimeFormat]
+---*/
+
+const numberingSystems = Intl.supportedValuesOf("numberingSystem");
+
+for (let numberingSystem of numberingSystems) {
+  let obj = new Intl.RelativeTimeFormat("en", {numberingSystem});
+  assert.sameValue(obj.resolvedOptions().numberingSystem, numberingSystem,
+                   `${numberingSystem} is supported by RelativeTimeFormat`);
+}
+
+for (let numberingSystem of allNumberingSystems()) {
+  let obj = new Intl.RelativeTimeFormat("en", {numberingSystem});
+  if (obj.resolvedOptions().numberingSystem === numberingSystem) {
+    assert(numberingSystems.includes(numberingSystem),
+           `${numberingSystem} supported but not returned by supportedValuesOf`);
+  } else {
+    assert(!numberingSystems.includes(numberingSystem),
+           `${numberingSystem} not supported but returned by supportedValuesOf`);
+  }
+}

--- a/test/intl402/Intl/supportedValuesOf/numberingSystems-with-simple-digit-mappings.js
+++ b/test/intl402/Intl/supportedValuesOf/numberingSystems-with-simple-digit-mappings.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "numberingSystem" values contain all numbering systems with simple digit mappings.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  5. Else if key is "numberingSystem", then
+    a. Let list be ! AvailableNumberingSystems( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableNumberingSystems ( )
+    The AvailableNumberingSystems abstract operation returns a List, ordered as
+    if an Array of the same values had been sorted using %Array.prototype.sort%
+    using undefined as comparefn, that contains unique numbering systems
+    identifiers identifying the numbering systems for which the implementation
+    provides the functionality of Intl.DateTimeFormat, Intl.NumberFormat, and
+    Intl.RelativeTimeFormat objects. The list must include the Numbering System
+    value of every row of Table 4, except the header row.
+includes: [testIntl.js]
+features: [Intl-enumeration]
+---*/
+
+const numberingSystems = Intl.supportedValuesOf("numberingSystem");
+
+// Table 10: Numbering systems with simple digit mappings
+for (let numberingSystem of Object.keys(numberingSystemDigits)) {
+  assert(numberingSystems.includes(numberingSystem),
+         `${numberingSystem} with simple digit mappings is supported`);
+}

--- a/test/intl402/Intl/supportedValuesOf/numberingSystems.js
+++ b/test/intl402/Intl/supportedValuesOf/numberingSystems.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "numberingSystem" values are sorted, unique, and match the type production.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  5. Else if key is "numberingSystem", then
+    a. Let list be ! AvailableNumberingSystems( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableNumberingSystems ( )
+    The AvailableNumberingSystems abstract operation returns a List, ordered as
+    if an Array of the same values had been sorted using %Array.prototype.sort%
+    using undefined as comparefn, that contains unique numbering systems
+    identifiers identifying the numbering systems for which the implementation
+    provides the functionality of Intl.DateTimeFormat, Intl.NumberFormat, and
+    Intl.RelativeTimeFormat objects. The list must include the Numbering System
+    value of every row of Table 4, except the header row.
+includes: [compareArray.js]
+features: [Intl-enumeration, Intl.Locale]
+---*/
+
+const numberingSystems = Intl.supportedValuesOf("numberingSystem");
+
+assert(Array.isArray(numberingSystems), "Returns an Array object.");
+assert.sameValue(Object.getPrototypeOf(numberingSystems), Array.prototype,
+                 "The array prototype is Array.prototype");
+
+const otherNumberingSystems = Intl.supportedValuesOf("numberingSystem");
+assert.notSameValue(otherNumberingSystems, numberingSystems,
+                    "Returns a new array object for each call.");
+
+assert.compareArray(numberingSystems, otherNumberingSystems.sort(),
+                    "The array is sorted.");
+
+assert.sameValue(new Set(numberingSystems).size, numberingSystems.length,
+                 "The array doesn't contain duplicates.");
+
+// https://unicode.org/reports/tr35/tr35.html#Unicode_locale_identifier
+const typeRE = /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/;
+for (let numberingSystem of numberingSystems) {
+  assert(typeRE.test(numberingSystem), `${numberingSystem} matches the 'type' production`);
+}
+
+for (let numberingSystem of numberingSystems) {
+  assert.sameValue(new Intl.Locale("und", {numberingSystem}).numberingSystem, numberingSystem,
+                   `${numberingSystem} is canonicalised`);
+}

--- a/test/intl402/Intl/supportedValuesOf/prop-desc.js
+++ b/test/intl402/Intl/supportedValuesOf/prop-desc.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  Intl.supportedValuesOf property attributes.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  18 ECMAScript Standard Built-in Objects:
+    Every other data property described in clauses 19 through 28 and in Annex B.2
+    has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [Intl-enumeration]
+---*/
+
+verifyProperty(Intl, "supportedValuesOf", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/intl402/Intl/supportedValuesOf/timeZones-accepted-by-DateTimeFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/timeZones-accepted-by-DateTimeFormat.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "timeZone" values can be used with DateTimeFormat.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  6. Else if key is "timeZone", then
+    a. Let list be ! AvailableTimeZones( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableTimeZones ()
+    The AvailableTimeZones abstract operation returns a sorted List of supported
+    Zone and Link names in the IANA Time Zone Database. The following steps are
+    taken:
+
+    1. Let names be a List of all supported Zone and Link names in the IANA Time
+       Zone Database.
+    2. Let result be a new empty List.
+    3. For each element name of names, do
+        a. Assert: ! IsValidTimeZoneName( name ) is true.
+        b. Let canonical be ! CanonicalizeTimeZoneName( name ).
+        c. If result does not contain an element equal to canonical, then
+            i. Append canonical to the end of result.
+    4. Sort result in order as if an Array of the same values had been sorted using
+       %Array.prototype.sort% using undefined as comparefn.
+    5. Return result.
+locale: [en]
+features: [Intl-enumeration]
+---*/
+
+const timeZones = Intl.supportedValuesOf("timeZone");
+
+for (let timeZone of timeZones) {
+  let obj = new Intl.DateTimeFormat("en", {timeZone});
+  assert.sameValue(obj.resolvedOptions().timeZone, timeZone,
+                   `${timeZone} is supported by DateTimeFormat`);
+}

--- a/test/intl402/Intl/supportedValuesOf/timeZones.js
+++ b/test/intl402/Intl/supportedValuesOf/timeZones.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "timeZone" values are sorted, unique, and canonicalised.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  6. Else if key is "timeZone", then
+    a. Let list be ! AvailableTimeZones( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableTimeZones ()
+    The AvailableTimeZones abstract operation returns a sorted List of supported
+    Zone and Link names in the IANA Time Zone Database. The following steps are
+    taken:
+
+    1. Let names be a List of all supported Zone and Link names in the IANA Time
+       Zone Database.
+    2. Let result be a new empty List.
+    3. For each element name of names, do
+        a. Assert: ! IsValidTimeZoneName( name ) is true.
+        b. Let canonical be ! CanonicalizeTimeZoneName( name ).
+        c. If result does not contain an element equal to canonical, then
+            i. Append canonical to the end of result.
+    4. Sort result in order as if an Array of the same values had been sorted using
+       %Array.prototype.sort% using undefined as comparefn.
+    5. Return result.
+includes: [compareArray.js, testIntl.js]
+features: [Intl-enumeration]
+---*/
+
+const timeZones = Intl.supportedValuesOf("timeZone");
+
+assert(Array.isArray(timeZones), "Returns an Array object.");
+assert.sameValue(Object.getPrototypeOf(timeZones), Array.prototype,
+                 "The array prototype is Array.prototype");
+
+const otherTimeZones = Intl.supportedValuesOf("timeZone");
+assert.notSameValue(otherTimeZones, timeZones,
+                    "Returns a new array object for each call.");
+
+assert.compareArray(timeZones, otherTimeZones.sort(),
+                    "The array is sorted.");
+
+assert.sameValue(new Set(timeZones).size, timeZones.length,
+                 "The array doesn't contain duplicates.");
+
+for (let timeZone of timeZones) {
+  assert(isCanonicalizedStructurallyValidTimeZoneName(timeZone),
+         `${timeZone} is a canonicalised and structurally valid time zone name`);
+}

--- a/test/intl402/Intl/supportedValuesOf/units-accepted-by-NumberFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/units-accepted-by-NumberFormat.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "unit" values can be used with NumberFormat.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  7. Else if key is "unit", then
+    a. Let list be ! AvailableUnits( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableUnits ( )
+    The AvailableUnits abstract operation returns a List, ordered as if an Array
+    of the same values had been sorted using %Array.prototype.sort% using
+    undefined as comparefn, that contains the unique values of simple unit
+    identifiers listed in every row of Table 1, except the header row.
+includes: [testIntl.js]
+locale: [en]
+features: [Intl-enumeration]
+---*/
+
+const units = Intl.supportedValuesOf("unit");
+
+for (let unit of units) {
+  let obj = new Intl.NumberFormat("en", {style: "unit", unit});
+  assert.sameValue(obj.resolvedOptions().unit, unit,
+                   `${unit} is supported by NumberFormat`);
+}
+
+for (let unit of allSimpleSanctionedUnits()) {
+  let obj = new Intl.NumberFormat("en", {style: "unit", unit});
+  if (obj.resolvedOptions().unit === unit) {
+    assert(units.includes(unit),
+           `${unit} supported but not returned by supportedValuesOf`);
+  } else {
+    assert(!units.includes(unit),
+           `${unit} not supported but returned by supportedValuesOf`);
+  }
+}

--- a/test/intl402/Intl/supportedValuesOf/units.js
+++ b/test/intl402/Intl/supportedValuesOf/units.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2021 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.supportedvaluesof
+description: >
+  The returned "unit" values are sorted, unique, and well-formed.
+info: |
+  Intl.supportedValuesOf ( key )
+
+  1. Let key be ? ToString(key).
+  ...
+  7. Else if key is "unit", then
+    a. Let list be ! AvailableUnits( ).
+  ...
+  9. Return ! CreateArrayFromList( list ).
+
+  AvailableUnits ( )
+    The AvailableUnits abstract operation returns a List, ordered as if an Array
+    of the same values had been sorted using %Array.prototype.sort% using
+    undefined as comparefn, that contains the unique values of simple unit
+    identifiers listed in every row of Table 1, except the header row.
+includes: [compareArray.js, testIntl.js]
+features: [Intl-enumeration]
+---*/
+
+const units = Intl.supportedValuesOf("unit");
+
+assert(Array.isArray(units), "Returns an Array object.");
+assert.sameValue(Object.getPrototypeOf(units), Array.prototype,
+                 "The array prototype is Array.prototype");
+
+const otherUnits = Intl.supportedValuesOf("unit");
+assert.notSameValue(otherUnits, units,
+                    "Returns a new array object for each call.");
+
+assert.compareArray(units, otherUnits.sort(),
+                    "The array is sorted.");
+
+assert.sameValue(new Set(units).size, units.length,
+                 "The array doesn't contain duplicates.");
+
+const simpleSanctioned = allSimpleSanctionedUnits();
+
+for (let unit of units) {
+  assert(simpleSanctioned.includes(unit), `${unit} is a simple, sanctioned unit`);
+  assert(!unit.includes("-per-"), `${unit} isn't a compound unit`);
+}

--- a/test/intl402/NumberFormat/constructor-unit.js
+++ b/test/intl402/NumberFormat/constructor-unit.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-initializenumberformat
 description: Checks handling of the unit style.
+includes: [testIntl.js]
 features: [Intl.NumberFormat-unified]
 ---*/
 
@@ -51,51 +52,7 @@ function check(unit) {
   assert.sameValue(options.unit, unit);
 }
 
-const units = [
-  "acre",
-  "bit",
-  "byte",
-  "celsius",
-  "centimeter",
-  "day",
-  "degree",
-  "fahrenheit",
-  "fluid-ounce",
-  "foot",
-  "gallon",
-  "gigabit",
-  "gigabyte",
-  "gram",
-  "hectare",
-  "hour",
-  "inch",
-  "kilobit",
-  "kilobyte",
-  "kilogram",
-  "kilometer",
-  "liter",
-  "megabit",
-  "megabyte",
-  "meter",
-  "mile",
-  "mile-scandinavian",
-  "millimeter",
-  "milliliter",
-  "millisecond",
-  "minute",
-  "month",
-  "ounce",
-  "percent",
-  "petabyte",
-  "pound",
-  "second",
-  "stone",
-  "terabit",
-  "terabyte",
-  "week",
-  "yard",
-  "year",
-];
+const units = allSimpleSanctionedUnits();
 
 for (const simpleUnit of units) {
   check(simpleUnit);

--- a/test/intl402/NumberFormat/prototype/format/numbering-systems.js
+++ b/test/intl402/NumberFormat/prototype/format/numbering-systems.js
@@ -7,93 +7,17 @@ description: >
     Tests that Intl.NumberFormat.prototype.format supports all
     numbering systems with simple digit mappings.
 author: Roozbeh Pournader
+includes: [testIntl.js]
 ---*/
 
-const numberingSystems = {
-    adlm: 0x1E950,
-    ahom: 0x11730,
-    arab: 0x0660,
-    arabext: 0x06F0,
-    bali: 0x1B50,
-    beng: 0x09E6,
-    bhks: 0x11C50,
-    brah: 0x11066,
-    cakm: 0x11136,
-    cham: 0xAA50,
-    deva: 0x0966,
-    diak: 0x11950,
-    fullwide: 0xFF10,
-    gong: 0x11DA0,
-    gonm: 0x11D50,
-    gujr: 0x0AE6,
-    guru: 0x0A66,
-    hanidec: [0x3007, 0x4E00, 0x4E8C, 0x4E09, 0x56DB,
-              0x4E94, 0x516D, 0x4E03, 0x516B, 0x4E5D],
-    hmng: 0x16B50,
-    hmnp: 0x1E140,
-    java: 0xA9D0,
-    kali: 0xA900,
-    khmr: 0x17E0,
-    knda: 0x0CE6,
-    lana: 0x1A80,
-    lanatham: 0x1A90,
-    laoo: 0x0ED0,
-    latn: 0x0030,
-    lepc: 0x1C40,
-    limb: 0x1946,
-    mathbold: 0x1D7CE,
-    mathdbl: 0x1D7D8,
-    mathmono: 0x1D7F6,
-    mathsanb: 0x1D7EC,
-    mathsans: 0x1D7E2,
-    mlym: 0x0D66,
-    modi: 0x11650,
-    mong: 0x1810,
-    mroo: 0x16A60,
-    mtei: 0xABF0,
-    mymr: 0x1040,
-    mymrshan: 0x1090,
-    mymrtlng: 0xA9F0,
-    newa: 0x11450,
-    nkoo: 0x07C0,
-    olck: 0x1C50,
-    orya: 0x0B66,
-    osma: 0x104A0,
-    rohg: 0x10D30,
-    saur: 0xA8D0,
-    segment: 0x1FBF0,
-    shrd: 0x111D0,
-    sind: 0x112F0,
-    sinh: 0x0DE6,
-    sora: 0x110F0,
-    sund: 0x1BB0,
-    takr: 0x116C0,
-    talu: 0x19D0,
-    tamldec: 0x0BE6,
-    telu: 0x0C66,
-    thai: 0x0E50,
-    tibt: 0x0F20,
-    tirh: 0x114D0,
-    vaii: 0xA620,
-    wara: 0x118E0,
-    wcho: 0x1E2F0,
-};
-
-for (let [numberingSystem, digitList] of Object.entries(numberingSystems)) {
-    if (typeof digitList === 'number') {
-        let zeroCode = digitList;
-        digitList = [];
-        for (let i = 0; i <= 9; ++i) {
-            digitList[i] = zeroCode + i;
-        }
-    }
-
+for (let [numberingSystem, digits] of Object.entries(numberingSystemDigits)) {
+    let digitList = [...digits];
     assert.sameValue(digitList.length, 10);
 
     let nf = new Intl.NumberFormat(undefined, {numberingSystem});
 
     for (let i = 0; i <= 9; ++i) {
-        assert.sameValue(nf.format(i), String.fromCodePoint(digitList[i]),
+        assert.sameValue(nf.format(i), digitList[i],
                          `numberingSystem: ${numberingSystem}, digit: ${i}`);
     }
 }

--- a/test/intl402/NumberFormat/prototype/format/units.js
+++ b/test/intl402/NumberFormat/prototype/format/units.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-intl.numberformat.prototype.format
 description: Checks handling of units.
+includes: [testIntl.js]
 features: [Intl.NumberFormat-unified]
 ---*/
 
@@ -13,51 +14,7 @@ function check(unit) {
   assert.notSameValue(s1, s2);
 }
 
-const units = [
-  "acre",
-  "bit",
-  "byte",
-  "celsius",
-  "centimeter",
-  "day",
-  "degree",
-  "fahrenheit",
-  "fluid-ounce",
-  "foot",
-  "gallon",
-  "gigabit",
-  "gigabyte",
-  "gram",
-  "hectare",
-  "hour",
-  "inch",
-  "kilobit",
-  "kilobyte",
-  "kilogram",
-  "kilometer",
-  "liter",
-  "megabit",
-  "megabyte",
-  "meter",
-  "mile",
-  "mile-scandinavian",
-  "millimeter",
-  "milliliter",
-  "millisecond",
-  "minute",
-  "month",
-  "ounce",
-  "percent",
-  "petabyte",
-  "pound",
-  "second",
-  "stone",
-  "terabit",
-  "terabyte",
-  "week",
-  "yard",
-  "year",
-];
+const units = allSimpleSanctionedUnits();
 
 for (const simpleUnit of units) {
   check(simpleUnit);


### PR DESCRIPTION
Covers the usual surface tests and additional functionality tests which were
upstreamed from existing tests in SpiderMonkey.

Fixes #3131