### PR TITLE
Tests covering normative Temporal changes from October '21 TC39 plenary

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.dateAdd(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/year-zero.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: Negative zero, as extended year, is invalid
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+const date = new Temporal.PlainDate(2000, 5, 2);
+const bad = "-000000-03-14";
+
+assert.throws(
+  RangeError,
+  () => calendar.dateUntil(bad, date),
+  "cannot use minus zero as extended date (first argument)"
+);
+
+assert.throws(
+  RangeError,
+  () => calendar.dateUntil(date, bad),
+  "cannot use minus zero as extended date (second argument)"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/day/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.day
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.day(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofweek
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.dayOfWeek(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofyear
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.dayOfYear(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinmonth
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.daysInMonth(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinweek
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.daysInWeek(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinyear
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.daysInYear(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.inleapyear
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.inLeapYear(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/month/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.month
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.month(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthcode
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.monthCode(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthsinyear
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.monthsInYear(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.weekofyear
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.weekOfYear(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/year/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.year
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.year(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Duration/compare/calendar-possibly-required.js
+++ b/test/built-ins/Temporal/Duration/compare/calendar-possibly-required.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: relativeTo argument needed if days = 0 but years/months/weeks non-zero
+features: [Temporal]
+---*/
+const duration1 = new Temporal.Duration(1);
+const duration2 = new Temporal.Duration(0, 12);
+const duration3 = new Temporal.Duration(0, 0, 5);
+const duration4 = new Temporal.Duration(0, 0, 0, 42);
+const relativeTo = new Temporal.PlainDate(2021, 12, 15);
+assert.throws(
+  RangeError,
+  () => { Temporal.Duration.compare(duration1, duration1); },
+  "cannot compare Duration values without relativeTo if year is non-zero"
+);
+assert.sameValue(0,
+  Temporal.Duration.compare(duration1, duration1, { relativeTo }),
+  "compare succeeds for year-only Duration provided relativeTo is supplied");
+assert.throws(
+  RangeError,
+  () => { Temporal.Duration.compare(duration2, duration2); },
+  "cannot compare Duration values without relativeTo if month is non-zero"
+);
+assert.sameValue(0,
+  Temporal.Duration.compare(duration2, duration2, { relativeTo }),
+  "compare succeeds for year-and-month Duration provided relativeTo is supplied");
+assert.throws(
+  RangeError,
+  () => { Temporal.Duration.compare(duration3, duration3); },
+  "cannot compare Duration values without relativeTo if week is non-zero"
+);
+assert.sameValue(0,
+  Temporal.Duration.compare(duration3, duration3, { relativeTo }),
+  "compare succeeds for year-and-month-and-week Duration provided relativeTo is supplied"
+);
+
+assert.sameValue(0,
+  Temporal.Duration.compare(duration4, duration4),
+  "compare succeeds for zero year-month-week non-zero day Duration even without relativeTo");
+
+// Double-check that the comparison also works with a relative-to argument
+assert.sameValue(0,
+  Temporal.Duration.compare(duration4, duration4, { relativeTo }),
+  "compare succeeds for zero year-month-week non-zero day Duration with relativeTo"
+);

--- a/test/built-ins/Temporal/Duration/compare/year-zero.js
+++ b/test/built-ins/Temporal/Duration/compare/year-zero.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: Negative zero, as an extended year, fails
+features: [Temporal]
+---*/
+
+const duration1 = new Temporal.Duration(1);
+const duration2 = new Temporal.Duration(2);
+const bad = "-000000-11-01";
+
+assert.throws(
+  RangeError,
+  () => Temporal.Duration.compare(duration1, duration2, { relativeTo: bad }),
+  "Cannot use negative zero as extended year"
+);

--- a/test/built-ins/Temporal/Duration/prototype/add/year-zero.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+let relativeTo = "-000000-11-04T00:00";
+assert.throws(
+  RangeError,
+  () => { instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }); },
+  "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Duration/prototype/round/calendar-possibly-required.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/calendar-possibly-required.js
@@ -1,0 +1,62 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: relativeTo argument required if days = 0 but years/months/weeks non-zero
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+const duration1 = new Temporal.Duration(1);
+const duration2 = new Temporal.Duration(0, 12);
+const duration3 = new Temporal.Duration(0, 0, 5);
+const duration4 = new Temporal.Duration(0, 0, 0, 42);
+const pd = new Temporal.PlainDate(2021, 12, 15);
+const relativeToYears = { relativeTo: pd, largestUnit: "years" };
+const relativeToMonths = { relativeTo: pd, largestUnit: "months" };
+const relativeToWeeks = { relativeTo: pd, largestUnit: "weeks" };
+const relativeToDays = { relativeTo: pd, largestUnit: "days" };
+
+assert.throws(
+  RangeError,
+  () => { duration1.round({ relativeTo: pd }); },
+  "rounding a year Duration fails without largest/smallest unit"
+);
+
+TemporalHelpers.assertDuration(duration1.round(relativeToYears), 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "round year duration to years");
+TemporalHelpers.assertDuration(duration1.round(relativeToMonths), 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, "round year duration to months");
+TemporalHelpers.assertDuration(duration1.round(relativeToWeeks), 0, 0, 52, 1, 0, 0, 0, 0, 0, 0, "round year duration to weeks");
+TemporalHelpers.assertDuration(duration1.round(relativeToDays), 0, 0, 0, 365, 0, 0, 0, 0, 0, 0, "round year duration to days");
+
+assert.throws(
+  RangeError,
+  () => { duration2.round({ relativeTo: pd }); },
+  "rounding a month Duration fails without largest/smallest unit"
+);
+
+TemporalHelpers.assertDuration(duration2.round(relativeToYears), 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "round month duration to years");
+TemporalHelpers.assertDuration(duration2.round(relativeToMonths), 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, "round month duration to months");
+TemporalHelpers.assertDuration(duration2.round(relativeToWeeks), 0, 0, 52, 1, 0, 0, 0, 0, 0, 0, "round month duration to weeks");
+TemporalHelpers.assertDuration(duration2.round(relativeToDays), 0, 0, 0, 365, 0, 0, 0, 0, 0, 0, "round month duration to days");
+
+assert.throws(
+  RangeError,
+  () => { duration3.round({ relativeTo: pd }); },
+  "rounding a week Duration fails without largest/smallest unit"
+);
+
+TemporalHelpers.assertDuration(duration3.round(relativeToYears), 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, "round week duration to years");
+TemporalHelpers.assertDuration(duration3.round(relativeToMonths), 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, "round week duration to months");
+TemporalHelpers.assertDuration(duration3.round(relativeToWeeks), 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, "round week duration to weeks");
+TemporalHelpers.assertDuration(duration3.round(relativeToDays), 0, 0, 0, 35, 0, 0, 0, 0, 0, 0, "round week duration to days");
+
+assert.throws(
+  RangeError,
+  () => { duration4.round({ relativeTo: pd }); },
+  "rounding a day Duration fails without largest/smallest unit"
+);
+
+TemporalHelpers.assertDuration(duration4.round(relativeToYears), 0, 1, 0, 11, 0, 0, 0, 0, 0, 0, "round day duration to years");
+TemporalHelpers.assertDuration(duration4.round(relativeToMonths), 0, 1, 0, 11, 0, 0, 0, 0, 0, 0, "round day duration to months");
+TemporalHelpers.assertDuration(duration4.round(relativeToWeeks), 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, "round day duration to weeks");
+TemporalHelpers.assertDuration(duration4.round(relativeToDays), 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, "round day duration to days");

--- a/test/built-ins/Temporal/Duration/prototype/round/year-zero.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+let relativeTo = "-000000-11-04T00:00";
+assert.throws(
+  RangeError,
+  () => { instance.round({ largestUnit: "years", relativeTo }); },
+  "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Duration/prototype/subtract/year-zero.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+let relativeTo = "-000000-11-04T00:00";
+assert.throws(
+  RangeError,
+  () => { instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }); },
+  "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Duration/prototype/total/calendar-possibly-required.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/calendar-possibly-required.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: Calendar required when days = 0 but years/months/weeks non-zero
+features: [Temporal]
+---*/
+
+const yearInstance = new Temporal.Duration(1999);
+const monthInstance = new Temporal.Duration(0, 49);
+const weekInstance = new Temporal.Duration(0, 0, 1);
+const dayInstance = new Temporal.Duration(0, 0, 0, 42);
+
+let relativeTo = new Temporal.PlainDate(2021, 12, 15);
+
+assert.throws(
+  RangeError,
+  () => { yearInstance.total({ unit: "days" }); },
+  "total a Duration with non-zero years fails without largest/smallest unit"
+);
+const yearResult = yearInstance.total({ unit: "days", relativeTo });
+assert.sameValue(yearResult, 730120, "year duration contains proper days");
+
+assert.throws(
+  RangeError,
+  () => { monthInstance.total({ unit: "days" }); },
+  "total a Duration with non-zero month fails without largest/smallest unit"
+);
+
+const monthResult = monthInstance.total({ unit: "days", relativeTo });
+assert.sameValue(monthResult, 1492, "month duration contains proper days");
+
+assert.throws(
+  RangeError,
+  () => { weekInstance.total({ unit: "days" }); },
+  "total a Duration with non-zero weeks fails without largest/smallest unit"
+);
+
+const weekResult = weekInstance.total({ unit: "days", relativeTo });
+assert.sameValue(weekResult, 7, "week duration contains proper days");
+
+const dayResultWithoutRelative = dayInstance.total({ unit: "days" });
+const dayResultWithRelative = dayInstance.total({ unit: "days", relativeTo });
+assert.sameValue(dayResultWithoutRelative, 42, "day duration without relative-to part contains proper days");
+assert.sameValue(dayResultWithRelative, 42, "day duration with relative-to part contains proper days");

--- a/test/built-ins/Temporal/Duration/prototype/total/year-zero.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+let relativeTo = "-000000-11-04T00:00";
+assert.throws(
+  RangeError,
+  () => { instance.total({ unit: "days", relativeTo }); },
+  "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/Instant/compare/year-zero.js
+++ b/test/built-ins/Temporal/Instant/compare/year-zero.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.compare
+description: Negative zero, as an extended year, fails
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+const bad = '-000000-03-30T00:45Z';
+
+assert.throws(RangeError,
+  () => Temporal.Instant.compare(bad, instance),
+  "minus zero is invalid extended year (first argument)");
+assert.throws(RangeError,
+  () => Temporal.Instant.compare(instance, bad),
+  "minus zero is invalid extended year (second argument)"
+);

--- a/test/built-ins/Temporal/Instant/from/year-zero.js
+++ b/test/built-ins/Temporal/Instant/from/year-zero.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.from
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "-000000-03-31T00:45Z",
+  "-000000-03-31T01:45+01:00",
+  "-000000-03-31T01:45:00+01:00[UTC]"
+];
+
+invalidStrings.forEach((str) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.Instant.from(str),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/Instant/prototype/equals/year-zero.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/year-zero.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.equals
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+    "-000000-03-30T00:45Z",
+    "-000000-03-30T01:45+01:00",
+    "-000000-03-30T01:45:00+01:00[UTC]"
+];
+const instance = new Temporal.Instant(0n);
+invalidStrings.forEach((str) => {
+  assert.throws(
+    RangeError,
+    () => instance.equals(str),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/Instant/prototype/since/year-zero.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/year-zero.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+    "-000000-03-30T00:45Z",
+    "-000000-03-30T01:45+01:00",
+    "-000000-03-30T01:45:00+01:00[UTC]"
+];
+const instance = new Temporal.Instant(0n);
+invalidStrings.forEach((str) => {
+  assert.throws(
+    RangeError,
+    () => instance.since(str),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/Instant/prototype/until/year-zero.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/year-zero.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+    "-000000-03-30T00:45Z",
+    "-000000-03-30T01:45+01:00",
+    "-000000-03-30T01:45:00+01:00[UTC]"
+];
+const instance = new Temporal.Instant(0n);
+invalidStrings.forEach((str) => {
+  assert.throws(
+    RangeError,
+    () => instance.until(str),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/compare/year-zero.js
+++ b/test/built-ins/Temporal/PlainDate/compare/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Negative zero, as an extended year, fails
+esid: sec-temporal.plaindate.compare
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+const bad = "-000000-08-24";
+
+assert.throws(RangeError,
+  () => Temporal.PlainDate.compare(bad, instance),
+  "Minus zero is an invalid extended year (first argument)"
+);
+
+assert.throws(RangeError,
+  () => Temporal.PlainDate.compare(instance, bad),
+  "Minus zero is an invalid extended year (second argument)"
+);

--- a/test/built-ins/Temporal/PlainDate/from/year-zero.js
+++ b/test/built-ins/Temporal/PlainDate/from/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const arg = "-000000-10-31";
+
+assert.throws(
+    RangeError,
+    () => { Temporal.PlainDate.from(arg); },
+    "reject minus zero as extended year"
+);
+

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/year-zero.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.equals
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+assert.throws(
+    RangeError,
+    () => { instance.equals(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/PlainDate/prototype/since/year-zero.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+assert.throws(
+    RangeError,
+    () => { instance.since(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/year-zero.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplaindatetime
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-12-07T03:24:30',
+  '-000000-12-07T03:24:30+01:00[UTC]'
+];
+const instance = new Temporal.PlainDate(2000, 5, 2);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.toPlainDateTime(arg),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/year-zero.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-12-07T03:24:30',
+  '-000000-12-07T03:24:30+01:00[UTC]'
+];
+const instance = new Temporal.PlainDate(2000, 5, 2);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" }),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/prototype/until/year-zero.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+assert.throws(
+    RangeError,
+    () => { instance.until(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/PlainDateTime/compare/year-zero.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Negative zero, as an extended year, fails
+esid: sec-temporal.plaindatetime.compare
+features: [Temporal]
+---*/
+
+const ok = new Temporal.PlainDateTime(2000, 5, 2, 15);
+const bad = "-000000-12-07T03:24:30";
+
+assert.throws(RangeError,
+  () => Temporal.PlainDateTime.compare(bad,ok),
+  "Cannot use minus zero as extended year (first argument)"
+);
+
+assert.throws(RangeError,
+  () => Temporal.PlainDateTime.compare(ok, bad),
+  "Cannot use minus zero as extended year (second argument)"
+);

--- a/test/built-ins/Temporal/PlainDateTime/from/year-zero.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/year-zero.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
+];
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => { Temporal.PlainDateTime.from(arg); },
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/year-zero.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
+];
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => { instance.equals(arg); },
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/year-zero.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
+];
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => { instance.since(arg); },
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/year-zero.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
+];
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => { instance.until(arg); },
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/year-zero.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaindate
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+assert.throws(
+    RangeError,
+    () => { instance.withPlainDate(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/year-zero.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaintime
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-12-07T03:24:30',
+  '-000000-12-07T03:24:30+01:00[UTC]'
+];
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.withPlainTime(arg),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainMonthDay/from/year-zero.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/year-zero.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+    "-000000-08",
+    "-000000-08-24",
+    "-000000-08-24T15:43:27",
+    "-000000-08-24T15:43:27+01:00[UTC]"
+];
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => { Temporal.PlainMonthDay.from(arg); },
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/year-zero.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/year-zero.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+    "-000000-08",
+    "-000000-08-24",
+    "-000000-08-24T15:43:27",
+    "-000000-08-24T15:43:27+01:00[UTC]"
+];
+const instance = new Temporal.PlainMonthDay(5, 2);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/compare/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/compare/year-zero.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.compare
+description: Negative zero, as an extended year, fails
+features: [Temporal]
+---*/
+
+const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const bad = "-000000-12-07T03:24:30";
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainTime.compare(bad, time),
+  "Cannot use minus zero as extended year (first argument)"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainTime.compare(time, bad),
+  "Cannot use minus zero as extended year (second argument)"
+);

--- a/test/built-ins/Temporal/PlainTime/from/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/from/year-zero.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.from
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-12-07T03:24:30',
+  '-000000-12-07T03:24:30+01:00[UTC]'
+];
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => { Temporal.PlainTime.from(arg); },
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.equals
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-12-07T03:24:30',
+  '-000000-12-07T03:24:30+01:00[UTC]'
+];
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/since/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-12-07T03:24:30',
+  '-000000-12-07T03:24:30+01:00[UTC]'
+];
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.toplaindatetime
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+assert.throws(
+    RangeError,
+    () => { instance.toPlainDateTime(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+assert.throws(
+    RangeError,
+    () => { instance.toZonedDateTime({ plainDate: arg }); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/PlainTime/prototype/until/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-12-07T03:24:30',
+  '-000000-12-07T03:24:30+01:00[UTC]'
+];
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainYearMonth/compare/year-zero.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/year-zero.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Negative zero, as an extended year, fails
+esid: sec-temporal.plainyearmonth.compare
+features: [Temporal]
+---*/
+
+const ok = new Temporal.PlainYearMonth(2000, 5);
+const bad = "-000000-06";
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.compare(bad, ok),
+  "Cannot use minus zero as extended year (first argument)"
+);
+
+assert.throws(
+  RangeError,
+  () => Temporal.PlainYearMonth.compare(ok, bad),
+  "Cannot use minus zero as extended year (second argument)"
+);

--- a/test/built-ins/Temporal/PlainYearMonth/from/year-zero.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/year-zero.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-06',
+  '-000000-06-24',
+  '-000000-06-24T15:43:27',
+  '-000000-06-24T15:43:27+01:00[UTC]'
+];
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => { Temporal.PlainYearMonth.from(arg); },
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/year-zero.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/year-zero.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.equals
+description: RangeError thrown if a string with UTC designator is used as a PlainYearMonth
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-06',
+  '-000000-06-24',
+  '-000000-06-24T15:43:27',
+  '-000000-06-24T15:43:27+01:00[UTC]'
+];
+const instance = new Temporal.PlainYearMonth(2000, 5);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/year-zero.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/year-zero.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: RangeError thrown if a string with UTC designator is used as a PlainYearMonth
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-06',
+  '-000000-06-24',
+  '-000000-06-24T15:43:27',
+  '-000000-06-24T15:43:27+01:00[UTC]'
+];
+const instance = new Temporal.PlainYearMonth(2000, 5);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/year-zero.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/year-zero.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: RangeError thrown if a string with UTC designator is used as a PlainYearMonth
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-06',
+  '-000000-06-24',
+  '-000000-06-24T15:43:27',
+  '-000000-06-24T15:43:27+01:00[UTC]'
+];
+const instance = new Temporal.PlainYearMonth(2000, 5);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/year-zero.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
+];
+const instance = new Temporal.TimeZone("UTC");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => { instance.getInstantFor(arg); },
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/year-zero.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/year-zero.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getnexttransition
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+let str = "-000000-01-01T00:00";
+assert.throws(RangeError, () => instance.getNextTransition(str), "reject minus zero as extended year");

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/year-zero.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/year-zero.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getoffsetnanosecondsfor
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+let str = "-000000-01-01T00:00";
+assert.throws(RangeError, () => instance.getOffsetNanosecondsFor(str), "reject minus zero as extended year");

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/year-zero.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/year-zero.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getoffsetstringfor
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+let str = "-000000-01-01T00:00";
+assert.throws(RangeError, () => instance.getOffsetStringFor(str), "reject minus zero as extended year");

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/year-zero.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/year-zero.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+    "-000000-03-30T00:45Z",
+    "-000000-03-30T01:45+01:00",
+    "-000000-03-30T01:45:00+01:00[UTC]"
+];
+const instance = new Temporal.TimeZone("UTC");
+invalidStrings.forEach((str) => {
+  assert.throws(
+    RangeError,
+    () => instance.getPlainDateTimeFor(str),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/year-zero.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
+];
+const instance = new Temporal.TimeZone("UTC");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => { instance.getPossibleInstantsFor(arg); },
+    "reject minus zero as extended year"
+  );
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/year-zero.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/year-zero.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getprevioustransition
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+let str = "-000000-01-01T00:00";
+assert.throws(RangeError, () => instance.getPreviousTransition(str), "reject minus zero as extended year");

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-offset-not-agreeing-with-timezone.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-offset-not-agreeing-with-timezone.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: Property bag with offset property is rejected if offset does not agree with time zone
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("+01:00");
+const datetime = new Temporal.ZonedDateTime(0n, timeZone);
+
+const properties = { year: 2021, month: 10, day: 28, offset: "-07:00", timeZone };
+assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(properties, datetime), "offset property not matching time zone is rejected (first argument)");
+assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(datetime, properties), "offset property not matching time zone is rejected (second argument)");

--- a/test/built-ins/Temporal/ZonedDateTime/compare/year-zero.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/year-zero.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: Negative zero, as an extended year, fails
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
+const bad = "-000000-08-19T17:30Z";
+
+assert.throws(RangeError,
+  () => Temporal.ZonedDateTime.compare(bad, instance),
+  "cannot use negative zero as extended year (first argument)"
+);
+assert.throws(RangeError,
+  () => Temporal.ZonedDateTime.compare(instance, bad),
+  "cannot use negative zero as extended year (second argument)"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-offset-not-agreeing-with-timezone.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-offset-not-agreeing-with-timezone.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: Property bag with offset property is rejected if offset does not agree with time zone
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("+01:00");
+
+const properties = { year: 2021, month: 10, day: 28, offset: "-07:00", timeZone };
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from(properties), "offset property not matching time zone is rejected");

--- a/test/built-ins/Temporal/ZonedDateTime/from/year-zero.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/year-zero.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const str = "-0000000-01-01T00:02:00.000000000+00:00[UTC]";
+
+assert.throws(RangeError, () => { Temporal.ZonedDateTime.from(str); }, "reject minus zero as extended year");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-offset-not-agreeing-with-timezone.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-offset-not-agreeing-with-timezone.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: Property bag with offset property is rejected if offset does not agree with time zone
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("+01:00");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const properties = { year: 2021, month: 10, day: 28, offset: "-07:00", timeZone };
+assert.throws(RangeError, () => instance.equals(properties), "offset property not matching time zone is rejected");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/year-zero.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/year-zero.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+const str = "-0000000-01-01T00:02:00.000000000+00:00[UTC]";
+
+assert.throws(RangeError, () => { instance.equals(str); }, "reject minus zero as extended year");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-offset-not-agreeing-with-timezone.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-offset-not-agreeing-with-timezone.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: Property bag with offset property is rejected if offset does not agree with time zone
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("+01:00");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const properties = { year: 2021, month: 10, day: 28, offset: "-07:00", timeZone };
+assert.throws(RangeError, () => instance.since(properties), "offset property not matching time zone is rejected");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/year-zero.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/year-zero.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+const str = "-0000000-01-01T00:02:00.000000000+00:00[UTC]";
+
+assert.throws(RangeError, () => { instance.since(str); }, "reject minus zero as extended year");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-offset-not-agreeing-with-timezone.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-offset-not-agreeing-with-timezone.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: Property bag with offset property is rejected if offset does not agree with time zone
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("+01:00");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const properties = { year: 2021, month: 10, day: 28, offset: "-07:00", timeZone };
+assert.throws(RangeError, () => instance.until(properties), "offset property not matching time zone is rejected");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/year-zero.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/year-zero.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: Negative zero, as an extended year, is rejected
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+const str = "-0000000-01-01T00:02:00.000000000+00:00[UTC]";
+
+assert.throws(RangeError, () => { instance.until(str); }, "reject minus zero as extended year");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/year-zero.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+assert.throws(
+    RangeError,
+    () => { instance.withPlainDate(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/year-zero.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/year-zero.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaintime
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const invalidStrings = [
+  '-000000-12-07T03:24:30',
+  '-000000-12-07T03:24:30+01:00[UTC]'
+];
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.withPlainTime(arg),
+    "reject minus zero as extended year"
+  );
+});

--- a/test/intl402/Temporal/Calendar/prototype/era/year-zero.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.era
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.era(arg); },
+    "reject minus zero as extended year"
+);

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/year-zero.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/year-zero.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.erayear
+description: Negative zero, as an extended year, is rejected
+features: [Temporal, arrow-function]
+---*/
+
+const arg = "-000000-10-31";
+const instance = new Temporal.Calendar("iso8601");
+
+assert.throws(
+    RangeError,
+    () => { instance.eraYear(arg); },
+    "reject minus zero as extended year"
+);


### PR DESCRIPTION
This is the final batch of tests covering the normative changes that achieved consensus in the TC39 plenary of October 2021. Each commit message contains a link back to the relevant issue or pull request into the proposal text.

It contains work from @jessealama and me.