### PR TITLE
Add annotations for named capture groups in match indices tests

### DIFF
--- a/test/built-ins/RegExp/match-indices/indices-array-non-unicode-match.js
+++ b/test/built-ins/RegExp/match-indices/indices-array-non-unicode-match.js
@@ -5,7 +5,7 @@
 description: Basic matching cases with non-unicode matches.
 includes: [compareArray.js, propertyHelper.js, deepEqual.js]
 esid: sec-regexpbuiltinexec
-features: [regexp-match-indices]
+features: [regexp-named-groups, regexp-match-indices]
 info: |
   Runtime Semantics: RegExpBuiltinExec ( R, S )
     ...

--- a/test/built-ins/RegExp/match-indices/indices-array-unicode-match.js
+++ b/test/built-ins/RegExp/match-indices/indices-array-unicode-match.js
@@ -5,7 +5,7 @@
 description: Basic matching cases with non-unicode matches.
 includes: [compareArray.js, propertyHelper.js, deepEqual.js]
 esid: sec-regexpbuiltinexec
-features: [regexp-match-indices]
+features: [regexp-named-groups, regexp-match-indices]
 info: |
   Runtime Semantics: RegExpBuiltinExec ( R, S )
     ...

--- a/test/built-ins/RegExp/match-indices/indices-array-unicode-property-names.js
+++ b/test/built-ins/RegExp/match-indices/indices-array-unicode-property-names.js
@@ -5,7 +5,7 @@
 description: Basic matching cases with non-unicode matches.
 includes: [compareArray.js]
 esid: sec-makeindicesarray
-features: [regexp-match-indices]
+features: [regexp-named-groups, regexp-match-indices]
 ---*/
 
 assert.compareArray([1, 2], /(?<π>a)/du.exec("bab").indices.groups.π);


### PR DESCRIPTION
The feature tag for named capture groups is missing in these tests.