### PR TITLE
Move IANA TimeZone tests to intl402

### DIFF
--- a/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
@@ -19,14 +19,6 @@ assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO({ timeZone }), "ba
   "2021-08-19T1730-07:00",
   "2021-08-19T17:30-0700",
   "2021-08-19T1730-0700",
-  "2021-08-19T17:30[America/Vancouver]",
-  "2021-08-19T1730[America/Vancouver]",
-  "2021-08-19T17:30Z[America/Vancouver]",
-  "2021-08-19T1730Z[America/Vancouver]",
-  "2021-08-19T17:30-07:00[America/Vancouver]",
-  "2021-08-19T1730-07:00[America/Vancouver]",
-  "2021-08-19T17:30-0700[America/Vancouver]",
-  "2021-08-19T1730-0700[America/Vancouver]",
 ].forEach((timeZone) => {
   Temporal.Now.plainDateTimeISO(timeZone);
   Temporal.Now.plainDateTimeISO({ timeZone });

--- a/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
@@ -19,6 +19,14 @@ assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO({ timeZone }), "ba
   "2021-08-19T1730-07:00",
   "2021-08-19T17:30-0700",
   "2021-08-19T1730-0700",
+  "2021-08-19T17:30[UTC]",
+  "2021-08-19T1730[UTC]",
+  "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T1730Z[UTC]",
+  "2021-08-19T17:30-07:00[UTC]",
+  "2021-08-19T1730-07:00[UTC]",
+  "2021-08-19T17:30-0700[UTC]",
+  "2021-08-19T1730-0700[UTC]",
 ].forEach((timeZone) => {
   Temporal.Now.plainDateTimeISO(timeZone);
   Temporal.Now.plainDateTimeISO({ timeZone });

--- a/test/built-ins/Temporal/Now/zonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/timezone-string-datetime.js
@@ -25,6 +25,6 @@ assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offse
 
 timeZone = "2021-08-19T17:30-0700";
 const result5 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
+assert.sameValue(result5.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
 const result6 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");

--- a/test/built-ins/Temporal/Now/zonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/timezone-string-datetime.js
@@ -23,20 +23,8 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30-0700";
 const result5 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
 const result6 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
-const result7 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
-const result8 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
-const result9 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
-const result10 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");

--- a/test/built-ins/Temporal/Now/zonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/timezone-string-datetime.js
@@ -23,8 +23,20 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-0700";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result5.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
+assert.sameValue(result5.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone");
 const result6 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result6.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[UTC]";
+const result7 = Temporal.Now.zonedDateTime("iso8601", timeZone);
+assert.sameValue(result7.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone");
+const result8 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
+assert.sameValue(result8.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[UTC]";
+const result9 = Temporal.Now.zonedDateTime("iso8601", timeZone);
+assert.sameValue(result9.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone");
+const result10 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
+assert.sameValue(result10.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
@@ -23,20 +23,8 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = Temporal.Now.zonedDateTimeISO({ timeZone });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30-0700";
 const result5 = Temporal.Now.zonedDateTimeISO(timeZone);
-assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result5.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
 const result6 = Temporal.Now.zonedDateTimeISO({ timeZone });
-assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
-const result7 = Temporal.Now.zonedDateTimeISO(timeZone);
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
-const result8 = Temporal.Now.zonedDateTimeISO({ timeZone });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
-const result9 = Temporal.Now.zonedDateTimeISO(timeZone);
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
-const result10 = Temporal.Now.zonedDateTimeISO({ timeZone });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");

--- a/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
@@ -23,8 +23,20 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = Temporal.Now.zonedDateTimeISO({ timeZone });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-0700";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = Temporal.Now.zonedDateTimeISO(timeZone);
-assert.sameValue(result5.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
+assert.sameValue(result5.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone");
 const result6 = Temporal.Now.zonedDateTimeISO({ timeZone });
-assert.sameValue(result6.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[UTC]";
+const result7 = Temporal.Now.zonedDateTimeISO(timeZone);
+assert.sameValue(result7.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone");
+const result8 = Temporal.Now.zonedDateTimeISO({ timeZone });
+assert.sameValue(result8.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[UTC]";
+const result9 = Temporal.Now.zonedDateTimeISO(timeZone);
+assert.sameValue(result9.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone");
+const result10 = Temporal.Now.zonedDateTimeISO({ timeZone });
+assert.sameValue(result10.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
+++ b/test/intl402/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-temporal.now.plaindatetimeiso
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances
+features: [Temporal]
+---*/
+
+let timeZone = "2021-08-19T17:30";
+assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO(timeZone), "bare date-time string is not a time zone");
+assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO({ timeZone }), "bare date-time string is not a time zone");
+
+// The following are all valid strings so should not throw:
+
+[
+  "2021-08-19T17:30Z",
+  "2021-08-19T1730Z",
+  "2021-08-19T17:30-07:00",
+  "2021-08-19T1730-07:00",
+  "2021-08-19T17:30-0700",
+  "2021-08-19T1730-0700",
+  "2021-08-19T17:30[America/Vancouver]",
+  "2021-08-19T1730[America/Vancouver]",
+  "2021-08-19T17:30Z[America/Vancouver]",
+  "2021-08-19T1730Z[America/Vancouver]",
+  "2021-08-19T17:30-07:00[America/Vancouver]",
+  "2021-08-19T1730-07:00[America/Vancouver]",
+  "2021-08-19T17:30-0700[America/Vancouver]",
+  "2021-08-19T1730-0700[America/Vancouver]",
+].forEach((timeZone) => {
+  Temporal.Now.plainDateTimeISO(timeZone);
+  Temporal.Now.plainDateTimeISO({ timeZone });
+});

--- a/test/intl402/Temporal/Now/zonedDateTime/timezone-string-datetime.js
+++ b/test/intl402/Temporal/Now/zonedDateTime/timezone-string-datetime.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.zoneddatetime
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances
+features: [Temporal]
+---*/
+
+let timeZone = "2021-08-19T17:30";
+assert.throws(RangeError, () => Temporal.Now.zonedDateTime("iso8601", timeZone), "bare date-time string is not a time zone");
+assert.throws(RangeError, () => Temporal.Now.zonedDateTime("iso8601", { timeZone }), "bare date-time string is not a time zone");
+
+timeZone = "2021-08-19T17:30Z";
+const result1 = Temporal.Now.zonedDateTime("iso8601", timeZone);
+assert.sameValue(result1.timeZone.id, "UTC", "date-time + Z is UTC time zone");
+const result2 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
+assert.sameValue(result2.timeZone.id, "UTC", "date-time + Z is UTC time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00";
+const result3 = Temporal.Now.zonedDateTime("iso8601", timeZone);
+assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
+const result4 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
+assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-0700";
+const result5 = Temporal.Now.zonedDateTime("iso8601", timeZone);
+assert.sameValue(result5.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
+const result6 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
+assert.sameValue(result6.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30[America/Vancouver]";
+const result7 = Temporal.Now.zonedDateTime("iso8601", timeZone);
+assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+const result8 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
+assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+const result9 = Temporal.Now.zonedDateTime("iso8601", timeZone);
+assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+const result10 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
+assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+const result11 = Temporal.Now.zonedDateTime("iso8601", timeZone);
+assert.sameValue(result11.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result12 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
+assert.sameValue(result12.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-0700[America/Vancouver]";
+const result13 = Temporal.Now.zonedDateTime("iso8601", timeZone);
+assert.sameValue(result13.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result14 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
+assert.sameValue(result14.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
+++ b/test/intl402/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
@@ -1,0 +1,54 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.zoneddatetimeiso
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances
+features: [Temporal]
+---*/
+
+let timeZone = "2021-08-19T17:30";
+assert.throws(RangeError, () => Temporal.Now.zonedDateTimeISO(timeZone), "bare date-time string is not a time zone");
+assert.throws(RangeError, () => Temporal.Now.zonedDateTimeISO({ timeZone }), "bare date-time string is not a time zone");
+
+timeZone = "2021-08-19T17:30Z";
+const result1 = Temporal.Now.zonedDateTimeISO(timeZone);
+assert.sameValue(result1.timeZone.id, "UTC", "date-time + Z is UTC time zone");
+const result2 = Temporal.Now.zonedDateTimeISO({ timeZone });
+assert.sameValue(result2.timeZone.id, "UTC", "date-time + Z is UTC time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00";
+const result3 = Temporal.Now.zonedDateTimeISO(timeZone);
+assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
+const result4 = Temporal.Now.zonedDateTimeISO({ timeZone });
+assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-0700";
+const result5 = Temporal.Now.zonedDateTimeISO(timeZone);
+assert.sameValue(result5.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
+const result6 = Temporal.Now.zonedDateTimeISO({ timeZone });
+assert.sameValue(result6.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30[America/Vancouver]";
+const result7 = Temporal.Now.zonedDateTimeISO(timeZone);
+assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+const result8 = Temporal.Now.zonedDateTimeISO({ timeZone });
+assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+const result9 = Temporal.Now.zonedDateTimeISO(timeZone);
+assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+const result10 = Temporal.Now.zonedDateTimeISO({ timeZone });
+assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+const result11 = Temporal.Now.zonedDateTimeISO(timeZone);
+assert.sameValue(result11.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result12 = Temporal.Now.zonedDateTimeISO({ timeZone });
+assert.sameValue(result12.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-0700[America/Vancouver]";
+const result13 = Temporal.Now.zonedDateTimeISO(timeZone);
+assert.sameValue(result13.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result14 = Temporal.Now.zonedDateTimeISO({ timeZone });
+assert.sameValue(result14.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");


### PR DESCRIPTION
IANA TimeZone name other than "UTC" is only required if the implementation " includes the ECMA-402 Internationalization API"
https://tc39.es/proposal-temporal/#sec-isvalidtimezonename
Therefore, we need to split the test and keep this one  without checking "America/Vancouver" and move those test on IATA timezone name other than UTC to under intl402
Add test cases to test withtout the ":" between TimeZoneUTCOffsetHour and TimeZoneUTCOffsetMinute
in the TimeZoneNumericUTCOffset string see https://tc39.es/proposal-temporal/#prod-TimeZoneNumericUTCOffset