### PR TITLE
Shadow Realms: Check the function prototype of all points of wrapping

### DIFF
--- a/test/built-ins/ShadowRealm/prototype/evaluate/wrapped-function-proto-from-caller-realm.js
+++ b/test/built-ins/ShadowRealm/prototype/evaluate/wrapped-function-proto-from-caller-realm.js
@@ -35,5 +35,10 @@ var other = $262.createRealm().global;
 var OtherShadowRealm = other.ShadowRealm;
 
 var realm = Reflect.construct(OtherShadowRealm, []);
-var fn = realm.evaluate('() => {}');
+
+var checkArgWrapperFn = realm.evaluate('(x) => { return Object.getPrototypeOf(x) === Function.prototype }')
+assert.sameValue(checkArgWrapperFn(() => {}), true, 'callable arguments passed into WrappedFunction should be wrapped in target realm');
+
+var fn = realm.evaluate('() => { return () => { return 1 } }');
 assert.sameValue(Object.getPrototypeOf(fn), Function.prototype, 'WrappedFunction should be derived from the caller realm');
+assert.sameValue(Object.getPrototypeOf(fn()), Function.prototype, 'callable results from WrappedFunction should be wrapped in caller realm');


### PR DESCRIPTION
Expanding the test added in https://github.com/tc39/test262/pull/3230 to cover all points at which wrapping occurs in the Shadow Realm proposal. 
I think I got the caller/target realm expectations correct, but definitely worth a close review

As a side note, I'm having some issues adapting [the JSC implementation](https://bugs.webkit.org/show_bug.cgi?id=230602) to satisfy this test and was offhand wondering: how important is the detail that the wrapped function's prototype pertains to the caller realm and not the target realm to the behavior of the feature?

cc/ @legendecas @rwaldron @leobalter 