### PR TITLE
Improve errors in NumberFormat#formatToParts tests

### DIFF
--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-currency-de-DE.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-currency-de-DE.js
@@ -60,11 +60,11 @@ const tests = [
 
 for (const [signDisplay, negative, negativeNearZero, negativeZero, zero, positiveNearZero, positive] of tests) {
   const nf = new Intl.NumberFormat("de-DE", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay });
-  verifyFormatParts(nf.formatToParts(-987), negative);
-  verifyFormatParts(nf.formatToParts(-0.0001), negativeNearZero);
-  verifyFormatParts(nf.formatToParts(-0), negativeZero);
-  verifyFormatParts(nf.formatToParts(0), zero);
-  verifyFormatParts(nf.formatToParts(0.0001), positiveNearZero);
-  verifyFormatParts(nf.formatToParts(987), positive);
+  verifyFormatParts(nf.formatToParts(-987), negative, "negative");
+  verifyFormatParts(nf.formatToParts(-0.0001), negativeNearZero, "negativeNearZero");
+  verifyFormatParts(nf.formatToParts(-0), negativeZero, "negativeZero");
+  verifyFormatParts(nf.formatToParts(0), zero, "zero");
+  verifyFormatParts(nf.formatToParts(0.0001), positiveNearZero, "positiveNearZero");
+  verifyFormatParts(nf.formatToParts(987), positive, "positive");
 }
 

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-currency-en-US.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-currency-en-US.js
@@ -60,11 +60,11 @@ const tests = [
 
 for (const [signDisplay, negative, negativeNearZero, negativeZero, zero, positiveNearZero, positive] of tests) {
   const nf = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay });
-  verifyFormatParts(nf.formatToParts(-987), negative);
-  verifyFormatParts(nf.formatToParts(-0.0001), negativeNearZero);
-  verifyFormatParts(nf.formatToParts(-0), negativeZero);
-  verifyFormatParts(nf.formatToParts(0), zero);
-  verifyFormatParts(nf.formatToParts(0.0001), positiveNearZero);
-  verifyFormatParts(nf.formatToParts(987), positive);
+  verifyFormatParts(nf.formatToParts(-987), negative, "negative");
+  verifyFormatParts(nf.formatToParts(-0.0001), negativeNearZero, "negativeNearZero");
+  verifyFormatParts(nf.formatToParts(-0), negativeZero, "negativeZero");
+  verifyFormatParts(nf.formatToParts(0), zero, "zero");
+  verifyFormatParts(nf.formatToParts(0.0001), positiveNearZero, "positiveNearZero");
+  verifyFormatParts(nf.formatToParts(987), positive, "positive");
 }
 

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-currency-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-currency-ja-JP.js
@@ -60,11 +60,11 @@ const tests = [
 
 for (const [signDisplay, negative, negativeNearZero, negativeZero, zero, positiveNearZero, positive] of tests) {
   const nf = new Intl.NumberFormat("ja-JP", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay });
-  verifyFormatParts(nf.formatToParts(-987), negative);
-  verifyFormatParts(nf.formatToParts(-0.0001), negativeNearZero);
-  verifyFormatParts(nf.formatToParts(-0), negativeZero);
-  verifyFormatParts(nf.formatToParts(0), zero);
-  verifyFormatParts(nf.formatToParts(0.0001), positiveNearZero);
-  verifyFormatParts(nf.formatToParts(987), positive);
+  verifyFormatParts(nf.formatToParts(-987), negative, "negative");
+  verifyFormatParts(nf.formatToParts(-0.0001), negativeNearZero, "negativeNearZero");
+  verifyFormatParts(nf.formatToParts(-0), negativeZero, "negativeZero");
+  verifyFormatParts(nf.formatToParts(0), zero, "zero");
+  verifyFormatParts(nf.formatToParts(0.0001), positiveNearZero, "positiveNearZero");
+  verifyFormatParts(nf.formatToParts(987), positive, "positive");
 }
 

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-currency-ko-KR.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-currency-ko-KR.js
@@ -60,11 +60,11 @@ const tests = [
 
 for (const [signDisplay, negative, negativeNearZero, negativeZero, zero, positiveNearZero, positive] of tests) {
   const nf = new Intl.NumberFormat("ko-KR", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay });
-  verifyFormatParts(nf.formatToParts(-987), negative);
-  verifyFormatParts(nf.formatToParts(-0.0001), negativeNearZero);
-  verifyFormatParts(nf.formatToParts(-0), negativeZero);
-  verifyFormatParts(nf.formatToParts(0), zero);
-  verifyFormatParts(nf.formatToParts(0.0001), positiveNearZero);
-  verifyFormatParts(nf.formatToParts(987), positive);
+  verifyFormatParts(nf.formatToParts(-987), negative, "negative");
+  verifyFormatParts(nf.formatToParts(-0.0001), negativeNearZero, "negativeNearZero");
+  verifyFormatParts(nf.formatToParts(-0), negativeZero, "negativeZero");
+  verifyFormatParts(nf.formatToParts(0), zero, "zero");
+  verifyFormatParts(nf.formatToParts(0.0001), positiveNearZero, "positiveNearZero");
+  verifyFormatParts(nf.formatToParts(987), positive, "positive");
 }
 

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-currency-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-currency-zh-TW.js
@@ -60,11 +60,11 @@ const tests = [
 
 for (const [signDisplay, negative, negativeNearZero, negativeZero, zero, positiveNearZero, positive] of tests) {
   const nf = new Intl.NumberFormat("zh-TW", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay });
-  verifyFormatParts(nf.formatToParts(-987), negative);
-  verifyFormatParts(nf.formatToParts(-0.0001), negativeNearZero);
-  verifyFormatParts(nf.formatToParts(-0), negativeZero);
-  verifyFormatParts(nf.formatToParts(0), zero);
-  verifyFormatParts(nf.formatToParts(0.0001), positiveNearZero);
-  verifyFormatParts(nf.formatToParts(987), positive);
+  verifyFormatParts(nf.formatToParts(-987), negative, "negative");
+  verifyFormatParts(nf.formatToParts(-0.0001), negativeNearZero, "negativeNearZero");
+  verifyFormatParts(nf.formatToParts(-0), negativeZero, "negativeZero");
+  verifyFormatParts(nf.formatToParts(0), zero, "zero");
+  verifyFormatParts(nf.formatToParts(0.0001), positiveNearZero, "positiveNearZero");
+  verifyFormatParts(nf.formatToParts(987), positive, "positive");
 }
 


### PR DESCRIPTION
Specify a descriptive value for the previously-unused third parameter of
the `verifyFormatParts` function in order to disambiguate error
messages.

This patch was generated with the following command:

    sed -i 's/\(verifyFormatParts([^,]\+, \)\([^,]\+\))/\1\2, "\2")/g' \
      test/intl402/NumberFormat/prototype/formatToParts/signDisplay-currency-*