### PR TITLE
Correct typo to improve coverage

### DIFF
--- a/test/language/expressions/division/S11.5.2_A4_T8.js
+++ b/test/language/expressions/division/S11.5.2_A4_T8.js
@@ -33,8 +33,8 @@ if (-0 / -1 !== +0) {
 if (+0 / 1 !== +0) {
   throw new Test262Error('#3.1: +0 / 1 === 0. Actual: ' + (+0 / 1));
 } else {
-  if (1 / (+0 / -1) !== Number.NEGATIVE_INFINITY) {
-    throw new Test262Error('#3.2: +0 / -1 === + 0. Actual: -0');
+  if (1 / (+0 / 1) !== Number.POSITIVE_INFINITY) {
+    throw new Test262Error('#3.2: +0 / 1 === + 0. Actual: -0');
   }
 }
 


### PR DESCRIPTION
Prior to this commit, the modified test included two different
expressions in positions that were meant to describe the same
expression. This meant that the value of the intended expression was
only partially verified.

Correct the test to fully verify the value of the expression.