### PR TITLE
Adds PYM.since rounding mode specs and related helper

### DIFF
--- a/harness/testEach.js
+++ b/harness/testEach.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: |
+    This defines a helper function to test table templates.
+defines: [testEach]
+---*/
+
+
+function testEach(strings, ...args) {
+
+  /*
+   * testEach`
+   *    num     | names
+   *    ${num1} | ${names1}
+   *    ${numN} | ${namesN}
+   *  `(({ num, names }) => {
+   *    .. fn called for each table row ..
+   *    .. asserts go here ..
+   *  })
+   *
+   *
+   * Tagged template string that accepts table of arguments and calls passed
+   * function once with each row's values.
+   *
+  */
+
+  const variableNames = strings.raw[0].split('|').map((name) => name.trim());
+
+  const zipped = args.reduce((acc, arg, idx) => {
+    const variableIdx = idx % variableNames.length;
+
+    if (variableIdx === 0) {
+      acc.push({})
+    }
+
+    const varToUpdate = variableNames[variableIdx];
+    const currentCollection = acc[acc.length - 1];
+
+    currentCollection[varToUpdate] = arg;
+    return acc;
+
+  }, []);
+
+
+  return (fn) => {
+    zipped.forEach((argumentSet) => {
+      fn(argumentSet)
+    });
+  }
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmodes-modes.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingmodes-modes.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Rounding modes work as expected
+includes: [testEach.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.PlainYearMonth(2019, 1);
+const later = new Temporal.PlainYearMonth(2021, 9);
+
+testEach`
+  roundingMode    | smallestUnit | expectedPositive | expectedNegative
+  ${'halfExpand'} | ${'years'}   | ${'P3Y'}         | ${'-P3Y'}
+  ${'halfExpand'} | ${'months'}  | ${'P2Y8M'}       | ${'-P2Y8M'}
+  ${'ceil'}       | ${'years'}   | ${'P3Y'}         | ${'-P2Y'}
+  ${'ceil'}       | ${'months'}  | ${'P2Y8M'}       | ${'-P2Y8M'}
+  ${'floor'}      | ${'years'}   | ${'P2Y'}         | ${'-P3Y'}
+  ${'floor'}      | ${'months'}  | ${'P2Y8M'}       | ${'-P2Y8M'}
+  ${'trunc'}      | ${'years'}   | ${'P2Y'}         | ${'-P2Y'}
+  ${'trunc'}      | ${'months'}  | ${'P2Y8M'}       | ${'-P2Y8M'}
+`(({ roundingMode, smallestUnit, expectedPositive, expectedNegative }) => {
+
+  const positiveDescription = `${roundingMode}, ${smallestUnit} rounds positive as expected`;
+  const negativeDescription = `${roundingMode}, ${smallestUnit} rounds negative as expected`;
+
+  const positiveComparison = later.since(earlier, { smallestUnit, roundingMode }).toString();
+  const negativeComparison = earlier.since(later, { smallestUnit, roundingMode }).toString();
+
+  assert.sameValue(positiveComparison, expectedPositive, positiveDescription);
+  assert.sameValue(negativeComparison, expectedNegative, negativeDescription);
+});


### PR DESCRIPTION
Like it says on the tin, this one adds rounding mode specs and a proposed helper. 

I broke this out from the other updates (https://github.com/tc39/test262/pull/3313, https://github.com/tc39/test262/pull/3314) so we can discuss the helper and its context.