### PR TITLE
Adapt ShadowRealm proxy coverage

### DIFF
--- a/test/built-ins/ShadowRealm/prototype/evaluate/returns-proxy-callable-object.js
+++ b/test/built-ins/ShadowRealm/prototype/evaluate/returns-proxy-callable-object.js
@@ -22,4 +22,11 @@ new Proxy(fn, {});
 
 assert.sameValue(typeof proxyCallable, 'function', 'wrapped proxy callable object is typeof function');
 assert.sameValue(proxyCallable(), 42, 'wrappedpfn() returns 42');
-assert.sameValue(proxyCallable instanceof Proxy, false, 'the wrapped function "hides" the proxy instance');
+assert.sameValue((new Proxy(proxyCallable, {}))(), 42, 'wrapped functions can be proxied');
+
+const getSecret = r.evaluate(`(obj) => { return obj.secret }`);
+const secretObj = { "secret": 496 };
+const dispatchToUnderlying = {
+  apply: (target, this_, args) => { return target(args); }
+};
+assert.throws(TypeError, () => (new Proxy(getSecret, dispatchToUnderlying))(secretObj), 'Proxying a wrapped function and invoking it still performs boundary checks');


### PR DESCRIPTION
 - I don't think `... instanceof Proxy` ([which is performed here](https://github.com/tc39/test262/pull/3210/files#diff-0dfc4b1a2e48f81f61b8ecf92f9aa16d306256682d107203c4372d4037b11beaR25)) is a valid check in JS; it throws an error on non-realm expressions as well
 - Add some additional coverage over proxy-ing wrapped functions to show that the underlying boundary checks are still made. Perhaps this is obvious and not worth having in the suite, so happy to remove it