### PR TITLE
Update tests for DataView & resizable Arraybuffer

### DIFF
--- a/test/built-ins/DataView/prototype/byteLength/resizable-array-buffer-auto.js
+++ b/test/built-ins/DataView/prototype/byteLength/resizable-array-buffer-auto.js
@@ -36,6 +36,13 @@ assert.sameValue(dataView.byteLength, expected, "following shrink (within bounds
 
 try {
   ab.resize(1);
+  expected = 0;
+} catch (_) {}
+
+assert.sameValue(dataView.byteLength, expected, "following shrink (on boundary)");
+
+try {
+  ab.resize(0);
   expected = TypeError;
 } catch (_) {
   expected = Test262Error;

--- a/test/built-ins/DataView/prototype/byteOffset/resizable-array-buffer-auto.js
+++ b/test/built-ins/DataView/prototype/byteOffset/resizable-array-buffer-auto.js
@@ -31,9 +31,15 @@ try {
 
 assert.sameValue(dataView.byteOffset, 1, "following shrink (within bounds)");
 
-var expectedError;
 try {
   ab.resize(1);
+} catch (_) {}
+
+assert.sameValue(dataView.byteOffset, 1, "following shrink (on boundary)");
+
+var expectedError;
+try {
+  ab.resize(0);
   expectedError = TypeError;
 } catch (_) {
   expectedError = Test262Error;


### PR DESCRIPTION
This change concerns normative text of the Resizable ArrayBuffer
proposal which is believed to be invalid in its current form; a patch
updating the text is under review [1].

[1] https://github.com/tc39/proposal-resizablearraybuffer/pull/78