### PR TITLE
Improve coverage for ops involving negative zero

### DIFF
--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A15.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A15.js
@@ -14,7 +14,5 @@ exponents[1] = -111;
 exponents[0] = -111111;
 
 for (var i = 0; i < exponents.length; i++) {
-  if ((base ** exponents[i]) !== -0) {
-    throw new Test262Error("(" + base + " ** " + exponents[i] + ") !== -0");
-  }
+  assert.sameValue(base ** exponents[i], -0, base + " ** " + exponents[i]);
 }

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A19.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A19.js
@@ -14,7 +14,5 @@ exponents[1] = 111;
 exponents[2] = 111111;
 
 for (var i = 0; i < exponents.length; i++) {
-  if ((base ** exponents[i]) !== -0) {
-    throw new Test262Error("(" + base + " **  " + exponents[i] + ") !== -0");
-  }
+  assert.sameValue(base ** exponents[i], -0, base + " **  " + exponents[i]);
 }

--- a/test/language/statements/throw/S12.13_A2_T5.js
+++ b/test/language/statements/throw/S12.13_A2_T5.js
@@ -71,5 +71,5 @@ try{
   throw -0;
 }
 catch(e){
-  if (e!==-0) throw new Test262Error('#8: Exception ===-0. Actual:  Exception ==='+ e );
+  assert.sameValue(e, -0);
 }

--- a/test/language/statements/try/S12.14_A18_T5.js
+++ b/test/language/statements/try/S12.14_A18_T5.js
@@ -96,5 +96,5 @@ try{
   throw -0;
 }
 catch(e){
-  if (e!==-0) throw new Test262Error('#11: Exception ===-0. Actual:  Exception ==='+ e  );
+  assert.sameValue(e, -0);
 }


### PR DESCRIPTION
Prior to this commit, the modified tests used the strict equality
operator to compare computed values with negative zero. Due to the
semantics of that operator, these tests would spuriously pass if the
value under test was in fact positive zero.

Update the tests to be more precise by instead asserting equality with
the `assert.sameValue` utility method (since that method correctly
distinguishes between negative zero and positive zero).

Thanks to @woess for helping uncover this by [identifying a related problem](https://github.com/tc39/test262/pull/3201).