### PR TITLE
Verify that `Temporal.*.prototype` isn't writeable

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/Calendar/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal-calendar-prototype
+description: The "prototype" property of Temporal.Calendar
+includes: [propertyHelper.js]
+features: [Temporal]
+---*/
+
+assert.sameValue(typeof Temporal.Calendar.prototype, "object");
+assert.notSameValue(Temporal.Calendar.prototype, null);
+
+verifyProperty(Temporal.Calendar, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Temporal/Duration/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/Duration/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal-duration-prototype
+description: The "prototype" property of Temporal.Duration
+includes: [propertyHelper.js]
+features: [Temporal]
+---*/
+
+assert.sameValue(typeof Temporal.Duration.prototype, "object");
+assert.notSameValue(Temporal.Duration.prototype, null);
+
+verifyProperty(Temporal.Duration, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Temporal/Instant/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/Instant/prototype/prop-desc.js
@@ -1,19 +1,17 @@
-// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal-instant-objects
+esid: sec-temporal-instant-prototype
 description: The "prototype" property of Temporal.Instant
 includes: [propertyHelper.js]
 features: [Temporal]
 ---*/
 
-const { Instant } = Temporal;
+assert.sameValue(typeof Temporal.Instant.prototype, "object");
+assert.notSameValue(Temporal.Instant.prototype, null);
 
-assert.sameValue(typeof Instant.prototype, "object");
-assert.notSameValue(Instant.prototype, null);
-
-verifyProperty(Instant, "prototype", {
+verifyProperty(Temporal.Instant, "prototype", {
   writable: false,
   enumerable: false,
   configurable: false,

--- a/test/built-ins/Temporal/PlainDate/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal-plaindate-prototype
+description: The "prototype" property of Temporal.PlainDate
+includes: [propertyHelper.js]
+features: [Temporal]
+---*/
+
+assert.sameValue(typeof Temporal.PlainDate.prototype, "object");
+assert.notSameValue(Temporal.PlainDate.prototype, null);
+
+verifyProperty(Temporal.PlainDate, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Temporal/PlainDateTime/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal-plaindatetime-prototype
+description: The "prototype" property of Temporal.PlainDateTime
+includes: [propertyHelper.js]
+features: [Temporal]
+---*/
+
+assert.sameValue(typeof Temporal.PlainDateTime.prototype, "object");
+assert.notSameValue(Temporal.PlainDateTime.prototype, null);
+
+verifyProperty(Temporal.PlainDateTime, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal-plainmonthday-prototype
+description: The "prototype" property of Temporal.PlainMonthDay
+includes: [propertyHelper.js]
+features: [Temporal]
+---*/
+
+assert.sameValue(typeof Temporal.PlainMonthDay.prototype, "object");
+assert.notSameValue(Temporal.PlainMonthDay.prototype, null);
+
+verifyProperty(Temporal.PlainMonthDay, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal-plaintime-prototype
+description: The "prototype" property of Temporal.PlainTime
+includes: [propertyHelper.js]
+features: [Temporal]
+---*/
+
+assert.sameValue(typeof Temporal.PlainTime.prototype, "object");
+assert.notSameValue(Temporal.PlainTime.prototype, null);
+
+verifyProperty(Temporal.PlainTime, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal-plainyearmonth-prototype
+description: The "prototype" property of Temporal.PlainYearMonth
+includes: [propertyHelper.js]
+features: [Temporal]
+---*/
+
+assert.sameValue(typeof Temporal.PlainYearMonth.prototype, "object");
+assert.notSameValue(Temporal.PlainYearMonth.prototype, null);
+
+verifyProperty(Temporal.PlainYearMonth, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal-timezone-prototype
+description: The "prototype" property of Temporal.TimeZone
+includes: [propertyHelper.js]
+features: [Temporal]
+---*/
+
+assert.sameValue(typeof Temporal.TimeZone.prototype, "object");
+assert.notSameValue(Temporal.TimeZone.prototype, null);
+
+verifyProperty(Temporal.TimeZone, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/prop-desc.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal-zoneddatetime-prototype
+description: The "prototype" property of Temporal.ZonedDateTime
+includes: [propertyHelper.js]
+features: [Temporal]
+---*/
+
+assert.sameValue(typeof Temporal.ZonedDateTime.prototype, "object");
+assert.notSameValue(Temporal.ZonedDateTime.prototype, null);
+
+verifyProperty(Temporal.ZonedDateTime, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});


### PR DESCRIPTION
This PR verifies that the `prototype` property of Temporal class constructors is not writeable, not configurable, and not enumerable.

Context: https://github.com/tc39/proposal-temporal/issues/1965.

Note that `verifyProperty()` removes the property being tested, so the `prototype` prop needs to be tested before testing the constructor itself.