### PR TITLE
Add tests for "Intl NumberFormat v3" proposal

### DIFF
--- a/test/intl402/NumberFormat/constructor-options-throwing-getters-rounding-increment.js
+++ b/test/intl402/NumberFormat/constructor-options-throwing-getters-rounding-increment.js
@@ -1,0 +1,17 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-initializenumberformat
+description: >
+  Exception from accessing the "roundingIncrement" option for the NumberFormat
+  constructor should be propagated to the caller
+features: [Intl.NumberFormat-v3]
+---*/
+
+assert.throws(Test262Error, function() {
+  new Intl.NumberFormat('en', {
+    get roundingIncrement() {
+      throw new Test262Error();
+    }
+  });
+});

--- a/test/intl402/NumberFormat/constructor-options-throwing-getters-rounding-priority.js
+++ b/test/intl402/NumberFormat/constructor-options-throwing-getters-rounding-priority.js
@@ -1,0 +1,17 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-initializenumberformat
+description: >
+  Exception from accessing the "roundingPriority" option for the NumberFormat
+  constructor should be propagated to the caller
+features: [Intl.NumberFormat-v3]
+---*/
+
+assert.throws(Test262Error, function() {
+  new Intl.NumberFormat('en', {
+    get roundingPriority() {
+      throw new Test262Error();
+    }
+  });
+});

--- a/test/intl402/NumberFormat/constructor-options-throwing-getters-trailing-zero-display.js
+++ b/test/intl402/NumberFormat/constructor-options-throwing-getters-trailing-zero-display.js
@@ -1,0 +1,17 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-initializenumberformat
+description: >
+  Exception from accessing the "trailingZeroDisplay" option for the
+  NumberFormat constructor should be propagated to the caller
+features: [Intl.NumberFormat-v3]
+---*/
+
+assert.throws(Test262Error, function() {
+  new Intl.NumberFormat('en', {
+    get trailingZeroDisplay() {
+      throw new Test262Error();
+    }
+  });
+});

--- a/test/intl402/NumberFormat/constructor-roundingIncrement-invalid.js
+++ b/test/intl402/NumberFormat/constructor-roundingIncrement-invalid.js
@@ -1,0 +1,43 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-initializenumberformat
+description: Rejects invalid values for roundingIncrement option.
+features: [Intl.NumberFormat-v3]
+---*/
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {roundingIncrement: 0});
+}, '0');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {roundingIncrement: 1.1});
+}, '1.1');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {roundingIncrement: 3});
+}, '3');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {roundingIncrement: 4});
+}, '4');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {roundingIncrement: 5000.1});
+}, '5000.1');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {roundingIncrement: 5001});
+}, '5001');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {roundingIncrement: 2, roundingPriority: 'morePrecision'});
+}, '2, roundingType is "morePrecision"');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {roundingIncrement: 2, roundingPriority: 'lessPrecision'});
+}, '2, roundingType is "lessPrecision"');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {roundingIncrement: 2, minimumSignificantDigits: 1});
+}, '2, roundingType is "significantDigits"');

--- a/test/intl402/NumberFormat/constructor-roundingIncrement.js
+++ b/test/intl402/NumberFormat/constructor-roundingIncrement.js
@@ -1,0 +1,49 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-initializenumberformat
+description: Checks handling of the roundingIncrement option to the NumberFormat constructor.
+includes: [compareArray.js]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const values = [
+  [undefined, 1],
+  [1, 1],
+  [2, 2],
+  [5, 5],
+  [10, 10],
+  [20, 20],
+  [25, 25],
+  [50, 50],
+  [100, 100],
+  [200, 200],
+  [250, 250],
+  [500, 500],
+  [1000, 1000],
+  [2000, 2000],
+  [2500, 2500],
+  [5000, 5000],
+  [true, 1],
+  ["2", 2],
+  [{valueOf: function() { return 5; }}, 5],
+];
+
+for (const [value, expected] of values) {
+  const callOrder = [];
+  const nf = new Intl.NumberFormat([], {
+    get notation() {
+      callOrder.push("notation");
+      return "compact";
+    },
+    get roundingIncrement() {
+      callOrder.push("roundingIncrement");
+      return value;
+    }
+  });
+  const resolvedOptions = nf.resolvedOptions();
+  assert("roundingIncrement" in resolvedOptions, "has property for value " + value);
+  assert.sameValue(resolvedOptions.roundingIncrement, expected);
+
+  assert.compareArray(callOrder, ["notation", "roundingIncrement"]);
+}

