### PR TITLE
Add tests: order of coercion of arguments vs NaN check in Date methods

### DIFF
--- a/test/built-ins/Date/prototype/setDate/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setDate/arg-coercion-order.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setdate
+description: Order of coercion of provided argument vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Let dt be ? ToNumber(date).
+  3. If t is NaN, return NaN.
+  4. Set t to LocalTime(t).
+  5. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt), TimeWithinDay(t)).
+  6. Let u be TimeClip(UTC(newDate)).
+  7. Set the [[DateValue]] internal slot of this Date object to u.
+  8. Return u.
+---*/
+
+var date = new Date(NaN);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 0;
+  }
+};
+
+var returnValue = date.setDate(arg);
+
+assert.sameValue(callCount, 1, 'ToNumber invoked exactly once');
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');

--- a/test/built-ins/Date/prototype/setHours/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setHours/arg-coercion-order.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.sethours
+description: Order of coercion of provided arguments vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Let h be ? ToNumber(hour).
+  3. If min is present, let m be ? ToNumber(min).
+  4. If sec is present, let s be ? ToNumber(sec).
+  5. If ms is present, let milli be ? ToNumber(ms).
+  6. If t is NaN, return NaN.
+  7. Set t to LocalTime(t).
+  8. If min is not present, let m be MinFromTime(t).
+  9. If sec is not present, let s be SecFromTime(t).
+  10. If ms is not present, let milli be msFromTime(t).
+  11. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  12. Let u be TimeClip(UTC(date)).
+  13. Set the [[DateValue]] internal slot of this Date object to u.
+  14. Return u.
+includes: [compareArray.js]
+---*/
+
+var date = new Date(NaN);
+var effects = [];
+var argHour = {
+  valueOf: function() {
+    effects.push('valueOf hour');
+    return 0;
+  }
+};
+var argMin = {
+  valueOf: function() {
+    effects.push('valueOf min');
+    return 0;
+  }
+};
+var argSec = {
+  valueOf: function() {
+    effects.push('valueOf sec');
+    return 0;
+  }
+};
+var argMs = {
+  valueOf: function() {
+    effects.push('valueOf ms');
+    return 0;
+  }
+};
+
+var returnValue = date.setHours(argHour, argMin, argSec, argMs);
+
+var expectedEffects = ['valueOf hour', 'valueOf min', 'valueOf sec', 'valueOf ms'];
+
+assert.compareArray(effects, expectedEffects);
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');

--- a/test/built-ins/Date/prototype/setMilliseconds/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setMilliseconds/arg-coercion-order.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmilliseconds
+description: Order of coercion of provided argument vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Set ms to ? ToNumber(ms).
+  3. If t is NaN, return NaN.
+  4. Set t to LocalTime(t).
+  5. Let time be MakeTime(HourFromTime(t), MinFromTime(t), SecFromTime(t), ms).
+  6. Let u be TimeClip(UTC(MakeDate(Day(t), time))).
+  7. Set the [[DateValue]] internal slot of this Date object to u.
+  8. Return u.
+---*/
+
+var date = new Date(NaN);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 0;
+  }
+};
+
+var returnValue = date.setMilliseconds(arg);
+
+assert.sameValue(callCount, 1, 'ToNumber invoked exactly once');
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');

--- a/test/built-ins/Date/prototype/setMinutes/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setMinutes/arg-coercion-order.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setminutes
+description: Order of coercion of provided argument vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Let m be ? ToNumber(min).
+  3. If sec is present, let s be ? ToNumber(sec).
+  4. If ms is present, let milli be ? ToNumber(ms).
+  5. If t is NaN, return NaN.
+  6. Set t to LocalTime(t).
+  7. If sec is not present, let s be SecFromTime(t).
+  8. If ms is not present, let milli be msFromTime(t).
+  9. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
+  10. Let u be TimeClip(UTC(date)).
+  11. Set the [[DateValue]] internal slot of this Date object to u.
+  12. Return u.
+includes: [compareArray.js]
+---*/
+
+var date = new Date(NaN);
+var effects = [];
+var argMin = {
+  valueOf: function() {
+    effects.push('valueOf min');
+    return 0;
+  }
+};
+var argSec = {
+  valueOf: function() {
+    effects.push('valueOf sec');
+    return 0;
+  }
+};
+var argMs = {
+  valueOf: function() {
+    effects.push('valueOf ms');
+    return 0;
+  }
+};
+
+var returnValue = date.setMinutes(argMin, argSec, argMs);
+
+var expectedEffects = ['valueOf min', 'valueOf sec', 'valueOf ms'];
+
+assert.compareArray(effects, expectedEffects);
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');

