### PR TITLE
Add tests: resizing ArrayBuffer during iteration

### DIFF
--- a/test/built-ins/Array/prototype/every/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/every/callbackfn-resize-arraybuffer.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.every
+description: TypedArray instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.every.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return true;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, true, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.every.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return true;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, true, 'result (grow)');
+});

--- a/test/built-ins/Array/prototype/filter/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/filter/callbackfn-resize-arraybuffer.js
@@ -1,0 +1,76 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.filter
+description: TypedArray instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var NaNvalue = (TA === Float32Array || TA === Float64Array) ? NaN : 0;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, finalResult, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.filter.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        finalResult = NaNvalue;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        finalResult = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return true;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.compareArray(result, [0, 0, finalResult], 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.filter.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return true;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.compareArray(result, expectedElements, 'result (grow)');
+});

--- a/test/built-ins/Array/prototype/find/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/find/callbackfn-resize-arraybuffer.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.find
+description: TypedArray instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.find.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, undefined, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.find.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, undefined, 'result (grow)');
+});

--- a/test/built-ins/Array/prototype/findIndex/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/findIndex/callbackfn-resize-arraybuffer.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.findindex
+description: TypedArray instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.findIndex.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, -1, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.findIndex.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, -1, 'result (grow)');
+});

--- a/test/built-ins/Array/prototype/findLast/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/findLast/callbackfn-resize-arraybuffer.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.findlast
+description: TypedArray instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var secondElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.findLast.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(BPE);
+        secondElement = undefined;
+        expectedElements = [0];
+        expectedIndices = [0];
+        expectedArrays = [sample];
+      } catch (_) {
+        secondElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [2, 1, 0];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, [0, secondElement, 0], 'elements (shrink)');
+  assert.compareArray(indices, [2, 1, 0], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, undefined, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.findLast.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, undefined, 'result (grow)');
+});

--- a/test/built-ins/Array/prototype/findLastIndex/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/findLastIndex/callbackfn-resize-arraybuffer.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.findlastindex
+description: TypedArray instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var secondElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.findLastIndex.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(BPE);
+        secondElement = undefined;
+        expectedElements = [0];
+        expectedIndices = [0];
+        expectedArrays = [sample];
+      } catch (_) {
+        secondElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [2, 1, 0];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, [0, secondElement, 0], 'elements (shrink)');
+  assert.compareArray(indices, [2, 1, 0], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, -1, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.findLastIndex.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, -1, 'result (grow)');
+});

--- a/test/built-ins/Array/prototype/forEach/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/forEach/callbackfn-resize-arraybuffer.js
@@ -1,0 +1,71 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.forEach
+description: TypedArray instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.forEach.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, undefined, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.forEach.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, undefined, 'result (grow)');
+});

--- a/test/built-ins/Array/prototype/map/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/map/callbackfn-resize-arraybuffer.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.map
+description: TypedArray instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var NaNvalue = (TA === Float32Array || TA === Float64Array) ? NaN : 0;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, finalResult, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.map.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        finalResult = NaNvalue;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        finalResult = 2;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+
+    return index;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.compareArray(result, [0, 1, finalResult], 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.map.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+
+    return index;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.compareArray(result, expectedIndices, 'result (grow)');
+});

