### PR TITLE
Relax tests for resolvedOptions property ordering

### DIFF
--- a/test/intl402/Collator/prototype/resolvedOptions/order.js
+++ b/test/intl402/Collator/prototype/resolvedOptions/order.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-intl.collator.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [compareArray.js]
 ---*/
 
 const options = new Intl.Collator([], {
@@ -18,14 +17,16 @@ const expected = [
   "sensitivity",
   "ignorePunctuation",
   "collation",
+  "numeric",
+  "caseFirst"
 ];
 
-if ("numeric" in options) {
-  expected.push("numeric");
-}
+const actual = Object.getOwnPropertyNames(options);
 
-if ("caseFirst" in options) {
-  expected.push("caseFirst");
+// Ensure all expected items are in actual and also allow other properties
+// implemented in new proposals.
+assert(actual.indexOf("locale") > -1, "\"locale\" is present");
+for (var i = 1; i < expected.length; i++) {
+  // Ensure the order as expected but allow additional new property in between
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]), `"${expected[i-1]}" precedes "${expected[i]}"`);
 }
-
-assert.compareArray(Object.getOwnPropertyNames(options), expected);

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-dayPeriod.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-dayPeriod.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-intl.datetimeformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [arrayContains.js]
 features: [Intl.DateTimeFormat-dayPeriod]
 ---*/
 
@@ -30,8 +29,8 @@ let actual = Object.getOwnPropertyNames(options);
 
 // Ensure all expected items are in actual and also allow other properties
 // implemented in new proposals.
-assert(arrayContains(actual, expected));
+assert(actual.indexOf("locale") > -1, "\"locale\" is present");
 for (var i = 1; i < expected.length; i++) {
   // Ensure the order as expected but allow additional new property in between
-  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]));
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]), `"${expected[i-1]}" precedes "${expected[i]}"`);
 }

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-fractionalSecondDigits.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-intl.datetimeformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [arrayContains.js]
 features: [Intl.DateTimeFormat-fractionalSecondDigits]
 ---*/
 
@@ -28,8 +27,8 @@ let actual = Object.getOwnPropertyNames(options);
 
 // Ensure all expected items are in actual and also allow other properties
 // implemented in new proposals.
-assert(arrayContains(actual, expected));
+assert(actual.indexOf("locale") > -1, "\"locale\" is present");
 for (var i = 1; i < expected.length; i++) {
   // Ensure the order as expected but allow additional new property in between
-  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]));
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]), `"${expected[i-1]}" precedes "${expected[i]}"`);
 }

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-style.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order-style.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-intl.datetimeformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [arrayContains.js]
 features: [Intl.DateTimeFormat-datetimestyle]
 ---*/
 
@@ -34,8 +33,8 @@ let actual = Object.getOwnPropertyNames(options);
 
 // Ensure all expected items are in actual and also allow other properties
 // implemented in new proposals.
-assert(arrayContains(actual, expected));
+assert(actual.indexOf("locale") > -1, "\"locale\" is present");
 for (var i = 1; i < expected.length; i++) {
   // Ensure the order as expected but allow additional new property in between
-  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]));
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]), `"${expected[i-1]}" precedes "${expected[i]}"`);
 }

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/order.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/order.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-intl.datetimeformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [arrayContains.js]
 ---*/
 
 const options = new Intl.DateTimeFormat([], {
@@ -42,8 +41,8 @@ let actual = Object.getOwnPropertyNames(options);
 
 // Ensure all expected items are in actual and also allow other properties
 // implemented in new proposals.
-assert(arrayContains(actual, expected));
+assert(actual.indexOf("locale") > -1, "\"locale\" is present");
 for (var i = 1; i < expected.length; i++) {
   // Ensure the order as expected but allow additional new property in between
-  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]));
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]), `"${expected[i-1]}" precedes "${expected[i]}"`);
 }

--- a/test/intl402/ListFormat/prototype/resolvedOptions/order.js
+++ b/test/intl402/ListFormat/prototype/resolvedOptions/order.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-Intl.ListFormat.prototype.resolvedOptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [compareArray.js]
 features: [Intl.ListFormat]
 ---*/
 
@@ -16,4 +15,12 @@ const expected = [
   "style",
 ];
 
