### PR TITLE
Intl.NumberFormat default useGrouping value is "auto"

### DIFF
--- a/test/intl402/NumberFormat/prototype/resolvedOptions/basic.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/basic.js
@@ -1,4 +1,5 @@
 // Copyright 2012 Mozilla Corporation. All rights reserved.
+// Copyright 2022 Apple Inc. All rights reserved.
 // This code is governed by the license found in the LICENSE file.
 
 /*---
@@ -9,6 +10,7 @@ description: >
     properties.
 author: Norbert Lindenberg
 includes: [testIntl.js, propertyHelper.js]
+features: [Intl.NumberFormat-v3]
 ---*/
 
 var actual = new Intl.NumberFormat().resolvedOptions();
@@ -25,7 +27,7 @@ assert.sameValue(actual.style, "decimal");
 assert.sameValue(actual.minimumIntegerDigits, 1);
 assert.sameValue(actual.minimumFractionDigits, 0);
 assert.sameValue(actual.maximumFractionDigits, 3);
-assert.sameValue(actual.useGrouping, true);
+assert.sameValue(actual.useGrouping, "auto");
 
 var dataPropertyDesc = { writable: true, enumerable: true, configurable: true };
 verifyProperty(actual, "locale", dataPropertyDesc);

--- a/test/intl402/NumberFormat/test-option-useGrouping.js
+++ b/test/intl402/NumberFormat/test-option-useGrouping.js
@@ -1,4 +1,5 @@
 // Copyright 2012 Mozilla Corporation. All rights reserved.
+// Copyright 2022 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -11,7 +12,25 @@ info: |
   published standard (when the tests' discrepancies can be resolved),
   implementations should only expect to pass one of these two tests.
 author: Norbert Lindenberg
-includes: [testIntl.js]
+features: [Intl.NumberFormat-v3]
 ---*/
 
-testOption(Intl.NumberFormat, "useGrouping", "boolean", undefined, true);
+function resolveUseGrouping(option) {
+  return new Intl.NumberFormat(undefined, { useGrouping: option }).resolvedOptions().useGrouping;
+}
+
+for (let string of ["min2", "auto", "always"]) {
+  assert.sameValue(resolveUseGrouping(string), string);
+}
+
+assert.sameValue(resolveUseGrouping(true), "always");
+assert.sameValue(resolveUseGrouping(false), false);
+assert.sameValue(resolveUseGrouping(undefined), "auto");
+
+for (let falsy of [0, null, ""]) {
+  assert.sameValue(resolveUseGrouping(falsy), false);
+}
+
+for (let truthy of [42, "MIN2", {}]) {
+  assert.throws(RangeError, () => { resolveUseGrouping(truthy); }, "Invalid truthy value");
+}


### PR DESCRIPTION
After Intl.NumberFormat v3, default useGrouping is "auto".