### PR TITLE
Remove roundingIncrement: 1.1 case which should NOT throw RangeError

### DIFF
--- a/test/intl402/NumberFormat/constructor-roundingIncrement-invalid.js
+++ b/test/intl402/NumberFormat/constructor-roundingIncrement-invalid.js
@@ -11,10 +11,6 @@ assert.throws(RangeError, function() {
 }, '0');
 
 assert.throws(RangeError, function() {
-  new Intl.NumberFormat([], {roundingIncrement: 1.1});
-}, '1.1');
-
-assert.throws(RangeError, function() {
   new Intl.NumberFormat([], {roundingIncrement: 3});
 }, '3');
 


### PR DESCRIPTION
roundingIncrement: 1.1 will not throw RangeError because
1.  roundingIncrement is read by calling GetNumberOption in step 21 of https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/diff.html#sec-initializenumberformat
2. GetNumberOption https://tc39.es/ecma402/#sec-getnumberoption will call DefaultNumberOption https://tc39.es/ecma402/#sec-defaultnumberoption and 
3. DefaultNumberOption will call floor() in step 3. so roundingIncrement will be 1 if the option bag has {roundingIncrement: 1.1}

