### PR TITLE
Focus test for BigInt v. of `copyWithin` method

### DIFF
--- a/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-this-out-of-bounds.js
+++ b/test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-this-out-of-bounds.js
@@ -29,14 +29,14 @@ testWithBigIntTypedArrayConstructors(TA => {
   } catch (_) {}
 
   // no error following grow:
-  array.copyWithin(new TA(), 0);
+  array.copyWithin(0, 0);
 
   try {
     ab.resize(BPE * 3);
   } catch (_) {}
 
   // no error following shrink (within bounds):
-  array.copyWithin(new TA(), 0);
+  array.copyWithin(0, 0);
 
   var expectedError;
   try {
@@ -53,7 +53,7 @@ testWithBigIntTypedArrayConstructors(TA => {
   }
 
   assert.throws(expectedError, () => {
-    array.copyWithin(new TA(), 0);
+    array.copyWithin(0, 0);
     throw new Test262Error('copyWithin completed successfully');
   });
 });


### PR DESCRIPTION
Prior to this commit, a test for %TypedArray%.prototype.copyWithin
provided a TypedArray instance as the first argument. That argument that
is interpreted as a number, so in relying on the conversion, the test
verified behavior beyond what it purported to test.

Simplify the test by using the desired number value directly.

@rwaldron This should have been included in gh-3215. Sorry for drawing this out!