### PR TITLE
Follow-up fix to `Add tests for ShadowRealm globalThis`

### DIFF
--- a/test/built-ins/ShadowRealm/prototype/evaluate/globalthis-config-only-properties.js
+++ b/test/built-ins/ShadowRealm/prototype/evaluate/globalthis-config-only-properties.js
@@ -73,7 +73,7 @@ const result = r.evaluate(`
   ];
 
   // Delete every name except globalThis, for now
-  names.filter(name => {
+  const remainingNames = names.filter(name => {
     if (esNonConfigValues.includes(name)) {
       return false;
     }
@@ -85,12 +85,12 @@ const result = r.evaluate(`
   });
 
   delete globalThis['globalThis'];
-  
+
   if (hasOwn.call(savedGlobal, 'globalThis')) {
-    names.push('globalThis');
+    remainingNames.push('globalThis');
   }
 
-  const failedDelete = names.join(', ');
+  const failedDelete = remainingNames.join(', ');
 
   failedDelete;
 `);


### PR DESCRIPTION
This test, introduced in https://github.com/tc39/test262/pull/3264, fails on the JSC implementation I'm working on. 
I believe it is is due to not using the result of the `.filter`, for which this PR offers a fix.