### PR TITLE
Ensure that no tests outside of intl402/ require IANA time zones

### DIFF
--- a/test/built-ins/Temporal/Duration/compare/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/compare/timezone-string-datetime.js
@@ -15,10 +15,19 @@ assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(
 
 [
   "2021-08-19T17:30Z",
+  "2021-08-19T1730Z",
   "2021-08-19T17:30-07:00",
+  "2021-08-19T1730-07:00",
+  "2021-08-19T17:30-0700",
+  "2021-08-19T1730-0700",
   "2021-08-19T17:30[UTC]",
+  "2021-08-19T1730[UTC]",
   "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T1730Z[UTC]",
   "2021-08-19T17:30-07:00[UTC]",
+  "2021-08-19T1730-07:00[UTC]",
+  "2021-08-19T17:30-0700[UTC]",
+  "2021-08-19T1730-0700[UTC]",
 ].forEach((timeZone) => {
   Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
   Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } });

--- a/test/built-ins/Temporal/Duration/compare/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/compare/timezone-string-datetime.js
@@ -16,9 +16,9 @@ assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(
 [
   "2021-08-19T17:30Z",
   "2021-08-19T17:30-07:00",
-  "2021-08-19T17:30[America/Vancouver]",
-  "2021-08-19T17:30Z[America/Vancouver]",
-  "2021-08-19T17:30-07:00[America/Vancouver]",
+  "2021-08-19T17:30[UTC]",
+  "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T17:30-07:00[UTC]",
 ].forEach((timeZone) => {
   Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
   Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } });

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-string-datetime.js
@@ -24,17 +24,17 @@ relativeTo = "2019-11-01T00:00-07:00";
 const result3 = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
 TemporalHelpers.assertDuration(result3, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + offset is a plain relativeTo");
 
-relativeTo = "2019-11-01T00:00[America/Vancouver]";
+relativeTo = "2019-11-01T00:00[-07:00]";
 const result4 = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
-TemporalHelpers.assertDuration(result4, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + IANA annotation is a zoned relativeTo");
+TemporalHelpers.assertDuration(result4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00Z[America/Vancouver]";
+relativeTo = "2019-11-01T00:00Z[-07:00]";
 const result5 = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
-TemporalHelpers.assertDuration(result5, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation is a zoned relativeTo");
+TemporalHelpers.assertDuration(result5, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00-07:00[America/Vancouver]";
+relativeTo = "2019-11-01T00:00+00:00[UTC]";
 const result6 = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
-TemporalHelpers.assertDuration(result6, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation is a zoned relativeTo");
+TemporalHelpers.assertDuration(result6, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00+04:15[America/Vancouver]";
+relativeTo = "2019-11-01T00:00+04:15[UTC]";
 assert.throws(RangeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), "date-time + offset + IANA annotation throws if wall time and exact time mismatch");

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-string-zoneddatetime-wrong-offset.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-string-zoneddatetime-wrong-offset.js
@@ -9,4 +9,8 @@ features: [Temporal]
 
 const instance = new Temporal.Duration(1, 0, 0, 1);
 const relativeTo = "2000-01-01T00:00+05:30[UTC]";
-assert.throws(RangeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }));
+assert.throws(
+  RangeError,
+  () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }),
+  "add should throw RangeError on a string with UTC offset mismatch"
+);

--- a/test/built-ins/Temporal/Duration/prototype/add/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/timezone-string-datetime.js
@@ -18,9 +18,9 @@ assert.throws(RangeError, () => instance.add(new Temporal.Duration(1), { relativ
 [
   "2021-08-19T17:30Z",
   "2021-08-19T17:30-07:00",
-  "2021-08-19T17:30[America/Vancouver]",
-  "2021-08-19T17:30Z[America/Vancouver]",
-  "2021-08-19T17:30-07:00[America/Vancouver]",
+  "2021-08-19T17:30[UTC]",
+  "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T17:30-07:00[UTC]",
 ].forEach((timeZone) => {
   instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
   instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } });

--- a/test/built-ins/Temporal/Duration/prototype/add/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/timezone-string-datetime.js
@@ -17,10 +17,19 @@ assert.throws(RangeError, () => instance.add(new Temporal.Duration(1), { relativ
 
 [
   "2021-08-19T17:30Z",
+  "2021-08-19T1730Z",
   "2021-08-19T17:30-07:00",
+  "2021-08-19T1730-07:00",
+  "2021-08-19T17:30-0700",
+  "2021-08-19T1730-0700",
   "2021-08-19T17:30[UTC]",
+  "2021-08-19T1730[UTC]",
   "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T1730Z[UTC]",
   "2021-08-19T17:30-07:00[UTC]",
+  "2021-08-19T1730-07:00[UTC]",
+  "2021-08-19T17:30-0700[UTC]",
+  "2021-08-19T1730-0700[UTC]",
 ].forEach((timeZone) => {
   instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
   instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } });

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-string-datetime.js
@@ -24,17 +24,17 @@ relativeTo = "2019-11-01T00:00-07:00";
 const result3 = instance.round({ largestUnit: "years", relativeTo });
 TemporalHelpers.assertDuration(result3, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, "date-time + offset is a plain relativeTo");
 
-relativeTo = "2019-11-01T00:00[America/Vancouver]";
+relativeTo = "2019-11-01T00:00[-07:00]";
 const result4 = instance.round({ largestUnit: "years", relativeTo });
-TemporalHelpers.assertDuration(result4, 1, 0, 0, 0, 24, 0, 0, 0, 0, 0, "date-time + IANA annotation is a zoned relativeTo");
+TemporalHelpers.assertDuration(result4, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, "date-time + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00Z[America/Vancouver]";
+relativeTo = "2019-11-01T00:00Z[-07:00]";
 const result5 = instance.round({ largestUnit: "years", relativeTo });
-TemporalHelpers.assertDuration(result5, 1, 0, 0, 0, 24, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation is a zoned relativeTo");
+TemporalHelpers.assertDuration(result5, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00-07:00[America/Vancouver]";
+relativeTo = "2019-11-01T00:00+00:00[UTC]";
 const result6 = instance.round({ largestUnit: "years", relativeTo });
-TemporalHelpers.assertDuration(result6, 1, 0, 0, 0, 24, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation is a zoned relativeTo");
+TemporalHelpers.assertDuration(result6, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00+04:15[America/Vancouver]";
+relativeTo = "2019-11-01T00:00+04:15[UTC]";
 assert.throws(RangeError, () => instance.round({ largestUnit: "years", relativeTo }), "date-time + offset + IANA annotation throws if wall time and exact time mismatch");

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-string-zoneddatetime-wrong-offset.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-string-zoneddatetime-wrong-offset.js
@@ -9,4 +9,8 @@ features: [Temporal]
 
 const instance = new Temporal.Duration(1, 0, 0, 0, 24);
 const relativeTo = "2000-01-01T00:00+05:30[UTC]";
-assert.throws(RangeError, () => instance.round({ largestUnit: "years", relativeTo }));
+assert.throws(
+  RangeError,
+  () => instance.round({ largestUnit: "years", relativeTo }),
+  "round should throw RangeError on a string with UTC offset mismatch"
+);

--- a/test/built-ins/Temporal/Duration/prototype/round/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/timezone-string-datetime.js
@@ -18,9 +18,9 @@ assert.throws(RangeError, () => instance.round({ largestUnit: "months", relative
 [
   "2021-08-19T17:30Z",
   "2021-08-19T17:30-07:00",
-  "2021-08-19T17:30[America/Vancouver]",
-  "2021-08-19T17:30Z[America/Vancouver]",
-  "2021-08-19T17:30-07:00[America/Vancouver]",
+  "2021-08-19T17:30[UTC]",
+  "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T17:30-07:00[UTC]",
 ].forEach((timeZone) => {
   instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
   instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } });

--- a/test/built-ins/Temporal/Duration/prototype/round/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/timezone-string-datetime.js
@@ -17,10 +17,19 @@ assert.throws(RangeError, () => instance.round({ largestUnit: "months", relative
 
 [
   "2021-08-19T17:30Z",
+  "2021-08-19T1730Z",
   "2021-08-19T17:30-07:00",
+  "2021-08-19T1730-07:00",
+  "2021-08-19T17:30-0700",
+  "2021-08-19T1730-0700",
   "2021-08-19T17:30[UTC]",
+  "2021-08-19T1730[UTC]",
   "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T1730Z[UTC]",
   "2021-08-19T17:30-07:00[UTC]",
+  "2021-08-19T1730-07:00[UTC]",
+  "2021-08-19T17:30-0700[UTC]",
+  "2021-08-19T1730-0700[UTC]",
 ].forEach((timeZone) => {
   instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
   instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } });

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-string-datetime.js
@@ -24,17 +24,17 @@ relativeTo = "2019-11-01T00:00-07:00";
 const result3 = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
 TemporalHelpers.assertDuration(result3, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + offset is a plain relativeTo");
 
-relativeTo = "2019-11-01T00:00[America/Vancouver]";
+relativeTo = "2019-11-01T00:00[-07:00]";
 const result4 = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
-TemporalHelpers.assertDuration(result4, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + IANA annotation is a zoned relativeTo");
+TemporalHelpers.assertDuration(result4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00Z[America/Vancouver]";
+relativeTo = "2019-11-01T00:00Z[-07:00]";
 const result5 = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
-TemporalHelpers.assertDuration(result5, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation is a zoned relativeTo");
+TemporalHelpers.assertDuration(result5, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00-07:00[America/Vancouver]";
+relativeTo = "2019-11-01T00:00+00:00[UTC]";
 const result6 = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
-TemporalHelpers.assertDuration(result6, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation is a zoned relativeTo");
+TemporalHelpers.assertDuration(result6, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00+04:15[America/Vancouver]";
+relativeTo = "2019-11-01T00:00+04:15[UTC]";
 assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), "date-time + offset + IANA annotation throws if wall time and exact time mismatch");

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-string-zoneddatetime-wrong-offset.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-string-zoneddatetime-wrong-offset.js
@@ -9,4 +9,8 @@ features: [Temporal]
 
 const instance = new Temporal.Duration(1, 0, 0, 1);
 const relativeTo = "2000-01-01T00:00+05:30[UTC]";
-assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }));
+assert.throws(
+  RangeError,
+  () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }),
+  "subtract should throw RangeError on a string with UTC offset mismatch"
+);

--- a/test/built-ins/Temporal/Duration/prototype/subtract/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/timezone-string-datetime.js
@@ -17,10 +17,19 @@ assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(1), { re
 
 [
   "2021-08-19T17:30Z",
+  "2021-08-19T1730Z",
   "2021-08-19T17:30-07:00",
+  "2021-08-19T1730-07:00",
+  "2021-08-19T17:30-0700",
+  "2021-08-19T1730-0700",
   "2021-08-19T17:30[UTC]",
+  "2021-08-19T1730[UTC]",
   "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T1730Z[UTC]",
   "2021-08-19T17:30-07:00[UTC]",
+  "2021-08-19T1730-07:00[UTC]",
+  "2021-08-19T17:30-0700[UTC]",
+  "2021-08-19T1730-0700[UTC]",
 ].forEach((timeZone) => {
   instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
   instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } });

--- a/test/built-ins/Temporal/Duration/prototype/subtract/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/timezone-string-datetime.js
@@ -18,9 +18,9 @@ assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(1), { re
 [
   "2021-08-19T17:30Z",
   "2021-08-19T17:30-07:00",
-  "2021-08-19T17:30[America/Vancouver]",
-  "2021-08-19T17:30Z[America/Vancouver]",
-  "2021-08-19T17:30-07:00[America/Vancouver]",
+  "2021-08-19T17:30[UTC]",
+  "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T17:30-07:00[UTC]",
 ].forEach((timeZone) => {
   instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
   instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } });

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-string-datetime.js
@@ -23,17 +23,17 @@ relativeTo = "2019-11-01T00:00-07:00";
 const result3 = instance.total({ unit: "days", relativeTo });
 assert.sameValue(result3, 367, "date-time + offset is a plain relativeTo");
 
-relativeTo = "2019-11-01T00:00[America/Vancouver]";
+relativeTo = "2019-11-01T00:00[-07:00]";
 const result4 = instance.total({ unit: "days", relativeTo });
-assert.sameValue(result4, 366.96, "date-time + IANA annotation is a zoned relativeTo");
+assert.sameValue(result4, 367, "date-time + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00Z[America/Vancouver]";
+relativeTo = "2019-11-01T00:00Z[-07:00]";
 const result5 = instance.total({ unit: "days", relativeTo });
-assert.sameValue(result5, 366.96, "date-time + Z + IANA annotation is a zoned relativeTo");
+assert.sameValue(result5, 367, "date-time + Z + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00-07:00[America/Vancouver]";
+relativeTo = "2019-11-01T00:00+00:00[UTC]";
 const result6 = instance.total({ unit: "days", relativeTo });
-assert.sameValue(result6, 366.96, "date-time + offset + IANA annotation is a zoned relativeTo");
+assert.sameValue(result6, 367, "date-time + offset + IANA annotation is a zoned relativeTo");
 
-relativeTo = "2019-11-01T00:00+04:15[America/Vancouver]";
+relativeTo = "2019-11-01T00:00+04:15[UTC]";
 assert.throws(RangeError, () => instance.total({ unit: "days", relativeTo }), "date-time + offset + IANA annotation throws if wall time and exact time mismatch");

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-string-zoneddatetime-wrong-offset.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-string-zoneddatetime-wrong-offset.js
@@ -9,4 +9,8 @@ features: [Temporal]
 
 const instance = new Temporal.Duration(1, 0, 0, 0, 24);
 const relativeTo = "2000-01-01T00:00+05:30[UTC]";
-assert.throws(RangeError, () => instance.total({ unit: "days", relativeTo }));
+assert.throws(
+  RangeError,
+  () => instance.total({ unit: "days", relativeTo }),
+  "total should throw RangeError on a string with UTC offset mismatch"
+);

--- a/test/built-ins/Temporal/Duration/prototype/total/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/timezone-string-datetime.js
@@ -18,9 +18,9 @@ assert.throws(RangeError, () => instance.total({ unit: "months", relativeTo: { y
 [
   "2021-08-19T17:30Z",
   "2021-08-19T17:30-07:00",
-  "2021-08-19T17:30[America/Vancouver]",
-  "2021-08-19T17:30Z[America/Vancouver]",
-  "2021-08-19T17:30-07:00[America/Vancouver]",
+  "2021-08-19T17:30[UTC]",
+  "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T17:30-07:00[UTC]",
 ].forEach((timeZone) => {
   instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
   instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } });

--- a/test/built-ins/Temporal/Duration/prototype/total/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/timezone-string-datetime.js
@@ -17,10 +17,19 @@ assert.throws(RangeError, () => instance.total({ unit: "months", relativeTo: { y
 
 [
   "2021-08-19T17:30Z",
+  "2021-08-19T1730Z",
   "2021-08-19T17:30-07:00",
+  "2021-08-19T1730-07:00",
+  "2021-08-19T17:30-0700",
+  "2021-08-19T1730-0700",
   "2021-08-19T17:30[UTC]",
+  "2021-08-19T1730[UTC]",
   "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T1730Z[UTC]",
   "2021-08-19T17:30-07:00[UTC]",
+  "2021-08-19T1730-07:00[UTC]",
+  "2021-08-19T17:30-0700[UTC]",
+  "2021-08-19T1730-0700[UTC]",
 ].forEach((timeZone) => {
   instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } });
   instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } });

--- a/test/built-ins/Temporal/Instant/compare/instant-string.js
+++ b/test/built-ins/Temporal/Instant/compare/instant-string.js
@@ -13,7 +13,7 @@ const hourBefore = new Temporal.Instant(-3600_000_000_000n);
 let str = "1970-01-01T00:00";
 assert.throws(RangeError, () => Temporal.Instant.compare(str, epoch), "bare date-time string is not an instant (first argument)");
 assert.throws(RangeError, () => Temporal.Instant.compare(epoch, str), "bare date-time string is not an instant (second argument)");
-str = "1970-01-01T00:00[America/Vancouver]";
+str = "1970-01-01T00:00[UTC]";
 assert.throws(RangeError, () => Temporal.Instant.compare(str, epoch), "date-time + IANA annotation is not an instant (first argument)");
 assert.throws(RangeError, () => Temporal.Instant.compare(epoch, str), "date-time + IANA annotation is not an instant (second argument)");
 
@@ -25,10 +25,10 @@ str = "1970-01-01T00:00+01:00";
 assert.sameValue(Temporal.Instant.compare(str, hourBefore), 0, "date-time + offset preserves exact time with offset (first argument)");
 assert.sameValue(Temporal.Instant.compare(hourBefore, str), 0, "date-time + offset preserves exact time with offset (second argument)");
 
-str = "1970-01-01T00:00Z[America/Vancouver]";
+str = "1970-01-01T00:00Z[Etc/Ignored]";
 assert.sameValue(Temporal.Instant.compare(str, epoch), 0, "date-time + Z + IANA annotation ignores the IANA annotation (first argument)");
 assert.sameValue(Temporal.Instant.compare(epoch, str), 0, "date-time + Z + IANA annotation ignores the IANA annotation (second argument)");
 
-str = "1970-01-01T00:00+01:00[America/Vancouver]";
+str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 assert.sameValue(Temporal.Instant.compare(str, hourBefore), 0, "date-time + offset + IANA annotation ignores the IANA annotation (first argument)");
 assert.sameValue(Temporal.Instant.compare(hourBefore, str), 0, "date-time + offset + IANA annotation ignores the IANA annotation (second argument)");

--- a/test/built-ins/Temporal/Instant/from/instant-string.js
+++ b/test/built-ins/Temporal/Instant/from/instant-string.js
@@ -9,7 +9,7 @@ features: [Temporal]
 
 let str = "1970-01-01T00:00";
 assert.throws(RangeError, () => Temporal.Instant.from(str), "bare date-time string is not an instant");
-str = "1970-01-01T00:00[America/Vancouver]";
+str = "1970-01-01T00:00[UTC]";
 assert.throws(RangeError, () => Temporal.Instant.from(str), "date-time + IANA annotation is not an instant");
 
 str = "1970-01-01T00:00Z";
@@ -20,10 +20,10 @@ str = "1970-01-01T00:00+01:00";
 const result2 = Temporal.Instant.from(str);
 assert.sameValue(result2.epochNanoseconds, -3600_000_000_000n, "date-time + offset preserves exact time with offset");
 
-str = "1970-01-01T00:00Z[America/Vancouver]";
+str = "1970-01-01T00:00Z[Etc/Ignored]";
 const result3 = Temporal.Instant.from(str);
 assert.sameValue(result3.epochNanoseconds, 0n, "date-time + Z + IANA annotation ignores the IANA annotation");
 
-str = "1970-01-01T00:00+01:00[America/Vancouver]";
+str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 const result4 = Temporal.Instant.from(str);
 assert.sameValue(result4.epochNanoseconds, -3600_000_000_000n, "date-time + offset + IANA annotation ignores the IANA annotation");

--- a/test/built-ins/Temporal/Instant/prototype/equals/instant-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/instant-string.js
@@ -11,7 +11,7 @@ const instance = new Temporal.Instant(0n);
 
 let str = "1970-01-01T00:00";
 assert.throws(RangeError, () => instance.equals(str), "bare date-time string is not an instant");
-str = "1970-01-01T00:00[America/Vancouver]";
+str = "1970-01-01T00:00[UTC]";
 assert.throws(RangeError, () => instance.equals(str), "date-time + IANA annotation is not an instant");
 
 str = "1970-01-01T00:00Z";
@@ -22,10 +22,10 @@ str = "1970-01-01T00:00+01:00";
 const result2 = instance.equals(str);
 assert.sameValue(result2, false, "date-time + offset preserves exact time with offset");
 
-str = "1970-01-01T00:00Z[America/Vancouver]";
+str = "1970-01-01T00:00Z[Etc/Ignored]";
 const result3 = instance.equals(str);
 assert.sameValue(result3, true, "date-time + Z + IANA annotation ignores the IANA annotation");
 
-str = "1970-01-01T00:00+01:00[America/Vancouver]";
+str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 const result4 = instance.equals(str);
 assert.sameValue(result4, false, "date-time + offset + IANA annotation ignores the IANA annotation");

--- a/test/built-ins/Temporal/Instant/prototype/since/instant-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/instant-string.js
@@ -12,7 +12,7 @@ const instance = new Temporal.Instant(0n);
 
 let str = "1970-01-01T00:00";
 assert.throws(RangeError, () => instance.since(str), "bare date-time string is not an instant");
-str = "1970-01-01T00:00[America/Vancouver]";
+str = "1970-01-01T00:00[UTC]";
 assert.throws(RangeError, () => instance.since(str), "date-time + IANA annotation is not an instant");
 
 str = "1970-01-01T00:00Z";
@@ -23,10 +23,10 @@ str = "1970-01-01T00:00+01:00";
 const result2 = instance.since(str);
 TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 3600, 0, 0, 0, "date-time + offset preserves exact time with offset");
 
-str = "1970-01-01T00:00Z[America/Vancouver]";
+str = "1970-01-01T00:00Z[Etc/Ignored]";
 const result3 = instance.since(str);
 TemporalHelpers.assertDuration(result3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation ignores the IANA annotation");
 
-str = "1970-01-01T00:00+01:00[America/Vancouver]";
+str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 const result4 = instance.since(str);
 TemporalHelpers.assertDuration(result4, 0, 0, 0, 0, 0, 0, 3600, 0, 0, 0, "date-time + offset + IANA annotation ignores the IANA annotation");

--- a/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/timezone-string-datetime.js
@@ -25,20 +25,20 @@ assert.sameValue(result3.substr(-6), "-07:00", "date-time + offset is the offset
 const result4 = instance.toString({ timeZone: { timeZone } });
 assert.sameValue(result4.substr(-6), "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = instance.toString({ timeZone });
-assert.sameValue(result5.substr(-6), "-08:00", "date-time + IANA annotation is the offset time zone");
+assert.sameValue(result5.substr(-6), "+00:00", "date-time + IANA annotation is the offset time zone");
 const result6 = instance.toString({ timeZone: { timeZone } });
-assert.sameValue(result6.substr(-6), "-08:00", "date-time + IANA annotation is the offset time zone (string in property bag)");
+assert.sameValue(result6.substr(-6), "+00:00", "date-time + IANA annotation is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 const result7 = instance.toString({ timeZone });
-assert.sameValue(result7.substr(-6), "-08:00", "date-time + Z + IANA annotation is the offset time zone");
+assert.sameValue(result7.substr(-6), "+00:00", "date-time + Z + IANA annotation is the offset time zone");
 const result8 = instance.toString({ timeZone: { timeZone } });
-assert.sameValue(result8.substr(-6), "-08:00", "date-time + Z + IANA annotation is the offset time zone (string in property bag)");
+assert.sameValue(result8.substr(-6), "+00:00", "date-time + Z + IANA annotation is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 const result9 = instance.toString({ timeZone });
-assert.sameValue(result9.substr(-6), "-08:00", "date-time + offset + IANA annotation is the offset time zone");
+assert.sameValue(result9.substr(-6), "+00:00", "date-time + offset + IANA annotation is the offset time zone");
 const result10 = instance.toString({ timeZone: { timeZone } });
-assert.sameValue(result10.substr(-6), "-08:00", "date-time + offset + IANA annotation is the offset time zone (string in property bag)");
+assert.sameValue(result10.substr(-6), "+00:00", "date-time + offset + IANA annotation is the offset time zone (string in property bag)");

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -25,20 +25,20 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = instance.toZonedDateTime({ timeZone: { timeZone }, calendar: "iso8601" });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = instance.toZonedDateTime({ timeZone, calendar: "iso8601" });
-assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result5.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone");
 const result6 = instance.toZonedDateTime({ timeZone: { timeZone }, calendar: "iso8601" });
-assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 const result7 = instance.toZonedDateTime({ timeZone, calendar: "iso8601" });
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+assert.sameValue(result7.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone");
 const result8 = instance.toZonedDateTime({ timeZone: { timeZone }, calendar: "iso8601" });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result8.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 const result9 = instance.toZonedDateTime({ timeZone, calendar: "iso8601" });
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+assert.sameValue(result9.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone");
 const result10 = instance.toZonedDateTime({ timeZone: { timeZone }, calendar: "iso8601" });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result10.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-string-datetime.js
@@ -25,20 +25,20 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = instance.toZonedDateTimeISO({ timeZone });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = instance.toZonedDateTimeISO(timeZone);
-assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result5.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone");
 const result6 = instance.toZonedDateTimeISO({ timeZone });
-assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 const result7 = instance.toZonedDateTimeISO(timeZone);
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+assert.sameValue(result7.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone");
 const result8 = instance.toZonedDateTimeISO({ timeZone });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result8.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 const result9 = instance.toZonedDateTimeISO(timeZone);
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+assert.sameValue(result9.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone");
 const result10 = instance.toZonedDateTimeISO({ timeZone });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result10.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/built-ins/Temporal/Instant/prototype/until/instant-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/instant-string.js
@@ -12,7 +12,7 @@ const instance = new Temporal.Instant(0n);
 
 let str = "1970-01-01T00:00";
 assert.throws(RangeError, () => instance.until(str), "bare date-time string is not an instant");
-str = "1970-01-01T00:00[America/Vancouver]";
+str = "1970-01-01T00:00[UTC]";
 assert.throws(RangeError, () => instance.until(str), "date-time + IANA annotation is not an instant");
 
 str = "1970-01-01T00:00Z";
@@ -23,10 +23,10 @@ str = "1970-01-01T00:00+01:00";
 const result2 = instance.until(str);
 TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, -3600, 0, 0, 0, "date-time + offset preserves exact time with offset");
 
-str = "1970-01-01T00:00Z[America/Vancouver]";
+str = "1970-01-01T00:00Z[Etc/Ignored]";
 const result3 = instance.until(str);
 TemporalHelpers.assertDuration(result3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation ignores the IANA annotation");
 
-str = "1970-01-01T00:00+01:00[America/Vancouver]";
+str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 const result4 = instance.until(str);
 TemporalHelpers.assertDuration(result4, 0, 0, 0, 0, 0, 0, -3600, 0, 0, 0, "date-time + offset + IANA annotation ignores the IANA annotation");

--- a/test/built-ins/Temporal/Now/plainDate/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDate/timezone-string-datetime.js
@@ -16,9 +16,9 @@ assert.throws(RangeError, () => Temporal.Now.plainDate("iso8601", { timeZone }),
 [
   "2021-08-19T17:30Z",
   "2021-08-19T17:30-07:00",
-  "2021-08-19T17:30[America/Vancouver]",
-  "2021-08-19T17:30Z[America/Vancouver]",
-  "2021-08-19T17:30-07:00[America/Vancouver]",
+  "2021-08-19T17:30[UTC]",
+  "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T17:30-07:00[UTC]",
 ].forEach((timeZone) => {
   Temporal.Now.plainDate("iso8601", timeZone);
   Temporal.Now.plainDate("iso8601", { timeZone });

--- a/test/built-ins/Temporal/Now/plainDate/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDate/timezone-string-datetime.js
@@ -15,10 +15,19 @@ assert.throws(RangeError, () => Temporal.Now.plainDate("iso8601", { timeZone }),
 
 [
   "2021-08-19T17:30Z",
+  "2021-08-19T1730Z",
   "2021-08-19T17:30-07:00",
+  "2021-08-19T1730-07:00",
+  "2021-08-19T17:30-0700",
+  "2021-08-19T1730-0700",
   "2021-08-19T17:30[UTC]",
+  "2021-08-19T1730[UTC]",
   "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T1730Z[UTC]",
   "2021-08-19T17:30-07:00[UTC]",
+  "2021-08-19T1730-07:00[UTC]",
+  "2021-08-19T17:30-0700[UTC]",
+  "2021-08-19T1730-0700[UTC]",
 ].forEach((timeZone) => {
   Temporal.Now.plainDate("iso8601", timeZone);
   Temporal.Now.plainDate("iso8601", { timeZone });

--- a/test/built-ins/Temporal/Now/plainDateISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDateISO/timezone-string-datetime.js
@@ -16,9 +16,9 @@ assert.throws(RangeError, () => Temporal.Now.plainDateISO({ timeZone }), "bare d
 [
   "2021-08-19T17:30Z",
   "2021-08-19T17:30-07:00",
-  "2021-08-19T17:30[America/Vancouver]",
-  "2021-08-19T17:30Z[America/Vancouver]",
-  "2021-08-19T17:30-07:00[America/Vancouver]",
+  "2021-08-19T17:30[UTC]",
+  "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T17:30-07:00[UTC]",
 ].forEach((timeZone) => {
   Temporal.Now.plainDateISO(timeZone);
   Temporal.Now.plainDateISO({ timeZone });

--- a/test/built-ins/Temporal/Now/plainDateISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDateISO/timezone-string-datetime.js
@@ -15,10 +15,19 @@ assert.throws(RangeError, () => Temporal.Now.plainDateISO({ timeZone }), "bare d
 
 [
   "2021-08-19T17:30Z",
+  "2021-08-19T1730Z",
   "2021-08-19T17:30-07:00",
+  "2021-08-19T1730-07:00",
+  "2021-08-19T17:30-0700",
+  "2021-08-19T1730-0700",
   "2021-08-19T17:30[UTC]",
+  "2021-08-19T1730[UTC]",
   "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T1730Z[UTC]",
   "2021-08-19T17:30-07:00[UTC]",
+  "2021-08-19T1730-07:00[UTC]",
+  "2021-08-19T17:30-0700[UTC]",
+  "2021-08-19T1730-0700[UTC]",
 ].forEach((timeZone) => {
   Temporal.Now.plainDateISO(timeZone);
   Temporal.Now.plainDateISO({ timeZone });

--- a/test/built-ins/Temporal/Now/plainDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/timezone-string-datetime.js
@@ -16,9 +16,9 @@ assert.throws(RangeError, () => Temporal.Now.plainDateTime("iso8601", { timeZone
 [
   "2021-08-19T17:30Z",
   "2021-08-19T17:30-07:00",
-  "2021-08-19T17:30[America/Vancouver]",
-  "2021-08-19T17:30Z[America/Vancouver]",
-  "2021-08-19T17:30-07:00[America/Vancouver]",
+  "2021-08-19T17:30[UTC]",
+  "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T17:30-07:00[UTC]",
 ].forEach((timeZone) => {
   Temporal.Now.plainDateTime("iso8601", timeZone);
   Temporal.Now.plainDateTime("iso8601", { timeZone });

--- a/test/built-ins/Temporal/Now/plainDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/timezone-string-datetime.js
@@ -15,10 +15,19 @@ assert.throws(RangeError, () => Temporal.Now.plainDateTime("iso8601", { timeZone
 
 [
   "2021-08-19T17:30Z",
+  "2021-08-19T1730Z",
   "2021-08-19T17:30-07:00",
+  "2021-08-19T1730-07:00",
+  "2021-08-19T17:30-0700",
+  "2021-08-19T1730-0700",
   "2021-08-19T17:30[UTC]",
+  "2021-08-19T1730[UTC]",
   "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T1730Z[UTC]",
   "2021-08-19T17:30-07:00[UTC]",
+  "2021-08-19T1730-07:00[UTC]",
+  "2021-08-19T17:30-0700[UTC]",
+  "2021-08-19T1730-0700[UTC]",
 ].forEach((timeZone) => {
   Temporal.Now.plainDateTime("iso8601", timeZone);
   Temporal.Now.plainDateTime("iso8601", { timeZone });

--- a/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-string-datetime.js
@@ -1,5 +1,6 @@
 // Copyright (C) 2021 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
+
 /*---
 esid: sec-temporal.now.plaindatetimeiso
 description: Conversion of ISO date-time strings to Temporal.TimeZone instances

--- a/test/built-ins/Temporal/Now/plainTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainTimeISO/timezone-string-datetime.js
@@ -16,9 +16,9 @@ assert.throws(RangeError, () => Temporal.Now.plainTimeISO({ timeZone }), "bare d
 [
   "2021-08-19T17:30Z",
   "2021-08-19T17:30-07:00",
-  "2021-08-19T17:30[America/Vancouver]",
-  "2021-08-19T17:30Z[America/Vancouver]",
-  "2021-08-19T17:30-07:00[America/Vancouver]",
+  "2021-08-19T17:30[UTC]",
+  "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T17:30-07:00[UTC]",
 ].forEach((timeZone) => {
   Temporal.Now.plainTimeISO(timeZone);
   Temporal.Now.plainTimeISO({ timeZone });

--- a/test/built-ins/Temporal/Now/plainTimeISO/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/Now/plainTimeISO/timezone-string-datetime.js
@@ -15,10 +15,19 @@ assert.throws(RangeError, () => Temporal.Now.plainTimeISO({ timeZone }), "bare d
 
 [
   "2021-08-19T17:30Z",
+  "2021-08-19T1730Z",
   "2021-08-19T17:30-07:00",
+  "2021-08-19T1730-07:00",
+  "2021-08-19T17:30-0700",
+  "2021-08-19T1730-0700",
   "2021-08-19T17:30[UTC]",
+  "2021-08-19T1730[UTC]",
   "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T1730Z[UTC]",
   "2021-08-19T17:30-07:00[UTC]",
+  "2021-08-19T1730-07:00[UTC]",
+  "2021-08-19T17:30-0700[UTC]",
+  "2021-08-19T1730-0700[UTC]",
 ].forEach((timeZone) => {
   Temporal.Now.plainTimeISO(timeZone);
   Temporal.Now.plainTimeISO({ timeZone });

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/basic.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/basic.js
@@ -8,23 +8,23 @@ features: [Temporal]
 ---*/
 
 const plainDate = Temporal.PlainDate.from("2020-01-01");
-const timeZone = Temporal.TimeZone.from("America/Los_Angeles");
+const timeZone = Temporal.TimeZone.from("UTC");
 const plainTime = Temporal.PlainTime.from("12:00");
 
 let result = plainDate.toZonedDateTime({ timeZone, plainTime });
-assert.sameValue(result.toString(), "2020-01-01T12:00:00-08:00[America/Los_Angeles]", "objects passed");
+assert.sameValue(result.toString(), "2020-01-01T12:00:00+00:00[UTC]", "objects passed");
 
 result = plainDate.toZonedDateTime(timeZone);
-assert.sameValue(result.toString(), "2020-01-01T00:00:00-08:00[America/Los_Angeles]", "time zone object argument");
+assert.sameValue(result.toString(), "2020-01-01T00:00:00+00:00[UTC]", "time zone object argument");
 
-result = plainDate.toZonedDateTime("America/Los_Angeles");
-assert.sameValue(result.toString(), "2020-01-01T00:00:00-08:00[America/Los_Angeles]", "time zone string argument");
+result = plainDate.toZonedDateTime("UTC");
+assert.sameValue(result.toString(), "2020-01-01T00:00:00+00:00[UTC]", "time zone string argument");
 
 result = plainDate.toZonedDateTime({ timeZone });
-assert.sameValue(result.toString(), "2020-01-01T00:00:00-08:00[America/Los_Angeles]", "time zone object property");
+assert.sameValue(result.toString(), "2020-01-01T00:00:00+00:00[UTC]", "time zone object property");
 
-result = plainDate.toZonedDateTime({ timeZone: "America/Los_Angeles", plainTime });
-assert.sameValue(result.toString(), "2020-01-01T12:00:00-08:00[America/Los_Angeles]", "time zone string property");
+result = plainDate.toZonedDateTime({ timeZone: "UTC", plainTime });
+assert.sameValue(result.toString(), "2020-01-01T12:00:00+00:00[UTC]", "time zone string property");
 
 result = plainDate.toZonedDateTime({ timeZone, plainTime: "12:00" });
-assert.sameValue(result.toString(), "2020-01-01T12:00:00-08:00[America/Los_Angeles]", "time string property");
+assert.sameValue(result.toString(), "2020-01-01T12:00:00+00:00[UTC]", "time string property");

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -25,20 +25,20 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = instance.toZonedDateTime({ timeZone });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = instance.toZonedDateTime(timeZone);
-assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result5.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone");
 const result6 = instance.toZonedDateTime({ timeZone });
-assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 const result7 = instance.toZonedDateTime(timeZone);
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+assert.sameValue(result7.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone");
 const result8 = instance.toZonedDateTime({ timeZone });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result8.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 const result9 = instance.toZonedDateTime(timeZone);
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+assert.sameValue(result9.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone");
 const result10 = instance.toZonedDateTime({ timeZone });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result10.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -25,20 +25,20 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = instance.toZonedDateTime({ timeZone });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = instance.toZonedDateTime(timeZone);
-assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result5.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone");
 const result6 = instance.toZonedDateTime({ timeZone });
-assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 const result7 = instance.toZonedDateTime(timeZone);
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+assert.sameValue(result7.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone");
 const result8 = instance.toZonedDateTime({ timeZone });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result8.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 const result9 = instance.toZonedDateTime(timeZone);
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+assert.sameValue(result9.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone");
 const result10 = instance.toZonedDateTime({ timeZone });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result10.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/basic.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/basic.js
@@ -9,16 +9,16 @@ features: [Temporal]
 
 const plainTime = Temporal.PlainTime.from('12:00');
 const plainDate = Temporal.PlainDate.from('2020-07-08');
-const timeZone = Temporal.TimeZone.from('America/Los_Angeles');
+const timeZone = Temporal.TimeZone.from('-07:00');
 
 const objects = plainTime.toZonedDateTime({ timeZone, plainDate });
 assert.sameValue(objects.epochNanoseconds, 1594234800000000000n, "objects: epochNanoseconds");
 assert.sameValue(objects.timeZone, timeZone, "objects: timeZone");
 
-const timeZoneString = plainTime.toZonedDateTime({ timeZone: "America/Los_Angeles", plainDate });
+const timeZoneString = plainTime.toZonedDateTime({ timeZone: "-07:00", plainDate });
 assert.sameValue(timeZoneString.epochNanoseconds, 1594234800000000000n, "timeZone string: epochNanoseconds");
-assert.sameValue(timeZoneString.timeZone.id, "America/Los_Angeles", "timeZone string: timeZone");
+assert.sameValue(timeZoneString.timeZone.id, "-07:00", "timeZone string: timeZone");
 
 const plainDateString = plainTime.toZonedDateTime({ timeZone, plainDate: "2020-07-08" });
 assert.sameValue(plainDateString.epochNanoseconds, 1594234800000000000n, "plainDate string: epochNanoseconds");
-assert.sameValue(plainDateString.timeZone.id, "America/Los_Angeles", "plainDate string: timeZone");
+assert.sameValue(plainDateString.timeZone.id, "-07:00", "plainDate string: timeZone");

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -25,20 +25,20 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone: { timeZone } });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone });
-assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result5.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone");
 const result6 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone: { timeZone } });
-assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 const result7 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone });
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+assert.sameValue(result7.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone");
 const result8 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone: { timeZone } });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result8.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 const result9 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone });
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+assert.sameValue(result9.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone");
 const result10 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone: { timeZone } });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result10.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/built-ins/Temporal/TimeZone/from/argument-primitive.js
+++ b/test/built-ins/Temporal/TimeZone/from/argument-primitive.js
@@ -16,7 +16,7 @@ const primitives = [
   "string",
   "local",
   "Z",
-  "-08:00[America/Vancouver]",
+  "-00:00[UTC]",
   "+00:01.1",
   "-01.1",
   "1994-11-05T08:15:30+25:00",

--- a/test/built-ins/Temporal/TimeZone/from/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/TimeZone/from/timezone-string-datetime.js
@@ -23,20 +23,20 @@ assert.sameValue(result3.id, "-07:00", "date-time + offset is the offset time zo
 const result4 = Temporal.TimeZone.from({ timeZone });
 assert.sameValue(result4.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = Temporal.TimeZone.from(timeZone);
-assert.sameValue(result5.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result5.id, "UTC", "date-time + IANA annotation is the IANA time zone");
 const result6 = Temporal.TimeZone.from({ timeZone });
-assert.sameValue(result6.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result6.id, "UTC", "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 const result7 = Temporal.TimeZone.from(timeZone);
-assert.sameValue(result7.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+assert.sameValue(result7.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone");
 const result8 = Temporal.TimeZone.from({ timeZone });
-assert.sameValue(result8.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result8.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 const result9 = Temporal.TimeZone.from(timeZone);
-assert.sameValue(result9.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+assert.sameValue(result9.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone");
 const result10 = Temporal.TimeZone.from({ timeZone });
-assert.sameValue(result10.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result10.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/instant-string.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/instant-string.js
@@ -12,7 +12,7 @@ const instance = new Temporal.TimeZone("UTC");
 
 let str = "1970-01-01T00:00";
 assert.throws(RangeError, () => instance.getPlainDateTimeFor(str), "bare date-time string is not an instant");
-str = "1970-01-01T00:00[America/Vancouver]";
+str = "1970-01-01T00:00[UTC]";
 assert.throws(RangeError, () => instance.getPlainDateTimeFor(str), "date-time + IANA annotation is not an instant");
 
 str = "1970-01-01T00:00Z";
@@ -23,10 +23,10 @@ str = "1970-01-01T00:00+01:00";
 const result2 = instance.getPlainDateTimeFor(str);
 TemporalHelpers.assertPlainDateTime(result2, 1969, 12, "M12", 31, 23, 0, 0, 0, 0, 0, "date-time + offset preserves exact time with offset");
 
-str = "1970-01-01T00:00Z[America/Vancouver]";
+str = "1970-01-01T00:00Z[Etc/Ignored]";
 const result3 = instance.getPlainDateTimeFor(str);
 TemporalHelpers.assertPlainDateTime(result3, 1970, 1, "M01", 1, 0, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation ignores the IANA annotation");
 
-str = "1970-01-01T00:00+01:00[America/Vancouver]";
+str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 const result4 = instance.getPlainDateTimeFor(str);
 TemporalHelpers.assertPlainDateTime(result4, 1969, 12, "M12", 31, 23, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation ignores the IANA annotation");

--- a/test/built-ins/Temporal/ZonedDateTime/compare/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/timezone-string-datetime.js
@@ -20,9 +20,9 @@ assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(instance, { year:
 [
   "2021-08-19T17:30Z",
   "2021-08-19T17:30-07:00",
-  "2021-08-19T17:30[America/Vancouver]",
-  "2021-08-19T17:30Z[America/Vancouver]",
-  "2021-08-19T17:30-07:00[America/Vancouver]",
+  "2021-08-19T17:30[UTC]",
+  "2021-08-19T17:30Z[UTC]",
+  "2021-08-19T17:30-07:00[UTC]",
 ].forEach((timeZone) => {
   Temporal.ZonedDateTime.compare({ year: 2000, month: 5, day: 2, timeZone }, instance);
   Temporal.ZonedDateTime.compare(instance, { year: 2000, month: 5, day: 2, timeZone });

--- a/test/built-ins/Temporal/ZonedDateTime/compare/zoneddatetime-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/zoneddatetime-string.js
@@ -20,24 +20,24 @@ str = "1970-01-01T00:00+01:00";
 assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(str, epoch), "date-time + offset is not a ZonedDateTime (first argument)");
 assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(epoch, str), "date-time + offset is not a ZonedDateTime (second argument)");
 
-str = "1970-01-01T00:00[Europe/Berlin]";
+str = "1970-01-01T00:00[+01:00]";
 const result1 = Temporal.ZonedDateTime.compare(str, hourBefore);
 assert.sameValue(result1, 0, "date-time + IANA annotation preserves wall time in the time zone (first argument)");
 const result2 = Temporal.ZonedDateTime.compare(hourBefore, str);
 assert.sameValue(result2, 0, "date-time + IANA annotation preserves wall time in the time zone (second argument)");
 
-str = "1970-01-01T00:00Z[Europe/Berlin]";
+str = "1970-01-01T00:00Z[+01:00]";
 const result3 = Temporal.ZonedDateTime.compare(str, epoch);
 assert.sameValue(result3, 0, "date-time + Z + IANA annotation preserves exact time in the time zone (first argument)");
 const result4 = Temporal.ZonedDateTime.compare(epoch, str);
 assert.sameValue(result4, 0, "date-time + Z + IANA annotation preserves exact time in the time zone (second argument)");
 
-str = "1970-01-01T00:00+01:00[Europe/Berlin]";
+str = "1970-01-01T00:00+01:00[+01:00]";
 const result5 = Temporal.ZonedDateTime.compare(str, hourBefore);
 assert.sameValue(result5, 0, "date-time + offset + IANA annotation ensures both exact and wall time match (first argument)");
 const result6 = Temporal.ZonedDateTime.compare(hourBefore, str);
 assert.sameValue(result6, 0, "date-time + offset + IANA annotation ensures both exact and wall time match (second argument)");
 
-str = "1970-01-01T00:00-04:15[Europe/Berlin]";
+str = "1970-01-01T00:00-04:15[+01:00]";
 assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(str, epoch), "date-time + offset + IANA annotation throws if wall time and exact time mismatch (first argument)");
 assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(epoch, str), "date-time + offset + IANA annotation throws if wall time and exact time mismatch (second argument)");

--- a/test/built-ins/Temporal/ZonedDateTime/from/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/timezone-string-datetime.js
@@ -23,20 +23,20 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone: { timeZone } });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone });
-assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result5.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone");
 const result6 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone: { timeZone } });
-assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 const result7 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone });
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+assert.sameValue(result7.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone");
 const result8 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone: { timeZone } });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result8.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 const result9 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone });
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+assert.sameValue(result9.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone");
 const result10 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone: { timeZone } });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result10.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/built-ins/Temporal/ZonedDateTime/from/zoneddatetime-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/zoneddatetime-string.js
@@ -14,24 +14,24 @@ assert.throws(RangeError, () => Temporal.ZonedDateTime.from(str), "date-time + Z
 str = "1970-01-01T00:00+01:00";
 assert.throws(RangeError, () => Temporal.ZonedDateTime.from(str), "date-time + offset is not a ZonedDateTime");
 
-str = "1970-01-01T00:00[Europe/Berlin]";
+str = "1970-01-01T00:00[+01:00]";
 const result1 = Temporal.ZonedDateTime.from(str);
 assert.sameValue(result1.epochNanoseconds, -3600_000_000_000n, "date-time + IANA annotation preserves wall time in the time zone");
-assert.sameValue(result1.timeZone.toString(), "Europe/Berlin", "IANA annotation is not ignored");
+assert.sameValue(result1.timeZone.toString(), "+01:00", "IANA annotation is not ignored");
 
-str = "1970-01-01T00:00Z[Europe/Berlin]";
+str = "1970-01-01T00:00Z[+01:00]";
 const result2 = Temporal.ZonedDateTime.from(str);
 assert.sameValue(result2.epochNanoseconds, 0n, "date-time + Z + IANA annotation preserves exact time in the time zone");
-assert.sameValue(result2.timeZone.toString(), "Europe/Berlin", "IANA annotation is not ignored");
+assert.sameValue(result2.timeZone.toString(), "+01:00", "IANA annotation is not ignored");
 
-str = "1970-01-01T00:00+01:00[Europe/Berlin]";
+str = "1970-01-01T00:00+01:00[+01:00]";
 const result3 = Temporal.ZonedDateTime.from(str);
 assert.sameValue(result3.epochNanoseconds, -3600_000_000_000n, "date-time + offset + IANA annotation ensures both exact and wall time match");
-assert.sameValue(result3.timeZone.toString(), "Europe/Berlin", "IANA annotation is not ignored");
+assert.sameValue(result3.timeZone.toString(), "+01:00", "IANA annotation is not ignored");
 
-str = "1970-01-01T00:00-04:15[Europe/Berlin]";
+str = "1970-01-01T00:00-04:15[+01:00]";
 assert.throws(RangeError, () => Temporal.ZonedDateTime.from(str), "date-time + offset + IANA annotation throws if wall time and exact time mismatch");
 assert.throws(RangeError, () => Temporal.ZonedDateTime.from(str, { offset: "reject" }), "date-time + offset + IANA annotation throws if wall time and exact time mismatch (explicit reject option)");
 const result4 = Temporal.ZonedDateTime.from(str, { offset: "ignore" });
 assert.sameValue(result4.epochNanoseconds, -3600_000_000_000n, "date-time + wrong offset + IANA annotation preserves wall time in the time zone (offset: ignore option)");
-assert.sameValue(result4.timeZone.toString(), "Europe/Berlin", "IANA annotation is not ignored");
+assert.sameValue(result4.timeZone.toString(), "+01:00", "IANA annotation is not ignored");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/timezone-string-datetime.js
@@ -28,16 +28,15 @@ timeZone = "2021-02-19T17:30-08:00";
 assert(instance2.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone }), "date-time + offset is the offset time zone");
 assert(instance2.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone: { timeZone } }), "date-time + offset is the offset time zone (string in property bag)");
 
-expectedTimeZone = "America/Vancouver";
 const instance3 = new Temporal.ZonedDateTime(0n, expectedTimeZone);
-timeZone = "2021-02-19T17:30[America/Vancouver]";
+timeZone = "2021-02-19T17:30[-08:00]";
 assert(instance3.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone }), "date-time + IANA annotation is the IANA time zone");
 assert(instance3.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone: { timeZone } }), "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-02-19T17:30Z[America/Vancouver]";
+timeZone = "2021-02-19T17:30Z[-08:00]";
 assert(instance3.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone }), "date-time + Z + IANA annotation is the IANA time zone");
 assert(instance3.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone: { timeZone } }), "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-02-19T17:30-08:00[America/Vancouver]";
+timeZone = "2021-02-19T17:30-08:00[-08:00]";
 assert(instance3.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone }), "date-time + offset + IANA annotation is the IANA time zone");
 assert(instance3.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone: { timeZone } }), "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/timezone-string-datetime.js
@@ -28,16 +28,16 @@ timeZone = "2021-08-19T17:30-07:00";
 instance2.since({ year: 2020, month: 5, day: 2, timeZone });
 instance2.since({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });
 
-expectedTimeZone = "America/Vancouver";
+expectedTimeZone = "UTC";
 const instance3 = new Temporal.ZonedDateTime(0n, expectedTimeZone);
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 instance3.since({ year: 2020, month: 5, day: 2, timeZone });
 instance3.since({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 instance3.since({ year: 2020, month: 5, day: 2, timeZone });
 instance3.since({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 instance3.since({ year: 2020, month: 5, day: 2, timeZone });
 instance3.since({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/timezone-string-datetime.js
@@ -28,16 +28,16 @@ timeZone = "2021-08-19T17:30-07:00";
 instance2.until({ year: 2020, month: 5, day: 2, timeZone });
 instance2.until({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });
 
-expectedTimeZone = "America/Vancouver";
+expectedTimeZone = "UTC";
 const instance3 = new Temporal.ZonedDateTime(0n, expectedTimeZone);
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 instance3.until({ year: 2020, month: 5, day: 2, timeZone });
 instance3.until({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 instance3.until({ year: 2020, month: 5, day: 2, timeZone });
 instance3.until({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 instance3.until({ year: 2020, month: 5, day: 2, timeZone });
 instance3.until({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/with/offset-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/with/offset-undefined.js
@@ -14,7 +14,7 @@ info: |
 features: [Temporal]
 ---*/
 
-const timeZone = new Temporal.TimeZone("America/St_Johns");
+const timeZone = new Temporal.TimeZone("-03:30");
 
 const datetime = new Temporal.ZonedDateTime(1572757201_000_000_000n, timeZone);
 const explicit = datetime.with({ minute: 31 }, { offset: undefined });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone/timezone-string-datetime.js
@@ -25,20 +25,20 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = instance.withTimeZone({ timeZone });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = instance.withTimeZone(timeZone);
-assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result5.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone");
 const result6 = instance.withTimeZone({ timeZone });
-assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 const result7 = instance.withTimeZone(timeZone);
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+assert.sameValue(result7.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone");
 const result8 = instance.withTimeZone({ timeZone });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result8.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 const result9 = instance.withTimeZone(timeZone);
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+assert.sameValue(result9.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone");
 const result10 = instance.withTimeZone({ timeZone });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result10.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/built-ins/Temporal/ZonedDateTime/timezone-string-datetime.js
+++ b/test/built-ins/Temporal/ZonedDateTime/timezone-string-datetime.js
@@ -23,20 +23,20 @@ assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offse
 const result4 = new Temporal.ZonedDateTime(0n, { timeZone });
 assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30[America/Vancouver]";
+timeZone = "2021-08-19T17:30[UTC]";
 const result5 = new Temporal.ZonedDateTime(0n, timeZone);
-assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+assert.sameValue(result5.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone");
 const result6 = new Temporal.ZonedDateTime(0n, { timeZone });
-assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result6.timeZone.id, "UTC", "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+timeZone = "2021-08-19T17:30Z[UTC]";
 const result7 = new Temporal.ZonedDateTime(0n, timeZone);
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+assert.sameValue(result7.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone");
 const result8 = new Temporal.ZonedDateTime(0n, { timeZone });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result8.timeZone.id, "UTC", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
-timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+timeZone = "2021-08-19T17:30-07:00[UTC]";
 const result9 = new Temporal.ZonedDateTime(0n, timeZone);
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+assert.sameValue(result9.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone");
 const result10 = new Temporal.ZonedDateTime(0n, { timeZone });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result10.timeZone.id, "UTC", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/Duration/prototype/add/relativeto-string-datetime.js
+++ b/test/intl402/Temporal/Duration/prototype/add/relativeto-string-datetime.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: >
+    Conversion of ISO date-time strings as relativeTo option to
+    Temporal.ZonedDateTime or Temporal.PlainDateTime instances
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+let relativeTo = "2019-11-01T00:00[America/Vancouver]";
+const result4 = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
+TemporalHelpers.assertDuration(result4, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00Z[America/Vancouver]";
+const result5 = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
+TemporalHelpers.assertDuration(result5, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00-07:00[America/Vancouver]";
+const result6 = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
+TemporalHelpers.assertDuration(result6, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00+04:15[America/Vancouver]";
+assert.throws(RangeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), "date-time + offset + IANA annotation throws if wall time and exact time mismatch");

--- a/test/intl402/Temporal/Duration/prototype/round/relativeto-string-datetime.js
+++ b/test/intl402/Temporal/Duration/prototype/round/relativeto-string-datetime.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+    Conversion of ISO date-time strings as relativeTo option to
+    Temporal.ZonedDateTime or Temporal.PlainDateTime instances
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+let relativeTo = "2019-11-01T00:00[America/Vancouver]";
+const result4 = instance.round({ largestUnit: "years", relativeTo });
+TemporalHelpers.assertDuration(result4, 1, 0, 0, 0, 24, 0, 0, 0, 0, 0, "date-time + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00Z[America/Vancouver]";
+const result5 = instance.round({ largestUnit: "years", relativeTo });
+TemporalHelpers.assertDuration(result5, 1, 0, 0, 0, 24, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00-07:00[America/Vancouver]";
+const result6 = instance.round({ largestUnit: "years", relativeTo });
+TemporalHelpers.assertDuration(result6, 1, 0, 0, 0, 24, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00+04:15[America/Vancouver]";
+assert.throws(RangeError, () => instance.round({ largestUnit: "years", relativeTo }), "date-time + offset + IANA annotation throws if wall time and exact time mismatch");

--- a/test/intl402/Temporal/Duration/prototype/subtract/relativeto-string-datetime.js
+++ b/test/intl402/Temporal/Duration/prototype/subtract/relativeto-string-datetime.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: >
+    Conversion of ISO date-time strings as relativeTo option to
+    Temporal.ZonedDateTime or Temporal.PlainDateTime instances
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+let relativeTo = "2019-11-01T00:00[America/Vancouver]";
+const result4 = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
+TemporalHelpers.assertDuration(result4, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00Z[America/Vancouver]";
+const result5 = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
+TemporalHelpers.assertDuration(result5, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + Z + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00-07:00[America/Vancouver]";
+const result6 = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
+TemporalHelpers.assertDuration(result6, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00+04:15[America/Vancouver]";
+assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), "date-time + offset + IANA annotation throws if wall time and exact time mismatch");

--- a/test/intl402/Temporal/Duration/prototype/total/relativeto-string-datetime.js
+++ b/test/intl402/Temporal/Duration/prototype/total/relativeto-string-datetime.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+    Conversion of ISO date-time strings as relativeTo option to
+    Temporal.ZonedDateTime or Temporal.PlainDateTime instances
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+let relativeTo = "2019-11-01T00:00[America/Vancouver]";
+const result4 = instance.total({ unit: "days", relativeTo });
+assert.sameValue(result4, 366.96, "date-time + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00Z[America/Vancouver]";
+const result5 = instance.total({ unit: "days", relativeTo });
+assert.sameValue(result5, 366.96, "date-time + Z + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00-07:00[America/Vancouver]";
+const result6 = instance.total({ unit: "days", relativeTo });
+assert.sameValue(result6, 366.96, "date-time + offset + IANA annotation is a zoned relativeTo");
+
+relativeTo = "2019-11-01T00:00+04:15[America/Vancouver]";
+assert.throws(RangeError, () => instance.total({ unit: "days", relativeTo }), "date-time + offset + IANA annotation throws if wall time and exact time mismatch");

--- a/test/intl402/Temporal/Instant/prototype/toString/timezone-string-datetime.js
+++ b/test/intl402/Temporal/Instant/prototype/toString/timezone-string-datetime.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
+const result1 = instance.toString({ timeZone });
+assert.sameValue(result1.substr(-6), "-08:00", "date-time + IANA annotation is the IANA time zone");
+const result2 = instance.toString({ timeZone: { timeZone } });
+assert.sameValue(result2.substr(-6), "-08:00", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+const result3 = instance.toString({ timeZone });
+assert.sameValue(result3.substr(-6), "-08:00", "date-time + Z + IANA annotation is the IANA time zone");
+const result4 = instance.toString({ timeZone: { timeZone } });
+assert.sameValue(result4.substr(-6), "-08:00", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+const result5 = instance.toString({ timeZone });
+assert.sameValue(result5.substr(-6), "-08:00", "date-time + offset + IANA annotation is the IANA time zone");
+const result6 = instance.toString({ timeZone: { timeZone } });
+assert.sameValue(result6.substr(-6), "-08:00", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/Instant/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/intl402/Temporal/Instant/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tozoneddatetime
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
+const result1 = instance.toZonedDateTime({ timeZone, calendar: "iso8601" });
+assert.sameValue(result1.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+const result2 = instance.toZonedDateTime({ timeZone: { timeZone }, calendar: "iso8601" });
+assert.sameValue(result2.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+const result3 = instance.toZonedDateTime({ timeZone, calendar: "iso8601" });
+assert.sameValue(result3.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+const result4 = instance.toZonedDateTime({ timeZone: { timeZone }, calendar: "iso8601" });
+assert.sameValue(result4.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+const result5 = instance.toZonedDateTime({ timeZone, calendar: "iso8601" });
+assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result6 = instance.toZonedDateTime({ timeZone: { timeZone }, calendar: "iso8601" });
+assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-string-datetime.js
+++ b/test/intl402/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-string-datetime.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tozoneddatetimeiso
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
+const result1 = instance.toZonedDateTimeISO(timeZone);
+assert.sameValue(result1.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+const result2 = instance.toZonedDateTimeISO({ timeZone });
+assert.sameValue(result2.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+const result3 = instance.toZonedDateTimeISO(timeZone);
+assert.sameValue(result3.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+const result4 = instance.toZonedDateTimeISO({ timeZone });
+assert.sameValue(result4.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+const result5 = instance.toZonedDateTimeISO(timeZone);
+assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result6 = instance.toZonedDateTimeISO({ timeZone });
+assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/Now/zonedDateTime/timezone-string-datetime.js
+++ b/test/intl402/Temporal/Now/zonedDateTime/timezone-string-datetime.js
@@ -3,52 +3,24 @@
 
 /*---
 esid: sec-temporal.now.zoneddatetime
-description: Conversion of ISO date-time strings to Temporal.TimeZone instances
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
 features: [Temporal]
 ---*/
 
-let timeZone = "2021-08-19T17:30";
-assert.throws(RangeError, () => Temporal.Now.zonedDateTime("iso8601", timeZone), "bare date-time string is not a time zone");
-assert.throws(RangeError, () => Temporal.Now.zonedDateTime("iso8601", { timeZone }), "bare date-time string is not a time zone");
-
-timeZone = "2021-08-19T17:30Z";
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
 const result1 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result1.timeZone.id, "UTC", "date-time + Z is UTC time zone");
+assert.sameValue(result1.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
 const result2 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result2.timeZone.id, "UTC", "date-time + Z is UTC time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30-07:00";
-const result3 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
-const result4 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30-0700";
-const result5 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result5.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
-const result6 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result6.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30[America/Vancouver]";
-const result7 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
-const result8 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result2.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
 timeZone = "2021-08-19T17:30Z[America/Vancouver]";
-const result9 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
-const result10 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+const result3 = Temporal.Now.zonedDateTime("iso8601", timeZone);
+assert.sameValue(result3.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+const result4 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
+assert.sameValue(result4.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
 timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
-const result11 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result11.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
-const result12 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result12.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30-0700[America/Vancouver]";
-const result13 = Temporal.Now.zonedDateTime("iso8601", timeZone);
-assert.sameValue(result13.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
-const result14 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
-assert.sameValue(result14.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+const result5 = Temporal.Now.zonedDateTime("iso8601", timeZone);
+assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result6 = Temporal.Now.zonedDateTime("iso8601", { timeZone });
+assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/Now/zonedDateTime/timezone-string-datetime.js
+++ b/test/intl402/Temporal/Now/zonedDateTime/timezone-string-datetime.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---

--- a/test/intl402/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
+++ b/test/intl402/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
@@ -3,52 +3,24 @@
 
 /*---
 esid: sec-temporal.now.zoneddatetimeiso
-description: Conversion of ISO date-time strings to Temporal.TimeZone instances
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
 features: [Temporal]
 ---*/
 
-let timeZone = "2021-08-19T17:30";
-assert.throws(RangeError, () => Temporal.Now.zonedDateTimeISO(timeZone), "bare date-time string is not a time zone");
-assert.throws(RangeError, () => Temporal.Now.zonedDateTimeISO({ timeZone }), "bare date-time string is not a time zone");
-
-timeZone = "2021-08-19T17:30Z";
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
 const result1 = Temporal.Now.zonedDateTimeISO(timeZone);
-assert.sameValue(result1.timeZone.id, "UTC", "date-time + Z is UTC time zone");
+assert.sameValue(result1.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
 const result2 = Temporal.Now.zonedDateTimeISO({ timeZone });
-assert.sameValue(result2.timeZone.id, "UTC", "date-time + Z is UTC time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30-07:00";
-const result3 = Temporal.Now.zonedDateTimeISO(timeZone);
-assert.sameValue(result3.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
-const result4 = Temporal.Now.zonedDateTimeISO({ timeZone });
-assert.sameValue(result4.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30-0700";
-const result5 = Temporal.Now.zonedDateTimeISO(timeZone);
-assert.sameValue(result5.timeZone.id, "-07:00", "date-time + offset is the offset time zone");
-const result6 = Temporal.Now.zonedDateTimeISO({ timeZone });
-assert.sameValue(result6.timeZone.id, "-07:00", "date-time + offset is the offset time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30[America/Vancouver]";
-const result7 = Temporal.Now.zonedDateTimeISO(timeZone);
-assert.sameValue(result7.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
-const result8 = Temporal.Now.zonedDateTimeISO({ timeZone });
-assert.sameValue(result8.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+assert.sameValue(result2.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
 
 timeZone = "2021-08-19T17:30Z[America/Vancouver]";
-const result9 = Temporal.Now.zonedDateTimeISO(timeZone);
-assert.sameValue(result9.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
-const result10 = Temporal.Now.zonedDateTimeISO({ timeZone });
-assert.sameValue(result10.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+const result3 = Temporal.Now.zonedDateTimeISO(timeZone);
+assert.sameValue(result3.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+const result4 = Temporal.Now.zonedDateTimeISO({ timeZone });
+assert.sameValue(result4.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
 
 timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
-const result11 = Temporal.Now.zonedDateTimeISO(timeZone);
-assert.sameValue(result11.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
-const result12 = Temporal.Now.zonedDateTimeISO({ timeZone });
-assert.sameValue(result12.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
-
-timeZone = "2021-08-19T17:30-0700[America/Vancouver]";
-const result13 = Temporal.Now.zonedDateTimeISO(timeZone);
-assert.sameValue(result13.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
-const result14 = Temporal.Now.zonedDateTimeISO({ timeZone });
-assert.sameValue(result14.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");
+const result5 = Temporal.Now.zonedDateTimeISO(timeZone);
+assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result6 = Temporal.Now.zonedDateTimeISO({ timeZone });
+assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
+++ b/test/intl402/Temporal/Now/zonedDateTimeISO/timezone-string-datetime.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---

--- a/test/intl402/Temporal/PlainDate/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/intl402/Temporal/PlainDate/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
+const result1 = instance.toZonedDateTime(timeZone);
+assert.sameValue(result1.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+const result2 = instance.toZonedDateTime({ timeZone });
+assert.sameValue(result2.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+const result3 = instance.toZonedDateTime(timeZone);
+assert.sameValue(result3.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+const result4 = instance.toZonedDateTime({ timeZone });
+assert.sameValue(result4.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+const result5 = instance.toZonedDateTime(timeZone);
+assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result6 = instance.toZonedDateTime({ timeZone });
+assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tozoneddatetime
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
+
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
+const result1 = instance.toZonedDateTime(timeZone);
+assert.sameValue(result1.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+const result2 = instance.toZonedDateTime({ timeZone });
+assert.sameValue(result2.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+const result3 = instance.toZonedDateTime(timeZone);
+assert.sameValue(result3.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+const result4 = instance.toZonedDateTime({ timeZone });
+assert.sameValue(result4.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+const result5 = instance.toZonedDateTime(timeZone);
+assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result6 = instance.toZonedDateTime({ timeZone });
+assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/PlainTime/prototype/toZonedDateTime/timezone-string-datetime.js
+++ b/test/intl402/Temporal/PlainTime/prototype/toZonedDateTime/timezone-string-datetime.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime();
+
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
+const result1 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone });
+assert.sameValue(result1.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+const result2 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone: { timeZone } });
+assert.sameValue(result2.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+const result3 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone });
+assert.sameValue(result3.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+const result4 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone: { timeZone } });
+assert.sameValue(result4.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+const result5 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone });
+assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result6 = instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone: { timeZone } });
+assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/TimeZone/from/timezone-string-datetime.js
+++ b/test/intl402/Temporal/TimeZone/from/timezone-string-datetime.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.from
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
+features: [Temporal]
+---*/
+
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
+const result1 = Temporal.TimeZone.from(timeZone);
+assert.sameValue(result1.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+const result2 = Temporal.TimeZone.from({ timeZone });
+assert.sameValue(result2.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+const result3 = Temporal.TimeZone.from(timeZone);
+assert.sameValue(result3.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+const result4 = Temporal.TimeZone.from({ timeZone });
+assert.sameValue(result4.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+const result5 = Temporal.TimeZone.from(timeZone);
+assert.sameValue(result5.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result6 = Temporal.TimeZone.from({ timeZone });
+assert.sameValue(result6.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/ZonedDateTime/from/timezone-string-datetime.js
+++ b/test/intl402/Temporal/ZonedDateTime/from/timezone-string-datetime.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
+features: [Temporal]
+---*/
+
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
+const result1 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone });
+assert.sameValue(result1.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone");
+const result2 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone: { timeZone } });
+assert.sameValue(result2.timeZone.id, "America/Vancouver", "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+const result3 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone });
+assert.sameValue(result3.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone");
+const result4 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone: { timeZone } });
+assert.sameValue(result4.timeZone.id, "America/Vancouver", "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+const result5 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone });
+assert.sameValue(result5.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone");
+const result6 = Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone: { timeZone } });
+assert.sameValue(result6.timeZone.id, "America/Vancouver", "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/ZonedDateTime/prototype/equals/timezone-string-datetime.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/equals/timezone-string-datetime.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
+features: [Temporal]
+---*/
+
+const expectedTimeZone = "America/Vancouver";
+const instance = new Temporal.ZonedDateTime(0n, expectedTimeZone);
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
+assert(instance.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone }), "date-time + IANA annotation is the IANA time zone");
+assert(instance.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone: { timeZone } }), "date-time + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+assert(instance.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone }), "date-time + Z + IANA annotation is the IANA time zone");
+assert(instance.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone: { timeZone } }), "date-time + Z + IANA annotation is the IANA time zone (string in property bag)");
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+assert(instance.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone }), "date-time + offset + IANA annotation is the IANA time zone");
+assert(instance.equals({ year: 1969, month: 12, day: 31, hour: 16, timeZone: { timeZone } }), "date-time + offset + IANA annotation is the IANA time zone (string in property bag)");

--- a/test/intl402/Temporal/ZonedDateTime/prototype/since/timezone-string-datetime.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/since/timezone-string-datetime.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
+features: [Temporal]
+---*/
+
+const expectedTimeZone = "America/Vancouver";
+const instance = new Temporal.ZonedDateTime(0n, expectedTimeZone);
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
+instance.since({ year: 2020, month: 5, day: 2, timeZone });
+instance.since({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+instance.since({ year: 2020, month: 5, day: 2, timeZone });
+instance.since({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+instance.since({ year: 2020, month: 5, day: 2, timeZone });
+instance.since({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });

--- a/test/intl402/Temporal/ZonedDateTime/prototype/until/timezone-string-datetime.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/until/timezone-string-datetime.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: Conversion of ISO date-time strings to Temporal.TimeZone instances (with Intl time zones)
+features: [Temporal]
+---*/
+
+const expectedTimeZone = "America/Vancouver";
+const instance = new Temporal.ZonedDateTime(0n, expectedTimeZone);
+let timeZone = "2021-08-19T17:30[America/Vancouver]";
+instance.until({ year: 2020, month: 5, day: 2, timeZone });
+instance.until({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });
+
+timeZone = "2021-08-19T17:30Z[America/Vancouver]";
+instance.until({ year: 2020, month: 5, day: 2, timeZone });
+instance.until({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });
+
+timeZone = "2021-08-19T17:30-07:00[America/Vancouver]";
+instance.until({ year: 2020, month: 5, day: 2, timeZone });
+instance.until({ year: 2020, month: 5, day: 2, timeZone: { timeZone } });


### PR DESCRIPTION
As discussed in https://github.com/tc39/test262/pull/3286, tests in built-ins/ should not require that an implementation supports IANA time zones, because only implementations that conform to ECMA-402 are required to support those.

This PR changes the existing tests in built-ins/ so that they only use offset time zones or the "UTC" named time zone, which all implementations are required to support. In cases where that actually meant that certain functionality was no longer covered by tests, I added new tests in intl402/ to cover it.

Also includes some minor formatting and consistency fixes that I encountered along the way.