### PR TITLE
Correct negative-zero sign display tests

### DIFF
--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-de-DE.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-de-DE.js
@@ -10,7 +10,7 @@ features: [Intl.NumberFormat-v3]
 
 const nf = new Intl.NumberFormat("de-DE", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
 assert.sameValue(nf.format(-987), "-987,00 $");
-assert.sameValue(nf.format(-0.0001), "-0,00 $");
+assert.sameValue(nf.format(-0.0001), "0,00 $");
 assert.sameValue(nf.format(-0), "0,00 $");
 assert.sameValue(nf.format(0), "0,00 $");
 assert.sameValue(nf.format(0.0001), "0,00 $");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-en-US.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-en-US.js
@@ -10,7 +10,7 @@ features: [Intl.NumberFormat-v3]
 
 const nf = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
 assert.sameValue(nf.format(-987), "($987.00)");
-assert.sameValue(nf.format(-0.0001), "($0.00)");
+assert.sameValue(nf.format(-0.0001), "$0.00");
 assert.sameValue(nf.format(-0), "$0.00");
 assert.sameValue(nf.format(0), "$0.00");
 assert.sameValue(nf.format(0.0001), "$0.00");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-ja-JP.js
@@ -10,7 +10,7 @@ features: [Intl.NumberFormat-v3]
 
 const nf = new Intl.NumberFormat("ja-JP", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
 assert.sameValue(nf.format(-987), "($987.00)");
-assert.sameValue(nf.format(-0.0001), "($0.00)");
+assert.sameValue(nf.format(-0.0001), "$0.00");
 assert.sameValue(nf.format(-0), "$0.00");
 assert.sameValue(nf.format(0), "$0.00");
 assert.sameValue(nf.format(0.0001), "$0.00");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-ko-KR.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-ko-KR.js
@@ -10,7 +10,7 @@ features: [Intl.NumberFormat-v3]
 
 const nf = new Intl.NumberFormat("ko-KR", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
 assert.sameValue(nf.format(-987), "(US$987.00)");
-assert.sameValue(nf.format(-0.0001), "(US$0.00)");
+assert.sameValue(nf.format(-0.0001), "US$0.00");
 assert.sameValue(nf.format(-0), "US$0.00");
 assert.sameValue(nf.format(0), "US$0.00");
 assert.sameValue(nf.format(0.0001), "US$0.00");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-currency-zh-TW.js
@@ -10,8 +10,8 @@ features: [Intl.NumberFormat-v3]
 
 const nf = new Intl.NumberFormat("zh-TW", { style: "currency", currency: "USD", currencySign: "accounting", signDisplay: "negative" });
 assert.sameValue(nf.format(-987), "(US$987.00)");
-assert.sameValue(nf.format(-0.0001), "(US$0.00)");
+assert.sameValue(nf.format(-0.0001), "US$0.00");
 assert.sameValue(nf.format(-0), "US$0.00");
 assert.sameValue(nf.format(0), "US$0.00");
 assert.sameValue(nf.format(0.0001), "US$0.00");
-assert.sameValue(nf.format(987), "US$0.00");
+assert.sameValue(nf.format(987), "US$987.00");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-de-DE.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-de-DE.js
@@ -11,7 +11,7 @@ features: [Intl.NumberFormat-v3]
 const nf = new Intl.NumberFormat("de-DE", {signDisplay: "negative"});
 assert.sameValue(nf.format(-Infinity), "-∞", "-Infinity");
 assert.sameValue(nf.format(-987), "-987", "-987");
-assert.sameValue(nf.format(-0.0001), "-0", "-0.0001");
+assert.sameValue(nf.format(-0.0001), "0", "-0.0001");
 assert.sameValue(nf.format(-0), "0", "-0");
 assert.sameValue(nf.format(0), "0", "0");
 assert.sameValue(nf.format(0.0001), "0", "0.0001");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-en-US.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-en-US.js
@@ -11,7 +11,7 @@ features: [Intl.NumberFormat-v3]
 const nf = new Intl.NumberFormat("en-US", {signDisplay: "negative"});
 assert.sameValue(nf.format(-Infinity), "-∞", "-Infinity");
 assert.sameValue(nf.format(-987), "-987", "-987");
-assert.sameValue(nf.format(-0.0001), "-0", "-0.0001");
+assert.sameValue(nf.format(-0.0001), "0", "-0.0001");
 assert.sameValue(nf.format(-0), "0", "-0");
 assert.sameValue(nf.format(0), "0", "0");
 assert.sameValue(nf.format(0.0001), "0", "0.0001");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-ja-JP.js
@@ -11,7 +11,7 @@ features: [Intl.NumberFormat-v3]
 const nf = new Intl.NumberFormat("ja-JP", {signDisplay: "negative"});
 assert.sameValue(nf.format(-Infinity), "-∞", "-Infinity");
 assert.sameValue(nf.format(-987), "-987", "-987");
-assert.sameValue(nf.format(-0.0001), "-0", "-0.0001");
+assert.sameValue(nf.format(-0.0001), "0", "-0.0001");
 assert.sameValue(nf.format(-0), "0", "-0");
 assert.sameValue(nf.format(0), "0", "0");
 assert.sameValue(nf.format(0.0001), "0", "0.0001");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-ko-KR.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-ko-KR.js
@@ -11,7 +11,7 @@ features: [Intl.NumberFormat-v3]
 const nf = new Intl.NumberFormat("ko-KR", {signDisplay: "negative"});
 assert.sameValue(nf.format(-Infinity), "-∞", "-Infinity");
 assert.sameValue(nf.format(-987), "-987", "-987");
-assert.sameValue(nf.format(-0.0001), "-0", "-0.0001");
+assert.sameValue(nf.format(-0.0001), "0", "-0.0001");
 assert.sameValue(nf.format(-0), "0", "-0");
 assert.sameValue(nf.format(0), "0", "0");
 assert.sameValue(nf.format(0.0001), "0", "0.0001");

--- a/test/intl402/NumberFormat/prototype/format/signDisplay-negative-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/format/signDisplay-negative-zh-TW.js
@@ -11,7 +11,7 @@ features: [Intl.NumberFormat-v3]
 const nf = new Intl.NumberFormat("zh-TW", {signDisplay: "negative"});
 assert.sameValue(nf.format(-Infinity), "-∞", "-Infinity");
 assert.sameValue(nf.format(-987), "-987", "-987");
-assert.sameValue(nf.format(-0.0001), "-0", "-0.0001");
+assert.sameValue(nf.format(-0.0001), "0", "-0.0001");
 assert.sameValue(nf.format(-0), "0", "-0");
 assert.sameValue(nf.format(0), "0", "0");
 assert.sameValue(nf.format(0.0001), "0", "0.0001");

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-de-DE.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-de-DE.js
@@ -28,7 +28,7 @@ verifyFormatParts(
 );
 verifyFormatParts(
   nf.formatToParts(-0.0001),
-  [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"},{"type":"decimal","value":","},{"type":"fraction","value":"00"},{"type":"literal","value":" "},{"type":"currency","value":"$"}],
+  [{"type":"integer","value":"0"},{"type":"decimal","value":","},{"type":"fraction","value":"00"},{"type":"literal","value":" "},{"type":"currency","value":"$"}],
   "negativeNearZero"
 );
 verifyFormatParts(

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-en-US.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-en-US.js
@@ -28,7 +28,7 @@ verifyFormatParts(
 );
 verifyFormatParts(
   nf.formatToParts(-0.0001),
-  [{"type":"literal","value":"("},{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  [{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
   "negativeNearZero"
 );
 verifyFormatParts(

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-ja-JP.js
@@ -28,7 +28,7 @@ verifyFormatParts(
 );
 verifyFormatParts(
   nf.formatToParts(-0.0001),
-  [{"type":"literal","value":"("},{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  [{"type":"currency","value":"$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
   "negativeNearZero"
 );
 verifyFormatParts(

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-ko-KR.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-ko-KR.js
@@ -28,7 +28,7 @@ verifyFormatParts(
 );
 verifyFormatParts(
   nf.formatToParts(-0.0001),
-  [{"type":"literal","value":"("},{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  [{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
   "negativeNearZero"
 );
 verifyFormatParts(

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-currency-zh-TW.js
@@ -28,7 +28,7 @@ verifyFormatParts(
 );
 verifyFormatParts(
   nf.formatToParts(-0.0001),
-  [{"type":"literal","value":"("},{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"},{"type":"literal","value":")"}],
+  [{"type":"currency","value":"US$"},{"type":"integer","value":"0"},{"type":"decimal","value":"."},{"type":"fraction","value":"00"}],
   "negativeNearZero"
 );
 verifyFormatParts(

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-de-DE.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-de-DE.js
@@ -19,11 +19,12 @@ function verifyFormatParts(actual, expected, message) {
   }
 }
 
+const signDisplay = "negative";
 const nf = new Intl.NumberFormat("de-DE", {signDisplay: "negative"});
 
 verifyFormatParts(nf.formatToParts(-Infinity), [{"type":"minusSign","value":"-"},{"type":"infinity","value":"∞"}], `-Infinity (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(-987), [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}], `-987 (${signDisplay})`);
-verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(-0), [{"type":"integer","value":"0"}], `-0 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(0), [{"type":"integer","value":"0"}], `0 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(0.0001), [{"type":"integer","value":"0"}], `0.0001 (${signDisplay})`);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-en-US.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-en-US.js
@@ -19,11 +19,12 @@ function verifyFormatParts(actual, expected, message) {
   }
 }
 
+const signDisplay = "negative";
 const nf = new Intl.NumberFormat("en-US", {signDisplay: "negative"});
 
 verifyFormatParts(nf.formatToParts(-Infinity), [{"type":"minusSign","value":"-"},{"type":"infinity","value":"∞"}], `-Infinity (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(-987), [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}], `-987 (${signDisplay})`);
-verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(-0), [{"type":"integer","value":"0"}], `-0 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(0), [{"type":"integer","value":"0"}], `0 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(0.0001), [{"type":"integer","value":"0"}], `0.0001 (${signDisplay})`);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-ja-JP.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-ja-JP.js
@@ -19,11 +19,12 @@ function verifyFormatParts(actual, expected, message) {
   }
 }
 
+const signDisplay = "negative";
 const nf = new Intl.NumberFormat("ja-JP", {signDisplay: "negative"});
 
 verifyFormatParts(nf.formatToParts(-Infinity), [{"type":"minusSign","value":"-"},{"type":"infinity","value":"∞"}], `-Infinity (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(-987), [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}], `-987 (${signDisplay})`);
-verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(-0), [{"type":"integer","value":"0"}], `-0 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(0), [{"type":"integer","value":"0"}], `0 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(0.0001), [{"type":"integer","value":"0"}], `0.0001 (${signDisplay})`);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-ko-KR.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-ko-KR.js
@@ -19,11 +19,12 @@ function verifyFormatParts(actual, expected, message) {
   }
 }
 
+const signDisplay = "negative";
 const nf = new Intl.NumberFormat("ko-KR", {signDisplay: "negative"});
 
 verifyFormatParts(nf.formatToParts(-Infinity), [{"type":"minusSign","value":"-"},{"type":"infinity","value":"∞"}], `-Infinity (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(-987), [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}], `-987 (${signDisplay})`);
-verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(-0), [{"type":"integer","value":"0"}], `-0 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(0), [{"type":"integer","value":"0"}], `0 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(0.0001), [{"type":"integer","value":"0"}], `0.0001 (${signDisplay})`);

--- a/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-zh-TW.js
+++ b/test/intl402/NumberFormat/prototype/formatToParts/signDisplay-negative-zh-TW.js
@@ -19,11 +19,12 @@ function verifyFormatParts(actual, expected, message) {
   }
 }
 
+const signDisplay = "negative";
 const nf = new Intl.NumberFormat("zh-TW", {signDisplay: "negative"});
 
 verifyFormatParts(nf.formatToParts(-Infinity), [{"type":"minusSign","value":"-"},{"type":"infinity","value":"∞"}], `-Infinity (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(-987), [{"type":"minusSign","value":"-"},{"type":"integer","value":"987"}], `-987 (${signDisplay})`);
-verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"minusSign","value":"-"},{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
+verifyFormatParts(nf.formatToParts(-0.0001), [{"type":"integer","value":"0"}], `-0.0001 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(-0), [{"type":"integer","value":"0"}], `-0 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(0), [{"type":"integer","value":"0"}], `0 (${signDisplay})`);
 verifyFormatParts(nf.formatToParts(0.0001), [{"type":"integer","value":"0"}], `0.0001 (${signDisplay})`);


### PR DESCRIPTION
The negative sign is computed after rounding, so when the input `-0.0001` is
rounded to `-0`, the expected result should be `"0"` instead of `"-0"`.