### PR TITLE
Add missing propertyHelper.js include to WrappedFunction tests

### DIFF
--- a/test/built-ins/ShadowRealm/WrappedFunction/length.js
+++ b/test/built-ins/ShadowRealm/WrappedFunction/length.js
@@ -33,6 +33,7 @@ info: |
   ...
   2. Return ! DefinePropertyOrThrow(F, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }).
 
+includes: [propertyHelper.js]
 features: [ShadowRealm]
 ---*/
 

--- a/test/built-ins/ShadowRealm/WrappedFunction/name.js
+++ b/test/built-ins/ShadowRealm/WrappedFunction/name.js
@@ -23,6 +23,7 @@ info: |
   ...
   6. Return ! DefinePropertyOrThrow(F, "name", PropertyDescriptor { [[Value]]: name, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }).
 
+includes: [propertyHelper.js]
 features: [ShadowRealm]
 ---*/
 


### PR DESCRIPTION
`verifyProperty` needs to be included.
cc @legendecas @leobalter 