### PR TITLE
Various improvements to Temporal test consistency

### DIFF
--- a/test/built-ins/Temporal/Instant/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/largestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
 const later = new Temporal.Instant(1_000_090_061_987_654_321n);
-assert.throws(RangeError, () => later.since(earlier, { largestUnit: "other string" }));
+const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
+for (const largestUnit of values) {
+  assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
+}

--- a/test/built-ins/Temporal/Instant/prototype/since/largestunit-smallestunit-mismatch.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/largestunit-smallestunit-mismatch.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.prototype.since
+esid: sec-temporal.instant.prototype.since
 description: RangeError thrown when smallestUnit is larger than largestUnit
 features: [Temporal]
 ---*/
 
-const earlier = new Temporal.PlainDate(2000, 5, 2);
-const later = new Temporal.PlainDate(2001, 6, 3);
-const units = ["years", "months", "weeks", "days"];
+const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
+const later = new Temporal.Instant(1_000_090_061_987_654_321n);
+const units = ["hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds"];
 for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
   for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
     const largestUnit = units[largestIdx];

--- a/test/built-ins/Temporal/Instant/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/smallestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
 const later = new Temporal.Instant(1_000_090_061_987_654_321n);
-assert.throws(RangeError, () => later.since(earlier, { smallestUnit: "other string" }));
+const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
+for (const smallestUnit of values) {
+  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
+}

--- a/test/built-ins/Temporal/Instant/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/largestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
 const later = new Temporal.Instant(1_000_090_061_987_654_321n);
-assert.throws(RangeError, () => earlier.until(later, { largestUnit: "other string" }));
+const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
+for (const largestUnit of values) {
+  assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
+}

--- a/test/built-ins/Temporal/Instant/prototype/until/largestunit-smallestunit-mismatch.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/largestunit-smallestunit-mismatch.js
@@ -2,18 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.prototype.since
+esid: sec-temporal.instant.prototype.until
 description: RangeError thrown when smallestUnit is larger than largestUnit
 features: [Temporal]
 ---*/
 
-const earlier = new Temporal.PlainDate(2000, 5, 2);
-const later = new Temporal.PlainDate(2001, 6, 3);
-const units = ["years", "months", "weeks", "days"];
+const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
+const later = new Temporal.Instant(1_000_090_061_987_654_321n);
+const units = ["hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds"];
 for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
   for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
     const largestUnit = units[largestIdx];
     const smallestUnit = units[smallestIdx];
-    assert.throws(RangeError, () => later.since(earlier, { largestUnit, smallestUnit }));
+    assert.throws(RangeError, () => earlier.until(later, { largestUnit, smallestUnit }));
   }
 }

--- a/test/built-ins/Temporal/Instant/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/smallestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
 const later = new Temporal.Instant(1_000_090_061_987_654_321n);
