### PR TITLE
Add tests for "Intl NumberFormat v3" proposal

### DIFF
--- a/test/intl402/NumberFormat/prototype/format/value-decimal-string.js
+++ b/test/intl402/NumberFormat/prototype/format/value-decimal-string.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-number-format-functions
+description: >
+  Intl.NumberFormat.prototype.format converts its argument (called value) to a
+  number using ToIntlMathematicalValue.
+features: [Intl.NumberFormat-v3]
+locale: [en-US]
+---*/
+
+var nf = new Intl.NumberFormat('en-US');
+
+// The value 100,000 should only be interpreted as infinity if the input is the
+// string "Infinity".
+assert.sameValue(nf.format('100000'), '100,000');
+// The value -100,000 should only be interpreted as negative infinity if the
+// input is the string "-Infinity".
+assert.sameValue(nf.format('-100000'), '-100,000');
+
+assert.sameValue(nf.format('1.0000000000000001'), '1.0000000000000001');
+assert.sameValue(nf.format('-1.0000000000000001'), '1.0000000000000001');
+assert.sameValue(nf.format('987654321987654321'), '987,654,321,987,654,321');
+assert.sameValue(nf.format('-987654321987654321'), '-987,654,321,987,654,321');

--- a/test/intl402/NumberFormat/prototype/format/value-tonumber.js
+++ b/test/intl402/NumberFormat/prototype/format/value-tonumber.js
@@ -20,8 +20,8 @@ const toNumberResults = [
   [false, 0],
   ['42', 42],
   ['foo', NaN],
-  ['Infinity', 'Infinity'],
-  ['-Infinity', '-Infinity']
+  ['Infinity', Infinity],
+  ['-Infinity', -Infinity]
 ];
 
 const nf = new Intl.NumberFormat();

--- a/test/intl402/NumberFormat/prototype/format/value-tonumber.js
+++ b/test/intl402/NumberFormat/prototype/format/value-tonumber.js
@@ -19,7 +19,9 @@ const toNumberResults = [
   [true, 1],
   [false, 0],
   ['42', 42],
-  ['foo', NaN]
+  ['foo', NaN],
+  ['Infinity', 'Infinity'],
+  ['-Infinity', '-Infinity']
 ];
 
 const nf = new Intl.NumberFormat();


### PR DESCRIPTION
This patch is intended to cover only one aspect of the proposal for
ECMA402: the "interpret strings as decimals" feature.

---

The proposal text for this feature is still being refined; these tests reflect my understanding of the intention based on [this discussion in the proposal's repository](https://github.com/tc39/proposal-intl-numberformat-v3/pull/72).

@sffc would you mind taking a look?