### PR TITLE
change notation to "standard"

### DIFF
--- a/test/intl402/NumberFormat/constructor-roundingIncrement.js
+++ b/test/intl402/NumberFormat/constructor-roundingIncrement.js
@@ -34,7 +34,7 @@ for (const [value, expected] of values) {
   const nf = new Intl.NumberFormat([], {
     get notation() {
       callOrder.push("notation");
-      return "compact";
+      return "standard";
     },
     get roundingIncrement() {
       callOrder.push("roundingIncrement");


### PR DESCRIPTION
I do not believe this setup is correct if we use notation: "compact". 

in https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/diff.html#sec-setnfdigitoptions
notation is "compact"
mnsd is undefined
mxsd is undefined
mnfd is undefined
mxfd is undefined
hasSd is false
hasFd is false
needSd is false
needFd is false
so step 23 else block will be run
Set intlObj.[[RoundingType]] to morePrecision.
then in step 23 of https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/diff.html#sec-initializenumberformat
```
If roundingIncrement is not 1 and numberFormat.[[RoundingType]] is not fractionDigits, throw a RangeError exception.
```

@sffc @jugglinmike 