--- a/test/built-ins/Array/prototype/reduce/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/reduce/callbackfn-resize-arraybuffer.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.reduce
+description: TypedArray instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 3});
+  var sample = new TA(buffer);
+  var finalNext, expectedPrevs, expectedNexts, expectedIndices, expectedArrays;
+  var prevs, nexts, indices, arrays, result;
+
+  prevs = [];
+  nexts = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.reduce.call(sample, function(prev, next, index, array) {
+    if (prevs.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalNext = undefined;
+        expectedPrevs = [262, 0];
+        expectedNexts = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalNext = 0;
+        expectedPrevs = [262, 0, 1];
+        expectedNexts = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    prevs.push(prev);
+    nexts.push(next);
+    indices.push(index);
+    arrays.push(array);
+    return index;
+  }, 262);
+
+  assert.compareArray(prevs, [262, 0, 1], 'prevs (shrink)');
+  assert.compareArray(nexts, [0, 0, finalNext], 'nexts (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, 2, 'result (shrink)');
+
+  prevs = [];
+  nexts = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.reduce.call(sample, function(prev, next, index, array) {
+    if (prevs.length === 0) {
+      try {
+        buffer.resize(3 * BPE);
+      } catch (_) {}
+    }
+
+    prevs.push(prev);
+    nexts.push(next);
+    indices.push(index);
+    arrays.push(array);
+    return index;
+  }, 262);
+
+  assert.compareArray(prevs, expectedPrevs, 'prevs (grow)');
+  assert.compareArray(nexts, expectedNexts, 'nexts (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, expectedIndices[expectedIndices.length - 1], 'result (grow)');
+});

--- a/test/built-ins/Array/prototype/reduceRight/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/reduceRight/callbackfn-resize-arraybuffer.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.reduceright
+description: TypedArray instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 3});
+  var sample = new TA(buffer);
+  var secondNext, expectedPrevs, expectedNexts, expectedIndices, expectedArrays;
+  var prevs, nexts, indices, arrays, result;
+
+  prevs = [];
+  nexts = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.reduceRight.call(sample, function(prev, next, index, array) {
+    if (prevs.length === 0) {
+      try {
+        buffer.resize(BPE);
+        secondNext = undefined;
+        expectedPrevs = [262];
+        expectedNexts = [0];
+        expectedIndices = [0];
+        expectedArrays = [sample];
+      } catch (_) {
+        secondNext = 0;
+        expectedPrevs = [262, 2, 1];
+        expectedNexts = [0, 0, 0];
+        expectedIndices = [2, 1, 0];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    prevs.push(prev);
+    nexts.push(next);
+    indices.push(index);
+    arrays.push(array);
+    return index;
+  }, 262);
+
+  assert.compareArray(prevs, [262, 2, 1], 'prevs (shrink)');
+  assert.compareArray(nexts, [0, secondNext, 0], 'nexts (shrink)');
+  assert.compareArray(indices, [2, 1, 0], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, 0, 'result (shrink)');
+
+  prevs = [];
+  nexts = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.reduceRight.call(sample, function(prev, next, index, array) {
+    if (prevs.length === 0) {
+      try {
+        buffer.resize(3 * BPE);
+      } catch (_) {}
+    }
+
+    prevs.push(prev);
+    nexts.push(next);
+    indices.push(index);
+    arrays.push(array);
+    return index;
+  }, 262);
+
+  assert.compareArray(prevs, expectedPrevs, 'prevs (grow)');
+  assert.compareArray(nexts, expectedNexts, 'nexts (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, expectedIndices[expectedIndices.length - 1], 'result (grow)');
+});

--- a/test/built-ins/Array/prototype/some/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/some/callbackfn-resize-arraybuffer.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.some
+description: TypedArray instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.some.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, false, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = Array.prototype.some.call(sample, function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, false, 'result (grow)');
+});

--- a/test/built-ins/TypedArray/prototype/every/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/every/callbackfn-resize.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.every
+description: Instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.every(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return true;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, true, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.every(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return true;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, true, 'result (grow)');
+});

--- a/test/built-ins/TypedArray/prototype/filter/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/filter/callbackfn-resize.js
@@ -1,0 +1,76 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.filter
+description: Instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var NaNvalue = (TA === Float32Array || TA === Float64Array) ? NaN : 0;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, finalResult, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.filter(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        finalResult = NaNvalue;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        finalResult = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return true;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.compareArray(result, [0, 0, finalResult], 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.filter(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return true;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.compareArray(result, expectedElements, 'result (grow)');
+});

--- a/test/built-ins/TypedArray/prototype/find/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/find/callbackfn-resize.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.find
+description: Instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.find(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, undefined, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.find(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, undefined, 'result (grow)');
+});

--- a/test/built-ins/TypedArray/prototype/findIndex/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/findIndex/callbackfn-resize.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.findindex
+description: Instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.findIndex(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, -1, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.findIndex(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, -1, 'result (grow)');
+});

--- a/test/built-ins/TypedArray/prototype/findLast/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/findLast/callbackfn-resize.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.findlast
+description: Instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var secondElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.findLast(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(BPE);
+        secondElement = undefined;
+        expectedElements = [0];
+        expectedIndices = [0];
+        expectedArrays = [sample];
+      } catch (_) {
+        secondElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [2, 1, 0];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, [0, secondElement, 0], 'elements (shrink)');
+  assert.compareArray(indices, [2, 1, 0], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, undefined, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.findLast(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, undefined, 'result (grow)');
+});

