### PR TITLE
Fix unexpected pass on ShadowRealm wrapped function

### DIFF
--- a/test/built-ins/ShadowRealm/prototype/evaluate/wrapped-function-throws-typeerror-on-non-primitive-arguments.js
+++ b/test/built-ins/ShadowRealm/prototype/evaluate/wrapped-function-throws-typeerror-on-non-primitive-arguments.js
@@ -16,6 +16,12 @@ assert.sameValue(
 const r = new ShadowRealm();
 const wrappedFunction = r.evaluate('() => {}');
 
+assert.sameValue(
+  typeof wrappedFunction,
+  'function',
+  'This test must fail if wrappedFunction is not a function'
+);
+
 assert.throws(TypeError, () => wrappedFunction(1, globalThis), 'globalThis');
 assert.throws(TypeError, () => wrappedFunction(1, []), 'array literal');
 assert.throws(TypeError, () => wrappedFunction(1, {


### PR DESCRIPTION
When the `wrappedFunction` is not a function, the TypeError thrown on calling on `wrappedFunction` can unexpectedly pass the test.