### PR TITLE
set minimumFractionDigits: 1 in format-rounding-increment- test

### DIFF
--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-25.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-25.js
@@ -15,7 +15,7 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 25, maximumFractionDigits: 2},
+  {roundingIncrement: 25, maximumFractionDigits: 2, minimumFractionDigits: 1},
   {
     '1.2500': '1.25',
     '1.3125': '1.25',

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-250.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-250.js
@@ -15,7 +15,7 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 250, maximumFractionDigits: 3},
+  {roundingIncrement: 250, maximumFractionDigits: 3, minimumFractionDigits: 1},
   {
     '1.2500': '1.25',
     '1.3125': '1.25',

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2500.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2500.js
@@ -15,7 +15,7 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 2500, maximumFractionDigits: 4},
+  {roundingIncrement: 2500, maximumFractionDigits: 4, minimumFractionDigits: 1},
   {
     '1.2500': '1.25',
     '1.3125': '1.25',

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5.js
@@ -15,13 +15,13 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 5, maximumFractionDigits: 1},
+  {roundingIncrement: 5, maximumFractionDigits: 1, minimumFractionDigits: 1},
   {
     '1.500': '1.5',
     '1.625': '1.5',
-    '1.750': '2',
-    '1.875': '2',
-    '2.000': '2',
+    '1.750': '2.0',
+    '1.875': '2.0',
+    '2.000': '2.0',
   }
 );
 

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-50.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-50.js
@@ -15,13 +15,13 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 50, maximumFractionDigits: 2},
+  {roundingIncrement: 50, maximumFractionDigits: 2, minimumFractionDigits: 1},
   {
     '1.500': '1.5',
     '1.625': '1.5',
-    '1.750': '2',
-    '1.875': '2',
-    '2.000': '2',
+    '1.750': '2.0',
+    '1.875': '2.0',
+    '2.000': '2.0',
   }
 );
 

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-500.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-500.js
@@ -15,13 +15,13 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 500, maximumFractionDigits: 3},
+  {roundingIncrement: 500, maximumFractionDigits: 3, minimumFractionDigits: 1},
   {
     '1.500': '1.5',
     '1.625': '1.5',
-    '1.750': '2',
-    '1.875': '2',
-    '2.000': '2',
+    '1.750': '2.0',
+    '1.875': '2.0',
+    '2.000': '2.0',
   }
 );
 

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5000.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5000.js
@@ -15,13 +15,13 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 5000, maximumFractionDigits: 4},
+  {roundingIncrement: 5000, maximumFractionDigits: 4, minimumFractionDigits: 1},
   {
     '1.500': '1.5',
     '1.625': '1.5',
-    '1.750': '2',
-    '1.875': '2',
-    '2.000': '2',
+    '1.750': '2.0',
+    '1.875': '2.0',
+    '2.000': '2.0',
   }
 );
 

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-priority-less-precision.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-priority-less-precision.js
@@ -18,7 +18,7 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {useGrouping: false, roundingPriority: 'lessPrecision', minimumSignificantDigits: 2, minimumFractionDigitsDigits: 2},
+  {useGrouping: false, roundingPriority: 'lessPrecision', minimumSignificantDigits: 2, minimumFractionDigits: 2},
   {'1': '1.0'}
 );
 
@@ -26,7 +26,7 @@ testNumberFormat(
 testNumberFormat(
   locales,
   numberingSystems,
-  {useGrouping: false, roundingPriority: 'lessPrecision', minimumSignificantDigits: 3, minimumFractionDigitsDigits: 2},
+  {useGrouping: false, roundingPriority: 'lessPrecision', minimumSignificantDigits: 3, minimumFractionDigits: 1},
   {'1': '1.0'}
 );
 
@@ -34,7 +34,7 @@ testNumberFormat(
 testNumberFormat(
   locales,
   numberingSystems,
-  {useGrouping: false, roundingPriority: 'lessPrecision', maximumSignificantDigits: 2, maximumFractionDigitsDigits: 2},
+  {useGrouping: false, roundingPriority: 'lessPrecision', maximumSignificantDigits: 2, maximumFractionDigits: 2},
   {'1.23': '1.2'}
 );
 
@@ -42,6 +42,6 @@ testNumberFormat(
 testNumberFormat(
   locales,
   numberingSystems,
-  {useGrouping: false, roundingPriority: 'lessPrecision', maximumSignificantDigits: 3, maximumFractionDigitsDigits: 1},
+  {useGrouping: false, roundingPriority: 'lessPrecision', maximumSignificantDigits: 3, maximumFractionDigits: 1},
   {'1.234': '1.2'}
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-priority-less-precision.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-priority-less-precision.js
@@ -19,7 +19,7 @@ testNumberFormat(
   locales,
   numberingSystems,
   {useGrouping: false, roundingPriority: 'lessPrecision', minimumSignificantDigits: 2, minimumFractionDigits: 2},
-  {'1': '1.0'}
+  {'1': '1.00'}
 );
 
 // minimumSignificantDigits is more precise

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-priority-more-precision.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-priority-more-precision.js
@@ -18,7 +18,7 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {useGrouping: false, roundingPriority: 'morePrecision', minimumSignificantDigits: 2, minimumFractionDigitsDigits: 2},
+  {useGrouping: false, roundingPriority: 'morePrecision', minimumSignificantDigits: 2, minimumFractionDigits: 2},
   {'1': '1.00'}
 );
 
@@ -26,7 +26,7 @@ testNumberFormat(
 testNumberFormat(
   locales,
   numberingSystems,
-  {useGrouping: false, roundingPriority: 'morePrecision', minimumSignificantDigits: 3, minimumFractionDigitsDigits: 2},
+  {useGrouping: false, roundingPriority: 'morePrecision', minimumSignificantDigits: 3, minimumFractionDigits: 2},
   {'1': '1.00'}
 );
 
@@ -34,7 +34,7 @@ testNumberFormat(
 testNumberFormat(
   locales,
   numberingSystems,
-  {useGrouping: false, roundingPriority: 'morePrecision', maximumSignificantDigits: 2, maximumFractionDigitsDigits: 2},
+  {useGrouping: false, roundingPriority: 'morePrecision', maximumSignificantDigits: 2, maximumFractionDigits: 2},
   {'1.23': '1.23'}
 );
 
@@ -42,6 +42,6 @@ testNumberFormat(
 testNumberFormat(
   locales,
   numberingSystems,
-  {useGrouping: false, roundingPriority: 'morePrecision', maximumSignificantDigits: 3, maximumFractionDigitsDigits: 1},
+  {useGrouping: false, roundingPriority: 'morePrecision', maximumSignificantDigits: 3, maximumFractionDigits: 1},
   {'1.234': '1.23'}
 );


### PR DESCRIPTION
We need to set minimumFractionDigits: 1 for the case of {roundingIncrement: 5, maximumFractionDigits: 1} and also adjust the test expectation. 
Otherwise, inside testNumberFormat , it will call   getPatternParts to format 1.1 and -1.1 and cause pattern mismatch (because the result will be "1" instead of "1.1" in that configuration)

https://github.com/tc39/test262/blob/main/harness/testIntl.js#L2369