--- a/test/built-ins/Date/prototype/setMonth/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setMonth/arg-coercion-order.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setmonth
+description: Order of coercion of provided argument vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Let m be ? ToNumber(month).
+  3. If date is present, let dt be ? ToNumber(date).
+  4. If t is NaN, return NaN.
+  5. Set t to LocalTime(t).
+  6. If date is not present, let dt be DateFromTime(t).
+  7. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt), TimeWithinDay(t)).
+  8. Let u be TimeClip(UTC(newDate)).
+  9. Set the [[DateValue]] internal slot of this Date object to u.
+  10. Return u.
+includes: [compareArray.js]
+---*/
+
+var date = new Date(NaN);
+var effects = [];
+var argMonth = {
+  valueOf: function() {
+    effects.push('valueOf month');
+    return 0;
+  }
+};
+var argDate = {
+  valueOf: function() {
+    effects.push('valueOf date');
+    return 0;
+  }
+};
+
+var returnValue = date.setMonth(argMonth, argDate);
+
+var expectedEffects = ['valueOf month', 'valueOf date'];
+
+assert.compareArray(effects, expectedEffects);
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');

--- a/test/built-ins/Date/prototype/setSeconds/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setSeconds/arg-coercion-order.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setseconds
+description: Order of coercion of provided arguments vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Let s be ? ToNumber(sec).
+  3. If ms is present, let milli be ? ToNumber(ms).
+  4. If t is NaN, return NaN.
+  5. Set t to LocalTime(t).
+  6. If ms is not present, let milli be msFromTime(t).
+  7. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
+  8. Let u be TimeClip(UTC(date)).
+  9. Set the [[DateValue]] internal slot of this Date object to u.
+  10. Return u.
+includes: [compareArray.js]
+---*/
+
+var date = new Date(NaN);
+var effects = [];
+var argSec = {
+  valueOf: function() {
+    effects.push('valueOf sec');
+    return 0;
+  }
+};
+var argMs = {
+  valueOf: function() {
+    effects.push('valueOf ms');
+    return 0;
+  }
+};
+
+var returnValue = date.setSeconds(argSec, argMs);
+
+var expectedEffects = ['valueOf sec', 'valueOf ms'];
+
+assert.compareArray(effects, expectedEffects);
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');

--- a/test/built-ins/Date/prototype/setUTCDate/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setUTCDate/arg-coercion-order.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutcdate
+description: Order of coercion of provided argument vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Let dt be ? ToNumber(date).
+  3. If t is NaN, return NaN.
+  4. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt), TimeWithinDay(t)).
+  5. Let v be TimeClip(newDate).
+  6. Set the [[DateValue]] internal slot of this Date object to v.
+  7. Return v.
+---*/
+
+var date = new Date(NaN);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 0;
+  }
+};
+
+var returnValue = date.setUTCDate(arg);
+
+assert.sameValue(callCount, 1, 'ToNumber invoked exactly once');
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');

--- a/test/built-ins/Date/prototype/setUTCHours/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setUTCHours/arg-coercion-order.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutchours
+description: Order of coercion of provided arguments vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Let h be ? ToNumber(hour).
+  3. If min is present, let m be ? ToNumber(min).
+  4. If sec is present, let s be ? ToNumber(sec).
+  5. If ms is present, let milli be ? ToNumber(ms).
+  6. If t is NaN, return NaN.
+  7. If min is not present, let m be MinFromTime(t).
+  8. If sec is not present, let s be SecFromTime(t).
+  9. If ms is not present, let milli be msFromTime(t).
+  10. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+  11. Let v be TimeClip(date).
+  12. Set the [[DateValue]] internal slot of this Date object to v.
+  13. Return v.
+includes: [compareArray.js]
+---*/
+
+var date = new Date(NaN);
+var effects = [];
+var argHour = {
+  valueOf: function() {
+    effects.push('valueOf hour');
+    return 0;
+  }
+};
+var argMin = {
+  valueOf: function() {
+    effects.push('valueOf min');
+    return 0;
+  }
+};
+var argSec = {
+  valueOf: function() {
+    effects.push('valueOf sec');
+    return 0;
+  }
+};
+var argMs = {
+  valueOf: function() {
+    effects.push('valueOf ms');
+    return 0;
+  }
+};
+
+var returnValue = date.setUTCHours(argHour, argMin, argSec, argMs);
+
+var expectedEffects = ['valueOf hour', 'valueOf min', 'valueOf sec', 'valueOf ms'];
+
+assert.compareArray(effects, expectedEffects);
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');

--- a/test/built-ins/Date/prototype/setUTCMilliseconds/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setUTCMilliseconds/arg-coercion-order.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutcmilliseconds
+description: Order of coercion of provided argument vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Let dt be ? ToNumber(date).
+  3. If t is NaN, return NaN.
+  4. Set t to LocalTime(t).
+  5. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt), TimeWithinDay(t)).
+  6. Let u be TimeClip(UTC(newDate)).
+  7. Set the [[DateValue]] internal slot of this Date object to u.
+  8. Return u.
+---*/
+
+var date = new Date(NaN);
+var callCount = 0;
+var arg = {
+  valueOf: function() {
+    callCount += 1;
+    return 0;
+  }
+};
+
+var returnValue = date.setUTCMilliseconds(arg);
+
+assert.sameValue(callCount, 1, 'ToNumber invoked exactly once');
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');

