### PR TITLE
Add AggregateError as feature to seal-aggregateerror.js

### DIFF
--- a/test/built-ins/Object/seal/seal-aggregateerror.js
+++ b/test/built-ins/Object/seal/seal-aggregateerror.js
@@ -31,6 +31,7 @@ info: |
         Perform ? DefinePropertyOrThrow(O, k, desc).
   Return true.
 
+features: [AggregateError]
 ---*/
 
 Object.seal(new AggregateError([]));


### PR DESCRIPTION
Test case `seal-aggregateerror.js` cannot work without `AggregateError` being implemented.