-assert.throws(RangeError, () => earlier.until(later, { smallestUnit: "other string" }));
+const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
+for (const smallestUnit of values) {
+  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/largestunit-invalid-string.js
@@ -9,7 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDate(2000, 5, 2);
 const later = new Temporal.PlainDate(2001, 6, 3);
-const values = ["hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
+const values = ["era", "eraYear", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
 for (const largestUnit of values) {
   assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/since/largestunit-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/largestunit-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: Fallback value for largestUnit option
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.PlainDate(2000, 5, 2);
+const later = new Temporal.PlainDate(2001, 6, 3);
+
+const explicit = later.since(earlier, { largestUnit: undefined });
+TemporalHelpers.assertDuration(explicit, 0, 0, 0, 397, 0, 0, 0, 0, 0, 0, "default largestUnit is day");
+const implicit = later.since(earlier, {});
+TemporalHelpers.assertDuration(implicit, 0, 0, 0, 397, 0, 0, 0, 0, 0, 0, "default largestUnit is day");

--- a/test/built-ins/Temporal/PlainDate/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/smallestunit-invalid-string.js
@@ -9,7 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDate(2000, 5, 2);
 const later = new Temporal.PlainDate(2001, 6, 3);
-const values = ["era", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
+const values = ["era", "eraYear", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
 for (const smallestUnit of values) {
   assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/largestunit-invalid-string.js
@@ -9,7 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDate(2000, 5, 2);
 const later = new Temporal.PlainDate(2001, 6, 3);
-const values = ["hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
+const values = ["era", "eraYear", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
 for (const largestUnit of values) {
   assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/until/largestunit-smallestunit-mismatch.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/largestunit-smallestunit-mismatch.js
@@ -7,8 +7,8 @@ description: RangeError thrown when smallestUnit is larger than largestUnit
 features: [Temporal]
 ---*/
 
-const earlier = Temporal.PlainDate.from("2019-01-08");
-const later = Temporal.PlainDate.from("2021-09-07");
+const earlier = new Temporal.PlainDate(2000, 5, 2);
+const later = new Temporal.PlainDate(2001, 6, 3);
 const units = ["years", "months", "weeks", "days"];
 for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
   for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {

--- a/test/built-ins/Temporal/PlainDate/prototype/until/largestunit-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/largestunit-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: Fallback value for largestUnit option
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.PlainDate(2000, 5, 2);
+const later = new Temporal.PlainDate(2001, 6, 3);
+
+const explicit = earlier.until(later, { largestUnit: undefined });
+TemporalHelpers.assertDuration(explicit, 0, 0, 0, 397, 0, 0, 0, 0, 0, 0, "default largestUnit is day");
+const implicit = earlier.until(later, {});
+TemporalHelpers.assertDuration(implicit, 0, 0, 0, 397, 0, 0, 0, 0, 0, 0, "default largestUnit is day");

--- a/test/built-ins/Temporal/PlainDate/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/smallestunit-invalid-string.js
@@ -9,7 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDate(2000, 5, 2);
 const later = new Temporal.PlainDate(2001, 6, 3);
-const values = ["era", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
+const values = ["era", "eraYear", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
 for (const smallestUnit of values) {
   assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/largestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainDateTime(2001, 6, 3, 13, 35, 57, 987, 654, 321);
-assert.throws(RangeError, () => later.since(earlier, { largestUnit: "other string" }));
+const values = ["era", "eraYear", "other string"];
+for (const largestUnit of values) {
+  assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/largestunit-smallestunit-mismatch.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/largestunit-smallestunit-mismatch.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.prototype.since
+esid: sec-temporal.plaindatetime.prototype.since
 description: RangeError thrown when smallestUnit is larger than largestUnit
 features: [Temporal]
 ---*/
 
-const earlier = new Temporal.PlainDate(2000, 5, 2);
-const later = new Temporal.PlainDate(2001, 6, 3);
-const units = ["years", "months", "weeks", "days"];
+const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
+const later = new Temporal.PlainDateTime(2001, 6, 3, 13, 35, 57, 987, 654, 321);
+const units = ["years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds"];
 for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
   for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
     const largestUnit = units[largestIdx];

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/smallestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainDateTime(2000, 5, 3, 13, 35, 57, 987, 654, 321);
-assert.throws(RangeError, () => later.since(earlier, { smallestUnit: "other string" }));
+const values = ["era", "eraYear", "other string"];
+for (const smallestUnit of values) {
+  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/largestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainDateTime(2001, 6, 3, 13, 35, 57, 987, 654, 321);
-assert.throws(RangeError, () => earlier.until(later, { largestUnit: "other string" }));
+const values = ["era", "eraYear", "other string"];
+for (const largestUnit of values) {
+  assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/largestunit-smallestunit-mismatch.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/largestunit-smallestunit-mismatch.js
@@ -2,18 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.prototype.since
+esid: sec-temporal.plaindatetime.prototype.until
 description: RangeError thrown when smallestUnit is larger than largestUnit
 features: [Temporal]
 ---*/
 
-const earlier = new Temporal.PlainDate(2000, 5, 2);
-const later = new Temporal.PlainDate(2001, 6, 3);
-const units = ["years", "months", "weeks", "days"];
+const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
+const later = new Temporal.PlainDateTime(2001, 6, 3, 13, 35, 57, 987, 654, 321);
+const units = ["years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds"];
 for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
   for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
     const largestUnit = units[largestIdx];
     const smallestUnit = units[smallestIdx];
-    assert.throws(RangeError, () => later.since(earlier, { largestUnit, smallestUnit }));
+    assert.throws(RangeError, () => earlier.until(later, { largestUnit, smallestUnit }));
   }
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/smallestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainDateTime(2000, 5, 3, 13, 35, 57, 987, 654, 321);
-assert.throws(RangeError, () => earlier.until(later, { smallestUnit: "other string" }));
+const values = ["era", "eraYear", "other string"];
+for (const smallestUnit of values) {
+  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/largestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainTime(13, 35, 57, 987, 654, 321);
-assert.throws(RangeError, () => later.since(earlier, { largestUnit: "other string" }));
+const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
+for (const largestUnit of values) {
+  assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/since/largestunit-smallestunit-mismatch.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/largestunit-smallestunit-mismatch.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.prototype.since
+esid: sec-temporal.plaintime.prototype.since
 description: RangeError thrown when smallestUnit is larger than largestUnit
 features: [Temporal]
 ---*/
 
-const earlier = new Temporal.PlainDate(2000, 5, 2);
-const later = new Temporal.PlainDate(2001, 6, 3);
-const units = ["years", "months", "weeks", "days"];
+const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
+const later = new Temporal.PlainTime(13, 35, 57, 987, 654, 321);
+const units = ["hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds"];
 for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
   for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
     const largestUnit = units[largestIdx];

--- a/test/built-ins/Temporal/PlainTime/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/smallestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainTime(13, 35, 57, 987, 654, 321);
-assert.throws(RangeError, () => later.since(earlier, { smallestUnit: "other string" }));
+const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
+for (const smallestUnit of values) {
+  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/largestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainTime(13, 35, 57, 987, 654, 321);
-assert.throws(RangeError, () => earlier.until(later, { largestUnit: "other string" }));
+const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
+for (const largestUnit of values) {
+  assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/until/largestunit-smallestunit-mismatch.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/largestunit-smallestunit-mismatch.js
@@ -2,18 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.prototype.since
+esid: sec-temporal.plaintime.prototype.until
 description: RangeError thrown when smallestUnit is larger than largestUnit
 features: [Temporal]
 ---*/
 
-const earlier = new Temporal.PlainDate(2000, 5, 2);
-const later = new Temporal.PlainDate(2001, 6, 3);
-const units = ["years", "months", "weeks", "days"];
+const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
+const later = new Temporal.PlainTime(13, 35, 57, 987, 654, 321);
+const units = ["hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds"];
 for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
   for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
     const largestUnit = units[largestIdx];
     const smallestUnit = units[smallestIdx];
-    assert.throws(RangeError, () => later.since(earlier, { largestUnit, smallestUnit }));
+    assert.throws(RangeError, () => earlier.until(later, { largestUnit, smallestUnit }));
   }
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/smallestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainTime(13, 35, 57, 987, 654, 321);
-assert.throws(RangeError, () => earlier.until(later, { smallestUnit: "other string" }));
+const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
+for (const smallestUnit of values) {
+  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2001, 6);
-assert.throws(RangeError, () => later.since(earlier, { largestUnit: "other string" }));
+const values = ["era", "eraYear", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
+for (const largestUnit of values) {
+  assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-smallestunit-mismatch.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-smallestunit-mismatch.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.prototype.since
+esid: sec-temporal.plainyearmonth.prototype.since
 description: RangeError thrown when smallestUnit is larger than largestUnit
 features: [Temporal]
 ---*/
 
-const earlier = new Temporal.PlainDate(2000, 5, 2);
-const later = new Temporal.PlainDate(2001, 6, 3);
-const units = ["years", "months", "weeks", "days"];
+const earlier = new Temporal.PlainYearMonth(2000, 5);
+const later = new Temporal.PlainYearMonth(2001, 6);
+const units = ["years", "months"];
 for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
   for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
     const largestUnit = units[largestIdx];

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/smallestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2001, 6);
-assert.throws(RangeError, () => later.since(earlier, { smallestUnit: "other string" }));
+const values = ["era", "eraYear", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
+for (const smallestUnit of values) {
+  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2001, 6);
-assert.throws(RangeError, () => earlier.until(later, { largestUnit: "other string" }));
+const values = ["era", "eraYear", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
+for (const largestUnit of values) {
+  assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-smallestunit-mismatch.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-smallestunit-mismatch.js
@@ -2,18 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.prototype.since
+esid: sec-temporal.plainyearmonth.prototype.until
 description: RangeError thrown when smallestUnit is larger than largestUnit
 features: [Temporal]
 ---*/
 
-const earlier = new Temporal.PlainDate(2000, 5, 2);
-const later = new Temporal.PlainDate(2001, 6, 3);
-const units = ["years", "months", "weeks", "days"];
+const earlier = new Temporal.PlainYearMonth(2000, 5);
+const later = new Temporal.PlainYearMonth(2001, 6);
+const units = ["years", "months"];
 for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
   for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
     const largestUnit = units[largestIdx];
     const smallestUnit = units[smallestIdx];
-    assert.throws(RangeError, () => later.since(earlier, { largestUnit, smallestUnit }));
+    assert.throws(RangeError, () => earlier.until(later, { largestUnit, smallestUnit }));
   }
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/smallestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2001, 6);
-assert.throws(RangeError, () => earlier.until(later, { smallestUnit: "other string" }));
+const values = ["era", "eraYear", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
+for (const smallestUnit of values) {
+  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/largestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 const later = new Temporal.ZonedDateTime(1_000_090_061_987_654_321n, "UTC");
-assert.throws(RangeError, () => later.since(earlier, { largestUnit: "other string" }));
+const values = ["era", "eraYear", "other string"];
+for (const largestUnit of values) {
+  assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/largestunit-smallestunit-mismatch.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/largestunit-smallestunit-mismatch.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.prototype.since
+esid: sec-temporal.zoneddatetime.prototype.since
 description: RangeError thrown when smallestUnit is larger than largestUnit
 features: [Temporal]
 ---*/
 
-const earlier = new Temporal.PlainDate(2000, 5, 2);
-const later = new Temporal.PlainDate(2001, 6, 3);
-const units = ["years", "months", "weeks", "days"];
+const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+const later = new Temporal.ZonedDateTime(1_000_090_061_987_654_321n, "UTC");
+const units = ["years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds"];
 for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
   for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
     const largestUnit = units[largestIdx];

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/smallestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 const later = new Temporal.ZonedDateTime(1_000_090_061_987_654_321n, "UTC");
-assert.throws(RangeError, () => later.since(earlier, { smallestUnit: "other string" }));
+const values = ["era", "eraYear", "other string"];
+for (const smallestUnit of values) {
+  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/largestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 const later = new Temporal.ZonedDateTime(1_000_090_061_987_654_321n, "UTC");
-assert.throws(RangeError, () => earlier.until(later, { largestUnit: "other string" }));
+const values = ["era", "eraYear", "other string"];
+for (const largestUnit of values) {
+  assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/largestunit-smallestunit-mismatch.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/largestunit-smallestunit-mismatch.js
@@ -2,18 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.prototype.since
+esid: sec-temporal.zoneddatetime.prototype.until
 description: RangeError thrown when smallestUnit is larger than largestUnit
 features: [Temporal]
 ---*/
 
-const earlier = new Temporal.PlainDate(2000, 5, 2);
-const later = new Temporal.PlainDate(2001, 6, 3);
-const units = ["years", "months", "weeks", "days"];
+const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+const later = new Temporal.ZonedDateTime(1_000_090_061_987_654_321n, "UTC");
+const units = ["years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds"];
 for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
   for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
     const largestUnit = units[largestIdx];
     const smallestUnit = units[smallestIdx];
-    assert.throws(RangeError, () => later.since(earlier, { largestUnit, smallestUnit }));
+    assert.throws(RangeError, () => earlier.until(later, { largestUnit, smallestUnit }));
   }
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/smallestunit-invalid-string.js
@@ -9,4 +9,7 @@ features: [Temporal]
 
 const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 const later = new Temporal.ZonedDateTime(1_000_090_061_987_654_321n, "UTC");
-assert.throws(RangeError, () => earlier.until(later, { smallestUnit: "other string" }));
+const values = ["era", "eraYear", "other string"];
+for (const smallestUnit of values) {
+  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
+}


### PR DESCRIPTION
Here are some improvements that I noticed while working on testing the recent normative changes to Temporal. It involves making similar tests across similar API entry points consistent with each other.