### PR TITLE
Focus tests for `copyWithin` methods

### DIFF
--- a/test/built-ins/Array/prototype/copyWithin/coerced-values-target.js
+++ b/test/built-ins/Array/prototype/copyWithin/coerced-values-target.js
@@ -54,3 +54,8 @@ assert.compareArray(
   [0, 1, 2, 3].copyWithin(1.5, 0), [0, 0, 1, 2],
   '[0, 1, 2, 3].copyWithin(1.5, 0) must return [0, 0, 1, 2]'
 );
+
+assert.compareArray(
+  [0, 1, 2, 3].copyWithin({}, 1), [1, 2, 3, 3],
+  '[0, 1, 2, 3].copyWithin({}, 1) must return [1, 2, 3, 3]'
+);

--- a/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-target.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/coerced-values-target.js
@@ -89,4 +89,12 @@ testWithTypedArrayConstructors(function(TA) {
     ),
     '1.5 float value coerced to integer 1'
   );
+
+  assert(
+    compareArray(
+      new TA([0, 1, 2, 3]).copyWithin({}, 1),
+      [1, 2, 3, 3]
+    ),
+    'object value coerced to integer 0'
+  );
 });

--- a/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js
@@ -29,14 +29,14 @@ testWithTypedArrayConstructors(TA => {
   } catch (_) {}
 
   // no error following grow:
-  array.copyWithin(new TA(), 0);
+  array.copyWithin(0, 0);
 
   try {
     ab.resize(BPE * 3);
   } catch (_) {}
 
   // no error following shrink (within bounds):
-  array.copyWithin(new TA(), 0);
+  array.copyWithin(0, 0);
 
   var expectedError;
   try {
@@ -53,7 +53,7 @@ testWithTypedArrayConstructors(TA => {
   }
 
   assert.throws(expectedError, () => {
-    array.copyWithin(new TA(), 0);
+    array.copyWithin(0, 0);
     throw new Test262Error('copyWithin completed successfully');
   });
 });


### PR DESCRIPTION
Prior to this commit, a test for %TypedArray%.prototype.copyWithin
provided a TypedArray instance as the first argument. That argument that
is interpreted as a number, so in relying on the conversion, the test
verified behavior beyond what it purported to test.

Simplify the test by using the desired number value directly, and extend
the tests for type coercion to cover object values.

Resolves gh-3207.