### PR TITLE
Use BigInt values idiomatically

### DIFF
--- a/test/built-ins/TypedArray/prototype/includes/BigInt/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/includes/BigInt/return-abrupt-from-this-out-of-bounds.js
@@ -29,14 +29,14 @@ testWithBigIntTypedArrayConstructors(TA => {
   } catch (_) {}
 
   // no error following grow:
-  array.includes(0);
+  array.includes(0n);
 
   try {
     ab.resize(BPE * 3);
   } catch (_) {}
 
   // no error following shrink (within bounds):
-  array.includes(0);
+  array.includes(0n);
 
   var expectedError;
   try {
@@ -53,7 +53,7 @@ testWithBigIntTypedArrayConstructors(TA => {
   }
 
   assert.throws(expectedError, () => {
-    array.includes(0);
+    array.includes(0n);
     throw new Test262Error('includes completed successfully');
   });
 });

--- a/test/built-ins/TypedArray/prototype/indexOf/BigInt/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/indexOf/BigInt/return-abrupt-from-this-out-of-bounds.js
@@ -29,14 +29,14 @@ testWithBigIntTypedArrayConstructors(TA => {
   } catch (_) {}
 
   // no error following grow:
-  array.indexOf(0);
+  array.indexOf(0n);
 
   try {
     ab.resize(BPE * 3);
   } catch (_) {}
 
   // no error following shrink (within bounds):
-  array.indexOf(0);
+  array.indexOf(0n);
 
   var expectedError;
   try {
@@ -53,7 +53,7 @@ testWithBigIntTypedArrayConstructors(TA => {
   }
 
   assert.throws(expectedError, () => {
-    array.indexOf(0);
+    array.indexOf(0n);
     throw new Test262Error('indexOf completed successfully');
   });
 });

--- a/test/built-ins/TypedArray/prototype/join/BigInt/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/join/BigInt/return-abrupt-from-this-out-of-bounds.js
@@ -29,14 +29,14 @@ testWithBigIntTypedArrayConstructors(TA => {
   } catch (_) {}
 
   // no error following grow:
-  array.join(0);
+  array.join(',');
 
   try {
     ab.resize(BPE * 3);
   } catch (_) {}
 
   // no error following shrink (within bounds):
-  array.join(0);
+  array.join(',');
 
   var expectedError;
   try {
@@ -53,7 +53,7 @@ testWithBigIntTypedArrayConstructors(TA => {
   }
 
   assert.throws(expectedError, () => {
-    array.join(0);
+    array.join(',');
     throw new Test262Error('join completed successfully');
   });
 });

--- a/test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/return-abrupt-from-this-out-of-bounds.js
@@ -29,14 +29,14 @@ testWithBigIntTypedArrayConstructors(TA => {
   } catch (_) {}
 
   // no error following grow:
-  array.lastIndexOf(0);
+  array.lastIndexOf(0n);
 
   try {
     ab.resize(BPE * 3);
   } catch (_) {}
 
   // no error following shrink (within bounds):
-  array.lastIndexOf(0);
+  array.lastIndexOf(0n);
 
   var expectedError;
   try {
@@ -53,7 +53,7 @@ testWithBigIntTypedArrayConstructors(TA => {
   }
 
   assert.throws(expectedError, () => {
-    array.lastIndexOf(0);
+    array.lastIndexOf(0n);
     throw new Test262Error('lastIndexOf completed successfully');
   });
 });

--- a/test/built-ins/TypedArray/prototype/map/BigInt/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/map/BigInt/return-abrupt-from-this-out-of-bounds.js
@@ -29,14 +29,14 @@ testWithBigIntTypedArrayConstructors(TA => {
   } catch (_) {}
 
   // no error following grow:
-  array.map(() => {});
+  array.map(() => 0n);
 
   try {
     ab.resize(BPE * 3);
   } catch (_) {}
 
   // no error following shrink (within bounds):
-  array.map(() => {});
+  array.map(() => 0n);
 
   var expectedError;
   try {
@@ -53,7 +53,7 @@ testWithBigIntTypedArrayConstructors(TA => {
   }
 
   assert.throws(expectedError, () => {
-    array.map(() => {});
+    array.map(() => 0n);
     throw new Test262Error('map completed successfully');
   });
 });


### PR DESCRIPTION
Prior to this commit, a number of tests used non-BigInt values where
BigInt value are commonly used. Although this was technically
permissible to validate the behavior under test, the atypical usage
patterns tended to obscure the tests' purpose. Replace with more
appropriate values.

@rwaldron Unlike gh-3216, this patch is a subjective improvement to test clarity. You can take it or leave it.