### PR TITLE
Split tests and fix false positive (ShadowRealms)

### DIFF
--- a/test/built-ins/ShadowRealm/prototype/evaluate/returns-proxy-callable-object.js
+++ b/test/built-ins/ShadowRealm/prototype/evaluate/returns-proxy-callable-object.js
@@ -23,10 +23,3 @@ new Proxy(fn, {});
 assert.sameValue(typeof proxyCallable, 'function', 'wrapped proxy callable object is typeof function');
 assert.sameValue(proxyCallable(), 42, 'wrappedpfn() returns 42');
 assert.sameValue((new Proxy(proxyCallable, {}))(), 42, 'wrapped functions can be proxied');
-
-const getSecret = r.evaluate(`(obj) => { return obj.secret }`);
-const secretObj = { "secret": 496 };
-const dispatchToUnderlying = {
-  apply: (target, this_, args) => { return target(args); }
-};
-assert.throws(TypeError, () => (new Proxy(getSecret, dispatchToUnderlying))(secretObj), 'Proxying a wrapped function and invoking it still performs boundary checks');

--- a/test/built-ins/ShadowRealm/prototype/evaluate/wrapped-function-proxied-observes-boundary.js
+++ b/test/built-ins/ShadowRealm/prototype/evaluate/wrapped-function-proxied-observes-boundary.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-shadowrealm.prototype.evaluate
+description: >
+  Proxying a wrapped function and invoking it still performs boundary checks
+features: [ShadowRealm]
+---*/
+
+assert.sameValue(
+  typeof ShadowRealm.prototype.evaluate,
+  'function',
+  'This test must fail if ShadowRealm.prototype.evaluate is not a function'
+);
+
+const r = new ShadowRealm();
+
+const wrapped = r.evaluate(`() => { return 1; };`);
+
+const secretObj = {x: 2};
+
+let received;
+
+const proxiedWrapped = new Proxy(wrapped, {
+  apply(target, _, args) {
+    assert.sameValue(target, wrapped);
+    received = args;
+
+    // Object can't be sent to the other Realm
+    return target({x: 1});
+  }
+});
+
+assert.throws(
+  TypeError,
+  () => proxiedWrapped(secretObj),
+  'Proxying a wrapped function and invoking it still performs boundary checks'
+);
+
+assert.sameValue(received[0], secretObj, 'proxy still calls the handler trap');
+assert.sameValue(received.length, 1);


### PR DESCRIPTION
cc @philomates @rwaldron I did split this test file to separate the different goals of each test.

I did some other minor tweaks such as removing a false positive where the handler was calling `target(args)` and args is an array despite the `secretObj` sent and I avoided too much code inside the assert.throws function.