--- a/test/built-ins/TypedArray/prototype/findLastIndex/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/findLastIndex/callbackfn-resize.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.findlastindex
+description: Instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var secondElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.findLastIndex(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(BPE);
+        secondElement = undefined;
+        expectedElements = [0];
+        expectedIndices = [0];
+        expectedArrays = [sample];
+      } catch (_) {
+        secondElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [2, 1, 0];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, [0, secondElement, 0], 'elements (shrink)');
+  assert.compareArray(indices, [2, 1, 0], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, -1, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.findLastIndex(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, -1, 'result (grow)');
+});

--- a/test/built-ins/TypedArray/prototype/forEach/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/forEach/callbackfn-resize.js
@@ -1,0 +1,71 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.forEach
+description: Instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.forEach(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, undefined, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.forEach(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, undefined, 'result (grow)');
+});

--- a/test/built-ins/TypedArray/prototype/map/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/map/callbackfn-resize.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.map
+description: Instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var NaNvalue = (TA === Float32Array || TA === Float64Array) ? NaN : 0;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, finalResult, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.map(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        finalResult = NaNvalue;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        finalResult = 2;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+
+    return index;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.compareArray(result, [0, 1, finalResult], 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.map(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+
+    return index;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.compareArray(result, expectedIndices, 'result (grow)');
+});

--- a/test/built-ins/TypedArray/prototype/reduce/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/reduce/callbackfn-resize.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.reduce
+description: Instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 3});
+  var sample = new TA(buffer);
+  var finalNext, expectedPrevs, expectedNexts, expectedIndices, expectedArrays;
+  var prevs, nexts, indices, arrays, result;
+
+  prevs = [];
+  nexts = [];
+  indices = [];
+  arrays = [];
+  result = sample.reduce(function(prev, next, index, array) {
+    if (prevs.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalNext = undefined;
+        expectedPrevs = [262, 0];
+        expectedNexts = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalNext = 0;
+        expectedPrevs = [262, 0, 1];
+        expectedNexts = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    prevs.push(prev);
+    nexts.push(next);
+    indices.push(index);
+    arrays.push(array);
+    return index;
+  }, 262);
+
+  assert.compareArray(prevs, [262, 0, 1], 'prevs (shrink)');
+  assert.compareArray(nexts, [0, 0, finalNext], 'nexts (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, 2, 'result (shrink)');
+
+  prevs = [];
+  nexts = [];
+  indices = [];
+  arrays = [];
+  result = sample.reduce(function(prev, next, index, array) {
+    if (prevs.length === 0) {
+      try {
+        buffer.resize(3 * BPE);
+      } catch (_) {}
+    }
+
+    prevs.push(prev);
+    nexts.push(next);
+    indices.push(index);
+    arrays.push(array);
+    return index;
+  }, 262);
+
+  assert.compareArray(prevs, expectedPrevs, 'prevs (grow)');
+  assert.compareArray(nexts, expectedNexts, 'nexts (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, expectedIndices[expectedIndices.length - 1], 'result (grow)');
+});

--- a/test/built-ins/TypedArray/prototype/reduceRight/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/reduceRight/callbackfn-resize.js
@@ -1,0 +1,75 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.reduceright
+description: Instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 3});
+  var sample = new TA(buffer);
+  var secondNext, expectedPrevs, expectedNexts, expectedIndices, expectedArrays;
+  var prevs, nexts, indices, arrays, result;
+
+  prevs = [];
+  nexts = [];
+  indices = [];
+  arrays = [];
+  result = sample.reduceRight(function(prev, next, index, array) {
+    if (prevs.length === 0) {
+      try {
+        buffer.resize(BPE);
+        secondNext = undefined;
+        expectedPrevs = [262];
+        expectedNexts = [0];
+        expectedIndices = [0];
+        expectedArrays = [sample];
+      } catch (_) {
+        secondNext = 0;
+        expectedPrevs = [262, 2, 1];
+        expectedNexts = [0, 0, 0];
+        expectedIndices = [2, 1, 0];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    prevs.push(prev);
+    nexts.push(next);
+    indices.push(index);
+    arrays.push(array);
+    return index;
+  }, 262);
+
+  assert.compareArray(prevs, [262, 2, 1], 'prevs (shrink)');
+  assert.compareArray(nexts, [0, secondNext, 0], 'nexts (shrink)');
+  assert.compareArray(indices, [2, 1, 0], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, 0, 'result (shrink)');
+
+  prevs = [];
+  nexts = [];
+  indices = [];
+  arrays = [];
+  result = sample.reduceRight(function(prev, next, index, array) {
+    if (prevs.length === 0) {
+      try {
+        buffer.resize(3 * BPE);
+      } catch (_) {}
+    }
+
+    prevs.push(prev);
+    nexts.push(next);
+    indices.push(index);
+    arrays.push(array);
+    return index;
+  }, 262);
+
+  assert.compareArray(prevs, expectedPrevs, 'prevs (grow)');
+  assert.compareArray(nexts, expectedNexts, 'nexts (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, expectedIndices[expectedIndices.length - 1], 'result (grow)');
+});

--- a/test/built-ins/TypedArray/prototype/some/callbackfn-resize.js
+++ b/test/built-ins/TypedArray/prototype/some/callbackfn-resize.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-%typedarray%.prototype.some
+description: Instance buffer can be resized during iteration
+includes: [testTypedArray.js, compareArray.js]
+features: [TypedArray, resizable-arraybuffer]
+---*/
+
+// If the host chooses to throw as allowed by the specification, the observed
+// behavior will be identical to the case where `ArrayBuffer.prototype.resize`
+// has not been implemented. The following assertion prevents this test from
+// passing in runtimes which have not implemented the method.
+assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
+
+testWithTypedArrayConstructors(function(TA) {
+  var BPE = TA.BYTES_PER_ELEMENT;
+  var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
+  var sample = new TA(buffer);
+  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var elements, indices, arrays, result;
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.some(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(2 * BPE);
+        finalElement = undefined;
+        expectedElements = [0, 0];
+        expectedIndices = [0, 1];
+        expectedArrays = [sample, sample];
+      } catch (_) {
+        finalElement = 0;
+        expectedElements = [0, 0, 0];
+        expectedIndices = [0, 1, 2];
+        expectedArrays = [sample, sample, sample];
+      }
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
+  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
+  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.sameValue(result, false, 'result (shrink)');
+
+  elements = [];
+  indices = [];
+  arrays = [];
+  result = sample.some(function(element, index, array) {
+    if (elements.length === 0) {
+      try {
+        buffer.resize(4 * BPE);
+      } catch (_) {}
+    }
+
+    elements.push(element);
+    indices.push(index);
+    arrays.push(array);
+    return false;
+  });
+
+  assert.compareArray(elements, expectedElements, 'elements (grow)');
+  assert.compareArray(indices, expectedIndices, 'indices (grow)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
+  assert.sameValue(result, false, 'result (grow)');
+});


### PR DESCRIPTION
The Resizable ArrayBuffer proposal allows implementations to reject any
resize operation, so the tests must accommodate that possibility.

Mitigate the complexity this entails by minimizing branches and by
deferring assertions to locations with shallow call stacks.

---

Resolves gh-3245

I tested this using V8's in-progress implementation (version 9.8.1). More on V8's behavior below.

As noted in the commit message, these tests are much more complex than what we typically accept in Test262 because they have to accommodate the proposal's optional behavior. Each test includes two invocations of `ArrayBuffer.prototype.resize`, and because each invocation may succeed or throw an error, they support a total of four paths of execution. I've simulated those by running these tests an additional three times using overridden implementations of `resize` (one which throws on first invocation, one which throws on second invocation, and one which throws on both invocations).

@marjakh a couple things about V8's behavior:

- seven of the Array.prototype methods (`every`, `filter`, `forEach`, `map`, `reduce`, `reduceRight`, and `some`) appear to be responding to changes in length rather than operating on a cached value. I don't see any bugs in those tests, but I'm wrong about that quite frequently. Given that V8's support is a work-in-progress, does that behavior seem plausible to you?
- `Array.prototype.map` and `TypedArray.prototype.map` both crash when invoked on a TypedArray whose backing buffer is resizable

      $ ~/.jsvu/v8 --harmony-rab-gsab -e 'ab=new ArrayBuffer(1, {xmaxByteLength: 2}); a=new Int8Array(ab); a.map(()=>{})'
      $
      $ ~/.jsvu/v8 --harmony-rab-gsab -e 'ab=new ArrayBuffer(1, {maxByteLength: 2}); a=new Int8Array(ab); a.map(()=>{})'
      /home/mike/.jsvu/v8: line 2: 20644 Trace/breakpoint trap   (core dumped) "/home/mike/.jsvu/engines/v8/v8" --snapshot_blob="/home/mike/.jsvu/engines/v8/snapshot_blob.bin" "$@"