-assert.compareArray(Object.getOwnPropertyNames(options), expected);
+const actual = Object.getOwnPropertyNames(options);
+
+// Ensure all expected items are in actual and also allow other properties
+// implemented in new proposals.
+assert(actual.indexOf("locale") > -1, "\"locale\" is present");
+for (var i = 1; i < expected.length; i++) {
+  // Ensure the order as expected but allow additional new property in between
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]), `"${expected[i-1]}" precedes "${expected[i]}"`);
+}

--- a/test/intl402/NumberFormat/prototype/resolvedOptions/order.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/order.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-intl.numberformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [compareArray.js]
 features: [Intl.NumberFormat-unified]
 ---*/
 
@@ -31,4 +30,12 @@ const expected = [
   "signDisplay",
 ];
 
-assert.compareArray(Object.getOwnPropertyNames(options), expected);
+const actual = Object.getOwnPropertyNames(options);
+
+// Ensure all expected items are in actual and also allow other properties
+// implemented in new proposals.
+assert(actual.indexOf("locale") > -1, "\"locale\" is present");
+for (var i = 1; i < expected.length; i++) {
+  // Ensure the order as expected but allow additional new property in between
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]), `"${expected[i-1]}" precedes "${expected[i]}"`);
+}

--- a/test/intl402/PluralRules/prototype/resolvedOptions/order.js
+++ b/test/intl402/PluralRules/prototype/resolvedOptions/order.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-intl.numberformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [compareArray.js]
 features: [Intl.NumberFormat-unified]
 ---*/
 
@@ -22,4 +21,12 @@ const expected = [
   "pluralCategories",
 ];
 
-assert.compareArray(Object.getOwnPropertyNames(options), expected);
+const actual = Object.getOwnPropertyNames(options);
+
+// Ensure all expected items are in actual and also allow other properties
+// implemented in new proposals.
+assert(actual.indexOf("locale") > -1, "\"locale\" is present");
+for (var i = 1; i < expected.length; i++) {
+  // Ensure the order as expected but allow additional new property in between
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]), `"${expected[i-1]}" precedes "${expected[i]}"`);
+}

--- a/test/intl402/RelativeTimeFormat/prototype/resolvedOptions/order.js
+++ b/test/intl402/RelativeTimeFormat/prototype/resolvedOptions/order.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-intl.relativetimeformat.prototype.resolvedoptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [compareArray.js]
 features: [Intl.RelativeTimeFormat]
 ---*/
 
@@ -17,4 +16,12 @@ const expected = [
   "numberingSystem",
 ];
 
-assert.compareArray(Object.getOwnPropertyNames(options), expected);
+const actual = Object.getOwnPropertyNames(options);
+
+// Ensure all expected items are in actual and also allow other properties
+// implemented in new proposals.
+assert(actual.indexOf("locale") > -1, "\"locale\" is present");
+for (var i = 1; i < expected.length; i++) {
+  // Ensure the order as expected but allow additional new property in between
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]), `"${expected[i-1]}" precedes "${expected[i]}"`);
+}

--- a/test/intl402/Segmenter/prototype/resolvedOptions/order.js
+++ b/test/intl402/Segmenter/prototype/resolvedOptions/order.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-Intl.Segmenter.prototype.resolvedOptions
 description: Verifies the property order for the object returned by resolvedOptions().
-includes: [compareArray.js]
 features: [Intl.Segmenter]
 ---*/
 
@@ -17,4 +16,12 @@ const expected = [
   "granularity",
 ];
 
-assert.compareArray(Object.getOwnPropertyNames(options), expected);
+const actual = Object.getOwnPropertyNames(options);
+
+// Ensure all expected items are in actual and also allow other properties
+// implemented in new proposals.
+assert(actual.indexOf("locale") > -1, "\"locale\" is present");
+for (var i = 1; i < expected.length; i++) {
+  // Ensure the order as expected but allow additional new property in between
+  assert(actual.indexOf(expected[i-1]) < actual.indexOf(expected[i]), `"${expected[i-1]}" precedes "${expected[i]}"`);
+}


### PR DESCRIPTION
A number of tests for ECMA402 asserted the exact contents of the array
returned by various `resolvedOptions` methods. This conflicted with the
expectation that more options will be introduced by future editions of
the specification.

Update these tests to assert property order more generically in order to
accommodate implementation of future language proposals and more closely
align with similar tests.

Update all `resolvedOptions` tests to produce more meaningful error
messages (including replacing the generic `arrayContains` assertion with
a specific assertion regarding the value of the first array element).

---

This supports gh-3132