### PR TITLE
Add tests for "Intl NumberFormat v3" proposal

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -178,6 +178,10 @@ coalesce-expression
 # https://github.com/tc39-transfer/proposal-intl-displaynames
 Intl.DisplayNames
 
+# Intl.NumberFormat V3
+# https://github.com/tc39/proposal-intl-numberformat-v3
+Intl.NumberFormat-v3
+
 # Promise.any
 # https://github.com/tc39/proposal-promise-any
 Promise.any

--- a/test/intl402/NumberFormat/constructor-options-roundingMode-invalid.js
+++ b/test/intl402/NumberFormat/constructor-options-roundingMode-invalid.js
@@ -1,0 +1,33 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-initializenumberformat
+description: Abrupt completion from invalid values for `roundingMode`
+features: [Intl.NumberFormat-v3]
+---*/
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat('en', {roundingMode: null});
+}, 'null');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat('en', {roundingMode: 3});
+}, 'number');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat('en', {roundingMode: true});
+}, 'boolean');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat('en', {roundingMode: 'HalfExpand'});
+}, 'invalid string');
+
+var symbol = Symbol('halfExpand');
+assert.throws(TypeError, function() {
+  new Intl.NumberFormat('en', {roundingMode: symbol});
+}, 'Symbol');
+
+var brokenToString = { toString: function() { throw new Test262Error(); } };
+assert.throws(Test262Error, function() {
+  new Intl.NumberFormat('en', {roundingMode: brokenToString});
+}, 'broken `toString` implementation');

--- a/test/intl402/NumberFormat/constructor-options-throwing-getters-rounding-mode.js
+++ b/test/intl402/NumberFormat/constructor-options-throwing-getters-rounding-mode.js
@@ -1,0 +1,17 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-initializenumberformat
+description: >
+  Exception from accessing the "roundingMode" option for the NumberFormat
+  constructor should be propagated to the caller
+features: [Intl.NumberFormat-v3]
+---*/
+
+assert.throws(Test262Error, function() {
+  new Intl.NumberFormat('en', {
+    get roundingMode() {
+      throw new Test262Error();
+    }
+  });
+});

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-mode-ceil.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-mode-ceil.js
@@ -1,0 +1,32 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roundingMode is "ceil", rounding tends toward positive infinity
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingMode: 'ceil', maximumSignificantDigits: 2},
+  {
+    '1.101': '1.2',
+    '1.15': '1.2',
+    '1.1999': '1.2',
+    '1.25': '1.3',
+    '0': '0',
+    '-0': '-0',
+    '-1.101': '-1.1',
+    '-1.15': '-1.1',
+    '-1.1999': '-1.1',
+    '-1.25': '-1.2'
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-mode-expand.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-mode-expand.js
@@ -1,0 +1,32 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roundingMode is "expand", rounding tends away from zero
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingMode: 'expand', maximumSignificantDigits: 2},
+  {
+    '1.101': '1.2',
+    '1.15': '1.2',
+    '1.1999': '1.2',
+    '1.25': '1.3',
+    '0': '0',
+    '-0': '-0',
+    '-1.101': '-1.2',
+    '-1.15': '-1.2',
+    '-1.1999': '-1.2',
+    '-1.25': '-1.3'
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-mode-floor.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-mode-floor.js
@@ -1,0 +1,32 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roundingMode is "floor", rounding tends toward negative infinity
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingMode: 'floor', maximumSignificantDigits: 2},
+  {
+    '1.101': '1.1',
+    '1.15': '1.1',
+    '1.1999': '1.1',
+    '1.25': '1.2',
+    '0': '0',
+    '-0': '-0',
+    '-1.101': '-1.2',
+    '-1.15': '-1.2',
+    '-1.1999': '-1.2',
+    '-1.25': '-1.3'
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-ceil.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-ceil.js
@@ -1,0 +1,33 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roundingMode is "halfExpand", rounding tends toward the closest value
+  with ties tending toward positive infinity
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingMode: 'halfCeil', maximumSignificantDigits: 2},
+  {
+    '1.101': '1.1',
+    '1.15': '1.2',
+    '1.1999': '1.2',
+    '1.25': '1.3',
+    '0': '0',
+    '-0': '-0',
+    '-1.101': '-1.1',
+    '-1.15': '-1.1',
+    '-1.1999': '-1.2',
+    '-1.25': '-1.2'
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-even.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-even.js
@@ -1,0 +1,34 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roundingMode is "halfEven", rounding tends toward the closest value
+  with ties tending toward the value with even cardinality
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingMode: 'halfEven', maximumSignificantDigits: 2},
+  {
+    '1.101': '1.1',
+    '1.15': '1.2',
+    '1.1999': '1.2',
+    '1.25': '1.2',
+    '0': '0',
+    '-0': '-0',
+    '-1.101': '-1.1',
+    '-1.15': '-1.2',
+    '-1.1999': '-1.2',
+    '-1.25': '-1.2'
+  }
+);
+

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-expand.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-expand.js
@@ -1,0 +1,33 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roundingMode is "halfExpand", rounding tends toward the closest value
+  with ties tending away from zero
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingMode: 'halfExpand', maximumSignificantDigits: 2},
+  {
+    '1.101': '1.1',
+    '1.15': '1.2',
+    '1.1999': '1.2',
+    '1.25': '1.3',
+    '0': '0',
+    '-0': '-0',
+    '-1.101': '-1.1',
+    '-1.15': '-1.2',
+    '-1.1999': '-1.2',
+    '-1.25': '-1.3'
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-floor.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-floor.js
@@ -1,0 +1,33 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roundingMode is "halfFloor", rounding tends toward the closest value
+  with ties tending toward negative infinity
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingMode: 'halfFloor', maximumSignificantDigits: 2},
+  {
+    '1.101': '1.1',
+    '1.15': '1.1',
+    '1.1999': '1.2',
+    '1.25': '1.2',
+    '0': '0',
+    '-0': '-0',
+    '-1.101': '-1.1',
+    '-1.15': '-1.2',
+    '-1.1999': '-1.2',
+    '-1.25': '-1.3'
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-trunc.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-mode-half-trunc.js
@@ -1,0 +1,33 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roundingMode is "halfTrunc", rounding tends toward the closest value
+  with ties tending toward zero
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingMode: 'halfTrunc', maximumSignificantDigits: 2},
+  {
+    '1.101': '1.1',
+    '1.15': '1.1',
+    '1.1999': '1.2',
+    '1.25': '1.2',
+    '0': '0',
+    '-0': '-0',
+    '-1.101': '-1.1',
+    '-1.15': '-1.1',
+    '-1.1999': '-1.2',
+    '-1.25': '-1.2'
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-mode-trunc.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-mode-trunc.js
@@ -1,0 +1,32 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roundingMode is "trunc", rounding tends toward zero
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingMode: 'trunc', maximumSignificantDigits: 2},
+  {
+    '1.101': '1.1',
+    '1.15': '1.1',
+    '1.1999': '1.1',
+    '1.25': '1.2',
+    '0': '0',
+    '-0': '-0',
+    '-1.101': '-1.1',
+    '-1.15': '-1.1',
+    '-1.1999': '-1.1',
+    '-1.25': '-1.2'
+  }
+);

