### PR TITLE
Test that `Array.prototype` methods throw on attempt to `[[Set]]` read-only `"length"`

### DIFF
--- a/test/built-ins/Array/prototype/pop/set-length-array-is-frozen.js
+++ b/test/built-ins/Array/prototype/pop/set-length-array-is-frozen.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.pop
+description: >
+  A TypeError is thrown when "length" is [[Set]] on a frozen array.
+info: |
+  Array.prototype.pop ( )
+
+  [...]
+  4. Else,
+    a. Assert: len > 0.
+    b. Let newLen be 𝔽(len - 1).
+    c. Let index be ! ToString(newLen).
+    d. Let element be ? Get(O, index).
+    e. Perform ? DeletePropertyOrThrow(O, index).
+    f. Perform ? Set(O, "length", newLen, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = new Array(1);
+var arrayPrototypeGet0Calls = 0;
+
+Object.defineProperty(Array.prototype, "0", {
+  get() {
+    Object.freeze(array);
+    arrayPrototypeGet0Calls++;
+  },
+});
+
+assert.throws(TypeError, function() {
+  array.pop();
+});
+
+assert.sameValue(array.length, 1);
+assert.sameValue(arrayPrototypeGet0Calls, 1);

--- a/test/built-ins/Array/prototype/pop/set-length-array-length-is-non-writable.js
+++ b/test/built-ins/Array/prototype/pop/set-length-array-length-is-non-writable.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.pop
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an array with non-writable "length".
+info: |
+  Array.prototype.pop ( )
+
+  [...]
+  4. Else,
+    a. Assert: len > 0.
+    b. Let newLen be 𝔽(len - 1).
+    c. Let index be ! ToString(newLen).
+    d. Let element be ? Get(O, index).
+    e. Perform ? DeletePropertyOrThrow(O, index).
+    f. Perform ? Set(O, "length", newLen, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = new Array(1);
+var arrayPrototypeGet0Calls = 0;
+
+Object.defineProperty(Array.prototype, "0", {
+  get() {
+    Object.defineProperty(array, "length", { writable: false });
+    arrayPrototypeGet0Calls++;
+  },
+});
+
+assert.throws(TypeError, function() {
+  array.pop();
+});
+
+assert.sameValue(array.length, 1);
+assert.sameValue(arrayPrototypeGet0Calls, 1);

--- a/test/built-ins/Array/prototype/pop/set-length-zero-array-is-frozen.js
+++ b/test/built-ins/Array/prototype/pop/set-length-zero-array-is-frozen.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.pop
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an empty frozen array.
+info: |
+  Array.prototype.pop ( )
+
+  [...]
+  3. If len = 0, then
+    a. Perform ? Set(O, "length", +0𝔽, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+Object.freeze(array);
+
+assert.throws(TypeError, function() {
+  array.pop();
+});

--- a/test/built-ins/Array/prototype/pop/set-length-zero-array-length-is-non-writable.js
+++ b/test/built-ins/Array/prototype/pop/set-length-zero-array-length-is-non-writable.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.pop
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an empty array with non-writable "length".
+info: |
+  Array.prototype.pop ( )
+
+  [...]
+  3. If len = 0, then
+    a. Perform ? Set(O, "length", +0𝔽, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+Object.defineProperty(array, "length", { writable: false });
+
+assert.throws(TypeError, function() {
+  array.pop();
+});

--- a/test/built-ins/Array/prototype/push/set-length-array-is-frozen.js
+++ b/test/built-ins/Array/prototype/push/set-length-array-is-frozen.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.push
+description: >
+  A TypeError is thrown when "length" is [[Set]] on a frozen array.
+info: |
+  Array.prototype.push ( ...items )
+
+  [...]
+  5. For each element E of items, do
+    a. Perform ? Set(O, ! ToString(𝔽(len)), E, true).
+    b. Set len to len + 1.
+  6. Perform ? Set(O, "length", 𝔽(len), true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+var arrayPrototypeSet0Calls = 0;
+
+Object.defineProperty(Array.prototype, "0", {
+  set(_val) {
+    Object.freeze(array);
+    arrayPrototypeSet0Calls++;
+  },
+});
+
+assert.throws(TypeError, function() {
+  array.push(1);
+});
+
+assert(!array.hasOwnProperty(0));
+assert.sameValue(array.length, 0);
+assert.sameValue(arrayPrototypeSet0Calls, 1);

--- a/test/built-ins/Array/prototype/push/set-length-array-length-is-non-writable.js
+++ b/test/built-ins/Array/prototype/push/set-length-array-length-is-non-writable.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.push
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an array with non-writable "length".
+info: |
+  Array.prototype.push ( ...items )
+
+  [...]
+  5. For each element E of items, do
+    a. Perform ? Set(O, ! ToString(𝔽(len)), E, true).
+    b. Set len to len + 1.
+  6. Perform ? Set(O, "length", 𝔽(len), true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+var arrayPrototypeSet0Calls = 0;
+
+Object.defineProperty(Array.prototype, "0", {
+  set(_val) {
+    Object.defineProperty(array, "length", { writable: false });
+    arrayPrototypeSet0Calls++;
+  },
+});
+
+assert.throws(TypeError, function() {
+  array.push(1);
+});
+
+assert(!array.hasOwnProperty(0));
+assert.sameValue(array.length, 0);
+assert.sameValue(arrayPrototypeSet0Calls, 1);

--- a/test/built-ins/Array/prototype/push/set-length-zero-array-is-frozen.js
+++ b/test/built-ins/Array/prototype/push/set-length-zero-array-is-frozen.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.push
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an empty frozen array.
+info: |
+  Array.prototype.push ( ...items )
+
+  [...]
+  2. Let len be ? LengthOfArrayLike(O).
+  [...]
+  6. Perform ? Set(O, "length", 𝔽(len), true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+Object.freeze(array);
+
+assert.throws(TypeError, function() {
+  array.push();
+});
+
+assert(!array.hasOwnProperty(0));
+assert.sameValue(array.length, 0);

--- a/test/built-ins/Array/prototype/push/set-length-zero-array-length-is-non-writable.js
+++ b/test/built-ins/Array/prototype/push/set-length-zero-array-length-is-non-writable.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.push
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an empty array with non-writable "length".
+info: |
+  Array.prototype.push ( ...items )
+
+  [...]
+  2. Let len be ? LengthOfArrayLike(O).
+  [...]
+  6. Perform ? Set(O, "length", 𝔽(len), true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+Object.defineProperty(array, "length", { writable: false });
+
+assert.throws(TypeError, function() {
+  array.push();
+});
+
+assert(!array.hasOwnProperty(0));
+assert.sameValue(array.length, 0);

--- a/test/built-ins/Array/prototype/shift/set-length-array-is-frozen.js
+++ b/test/built-ins/Array/prototype/shift/set-length-array-is-frozen.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.shift
+description: >
+  A TypeError is thrown when "length" is [[Set]] on a frozen array.
+info: |
+  Array.prototype.shift ( )
+
+  [...]
+  4. Let first be ? Get(O, "0").
+  [...]
+  8. Perform ? Set(O, "length", 𝔽(len - 1), true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = new Array(1);
+var arrayPrototypeGet0Calls = 0;
+
+Object.defineProperty(Array.prototype, "0", {
+  get() {
+    Object.freeze(array);
+    arrayPrototypeGet0Calls++;
+  },
+});
+
+assert.throws(TypeError, function() {
+  array.shift();
+});
+
+assert.sameValue(array.length, 1);
+assert.sameValue(arrayPrototypeGet0Calls, 1);

--- a/test/built-ins/Array/prototype/shift/set-length-array-length-is-non-writable.js
+++ b/test/built-ins/Array/prototype/shift/set-length-array-length-is-non-writable.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.shift
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an array with non-writable "length".
+info: |
+  Array.prototype.shift ( )
+
+  [...]
+  4. Let first be ? Get(O, "0").
+  [...]
+  8. Perform ? Set(O, "length", 𝔽(len - 1), true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = new Array(1);
+var arrayPrototypeGet0Calls = 0;
+
+Object.defineProperty(Array.prototype, "0", {
+  get() {
+    Object.defineProperty(array, "length", { writable: false });
+    arrayPrototypeGet0Calls++;
+  },
+});
+
+assert.throws(TypeError, function() {
+  array.shift();
+});
+
+assert.sameValue(array.length, 1);
+assert.sameValue(arrayPrototypeGet0Calls, 1);

--- a/test/built-ins/Array/prototype/shift/set-length-zero-array-is-frozen.js
+++ b/test/built-ins/Array/prototype/shift/set-length-zero-array-is-frozen.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.shift
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an empty frozen array.
+info: |
+  Array.prototype.shift ( )
+
+  [...]
+  3. If len = 0, then
+    a. Perform ? Set(O, "length", +0𝔽, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+Object.freeze(array);
+
+assert.throws(TypeError, function() {
+  array.shift();
+});

--- a/test/built-ins/Array/prototype/shift/set-length-zero-array-length-is-non-writable.js
+++ b/test/built-ins/Array/prototype/shift/set-length-zero-array-length-is-non-writable.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.shift
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an empty array with non-writable "length".
+info: |
+  Array.prototype.shift ( )
+
+  [...]
+  3. If len = 0, then
+    a. Perform ? Set(O, "length", +0𝔽, true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+Object.defineProperty(array, "length", { writable: false });
+
+assert.throws(TypeError, function() {
+  array.shift();
+});

--- a/test/built-ins/Array/prototype/unshift/set-length-array-is-frozen.js
+++ b/test/built-ins/Array/prototype/unshift/set-length-array-is-frozen.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.unshift
+description: >
+  A TypeError is thrown when "length" is [[Set]] on a frozen array.
+info: |
+  Array.prototype.unshift ( ...items )
+
+  [...]
+  4. If argCount > 0, then
+    [...]
+    d. Let j be +0𝔽.
+    e. For each element E of items, do
+        i. Perform ? Set(O, ! ToString(j), E, true).
+        ii. Set j to j + 1𝔽.
+  5. Perform ? Set(O, "length", 𝔽(len + argCount), true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+var arrayPrototypeSet0Calls = 0;
+
+Object.defineProperty(Array.prototype, "0", {
+  set(_val) {
+    Object.freeze(array);
+    arrayPrototypeSet0Calls++;
+  },
+});
+
+assert.throws(TypeError, function() {
+  array.unshift(1);
+});
+
+assert(!array.hasOwnProperty(0));
+assert.sameValue(array.length, 0);
+assert.sameValue(arrayPrototypeSet0Calls, 1);

--- a/test/built-ins/Array/prototype/unshift/set-length-array-length-is-non-writable.js
+++ b/test/built-ins/Array/prototype/unshift/set-length-array-length-is-non-writable.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.unshift
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an array with non-writable "length".
+info: |
+  Array.prototype.unshift ( ...items )
+
+  [...]
+  4. If argCount > 0, then
+    [...]
+    d. Let j be +0𝔽.
+    e. For each element E of items, do
+        i. Perform ? Set(O, ! ToString(j), E, true).
+        ii. Set j to j + 1𝔽.
+  5. Perform ? Set(O, "length", 𝔽(len + argCount), true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+var arrayPrototypeSet0Calls = 0;
+
+Object.defineProperty(Array.prototype, "0", {
+  set(_val) {
+    Object.defineProperty(array, "length", { writable: false });
+    arrayPrototypeSet0Calls++;
+  },
+});
+
+assert.throws(TypeError, function() {
+  array.unshift(1);
+});
+
+assert(!array.hasOwnProperty(0));
+assert.sameValue(array.length, 0);
+assert.sameValue(arrayPrototypeSet0Calls, 1);

--- a/test/built-ins/Array/prototype/unshift/set-length-zero-array-is-frozen.js
+++ b/test/built-ins/Array/prototype/unshift/set-length-zero-array-is-frozen.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.unshift
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an empty frozen array.
+info: |
+  Array.prototype.unshift ( ...items )
+
+  [...]
+  2. Let len be ? LengthOfArrayLike(O).
+  [...]
+  5. Perform ? Set(O, "length", 𝔽(len + argCount), true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+Object.freeze(array);
+
+assert.throws(TypeError, function() {
+  array.unshift();
+});
+
+assert(!array.hasOwnProperty(0));
+assert.sameValue(array.length, 0);

--- a/test/built-ins/Array/prototype/unshift/set-length-zero-array-length-is-non-writable.js
+++ b/test/built-ins/Array/prototype/unshift/set-length-zero-array-length-is-non-writable.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-array.prototype.unshift
+description: >
+  A TypeError is thrown when "length" is [[Set]] on an empty array with non-writable "length".
+info: |
+  Array.prototype.unshift ( ...items )
+
+  [...]
+  2. Let len be ? LengthOfArrayLike(O).
+  [...]
+  5. Perform ? Set(O, "length", 𝔽(len + argCount), true).
+
+  OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
+
+  [...]
+  2. If IsDataDescriptor(ownDesc) is true, then
+    a. If ownDesc.[[Writable]] is false, return false.
+
+  Set ( O, P, V, Throw )
+
+  [...]
+  1. Let success be ? O.[[Set]](P, V, O).
+  2. If success is false and Throw is true, throw a TypeError exception.
+---*/
+
+var array = [];
+Object.defineProperty(array, "length", { writable: false });
+
+assert.throws(TypeError, function() {
+  array.unshift();
+});
+
+assert(!array.hasOwnProperty(0));
+assert.sameValue(array.length, 0);


### PR DESCRIPTION
JSC bug: [Attempting to `[[Set]]` `JSArray`'s read-only `"length"` should throw even with current `[[Value]]`](https://bugs.webkit.org/show_bug.cgi?id=221177).