### PR TITLE
tools: enforce restriction on YAML includes key

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,8 +178,14 @@ negative:
 `includes: [file-list]`
 
 This key names a list of files in the `harness/` directory that will be included in the test environment prior to running the test.  Filenames **must** include the `.js` extension.
-
+Includes should use flow style without line break (separating items by commas and enclosing them in square brackets), block style (one line for each item, each line starting with a dash) isn't allowed.
 When some code is used repeatedly across a group of tests, it may be appropriate to define it in a harness file. This practice increases test complexity, so it should be applied sparingly.
+
+For example:
+
+```
+includes: [include1.js, include2.js]
+```
 
 #### author
 `author: [string]`

--- a/test/built-ins/Array/from/Array.from-descriptor.js
+++ b/test/built-ins/Array/from/Array.from-descriptor.js
@@ -3,8 +3,7 @@
 
 /*---
 description: Testing descriptor property of Array.from
-includes:
-    - propertyHelper.js
+includes: [propertyHelper.js]
 esid: sec-array.from
 ---*/
 

--- a/test/built-ins/Array/isArray/descriptor.js
+++ b/test/built-ins/Array/isArray/descriptor.js
@@ -3,8 +3,7 @@
 
 /*---
 description: Testing descriptor property of Array.isArray
-includes:
-    - propertyHelper.js
+includes: [propertyHelper.js]
 esid: sec-array.isarray
 ---*/
 

--- a/test/built-ins/Function/prototype/restricted-property-arguments.js
+++ b/test/built-ins/Function/prototype/restricted-property-arguments.js
@@ -3,8 +3,7 @@
 
 /*---
 description: Intrinsic %FunctionPrototype% has poisoned own property "arguments"
-includes:
-  - propertyHelper.js
+includes: [propertyHelper.js]
 es6id: 8.2.2 S12, 9.2.7
 ---*/
 

--- a/test/built-ins/Function/prototype/restricted-property-caller.js
+++ b/test/built-ins/Function/prototype/restricted-property-caller.js
@@ -3,8 +3,7 @@
 
 /*---
 description: Intrinsic %FunctionPrototype% has poisoned own property "caller"
-includes:
-  - propertyHelper.js
+includes: [propertyHelper.js]
 es6id: 8.2.2 S12, 9.2.7
 ---*/
 

--- a/test/built-ins/Object/assign/assign-descriptor.js
+++ b/test/built-ins/Object/assign/assign-descriptor.js
@@ -3,8 +3,7 @@
 
 /*---
 description: Testing descriptor property of Object.assign
-includes:
-    - propertyHelper.js
+includes: [propertyHelper.js]
 es6id: 19.1.2.1
 ---*/
 

--- a/test/built-ins/Object/defineProperties/15.2.3.7-6-a-36.js
+++ b/test/built-ins/Object/defineProperties/15.2.3.7-6-a-36.js
@@ -7,8 +7,7 @@ description: >
     Object.defineProperties - 'P' doesn't exist in 'O', test
     [[Configurable]] of 'P' is set as false value if absent in
     accessor descriptor 'desc' (8.12.9 step 4.b.i)
-includes:
-    - propertyHelper.js
+includes: [propertyHelper.js]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Object/hasOwn/descriptor.js
+++ b/test/built-ins/Object/hasOwn/descriptor.js
@@ -4,8 +4,7 @@
 /*---
 esid: sec-object.hasown
 description: Testing descriptor property of Object.hasOwn
-includes:
-    - propertyHelper.js
+includes: [propertyHelper.js]
 author: Jamie Kyle
 features: [Object.hasOwn]
 ---*/

--- a/test/built-ins/Promise/Symbol.species/symbol-species.js
+++ b/test/built-ins/Promise/Symbol.species/symbol-species.js
@@ -7,8 +7,7 @@ info: |
 es6id: 6.1.5.1
 author: Sam Mikes
 description: Promise[Symbol.species] exists per spec
-includes:
-  - propertyHelper.js
+includes: [propertyHelper.js]
 features: [Symbol.species]
 ---*/
 

--- a/test/built-ins/Symbol/species/basic.js
+++ b/test/built-ins/Symbol/species/basic.js
@@ -7,8 +7,7 @@ info: |
 es6id: 19.4.2.10
 author: Sam Mikes
 description: Symbol.species exists
-includes: 
-  - propertyHelper.js
+includes: [propertyHelper.js]
 features: [Symbol.species]
 ---*/
 

--- a/tools/lint/lib/checks/includes.py
+++ b/tools/lint/lib/checks/includes.py
@@ -37,9 +37,17 @@ class CheckIncludes(Check):
                 return True
         return False
 
+    @staticmethod
+    def _get_includes_flow_list(source):
+        match = re.search(r"includes:\s+\[(?P<includes>.+)\]", source)
+        return [inc.strip() for inc in match.group('includes').split(',') if inc] if match else []
+
     def run(self, name, meta, source):
         if not meta or 'includes' not in meta:
             return
+
+        if meta['includes'] != CheckIncludes._get_includes_flow_list(source):
+            return 'If present, the `includes` tag must use flow style, eg. includes: [include1.js, include2.js]'
 
         harness_files = [self._load(name) for name in meta['includes']]
 

--- a/tools/lint/test/fixtures/test/includes_invalid_non_flow_list.js
+++ b/tools/lint/test/fixtures/test/includes_invalid_non_flow_list.js
@@ -1,0 +1,13 @@
+INCLUDES
+^ expected errors | v input
+// Copyright (C) 2019 Mike Pennisi. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-assignment-operators-static-semantics-early-errors
+description: Minimal test
+includes:
+    - propertyHelper.js
+---*/
+
+// This file uses "includes" as non flow style
+verifyConfigurable(Object, '');


### PR DESCRIPTION
Includes key should use flow notation to be able parsed easier
as suggested in https://github.com/tc39/test262/issues/1997

Added this check to the linting script and updated tests accordingly.