### PR TITLE
Fix incorrect tests: new Date(-0).valueOf() and new Date(-1.23e-15).valueOf() should return +0.

### DIFF
--- a/test/built-ins/Date/prototype/valueOf/S9.4_A3_T1.js
+++ b/test/built-ins/Date/prototype/valueOf/S9.4_A3_T1.js
@@ -56,4 +56,4 @@ assert.sameValue(d11.valueOf(), 0, 'd11.valueOf() must return 0');
 
 // CHECK#12
 var d12 = new Date(-1.23e-15);
-assert.sameValue(d12.valueOf(), -0, 'd12.valueOf() must return -0');
+assert.sameValue(d12.valueOf(), 0, 'd12.valueOf() must return 0');

--- a/test/built-ins/Date/prototype/valueOf/S9.4_A3_T2.js
+++ b/test/built-ins/Date/prototype/valueOf/S9.4_A3_T2.js
@@ -30,4 +30,4 @@ assert.sameValue(d4.valueOf(), 0, 'd4.valueOf() must return 0');
 
 // CHECK#5
 var d5 = new Date(-0);
-assert.sameValue(d5.valueOf(), -0, 'd5.valueOf() must return -0');
+assert.sameValue(d5.valueOf(), 0, 'd5.valueOf() must return 0');


### PR DESCRIPTION
Fixes test regressions introduced by https://github.com/tc39/test262/pull/3144 (1c24e4b915a090ae1878da606a9cd1e62ca815ca) which changed:
```diff
 var d5 = new Date(-0);
-if (d5.valueOf() !== -0) {
-  throw new Test262Error('#5: var d5 = new Date(-0); d5.valueOf() === -0;');
-}
+assert.sameValue(d5.valueOf(), -0, 'd5.valueOf() must return -0');
```
and
```diff
 var d12 = new Date(-1.23e-15);
-if (d12.valueOf() !== -0) {
-  throw new Test262Error('#12: var d12 = new Date(-1.23e-15); d12.valueOf() === -0;');
-}
+assert.sameValue(d12.valueOf(), -0, 'd12.valueOf() must return -0');
```

This is wrong. The correct result is positive 0. (See [TimeClip](https://tc39.es/ecma262/#sec-timeclip) and [ToIntegerOrInfinity](https://tc39.es/ecma262/#sec-tointegerorinfinity) which returns either an integer (cannot be -0), +∞, or -∞.)
Arguably, the tests were always wrong, suggesting that the correct result be `-0`, but technically they were valid since `0 === -0`.
