### PR TITLE
Add test for shadow realms wrapped function behavior on throw

### DIFF
--- a/test/built-ins/ShadowRealm/prototype/evaluate/wrapped-function-throws-typeerror-on-exceptional-exit.js
+++ b/test/built-ins/ShadowRealm/prototype/evaluate/wrapped-function-throws-typeerror-on-exceptional-exit.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2021 Igalia SL. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-wrapped-function-exotic-objects-call-thisargument-argumentslist
+description: >
+  WrappedFunction throws a TypeError if the wrapped function throws.
+features: [ShadowRealm]
+---*/
+
+assert.sameValue(
+  typeof ShadowRealm.prototype.evaluate,
+  'function',
+  'This test must fail if ShadowRealm.prototype.evaluate is not a function'
+);
+
+const r = new ShadowRealm();
+
+assert.sameValue(
+  r.evaluate(`(f) => {
+    try {
+      f();
+    } catch (e) {
+      if (e instanceof TypeError) {
+        return 'ok';
+      } else {
+        return e.toString();
+      }
+    }
+    return 'normal exit';
+  }`)(() => { throw Error("ahh"); }),
+  'ok',
+  'WrappedFunction throws TypeError (from the calling realm) if the wrapped callable throws any exception'
+);
+
+assert.throws(
+  TypeError,
+  () => r.evaluate('() => { throw new Error("ahh"); }')(),
+  'WrappedFunction throws TypeError if the wrapped callable throws any exception'
+);


### PR DESCRIPTION
There was already existing coverage for when `evaluate`'d code directly throws, but not for wrapped functions; TypeError from the destination realm should be thrown whenever the a wrapped function throws, so cover that.

I signed the CLA--let me know if anything is missing : )