--- a/test/built-ins/Date/prototype/setUTCMinutes/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setUTCMinutes/arg-coercion-order.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutcminutes
+description: Order of coercion of provided argument vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Let m be ? ToNumber(min).
+  3. If sec is present, let s be ? ToNumber(sec).
+  4. If ms is present, let milli be ? ToNumber(ms).
+  5. If t is NaN, return NaN.
+  6. If sec is not present, let s be SecFromTime(t).
+  7. If ms is not present, let milli be msFromTime(t).
+  8. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
+  9. Let v be TimeClip(date).
+  10. Set the [[DateValue]] internal slot of this Date object to v.
+  11. Return v.
+includes: [compareArray.js]
+---*/
+
+var date = new Date(NaN);
+var effects = [];
+var argMin = {
+  valueOf: function() {
+    effects.push('valueOf min');
+    return 0;
+  }
+};
+var argSec = {
+  valueOf: function() {
+    effects.push('valueOf sec');
+    return 0;
+  }
+};
+var argMs = {
+  valueOf: function() {
+    effects.push('valueOf ms');
+    return 0;
+  }
+};
+
+var returnValue = date.setUTCMinutes(argMin, argSec, argMs);
+
+var expectedEffects = ['valueOf min', 'valueOf sec', 'valueOf ms'];
+
+assert.compareArray(effects, expectedEffects);
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');

--- a/test/built-ins/Date/prototype/setUTCMonth/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setUTCMonth/arg-coercion-order.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutcmonth
+description: Order of coercion of provided argument vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Let m be ? ToNumber(month).
+  3. If date is present, let dt be ? ToNumber(date).
+  4. If t is NaN, return NaN.
+  5. If date is not present, let dt be DateFromTime(t).
+  6. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt), TimeWithinDay(t)).
+  7. Let v be TimeClip(newDate).
+  8. Set the [[DateValue]] internal slot of this Date object to v.
+  9. Return v.
+includes: [compareArray.js]
+---*/
+
+var date = new Date(NaN);
+var effects = [];
+var argMonth = {
+  valueOf: function() {
+    effects.push('valueOf month');
+    return 0;
+  }
+};
+var argDate = {
+  valueOf: function() {
+    effects.push('valueOf date');
+    return 0;
+  }
+};
+
+var returnValue = date.setUTCMonth(argMonth, argDate);
+
+var expectedEffects = ['valueOf month', 'valueOf date'];
+
+assert.compareArray(effects, expectedEffects);
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');

--- a/test/built-ins/Date/prototype/setUTCSeconds/arg-coercion-order.js
+++ b/test/built-ins/Date/prototype/setUTCSeconds/arg-coercion-order.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2021 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-date.prototype.setutcseconds
+description: Order of coercion of provided arguments vs NaN check
+info: |
+  1. Let t be ? thisTimeValue(this value).
+  2. Let s be ? ToNumber(sec).
+  3. If ms is present, let milli be ? ToNumber(ms).
+  4. If t is NaN, return NaN.
+  5. If ms is not present, let milli be msFromTime(t).
+  6. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
+  7. Let v be TimeClip(date).
+  8. Set the [[DateValue]] internal slot of this Date object to v.
+  9. Return v.
+includes: [compareArray.js]
+---*/
+
+var date = new Date(NaN);
+var effects = [];
+var argSec = {
+  valueOf: function() {
+    effects.push('valueOf sec');
+    return 0;
+  }
+};
+var argMs = {
+  valueOf: function() {
+    effects.push('valueOf ms');
+    return 0;
+  }
+};
+
+var returnValue = date.setUTCSeconds(argSec, argMs);
+
+var expectedEffects = ['valueOf sec', 'valueOf ms'];
+
+assert.compareArray(effects, expectedEffects);
+assert.sameValue(returnValue, NaN, 'argument is ignored when `this` is an invalid date');
+assert.sameValue(date.getTime(), NaN, 'argument is ignored when `this` is an invalid date');


### PR DESCRIPTION
This adds tests for https://github.com/tc39/ecma262/pull/2136, which will (finally) allow it to land. Fixes https://github.com/tc39/test262/issues/2922.

All of the `Date.prototype.set*` methods get a new test except for setTime, setFullYear, and setUTCFullYear, which don't have anything to test (in the first case because `this` is ignored entirely except to check that it is a Date, in the latter two because they coerce to 0 rather than bailing when `this` holds a NaN).