### PR TITLE
Update DurationFormat tests

### DIFF
--- a/test/intl402/DurationFormat/instance/length.js
+++ b/test/intl402/DurationFormat/instance/length.js
@@ -25,8 +25,6 @@ features: [Intl.DurationFormat]
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.DurationFormat.length, 0);
-
 verifyProperty(Intl.DurationFormat, 'length', {
   value: 0,
   enumerable: false,

--- a/test/intl402/DurationFormat/instance/length.js
+++ b/test/intl402/DurationFormat/instance/length.js
@@ -27,6 +27,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(Intl.DurationFormat.length, 0);
 
-verifyNotEnumerable(Intl.DurationFormat, "length");
-verifyNotWritable(Intl.DurationFormat, "length");
-verifyConfigurable(Intl.DurationFormat, "length");
+verifyProperty(Intl.DurationFormat, 'length', {
+  enumerable: false,
+  writable: false,
+  configurable: true
+});

--- a/test/intl402/DurationFormat/instance/length.js
+++ b/test/intl402/DurationFormat/instance/length.js
@@ -28,6 +28,7 @@ includes: [propertyHelper.js]
 assert.sameValue(Intl.DurationFormat.length, 0);
 
 verifyProperty(Intl.DurationFormat, 'length', {
+  value: 0,
   enumerable: false,
   writable: false,
   configurable: true

--- a/test/intl402/DurationFormat/instance/name.js
+++ b/test/intl402/DurationFormat/instance/name.js
@@ -21,9 +21,8 @@ features: [Intl.DurationFormat]
 includes: [propertyHelper.js]
 ---*/
 
-assert.sameValue(Intl.DurationFormat.name, "DurationFormat");
-
 verifyProperty(Intl.DurationFormat, 'name', {
+  value: 'DurationFormat',
   enumerable: false,
   writable: false,
   configurable: true

--- a/test/intl402/DurationFormat/instance/name.js
+++ b/test/intl402/DurationFormat/instance/name.js
@@ -23,6 +23,8 @@ includes: [propertyHelper.js]
 
 assert.sameValue(Intl.DurationFormat.name, "DurationFormat");
 
-verifyNotEnumerable(Intl.DurationFormat, "name");
-verifyNotWritable(Intl.DurationFormat, "name");
-verifyConfigurable(Intl.DurationFormat, "name");
+verifyProperty(Intl.DurationFormat, 'name', {
+  enumerable: false,
+  writable: false,
+  configurable: true
+});

--- a/test/intl402/DurationFormat/instance/prop-desc.js
+++ b/test/intl402/DurationFormat/instance/prop-desc.js
@@ -25,6 +25,8 @@ features: [Intl.DurationFormat]
 includes: [propertyHelper.js]
 ---*/
 
-verifyNotEnumerable(Intl, "DurationFormat");
-verifyWritable(Intl, "DurationFormat");
-verifyConfigurable(Intl, "DurationFormat");
+verifyProperty(Intl, 'DurationFormat', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/test/intl402/DurationFormat/prototype/format/length.js
+++ b/test/intl402/DurationFormat/prototype/format/length.js
@@ -21,6 +21,7 @@ info: |
     object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
     [[Configurable]]: true }.
 
+features: [Intl.DurationFormat]
 includes: [propertyHelper.js]
 ---*/
 

--- a/test/intl402/DurationFormat/prototype/formatToParts/length.js
+++ b/test/intl402/DurationFormat/prototype/formatToParts/length.js
@@ -21,6 +21,7 @@ info: |
     object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
     [[Configurable]]: true }.
 
+features: [Intl.DurationFormat]
 includes: [propertyHelper.js]
 ---*/
 

--- a/test/intl402/DurationFormat/prototype/resolvedOptions/length.js
+++ b/test/intl402/DurationFormat/prototype/resolvedOptions/length.js
@@ -21,6 +21,7 @@ info: |
     object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
     [[Configurable]]: true }.
 
+features: [Intl.DurationFormat]
 includes: [propertyHelper.js]
 ---*/
 


### PR DESCRIPTION
Summary:

- Amend missing feature fields in test description 
- Update code style to use `verifyProperty` instead of method for each `Writable` , `Configurable` , `Enumerable`
- Also solves comments https://github.com/tc39/test262/pull/3378#discussion_r791500096 and https://github.com/tc39/test262/pull/3378#discussion_r791499618