### PR TITLE
Correct mistakes in support of proposal change

### DIFF
--- a/test/built-ins/TypedArray/prototype/byteOffset/BigInt/resizable-array-buffer-auto.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/BigInt/resizable-array-buffer-auto.js
@@ -34,13 +34,17 @@ testWithBigIntTypedArrayConstructors(function(TA) {
 
   assert.sameValue(array.byteOffset, BPE, "following shrink (within bounds)");
 
-  var expected;
   try {
     ab.resize(BPE);
+  } catch (_) {}
+
+  assert.sameValue(array.byteOffset, BPE, "following shrink (on boundary)");
+
+  var expected = BPE;
+  try {
+    ab.resize(0);
     expected = 0;
-  } catch (_) {
-    expected = BPE;
-  }
+  } catch (_) {}
 
   assert.sameValue(array.byteOffset, expected, "following shrink (out of bounds)");
 });

--- a/test/built-ins/TypedArray/prototype/byteOffset/resizable-array-buffer-auto.js
+++ b/test/built-ins/TypedArray/prototype/byteOffset/resizable-array-buffer-auto.js
@@ -34,14 +34,13 @@ testWithTypedArrayConstructors(function(TA) {
 
   assert.sameValue(array.byteOffset, BPE, "following shrink (within bounds)");
 
-  var expected = BPE;
   try {
     ab.resize(BPE);
-    expected = 0;
   } catch (_) {}
 
-  assert.sameValue(array.byteOffset, expected, "following shrink (on boundary)");
+  assert.sameValue(array.byteOffset, BPE, "following shrink (on boundary)");
 
+  var expected = BPE;
   try {
     ab.resize(0);
     expected = 0;


### PR DESCRIPTION
Ensure that when the ArrayBuffer of a length-tracking TypedArray is
resized to the address matching the TypedArray's byte offset, the
TypedArray is *not* considered "out of bounds."

Resolves gh-3206 (my thanks to @marjakh for reporting)