--- a/test/intl402/NumberFormat/prototype/resolvedOptions/roundingMode.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/roundingMode.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.resolvedoptions
+description: roundingMode property for the object returned by resolvedOptions()
+features: [Intl.NumberFormat-v3]
+---*/
+
+var options;
+
+options = new Intl.NumberFormat([], {}).resolvedOptions();
+assert.sameValue(options.roundingMode, 'halfExpand (default)');
+
+options = new Intl.NumberFormat([], {roundingMode: 'ceil'}).resolvedOptions();
+assert.sameValue(options.roundingMode, 'ceil');
+
+options = new Intl.NumberFormat([], {roundingMode: 'floor'}).resolvedOptions();
+assert.sameValue(options.roundingMode, 'floor');
+
+options = new Intl.NumberFormat([], {roundingMode: 'expand'}).resolvedOptions();
+assert.sameValue(options.roundingMode, 'expand');
+
+options = new Intl.NumberFormat([], {roundingMode: 'trunc'}).resolvedOptions();
+assert.sameValue(options.roundingMode, 'trunc');
+
+options = new Intl.NumberFormat([], {roundingMode: 'halfCeil'}).resolvedOptions();
+assert.sameValue(options.roundingMode, 'halfCeil');
+
+options = new Intl.NumberFormat([], {roundingMode: 'halfFloor'}).resolvedOptions();
+assert.sameValue(options.roundingMode, 'halfFloor');
+
+options = new Intl.NumberFormat([], {roundingMode: 'halfExpand'}).resolvedOptions();
+assert.sameValue(options.roundingMode, 'halfExpand');
+
+options = new Intl.NumberFormat([], {roundingMode: 'halfTrunc'}).resolvedOptions();
+assert.sameValue(options.roundingMode, 'halfTrunc');
+
+options = new Intl.NumberFormat([], {roundingMode: 'halfEven'}).resolvedOptions();
+assert.sameValue(options.roundingMode, 'halfEven');


### PR DESCRIPTION
This patch is intended to cover only one aspect of the proposal for
ECMA402: the "rounding mode" feature.

This is in service of gh-3132.