### PR TITLE
Assert array equivalency

### DIFF
--- a/test/built-ins/Promise/race/resolved-sequence-with-rejections.js
+++ b/test/built-ins/Promise/race/resolved-sequence-with-rejections.js
@@ -44,7 +44,7 @@ Promise.all([
     return checkSequence(sequence, 'Expected to be called second.');
   })
 ]).then(result => {
-  compareArray(result, [true, true, true]);
+  assert.compareArray(result, [true, true, true]);
   assert.sameValue(sequence.length, 5);
   checkSequence(sequence);
 }).then($DONE, $DONE);

--- a/test/built-ins/Promise/race/resolved-sequence.js
+++ b/test/built-ins/Promise/race/resolved-sequence.js
@@ -44,7 +44,7 @@ Promise.all([
     return checkSequence(sequence, 'Expected to be called second.');
   })
 ]).then(result => {
-  compareArray(result, [true, true, true]);
+  assert.compareArray(result, [true, true, true]);
   assert.sameValue(sequence.length, 5);
   checkSequence(sequence)
 }).then($DONE, $DONE);


### PR DESCRIPTION
The `compareArray` utility function returns a boolean value describing
whether or not the input arrays are equivalent--it does not throw an
exception when invoked with non-equivalent arrays. Prior to this commit,
however, two tests invoked `compareArray` without inspecting its return
value, so it had no impact on the result of the test.

Update the tests to fail when the "expected" and "actual" arrays are not
equivalent.