--- a/test/intl402/NumberFormat/constructor-trailingZeroDisplay-invalid.js
+++ b/test/intl402/NumberFormat/constructor-trailingZeroDisplay-invalid.js
@@ -1,0 +1,31 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-initializenumberformat
+description: Rejects invalid values for trailingZeroDisplay option.
+features: [Intl.NumberFormat-v3]
+---*/
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {trailingZeroDisplay: ''});
+}, 'empty string');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {trailingZeroDisplay: 'Auto'});
+}, 'Auto');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {trailingZeroDisplay: 'StripIfInteger'});
+}, 'StripIfInteger');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {trailingZeroDisplay: 'stripifinteger'});
+}, 'stripifinteger');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {trailingZeroDisplay: ' auto'});
+}, '" auto" (with leading space)');
+
+assert.throws(RangeError, function() {
+  new Intl.NumberFormat([], {trailingZeroDisplay: 'auto '});
+}, '"auto " (with trailing space)');

--- a/test/intl402/NumberFormat/constructor-trailingZeroDisplay.js
+++ b/test/intl402/NumberFormat/constructor-trailingZeroDisplay.js
@@ -1,0 +1,34 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-initializenumberformat
+description: Checks handling of the trailingZeroDisplay option to the NumberFormat constructor.
+includes: [compareArray.js]
+features: [Intl.NumberFormat-v3]
+---*/
+
+const values = [
+  [undefined, "auto"],
+  ["auto", "auto"],
+  ["stripIfInteger", "stripIfInteger"],
+  [{toString: function() { return "stripIfInteger"; }}, "stripIfInteger"],
+];
+
+for (const [value, expected] of values) {
+  const callOrder = [];
+  const nf = new Intl.NumberFormat([], {
+    get roundingIncrement() {
+      callOrder.push("roundingIncrement");
+      return 1;
+    },
+    get trailingZeroDisplay() {
+      callOrder.push("trailingZeroDisplay");
+      return value;
+    }
+  });
+  const resolvedOptions = nf.resolvedOptions();
+  assert("trailingZeroDisplay" in resolvedOptions, "has property for value " + value);
+  assert.sameValue(resolvedOptions.trailingZeroDisplay, expected);
+
+  assert.compareArray(callOrder, ["roundingIncrement", "trailingZeroDisplay"]);
+}

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-1.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-1.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `1`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 1, maximumFractionDigits: 1},
+  {
+    '1.100': '1.1',
+    '1.125': '1.1',
+    '1.150': '1.2',
+    '1.175': '1.2',
+    '1.200': '1.2',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 1, maximumFractionDigits: 2},
+  {
+    '1.0100': '1.01',
+    '1.0125': '1.01',
+    '1.0150': '1.02',
+    '1.0175': '1.02',
+    '1.0200': '1.02',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-10.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-10.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `10`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 10, maximumFractionDigits: 2},
+  {
+    '1.100': '1.1',
+    '1.125': '1.1',
+    '1.150': '1.2',
+    '1.175': '1.2',
+    '1.200': '1.2',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 10, maximumFractionDigits: 3},
+  {
+    '1.0100': '1.01',
+    '1.0125': '1.01',
+    '1.0150': '1.02',
+    '1.0175': '1.02',
+    '1.0200': '1.02',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-100.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-100.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `100`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 100, maximumFractionDigits: 3},
+  {
+    '1.100': '1.1',
+    '1.125': '1.1',
+    '1.150': '1.2',
+    '1.175': '1.2',
+    '1.200': '1.2',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 100, maximumFractionDigits: 4},
+  {
+    '1.0100': '1.01',
+    '1.0125': '1.01',
+    '1.0150': '1.02',
+    '1.0175': '1.02',
+    '1.0200': '1.02',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-1000.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-1000.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `1000`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 1000, maximumFractionDigits: 4},
+  {
+    '1.100': '1.1',
+    '1.125': '1.1',
+    '1.150': '1.2',
+    '1.175': '1.2',
+    '1.200': '1.2',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 1000, maximumFractionDigits: 5},
+  {
+    '1.0100': '1.01',
+    '1.0125': '1.01',
+    '1.0150': '1.02',
+    '1.0175': '1.02',
+    '1.0200': '1.02',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `2`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 2, maximumFractionDigits: 1},
+  {
+    '1.20': '1.2',
+    '1.25': '1.2',
+    '1.30': '1.4',
+    '1.35': '1.4',
+    '1.40': '1.4',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 2, maximumFractionDigits: 2},
+  {
+    '1.020': '1.02',
+    '1.025': '1.02',
+    '1.030': '1.04',
+    '1.035': '1.04',
+    '1.040': '1.04',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-20.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-20.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `20`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 20, maximumFractionDigits: 2},
+  {
+    '1.20': '1.2',
+    '1.25': '1.2',
+    '1.30': '1.4',
+    '1.35': '1.4',
+    '1.40': '1.4',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 20, maximumFractionDigits: 3},
+  {
+    '1.020': '1.02',
+    '1.025': '1.02',
+    '1.030': '1.04',
+    '1.035': '1.04',
+    '1.040': '1.04',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-200.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-200.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `200`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 200, maximumFractionDigits: 3},
+  {
+    '1.20': '1.2',
+    '1.25': '1.2',
+    '1.30': '1.4',
+    '1.35': '1.4',
+    '1.40': '1.4',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 200, maximumFractionDigits: 4},
+  {
+    '1.020': '1.02',
+    '1.025': '1.02',
+    '1.030': '1.04',
+    '1.035': '1.04',
+    '1.040': '1.04',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2000.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2000.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `2000`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 2000, maximumFractionDigits: 4},
+  {
+    '1.20': '1.2',
+    '1.25': '1.2',
+    '1.30': '1.4',
+    '1.35': '1.4',
+    '1.40': '1.4',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 2000, maximumFractionDigits: 5},
+  {
+    '1.020': '1.02',
+    '1.025': '1.02',
+    '1.030': '1.04',
+    '1.035': '1.04',
+    '1.040': '1.04',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-25.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-25.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `25`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 25, maximumFractionDigits: 2},
+  {
+    '1.2500': '1.25',
+    '1.3125': '1.25',
+    '1.3750': '1.5',
+    '1.4375': '1.5',
+    '1.5000': '1.5',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 25, maximumFractionDigits: 3},
+  {
+    '1.02500': '1.025',
+    '1.03125': '1.025',
+    '1.03750': '1.05',
+    '1.04375': '1.05',
+    '1.05000': '1.05',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-250.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-250.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `250`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 250, maximumFractionDigits: 3},
+  {
+    '1.2500': '1.25',
+    '1.3125': '1.25',
+    '1.3750': '1.5',
+    '1.4375': '1.5',
+    '1.5000': '1.5',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 250, maximumFractionDigits: 4},
+  {
+    '1.02500': '1.025',
+    '1.03125': '1.025',
+    '1.03750': '1.05',
+    '1.04375': '1.05',
+    '1.05000': '1.05',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2500.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2500.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `2500`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 2500, maximumFractionDigits: 4},
+  {
+    '1.2500': '1.25',
+    '1.3125': '1.25',
+    '1.3750': '1.5',
+    '1.4375': '1.5',
+    '1.5000': '1.5',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 2500, maximumFractionDigits: 5},
+  {
+    '1.02500': '1.025',
+    '1.03125': '1.025',
+    '1.03750': '1.05',
+    '1.04375': '1.05',
+    '1.05000': '1.05',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `5`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 5, maximumFractionDigits: 1},
+  {
+    '1.500': '1.5',
+    '1.625': '1.5',
+    '1.750': '2',
+    '1.875': '2',
+    '2.000': '2',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 5, maximumFractionDigits: 2},
+  {
+    '1.0500': '1.05',
+    '1.0625': '1.05',
+    '1.0750': '1.1',
+    '1.0875': '1.1',
+    '1.1000': '1.1',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-50.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-50.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `50`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 50, maximumFractionDigits: 2},
+  {
+    '1.500': '1.5',
+    '1.625': '1.5',
+    '1.750': '2',
+    '1.875': '2',
+    '2.000': '2',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 50, maximumFractionDigits: 3},
+  {
+    '1.0500': '1.05',
+    '1.0625': '1.05',
+    '1.0750': '1.1',
+    '1.0875': '1.1',
+    '1.1000': '1.1',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-500.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-500.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `500`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 500, maximumFractionDigits: 3},
+  {
+    '1.500': '1.5',
+    '1.625': '1.5',
+    '1.750': '2',
+    '1.875': '2',
+    '2.000': '2',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 500, maximumFractionDigits: 4},
+  {
+    '1.0500': '1.05',
+    '1.0625': '1.05',
+    '1.0750': '1.1',
+    '1.0875': '1.1',
+    '1.1000': '1.1',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5000.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5000.js
@@ -1,0 +1,39 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: When set to `5000`, roundingIncrement is correctly applied
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 5000, maximumFractionDigits: 4},
+  {
+    '1.500': '1.5',
+    '1.625': '1.5',
+    '1.750': '2',
+    '1.875': '2',
+    '2.000': '2',
+  }
+);
+
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {roundingIncrement: 5000, maximumFractionDigits: 5},
+  {
+    '1.0500': '1.05',
+    '1.0625': '1.05',
+    '1.0750': '1.1',
+    '1.0875': '1.1',
+    '1.1000': '1.1',
+  }
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-priority-auto.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-priority-auto.js
@@ -1,0 +1,47 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roungingPriority is "auto", the constraint on significant digits is
+  preferred over the constraint on fraction digits
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+// minimumSignificantDigits is less precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'auto', minimumSignificantDigits: 2, minimumFractionDigitsDigits: 2},
+  {'1': '1.0'}
+);
+
+// minimumSignificantDigits is more precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'auto', minimumSignificantDigits: 3, minimumFractionDigitsDigits: 2},
+  {'1': '1.00'}
+);
+
+// maximumSignificantDigits is less precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'auto', maximumSignificantDigits: 2, maximumFractionDigitsDigits: 2},
+  {'1.23': '1.2'}
+);
+
+// maximumSignificantDigits is more precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'auto', maximumSignificantDigits: 3, maximumFractionDigitsDigits: 1},
+  {'1.234': '1.23'}
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-priority-less-precision.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-priority-less-precision.js
@@ -1,0 +1,47 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roungingPriority is "lessPrecision", the constraint which produces the
+  less precise result is preferred
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+// minimumSignificantDigits is less precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'lessPrecision', minimumSignificantDigits: 2, minimumFractionDigitsDigits: 2},
+  {'1': '1.0'}
+);
+
+// minimumSignificantDigits is more precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'lessPrecision', minimumSignificantDigits: 3, minimumFractionDigitsDigits: 2},
+  {'1': '1.0'}
+);
+
+// maximumSignificantDigits is less precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'lessPrecision', maximumSignificantDigits: 2, maximumFractionDigitsDigits: 2},
+  {'1.23': '1.2'}
+);
+
+// maximumSignificantDigits is more precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'lessPrecision', maximumSignificantDigits: 3, maximumFractionDigitsDigits: 1},
+  {'1.234': '1.2'}
+);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-priority-more-precision.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-priority-more-precision.js
@@ -1,0 +1,47 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat.prototype.format
+description: >
+  When roungingPriority is "morePrecision", the constraint which produces the
+  more precise result is preferred
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
+---*/
+
+var locales = [
+  new Intl.NumberFormat().resolvedOptions().locale, 'ar', 'de', 'th', 'ja'
+];
+var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
+
+// minimumSignificantDigits is less precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'morePrecision', minimumSignificantDigits: 2, minimumFractionDigitsDigits: 2},
+  {'1': '1.00'}
+);
+
+// minimumSignificantDigits is more precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'morePrecision', minimumSignificantDigits: 3, minimumFractionDigitsDigits: 2},
+  {'1': '1.00'}
+);
+
+// maximumSignificantDigits is less precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'morePrecision', maximumSignificantDigits: 2, maximumFractionDigitsDigits: 2},
+  {'1.23': '1.23'}
+);
+
+// maximumSignificantDigits is more precise
+testNumberFormat(
+  locales,
+  numberingSystems,
+  {useGrouping: false, roundingPriority: 'morePrecision', maximumSignificantDigits: 3, maximumFractionDigitsDigits: 1},
+  {'1.234': '1.23'}
+);

