### PR TITLE
Fix: correct Resizable ArrayBuffer/Array tests

### DIFF
--- a/test/built-ins/Array/prototype/every/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/every/callbackfn-resize-arraybuffer.js
@@ -17,7 +17,7 @@ testWithTypedArrayConstructors(function(TA) {
   var BPE = TA.BYTES_PER_ELEMENT;
   var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
   var sample = new TA(buffer);
-  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var expectedElements, expectedIndices, expectedArrays;
   var elements, indices, arrays, result;
 
   elements = [];
@@ -27,12 +27,10 @@ testWithTypedArrayConstructors(function(TA) {
     if (elements.length === 0) {
       try {
         buffer.resize(2 * BPE);
-        finalElement = undefined;
         expectedElements = [0, 0];
         expectedIndices = [0, 1];
         expectedArrays = [sample, sample];
       } catch (_) {
-        finalElement = 0;
         expectedElements = [0, 0, 0];
         expectedIndices = [0, 1, 2];
         expectedArrays = [sample, sample, sample];
@@ -45,9 +43,9 @@ testWithTypedArrayConstructors(function(TA) {
     return true;
   });
 
-  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
-  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
-  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.compareArray(elements, expectedElements, 'elements (shrink)');
+  assert.compareArray(indices, expectedIndices, 'indices (shrink)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (shrink)');
   assert.sameValue(result, true, 'result (shrink)');
 
   elements = [];

--- a/test/built-ins/Array/prototype/filter/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/filter/callbackfn-resize-arraybuffer.js
@@ -15,10 +15,9 @@ assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
 
 testWithTypedArrayConstructors(function(TA) {
   var BPE = TA.BYTES_PER_ELEMENT;
-  var NaNvalue = (TA === Float32Array || TA === Float64Array) ? NaN : 0;
   var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
   var sample = new TA(buffer);
-  var finalElement, finalResult, expectedElements, expectedIndices, expectedArrays;
+  var expectedElements, expectedIndices, expectedArrays;
   var elements, indices, arrays, result;
 
   elements = [];
@@ -28,14 +27,10 @@ testWithTypedArrayConstructors(function(TA) {
     if (elements.length === 0) {
       try {
         buffer.resize(2 * BPE);
-        finalElement = undefined;
-        finalResult = NaNvalue;
         expectedElements = [0, 0];
         expectedIndices = [0, 1];
         expectedArrays = [sample, sample];
       } catch (_) {
-        finalElement = 0;
-        finalResult = 0;
         expectedElements = [0, 0, 0];
         expectedIndices = [0, 1, 2];
         expectedArrays = [sample, sample, sample];
@@ -48,10 +43,10 @@ testWithTypedArrayConstructors(function(TA) {
     return true;
   });
 
-  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
-  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
-  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
-  assert.compareArray(result, [0, 0, finalResult], 'result (shrink)');
+  assert.compareArray(elements, expectedElements, 'elements (shrink)');
+  assert.compareArray(indices, expectedIndices, 'indices (shrink)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (shrink)');
+  assert.compareArray(result, expectedElements, 'result (shrink)');
 
   elements = [];
   indices = [];

--- a/test/built-ins/Array/prototype/forEach/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/forEach/callbackfn-resize-arraybuffer.js
@@ -17,7 +17,7 @@ testWithTypedArrayConstructors(function(TA) {
   var BPE = TA.BYTES_PER_ELEMENT;
   var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
   var sample = new TA(buffer);
-  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var expectedElements, expectedIndices, expectedArrays;
   var elements, indices, arrays, result;
 
   elements = [];
@@ -27,12 +27,10 @@ testWithTypedArrayConstructors(function(TA) {
     if (elements.length === 0) {
       try {
         buffer.resize(2 * BPE);
-        finalElement = undefined;
         expectedElements = [0, 0];
         expectedIndices = [0, 1];
         expectedArrays = [sample, sample];
       } catch (_) {
-        finalElement = 0;
         expectedElements = [0, 0, 0];
         expectedIndices = [0, 1, 2];
         expectedArrays = [sample, sample, sample];
@@ -44,9 +42,9 @@ testWithTypedArrayConstructors(function(TA) {
     arrays.push(array);
   });
 
-  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
-  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
-  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.compareArray(elements, expectedElements, 'elements (shrink)');
+  assert.compareArray(indices, expectedIndices, 'indices (shrink)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (shrink)');
   assert.sameValue(result, undefined, 'result (shrink)');
 
   elements = [];

--- a/test/built-ins/Array/prototype/map/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/map/callbackfn-resize-arraybuffer.js
@@ -15,10 +15,9 @@ assert.sameValue(typeof ArrayBuffer.prototype.resize, 'function');
 
 testWithTypedArrayConstructors(function(TA) {
   var BPE = TA.BYTES_PER_ELEMENT;
-  var NaNvalue = (TA === Float32Array || TA === Float64Array) ? NaN : 0;
   var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
   var sample = new TA(buffer);
-  var finalElement, finalResult, expectedElements, expectedIndices, expectedArrays;
+  var finalResult, expectedElements, expectedIndices, expectedArrays;
   var elements, indices, arrays, result;
 
   elements = [];
@@ -28,13 +27,11 @@ testWithTypedArrayConstructors(function(TA) {
     if (elements.length === 0) {
       try {
         buffer.resize(2 * BPE);
-        finalElement = undefined;
-        finalResult = NaNvalue;
+        finalResult = undefined;
         expectedElements = [0, 0];
         expectedIndices = [0, 1];
         expectedArrays = [sample, sample];
       } catch (_) {
-        finalElement = 0;
         finalResult = 2;
         expectedElements = [0, 0, 0];
         expectedIndices = [0, 1, 2];
@@ -49,9 +46,9 @@ testWithTypedArrayConstructors(function(TA) {
     return index;
   });
 
-  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
-  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
-  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.compareArray(elements, expectedElements, 'elements (shrink)');
+  assert.compareArray(indices, expectedIndices, 'indices (shrink)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (shrink)');
   assert.compareArray(result, [0, 1, finalResult], 'result (shrink)');
 
   elements = [];

--- a/test/built-ins/Array/prototype/reduce/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/reduce/callbackfn-resize-arraybuffer.js
@@ -11,7 +11,7 @@ testWithTypedArrayConstructors(function(TA) {
   var BPE = TA.BYTES_PER_ELEMENT;
   var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 3});
   var sample = new TA(buffer);
-  var finalNext, expectedPrevs, expectedNexts, expectedIndices, expectedArrays;
+  var expectedPrevs, expectedNexts, expectedIndices, expectedArrays;
   var prevs, nexts, indices, arrays, result;
 
   prevs = [];
@@ -22,13 +22,11 @@ testWithTypedArrayConstructors(function(TA) {
     if (prevs.length === 0) {
       try {
         buffer.resize(2 * BPE);
-        finalNext = undefined;
         expectedPrevs = [262, 0];
         expectedNexts = [0, 0];
         expectedIndices = [0, 1];
         expectedArrays = [sample, sample];
       } catch (_) {
-        finalNext = 0;
         expectedPrevs = [262, 0, 1];
         expectedNexts = [0, 0, 0];
         expectedIndices = [0, 1, 2];
@@ -43,11 +41,11 @@ testWithTypedArrayConstructors(function(TA) {
     return index;
   }, 262);
 
-  assert.compareArray(prevs, [262, 0, 1], 'prevs (shrink)');
-  assert.compareArray(nexts, [0, 0, finalNext], 'nexts (shrink)');
-  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
-  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
-  assert.sameValue(result, 2, 'result (shrink)');
+  assert.compareArray(prevs, expectedPrevs, 'prevs (shrink)');
+  assert.compareArray(nexts, expectedNexts, 'nexts (shrink)');
+  assert.compareArray(indices, expectedIndices, 'indices (shrink)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (shrink)');
+  assert.sameValue(result, expectedIndices[expectedIndices.length - 1], 'result (shrink)');
 
   prevs = [];
   nexts = [];

--- a/test/built-ins/Array/prototype/reduceRight/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/reduceRight/callbackfn-resize-arraybuffer.js
@@ -11,7 +11,8 @@ testWithTypedArrayConstructors(function(TA) {
   var BPE = TA.BYTES_PER_ELEMENT;
   var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 3});
   var sample = new TA(buffer);
-  var secondNext, expectedPrevs, expectedNexts, expectedIndices, expectedArrays;
+  var expectedPrevsShrink, expectedNextsShrink, expectedIndicesShrink, expectedArraysShrink;
+  var expectedPrevsGrow, expectedNextsGrow, expectedIndicesGrow, expectedArraysGrow;
   var prevs, nexts, indices, arrays, result;
 
   prevs = [];
@@ -22,17 +23,19 @@ testWithTypedArrayConstructors(function(TA) {
     if (prevs.length === 0) {
       try {
         buffer.resize(BPE);
-        secondNext = undefined;
-        expectedPrevs = [262];
-        expectedNexts = [0];
-        expectedIndices = [0];
-        expectedArrays = [sample];
+        expectedPrevsShrink = [262, 2];
+        expectedNextsShrink = [0, 0];
+        expectedIndicesShrink = [2, 0];
+        expectedArraysShrink = [sample, sample];
+        expectedPrevsGrow = [262];
+        expectedNextsGrow = [0];
+        expectedIndicesGrow = [0];
+        expectedArraysGrow = [sample];
       } catch (_) {
-        secondNext = 0;
-        expectedPrevs = [262, 2, 1];
-        expectedNexts = [0, 0, 0];
-        expectedIndices = [2, 1, 0];
-        expectedArrays = [sample, sample, sample];
+        expectedPrevsShrink = expectedPrevsGrow = [262, 2, 1];
+        expectedNextsShrink = expectedNextsGrow = [0, 0, 0];
+        expectedIndicesShrink = expectedIndicesGrow = [2, 1, 0];
+        expectedArraysShrink = expectedArraysGrow = [sample, sample, sample];
       }
     }
 
@@ -43,10 +46,10 @@ testWithTypedArrayConstructors(function(TA) {
     return index;
   }, 262);
 
-  assert.compareArray(prevs, [262, 2, 1], 'prevs (shrink)');
-  assert.compareArray(nexts, [0, secondNext, 0], 'nexts (shrink)');
-  assert.compareArray(indices, [2, 1, 0], 'indices (shrink)');
-  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.compareArray(prevs, expectedPrevsShrink, 'prevs (shrink)');
+  assert.compareArray(nexts, expectedNextsShrink, 'nexts (shrink)');
+  assert.compareArray(indices, expectedIndicesShrink, 'indices (shrink)');
+  assert.compareArray(arrays, expectedArraysShrink, 'arrays (shrink)');
   assert.sameValue(result, 0, 'result (shrink)');
 
   prevs = [];
@@ -67,9 +70,9 @@ testWithTypedArrayConstructors(function(TA) {
     return index;
   }, 262);
 
-  assert.compareArray(prevs, expectedPrevs, 'prevs (grow)');
-  assert.compareArray(nexts, expectedNexts, 'nexts (grow)');
-  assert.compareArray(indices, expectedIndices, 'indices (grow)');
-  assert.compareArray(arrays, expectedArrays, 'arrays (grow)');
-  assert.sameValue(result, expectedIndices[expectedIndices.length - 1], 'result (grow)');
+  assert.compareArray(prevs, expectedPrevsGrow, 'prevs (grow)');
+  assert.compareArray(nexts, expectedNextsGrow, 'nexts (grow)');
+  assert.compareArray(indices, expectedIndicesGrow, 'indices (grow)');
+  assert.compareArray(arrays, expectedArraysGrow, 'arrays (grow)');
+  assert.sameValue(result, expectedIndicesGrow[expectedIndicesGrow.length - 1], 'result (grow)');
 });

--- a/test/built-ins/Array/prototype/some/callbackfn-resize-arraybuffer.js
+++ b/test/built-ins/Array/prototype/some/callbackfn-resize-arraybuffer.js
@@ -17,7 +17,7 @@ testWithTypedArrayConstructors(function(TA) {
   var BPE = TA.BYTES_PER_ELEMENT;
   var buffer = new ArrayBuffer(BPE * 3, {maxByteLength: BPE * 4});
   var sample = new TA(buffer);
-  var finalElement, expectedElements, expectedIndices, expectedArrays;
+  var expectedElements, expectedIndices, expectedArrays;
   var elements, indices, arrays, result;
 
   elements = [];
@@ -27,12 +27,10 @@ testWithTypedArrayConstructors(function(TA) {
     if (elements.length === 0) {
       try {
         buffer.resize(2 * BPE);
-        finalElement = undefined;
         expectedElements = [0, 0];
         expectedIndices = [0, 1];
         expectedArrays = [sample, sample];
       } catch (_) {
-        finalElement = 0;
         expectedElements = [0, 0, 0];
         expectedIndices = [0, 1, 2];
         expectedArrays = [sample, sample, sample];
@@ -45,9 +43,9 @@ testWithTypedArrayConstructors(function(TA) {
     return false;
   });
 
-  assert.compareArray(elements, [0, 0, finalElement], 'elements (shrink)');
-  assert.compareArray(indices, [0, 1, 2], 'indices (shrink)');
-  assert.compareArray(arrays, [sample, sample, sample], 'arrays (shrink)');
+  assert.compareArray(elements, expectedElements, 'elements (shrink)');
+  assert.compareArray(indices, expectedIndices, 'indices (shrink)');
+  assert.compareArray(arrays, expectedArrays, 'arrays (shrink)');
   assert.sameValue(result, false, 'result (shrink)');
 
   elements = [];


### PR DESCRIPTION
Prior to this patch, the tests for certain Array prototype methods
incorrectly expected all elements to be "visited" even when a given
property was not present according to HasProperty.

Update the tests to reflect the fact that under such conditions, the
removed element is not visited.

@marjakh  @phoddie Since I authored the mistaken tests, it's particularly important that someone closer to an implementation reviews this patch. Would you mind taking a look?