### PR TITLE
Correct test for Temporal.Instant#toString

### DIFF
--- a/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-datetime.js
@@ -4,7 +4,6 @@
 /*---
 esid: sec-temporal.instant.prototype.tostring
 description: Conversion of ISO date-time strings to Temporal.TimeZone instances
-includes: [arrayContains.js]
 features: [Temporal]
 ---*/
 
@@ -16,30 +15,30 @@ assert.throws(RangeError, () => instance.toString({ timeZone: { timeZone } }), "
 
 timeZone = "2021-08-19T17:30Z";
 const result1 = instance.toString({ timeZone });
-arrayContains(result1, "UTC", "date-time + Z is UTC time zone");
+assert.sameValue(result1.substr(-6), "+00:00", "date-time + Z is UTC time zone");
 const result2 = instance.toString({ timeZone: { timeZone } });
-arrayContains(result2, "UTC", "date-time + Z is UTC time zone (string in property bag)");
+assert.sameValue(result2.substr(-6), "+00:00", "date-time + Z is UTC time zone (string in property bag)");
 
 timeZone = "2021-08-19T17:30-07:00";
 const result3 = instance.toString({ timeZone });
-arrayContains(result3, "-07:00", "date-time + offset is the offset time zone");
+assert.sameValue(result3.substr(-6), "-07:00", "date-time + offset is the offset time zone");
 const result4 = instance.toString({ timeZone: { timeZone } });
-arrayContains(result4, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
+assert.sameValue(result4.substr(-6), "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
 timeZone = "2021-08-19T17:30[America/Vancouver]";
 const result5 = instance.toString({ timeZone });
-arrayContains(result5, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result5.substr(-6), "-08:00", "date-time + IANA annotation is the offset time zone");
 const result6 = instance.toString({ timeZone: { timeZone } });
-arrayContains(result6, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result6.substr(-6), "-08:00", "date-time + IANA annotation is the offset time zone (string in property bag)");
 
 timeZone = "2021-08-19T17:30Z[America/Vancouver]";
 const result7 = instance.toString({ timeZone });
-arrayContains(result7, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+assert.sameValue(result7.substr(-6), "-08:00", "date-time + Z + IANA annotation is the offset time zone");
 const result8 = instance.toString({ timeZone: { timeZone } });
-arrayContains(result8, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result8.substr(-6), "-08:00", "date-time + Z + IANA annotation is the offset time zone (string in property bag)");
 
 timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
 const result9 = instance.toString({ timeZone });
-arrayContains(result9, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+assert.sameValue(result9.substr(-6), "-08:00", "date-time + offset + IANA annotation is the offset time zone");
 const result10 = instance.toString({ timeZone: { timeZone } });
-arrayContains(result10, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result10.substr(-6), "-08:00", "date-time + offset + IANA annotation is the offset time zone (string in property bag)");


### PR DESCRIPTION
Prior to this patch, the modified test invoked the `arrayContains`
utility function without referencing its return value. Unlike Test262's
assertion functions, `arrayContains` does not throw an error when the
expectation is violated, so the prior usage did not influence test
results.

Additionally, the prior version of this test documented incorrect
expectations regarding the expected value produced by the method under
test. Due to the above, these expectations were not enforced.

Correct the test's expectations and enforce those expectations with a
function that will reliably produce an exception if violated.

/cc @ptomato