### PR TITLE
Improve coverage by invoking functions as intended

### DIFF
--- a/src/computed-property-names/computed-property-name-from-yield-expression.case
+++ b/src/computed-property-names/computed-property-name-from-yield-expression.case
@@ -15,3 +15,5 @@ yield 9
 9
 //- teardown
 }
+var iter = g();
+while (iter.next().done === false) ;

--- a/test/built-ins/Array/prototype/reduce/15.4.4.21-9-8.js
+++ b/test/built-ins/Array/prototype/reduce/15.4.4.21-9-8.js
@@ -25,7 +25,7 @@ Object.defineProperty(obj, "0", {
   configurable: true
 });
 
-Array.prototype.reduce.call(obj, function() {}, "initialValue");
+Array.prototype.reduce.call(obj, callbackfn, "initialValue");
 
 assert.sameValue(accessed, false, 'accessed');
 assert.sameValue(callbackAccessed, false, 'callbackAccessed');

--- a/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-8.js
+++ b/test/built-ins/Array/prototype/reduceRight/15.4.4.22-9-8.js
@@ -9,9 +9,10 @@ description: >
 ---*/
 
 var accessed = false;
+var callbackAccessed = false;
 
 function callbackfn() {
-  accessed = true;
+  callbackAccessed = true;
 }
 
 var obj = {
@@ -26,6 +27,7 @@ Object.defineProperty(obj, "5", {
   configurable: true
 });
 
-Array.prototype.reduceRight.call(obj, function() {}, "initialValue");
+Array.prototype.reduceRight.call(obj, callbackfn, "initialValue");
 
 assert.sameValue(accessed, false, 'accessed');
+assert.sameValue(callbackAccessed, false, 'callbackAccessed');

--- a/test/language/expressions/await/await-throws-rejections.js
+++ b/test/language/expressions/await/await-throws-rejections.js
@@ -6,6 +6,7 @@ author: Brian Terlson <brian.terlson@microsoft.com>
 esid: pending
 description: >
   Await throws errors from rejected promises
+flags: [async]
 ---*/
 
 async function foo() {
@@ -21,3 +22,4 @@ async function foo() {
   assert(caught);
 }
 
+foo().then($DONE, $DONE);

--- a/test/language/expressions/class/cpn-class-expr-accessors-computed-property-name-from-yield-expression.js
+++ b/test/language/expressions/class/cpn-class-expr-accessors-computed-property-name-from-yield-expression.js
@@ -92,3 +92,5 @@ assert.sameValue(
 );
 
 }
+var iter = g();
+while (iter.next().done === false) ;

--- a/test/language/expressions/class/cpn-class-expr-computed-property-name-from-yield-expression.js
+++ b/test/language/expressions/class/cpn-class-expr-computed-property-name-from-yield-expression.js
@@ -65,3 +65,5 @@ assert.sameValue(
 );
 
 }
+var iter = g();
+while (iter.next().done === false) ;

--- a/test/language/expressions/class/cpn-class-expr-fields-computed-property-name-from-yield-expression.js
+++ b/test/language/expressions/class/cpn-class-expr-fields-computed-property-name-from-yield-expression.js
@@ -62,3 +62,5 @@ assert.sameValue(
 );
 
 }
+var iter = g();
+while (iter.next().done === false) ;

--- a/test/language/expressions/class/cpn-class-expr-fields-methods-computed-property-name-from-yield-expression.js
+++ b/test/language/expressions/class/cpn-class-expr-fields-methods-computed-property-name-from-yield-expression.js
@@ -66,3 +66,5 @@ assert.sameValue(
 );
 
 }
+var iter = g();
+while (iter.next().done === false) ;

--- a/test/language/expressions/object/cpn-obj-lit-computed-property-name-from-yield-expression.js
+++ b/test/language/expressions/object/cpn-obj-lit-computed-property-name-from-yield-expression.js
@@ -39,3 +39,5 @@ assert.sameValue(
 );
 
 }
+var iter = g();
+while (iter.next().done === false) ;

--- a/test/language/statements/class/cpn-class-decl-accessors-computed-property-name-from-yield-expression.js
+++ b/test/language/statements/class/cpn-class-decl-accessors-computed-property-name-from-yield-expression.js
@@ -92,3 +92,5 @@ assert.sameValue(
 );
 
 }
+var iter = g();
+while (iter.next().done === false) ;

--- a/test/language/statements/class/cpn-class-decl-computed-property-name-from-yield-expression.js
+++ b/test/language/statements/class/cpn-class-decl-computed-property-name-from-yield-expression.js
@@ -65,3 +65,5 @@ assert.sameValue(
 );
 
 }
+var iter = g();
+while (iter.next().done === false) ;

--- a/test/language/statements/class/cpn-class-decl-fields-computed-property-name-from-yield-expression.js
+++ b/test/language/statements/class/cpn-class-decl-fields-computed-property-name-from-yield-expression.js
@@ -62,3 +62,5 @@ assert.sameValue(
 );
 
 }
+var iter = g();
+while (iter.next().done === false) ;

--- a/test/language/statements/class/cpn-class-decl-fields-methods-computed-property-name-from-yield-expression.js
+++ b/test/language/statements/class/cpn-class-decl-fields-methods-computed-property-name-from-yield-expression.js
@@ -66,3 +66,5 @@ assert.sameValue(
 );
 
 }
+var iter = g();
+while (iter.next().done === false) ;


### PR DESCRIPTION
Some tests which include function declarations designed to verify
behavior do not reference those functions. Insert the references
necessary for those functions to serve their intended purpose.

Resolves gh-3229 along with a handful of other previously-unreported instances of this bug.