### PR TITLE
Use ECMAScript 6

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,3 +1,4 @@
 {
-    "predef": ["Intl"]
+    "predef": ["Intl"],
+    "esversion": 6
 }


### PR DESCRIPTION
Some IDEs (e.g., WebStorm) consult the `.jshintrc` file to figure out what "language level" they should use. It seems that we're using ECMAScript 6 pretty consistently, if not uniformly. This change makes that information explicit.