### PR TITLE
Correct assertion messages and improve coverage

### DIFF
--- a/test/built-ins/TypedArray/prototype/byteLength/BigInt/resizable-array-buffer-auto.js
+++ b/test/built-ins/TypedArray/prototype/byteLength/BigInt/resizable-array-buffer-auto.js
@@ -42,5 +42,12 @@ testWithBigIntTypedArrayConstructors(function(TA) {
     expected = 0;
   } catch (_) {}
 
+  assert.sameValue(array.byteLength, expected, "following shrink (on boundary)");
+
+  try {
+    ab.resize(0);
+    expected = 0;
+  } catch (_) {}
+
   assert.sameValue(array.byteLength, expected, "following shrink (out of bounds)");
 });

--- a/test/built-ins/TypedArray/prototype/length/BigInt/resizable-array-buffer-auto.js
+++ b/test/built-ins/TypedArray/prototype/length/BigInt/resizable-array-buffer-auto.js
@@ -42,5 +42,12 @@ testWithBigIntTypedArrayConstructors(function(TA) {
     expected = 0;
   } catch (_) {}
 
+  assert.sameValue(array.length, expected, "following shrink (on boundary)");
+
+  try {
+    ab.resize(0);
+    expected = 0;
+  } catch (_) {}
+
   assert.sameValue(array.length, expected, "following shrink (out of bounds)");
 });


### PR DESCRIPTION
Following a recent normative change to the Resizable ArrayBuffer
proposal [1], the term "out of bounds" no longer applies to
"length-tracking" TypedArrays whose underlying ArrayBuffer has been
resized to match their byte offset.

Reflect this in the tests by renaming the condition from "out of bounds"
to "on boundary" and by adding new assertions for true "out of bounds"
conditions.

[1] https://github.com/tc39/proposal-resizablearraybuffer/pull/70