### PR TITLE
Add tests for "Intl NumberFormat v3" proposal

### DIFF
--- a/test/intl402/NumberFormat/constructor-signDisplay-negative.js
+++ b/test/intl402/NumberFormat/constructor-signDisplay-negative.js
@@ -1,0 +1,25 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-initializenumberformat
+description: Checks handling of the compactDisplay option to the NumberFormat constructor.
+info: |
+  InitializeNumberFormat ( numberFormat, locales, options )
+
+  32. Let signDisplay be ? GetOption(options, "signDisplay", "string", « "auto", "never", "always", "exceptZero", "negative" », "auto").
+  33. Set numberFormat.[[SignDisplay]] to signDisplay.
+includes: [propertyHelper.js]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const nf = new Intl.NumberFormat([], {
+  signDisplay: 'negative',
+});
+const resolvedOptions = nf.resolvedOptions();
+
+verifyProperty(resolvedOptions, 'signDisplay', {
+  value: 'negative',
+  writable: true,
+  enumerable: true,
+  configurable: true
+});

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-de-DE.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-de-DE.js
@@ -1,0 +1,17 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [de-DE]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const nf = new Intl.NumberFormat("de-DE", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
+assert.sameValue(nf.format(-987), "-987,00 $");
+assert.sameValue(nf.format(-0.0001), "-0,00 $");
+assert.sameValue(nf.format(-0), "0,00 $");
+assert.sameValue(nf.format(0), "0,00 $");
+assert.sameValue(nf.format(0.0001), "0,00 $");
+assert.sameValue(nf.format(987), "987,00 $");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-en-US.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-en-US.js
@@ -1,0 +1,17 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [en-US]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const nf = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
+assert.sameValue(nf.format(-987), "($987.00)");
+assert.sameValue(nf.format(-0.0001), "($0.00)");
+assert.sameValue(nf.format(-0), "$0.00");
+assert.sameValue(nf.format(0), "$0.00");
+assert.sameValue(nf.format(0.0001), "$0.00");
+assert.sameValue(nf.format(987), "$987.00");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-ja-JP.js
@@ -1,0 +1,17 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [ja-JP]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const nf = new Intl.NumberFormat("ja-JP", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
+assert.sameValue(nf.format(-987), "($987.00)");
+assert.sameValue(nf.format(-0.0001), "($0.00)");
+assert.sameValue(nf.format(-0), "$0.00");
+assert.sameValue(nf.format(0), "$0.00");
+assert.sameValue(nf.format(0.0001), "$0.00");
+assert.sameValue(nf.format(987), "$987.00");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-ko-KR.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-ko-KR.js
@@ -1,0 +1,17 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [ko-KR]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const nf = new Intl.NumberFormat("ko-KR", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
+assert.sameValue(nf.format(-987), "(US$987.00)");
+assert.sameValue(nf.format(-0.0001), "(US$0.00)");
+assert.sameValue(nf.format(-0), "US$0.00");
+assert.sameValue(nf.format(0), "US$0.00");
+assert.sameValue(nf.format(0.0001), "US$0.00");
+assert.sameValue(nf.format(987), "US$987.00");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-zh-TW.js
@@ -1,0 +1,17 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [zh-TW]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const nf = new Intl.NumberFormat("zh-TW", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
+assert.sameValue(nf.format(-987), "(US$987.00)");
+assert.sameValue(nf.format(-0.0001), "(US$0.00)");
+assert.sameValue(nf.format(-0), "US$0.00");
+assert.sameValue(nf.format(0), "US$0.00");
+assert.sameValue(nf.format(0.0001), "US$0.00");
+assert.sameValue(nf.format(987), "US$0.00");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-de-DE.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-de-DE.js
@@ -1,0 +1,20 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [de-DE]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const nf = new Intl.NumberFormat("de-DE", {signDisplay: "negative"});
+assert.sameValue(nf.format(-Infinity), "-∞", "-Infinity");
+assert.sameValue(nf.format(-987), "-987", "-987");
+assert.sameValue(nf.format(-0.0001), "-0", "-0.0001");
+assert.sameValue(nf.format(-0), "0", "-0");
+assert.sameValue(nf.format(0), "0", "0");
+assert.sameValue(nf.format(0.0001), "0", "0.0001");
+assert.sameValue(nf.format(987), "987", "987");
+assert.sameValue(nf.format(Infinity), "∞", "Infinity");
+assert.sameValue(nf.format(NaN), "NaN", "NaN");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-en-US.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-en-US.js
@@ -1,0 +1,20 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [en-US]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const nf = new Intl.NumberFormat("en-US", {signDisplay: "negative"});
+assert.sameValue(nf.format(-Infinity), "-∞", "-Infinity");
+assert.sameValue(nf.format(-987), "-987", "-987");
+assert.sameValue(nf.format(-0.0001), "-0", "-0.0001");
+assert.sameValue(nf.format(-0), "0", "-0");
+assert.sameValue(nf.format(0), "0", "0");
+assert.sameValue(nf.format(0.0001), "0", "0.0001");
+assert.sameValue(nf.format(987), "987", "987");
+assert.sameValue(nf.format(Infinity), "∞", "Infinity");
+assert.sameValue(nf.format(NaN), "NaN", "NaN");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-ja-JP.js
@@ -1,0 +1,20 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [ja-JP]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const nf = new Intl.NumberFormat("ja-JP", {signDisplay: "negative"});
+assert.sameValue(nf.format(-Infinity), "-∞", "-Infinity");
+assert.sameValue(nf.format(-987), "-987", "-987");
+assert.sameValue(nf.format(-0.0001), "-0", "-0.0001");
+assert.sameValue(nf.format(-0), "0", "-0");
+assert.sameValue(nf.format(0), "0", "0");
+assert.sameValue(nf.format(0.0001), "0", "0.0001");
+assert.sameValue(nf.format(987), "987", "987");
+assert.sameValue(nf.format(Infinity), "∞", "Infinity");
+assert.sameValue(nf.format(NaN), "NaN", "NaN");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-ko-KR.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-ko-KR.js
@@ -1,0 +1,20 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [ko-KR]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const nf = new Intl.NumberFormat("ko-KR", {signDisplay: "negative"});
+assert.sameValue(nf.format(-Infinity), "-∞", "-Infinity");
+assert.sameValue(nf.format(-987), "-987", "-987");
+assert.sameValue(nf.format(-0.0001), "-0", "-0.0001");
+assert.sameValue(nf.format(-0), "0", "-0");
+assert.sameValue(nf.format(0), "0", "0");
+assert.sameValue(nf.format(0.0001), "0", "0.0001");
+assert.sameValue(nf.format(987), "987", "987");
+assert.sameValue(nf.format(Infinity), "∞", "Infinity");
+assert.sameValue(nf.format(NaN), "NaN", "NaN");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-zh-TW.js
@@ -1,0 +1,20 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [zh-TW]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const nf = new Intl.NumberFormat("zh-TW", {signDisplay: "negative"});
+assert.sameValue(nf.format(-Infinity), "-∞", "-Infinity");
+assert.sameValue(nf.format(-987), "-987", "-987");
+assert.sameValue(nf.format(-0.0001), "-0", "-0.0001");
+assert.sameValue(nf.format(-0), "0", "-0");
+assert.sameValue(nf.format(0), "0", "0");
+assert.sameValue(nf.format(0.0001), "0", "0.0001");
+assert.sameValue(nf.format(987), "987", "987");
+assert.sameValue(nf.format(Infinity), "∞", "Infinity");
+assert.sameValue(nf.format(NaN), "非數值", "NaN");

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-de-DE.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-de-DE.js
@@ -1,0 +1,53 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.formattoparts
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [de-DE]
+features: [Intl.NumberFormat-v3]
+---*/
+
+function verifyFormatParts(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < actual.length; ++i) {
+    assert.sameValue(actual[i].type, expected[i].type, `${message}: parts[${i}].type`);
+    assert.sameValue(actual[i].value, expected[i].value, `${message}: parts[${i}].value`);
+  }
+}
+
+const nf = new Intl.NumberFormat("de-DE", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
+
+verifyFormatParts(
+  nf.formatToParts(-987),
+  [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"},{"type":"decimal","value":","},{"type":"fraction","value":"00"},{"type":"literal","value":" "},{"type":"currency","value":"$"}],
+  "negative"
+);
+verifyFormatParts(
+  nf.formatToParts(-0.0001),
+  [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":","},{"type":"fraction","value":"00"},{"type":"literal","value":" "},{"type":"currency","value":"$"}],
+  "negativeNearZero"
+);
+verifyFormatParts(
+  nf.formatToParts(-0),
+  [{"type":"integer","value":"0"},{"type":"decimal","value":","},{"type":"fraction","value":"00"},{"type":"literal","value":" "},{"type":"currency","value":"$"}],
+  "negativeZero"
+);
+verifyFormatParts(
+  nf.formatToParts(0),
+  [{"type":"integer","value":"0"},{"type":"decimal","value":","},{"type":"fraction","value":"00"},{"type":"literal","value":" "},{"type":"currency","value":"$"}],
+  "zero"
+);
+verifyFormatParts(
+  nf.formatToParts(0.0001),
+  [{"type":"integer","value":"0"},{"type":"decimal","value":","},{"type":"fraction","value":"00"},{"type":"literal","value":" "},{"type":"currency","value":"$"}],
+  "positiveNearZero"
+);
+verifyFormatParts(
+  nf.formatToParts(987),
+  [{"type":"integer","value":"987"},{"type":"decimal","value":","},{"type":"fraction","value":"00"},{"type":"literal","value":" "},{"type":"currency","value":"$"}],
+  "positive"
+);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-en-US.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-en-US.js
@@ -1,0 +1,53 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.formattoparts
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [en-US]
+features: [Intl.NumberFormat-v3]
+---*/
+
+function verifyFormatParts(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < actual.length; ++i) {
+    assert.sameValue(actual[i].type, expected[i].type, `${message}: parts[${i}].type`);
+    assert.sameValue(actual[i].value, expected[i].value, `${message}: parts[${i}].value`);
+  }
+}
+
+const nf = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
+
+verifyFormatParts(
+  nf.formatToParts(-987),
+  [{"type":"literal","value":"("},{"type":"currency","value":"$"},{"type":"integer","value":"987"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  "negative"
+);
+verifyFormatParts(
+  nf.formatToParts(-0.0001),
+  [{"type":"literal","value":"("},{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  "negativeNearZero"
+);
+verifyFormatParts(
+  nf.formatToParts(-0),
+  [{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "negativeZero"
+);
+verifyFormatParts(
+  nf.formatToParts(0),
+  [{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "zero"
+);
+verifyFormatParts(
+  nf.formatToParts(0.0001),
+  [{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "positiveNearZero"
+);
+verifyFormatParts(
+  nf.formatToParts(987),
+  [{"type":"currency","value":"$"},{"type":"integer","value":"987"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "positive"
+);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-ja-JP.js
@@ -1,0 +1,53 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.formattoparts
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [ja-JP]
+features: [Intl.NumberFormat-v3]
+---*/
+
+function verifyFormatParts(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < actual.length; ++i) {
+    assert.sameValue(actual[i].type, expected[i].type, `${message}: parts[${i}].type`);
+    assert.sameValue(actual[i].value, expected[i].value, `${message}: parts[${i}].value`);
+  }
+}
+
+const nf = new Intl.NumberFormat("ja-JP", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
+
+verifyFormatParts(
+  nf.formatToParts(-987),
+  [{"type":"literal","value":"("},{"type":"currency","value":"$"},{"type":"integer","value":"987"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  "negative"
+);
+verifyFormatParts(
+  nf.formatToParts(-0.0001),
+  [{"type":"literal","value":"("},{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  "negativeNearZero"
+);
+verifyFormatParts(
+  nf.formatToParts(-0),
+  [{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "negativeZero"
+);
+verifyFormatParts(
+  nf.formatToParts(0),
+  [{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "zero"
+);
+verifyFormatParts(
+  nf.formatToParts(0.0001),
+  [{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "positiveNearZero"
+);
+verifyFormatParts(
+  nf.formatToParts(987),
+  [{"type":"currency","value":"$"},{"type":"integer","value":"987"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "positive"
+);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-ko-KR.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-ko-KR.js
@@ -1,0 +1,53 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.formattoparts
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [ko-KR]
+features: [Intl.NumberFormat-v3]
+---*/
+
+function verifyFormatParts(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < actual.length; ++i) {
+    assert.sameValue(actual[i].type, expected[i].type, `${message}: parts[${i}].type`);
+    assert.sameValue(actual[i].value, expected[i].value, `${message}: parts[${i}].value`);
+  }
+}
+
+const nf = new Intl.NumberFormat("ko-KR", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
+
+verifyFormatParts(
+  nf.formatToParts(-987),
+  [{"type":"literal","value":"("},{"type":"currency","value":"US$"},{"type":"integer","value":"987"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  "negative"
+);
+verifyFormatParts(
+  nf.formatToParts(-0.0001),
+  [{"type":"literal","value":"("},{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  "negativeNearZero"
+);
+verifyFormatParts(
+  nf.formatToParts(-0),
+  [{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "negativeZero"
+);
+verifyFormatParts(
+  nf.formatToParts(0),
+  [{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "zero"
+);
+verifyFormatParts(
+  nf.formatToParts(0.0001),
+  [{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "positiveNearZero"
+);
+verifyFormatParts(
+  nf.formatToParts(987),
+  [{"type":"currency","value":"US$"},{"type":"integer","value":"987"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "positive"
+);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-zh-TW.js
@@ -1,0 +1,53 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.formattoparts
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [zh-TW]
+features: [Intl.NumberFormat-v3]
+---*/
+
+function verifyFormatParts(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < actual.length; ++i) {
+    assert.sameValue(actual[i].type, expected[i].type, `${message}: parts[${i}].type`);
+    assert.sameValue(actual[i].value, expected[i].value, `${message}: parts[${i}].value`);
+  }
+}
+
+const nf = new Intl.NumberFormat("zh-TW", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
+
+verifyFormatParts(
+  nf.formatToParts(-987),
+  [{"type":"literal","value":"("},{"type":"currency","value":"US$"},{"type":"integer","value":"987"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  "negative"
+);
+verifyFormatParts(
+  nf.formatToParts(-0.0001),
+  [{"type":"literal","value":"("},{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  "negativeNearZero"
+);
+verifyFormatParts(
+  nf.formatToParts(-0),
+  [{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "negativeZero"
+);
+verifyFormatParts(
+  nf.formatToParts(0),
+  [{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "zero"
+);
+verifyFormatParts(
+  nf.formatToParts(0.0001),
+  [{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "positiveNearZero"
+);
+verifyFormatParts(
+  nf.formatToParts(987),
+  [{"type":"currency","value":"US$"},{"type":"integer","value":"987"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
+  "positive"
+);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-de-DE.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-de-DE.js
@@ -1,0 +1,32 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.formattoparts
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [de-DE]
+features: [Intl.NumberFormat-v3]
+---*/
+
+function verifyFormatParts(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < actual.length; ++i) {
+    assert.sameValue(actual[i].type, expected[i].type, `${message}: parts[${i}].type`);
+    assert.sameValue(actual[i].value, expected[i].value, `${message}: parts[${i}].value`);
+  }
+}
+
+const nf = new Intl.NumberFormat("de-DE", {signDisplay: "negative"});
+
+verifyFormatParts(nf.formatToParts(-Infinity), [{"type":"minusSign","value":"-"},{"type":"infinity","value":"∞"}], `-Infinity (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-987), [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}], `-987 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0), [{"type":"integer","value":"0"}], `-0 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(0), [{"type":"integer","value":"0"}], `0 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(0.0001), [{"type":"integer","value":"0"}], `0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(987), [{"type":"integer","value":"987"}], `987 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(Infinity), [{"type":"infinity","value":"∞"}], `Infinity (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(NaN), [{"type":"nan","value":"NaN"}], `NaN (${signDisplay})`);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-en-US.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-en-US.js
@@ -1,0 +1,32 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.formattoparts
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [en-US]
+features: [Intl.NumberFormat-v3]
+---*/
+
+function verifyFormatParts(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < actual.length; ++i) {
+    assert.sameValue(actual[i].type, expected[i].type, `${message}: parts[${i}].type`);
+    assert.sameValue(actual[i].value, expected[i].value, `${message}: parts[${i}].value`);
+  }
+}
+
+const nf = new Intl.NumberFormat("en-US", {signDisplay: "negative"});
+
+verifyFormatParts(nf.formatToParts(-Infinity), [{"type":"minusSign","value":"-"},{"type":"infinity","value":"∞"}], `-Infinity (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-987), [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}], `-987 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0), [{"type":"integer","value":"0"}], `-0 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(0), [{"type":"integer","value":"0"}], `0 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(0.0001), [{"type":"integer","value":"0"}], `0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(987), [{"type":"integer","value":"987"}], `987 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(Infinity), [{"type":"infinity","value":"∞"}], `Infinity (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(NaN), [{"type":"nan","value":"NaN"}], `NaN (${signDisplay})`);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-ja-JP.js
@@ -1,0 +1,32 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.formattoparts
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [ja-JP]
+features: [Intl.NumberFormat-v3]
+---*/
+
+function verifyFormatParts(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < actual.length; ++i) {
+    assert.sameValue(actual[i].type, expected[i].type, `${message}: parts[${i}].type`);
+    assert.sameValue(actual[i].value, expected[i].value, `${message}: parts[${i}].value`);
+  }
+}
+
+const nf = new Intl.NumberFormat("ja-JP", {signDisplay: "negative"});
+
+verifyFormatParts(nf.formatToParts(-Infinity), [{"type":"minusSign","value":"-"},{"type":"infinity","value":"∞"}], `-Infinity (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-987), [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}], `-987 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0), [{"type":"integer","value":"0"}], `-0 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(0), [{"type":"integer","value":"0"}], `0 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(0.0001), [{"type":"integer","value":"0"}], `0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(987), [{"type":"integer","value":"987"}], `987 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(Infinity), [{"type":"infinity","value":"∞"}], `Infinity (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(NaN), [{"type":"nan","value":"NaN"}], `NaN (${signDisplay})`);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-ko-KR.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-ko-KR.js
@@ -1,0 +1,32 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.formattoparts
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [ko-KR]
+features: [Intl.NumberFormat-v3]
+---*/
+
+function verifyFormatParts(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < actual.length; ++i) {
+    assert.sameValue(actual[i].type, expected[i].type, `${message}: parts[${i}].type`);
+    assert.sameValue(actual[i].value, expected[i].value, `${message}: parts[${i}].value`);
+  }
+}
+
+const nf = new Intl.NumberFormat("ko-KR", {signDisplay: "negative"});
+
+verifyFormatParts(nf.formatToParts(-Infinity), [{"type":"minusSign","value":"-"},{"type":"infinity","value":"∞"}], `-Infinity (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-987), [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}], `-987 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0), [{"type":"integer","value":"0"}], `-0 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(0), [{"type":"integer","value":"0"}], `0 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(0.0001), [{"type":"integer","value":"0"}], `0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(987), [{"type":"integer","value":"987"}], `987 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(Infinity), [{"type":"infinity","value":"∞"}], `Infinity (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(NaN), [{"type":"nan","value":"NaN"}], `NaN (${signDisplay})`);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-zh-TW.js
@@ -1,0 +1,32 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-intl.numberformat.prototype.formattoparts
+description: Checks handling of the signDisplay option to the NumberFormat constructor.
+locale: [zh-TW]
+features: [Intl.NumberFormat-v3]
+---*/
+
+function verifyFormatParts(actual, expected, message) {
+  assert.sameValue(Array.isArray(expected), true, `${message}: expected is Array`);
+  assert.sameValue(Array.isArray(actual), true, `${message}: actual is Array`);
+  assert.sameValue(actual.length, expected.length, `${message}: length`);
+
+  for (let i = 0; i < actual.length; ++i) {
+    assert.sameValue(actual[i].type, expected[i].type, `${message}: parts[${i}].type`);
+    assert.sameValue(actual[i].value, expected[i].value, `${message}: parts[${i}].value`);
+  }
+}
+
+const nf = new Intl.NumberFormat("zh-TW", {signDisplay: "negative"});
+
+verifyFormatParts(nf.formatToParts(-Infinity), [{"type":"minusSign","value":"-"},{"type":"infinity","value":"∞"}], `-Infinity (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-987), [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}], `-987 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0), [{"type":"integer","value":"0"}], `-0 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(0), [{"type":"integer","value":"0"}], `0 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(0.0001), [{"type":"integer","value":"0"}], `0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(987), [{"type":"integer","value":"987"}], `987 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(Infinity), [{"type":"infinity","value":"∞"}], `Infinity (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(NaN), [{"type":"nan","value":"非數值"}], `NaN (${signDisplay})`);


### PR DESCRIPTION
This patch is intended to cover only one aspect of the proposal for
ECMA402: the "negative sign display" feature.

This is in service of gh-3132