--- a/test/intl402/NumberFormat/test-option-roundingPriority.js
+++ b/test/intl402/NumberFormat/test-option-roundingPriority.js
@@ -1,0 +1,15 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-intl.numberformat
+description: Tests that the option roundingPriority is processed correctly.
+includes: [Intl.NumberFormat-v3]
+---*/
+
+testOption(
+  Intl.NumberFormat,
+  "roundingPriority",
+  "string",
+  ["auto", "morePrecision", "lessPrecision"],
+  "auto"
+);

--- a/test/intl402/NumberFormat/test-option-roundingPriority.js
+++ b/test/intl402/NumberFormat/test-option-roundingPriority.js
@@ -3,7 +3,8 @@
 /*---
 esid: sec-intl.numberformat
 description: Tests that the option roundingPriority is processed correctly.
-includes: [Intl.NumberFormat-v3]
+features: [Intl.NumberFormat-v3]
+includes: [testIntl.js]
 ---*/
 
 testOption(


### PR DESCRIPTION
This patch is intended to cover only one aspect of the proposal for
ECMA402: the "new rounding/precision options" feature.

---

This is in service of gh-3132.

@sffc Would you mind taking a look? I'm especially interested in your thoughts on the tests for the behavior of the `roundingIncrement` option. I don't understand why the proposal supports values that differ only in order of magnitude (e.g. 5 and 50) because it seems to me that either one could be used to achieve the same result, just using different values of `maxFractionDigit`. For instance,

    {maximumFractionDigits: 2, roundingIncrement: 5}

seems equivalent to

    {maximumFractionDigits: 3, roundingIncrement: 50}

The tests reflect this interpretation, so I suspect that either some of the expected values are incorrect, or meaningful edge cases are omitted.