### PR TITLE
Fix Intl.PluralRules.selectRange test

### DIFF
--- a/test/intl402/PluralRules/prototype/selectRange/default-en-us.js
+++ b/test/intl402/PluralRules/prototype/selectRange/default-en-us.js
@@ -9,6 +9,6 @@ features: [Intl.NumberFormat-v3]
 
 const pr = new Intl.PluralRules("en-US");
 
-assert.sameValue(pr.selectRange(102, 201), "few");
+assert.sameValue(pr.selectRange(102, 201), "other");
 assert.sameValue(pr.selectRange(200, 200), "other");
 


### PR DESCRIPTION
en-US's Intl.PluralRules.selectRange(102, 201) is "other", not "few".