### PR TITLE
Compound assignment to private references

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{README.md,package.json,.travis.yml,*.sh,*.js}]
+[{README.md,package.json,.travis.yml,*.sh,*.js,*.case,*.template}]
 indent_style = space
 indent_size = 2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -394,7 +394,7 @@ The Body of a test template matches that of a non-generated test in which an arb
 Expected [Frontmatter](#frontmatter) keys:
 Key | Description
 ------|-------------
-`path` | location within the published test hierarchy to output files created from this template, each with a path formed by appending the name of the corresponding test case file. For example, a template with `path` "/test/language/template1-" used by test case file case1.js will generate a test file for that case at "/test/language/template1-case1.js".
+`path` | location within the published test hierarchy to output files created from this template, each with a path formed by appending the name of the corresponding test case file. For example, a template with `path` "language/template1-" used by test case file case1.js will generate a test file for that case at "language/template1-case1.js".
 `name` | human-readable name of the syntactic form described by this template. Each generated test will have a `description` that is the result of appending the test template `name`, in parentheses, to the test case `desc` field.
 `esid` | see the general definition of the [`esid` frontmatter key](#esid).
 `info` | see the general definition of the [`info` frontmatter key](#info). Each generated test will have `info` that is the concatenation of the test template `info` field and the test case `info` field.

--- a/src/compound-assignment-private/add.case
+++ b/src/compound-assignment-private/add.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound addition assignment with target being a private reference
+---*/
+
+//- lhs
+1
+//- operator
++=
+//- rhs
+2
+//- result
+3

--- a/src/compound-assignment-private/and.case
+++ b/src/compound-assignment-private/and.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound logical-and assignment with target being a private reference
+---*/
+
+//- lhs
+true
+//- operator
+&&=
+//- rhs
+false
+//- result
+false

--- a/src/compound-assignment-private/bitand.case
+++ b/src/compound-assignment-private/bitand.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound bitwise-and assignment with target being a private reference
+---*/
+
+//- lhs
+0b0101
+//- operator
+&=
+//- rhs
+0b1010
+//- result
+0b0000

--- a/src/compound-assignment-private/bitor.case
+++ b/src/compound-assignment-private/bitor.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound bitwise-or assignment with target being a private reference
+---*/
+
+//- lhs
+0b0101
+//- operator
+|=
+//- rhs
+0b1010
+//- result
+0b1111

--- a/src/compound-assignment-private/bitxor.case
+++ b/src/compound-assignment-private/bitxor.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound bitwise-xor assignment with target being a private reference
+---*/
+
+//- lhs
+0x1111
+//- operator
+^=
+//- rhs
+0x1010
+//- result
+0x0101

--- a/src/compound-assignment-private/default/data-property.template
+++ b/src/compound-assignment-private/default/data-property.template
@@ -1,0 +1,51 @@
+// Copyright 2021 the V8 project authors; 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/compound-assignment/left-hand-side-private-reference-data-property-
+esid: sec-assignment-operators-runtime-semantics-evaluation
+info: |
+  sec-assignment-operators-runtime-semantics-evaluation
+  AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+    1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+    2. Let _lval_ be ? GetValue(_lref_).
+    ...
+    7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+    8. Perform ? PutValue(_lref_, _r_).
+    9. Return _r_.
+
+  sec-property-accessors-runtime-semantics-evaluation
+  MemberExpression : MemberExpression `.` PrivateIdentifier
+
+    1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+    2. Let _baseValue_ be ? GetValue(_baseReference_).
+    3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+    4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+  PutValue (V, W)
+    ...
+    5.b. If IsPrivateReference(_V_) is *true*, then
+      i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+  PrivateSet (O, P, value)
+    ...
+    3. If _entry_.[[Kind]] is ~field~, then
+      a. Set _entry_.[[Value]] to _value_.
+
+name: to a field
+features: [class-fields-private]
+---*/
+
+class C {
+  #field = /*{lhs}*/;
+  compoundAssignment() {
+    return this.#field /*{operator}*/ /*{rhs}*/;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), /*{result}*/, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), /*{result}*/, "PutValue should store the result in the private reference");

--- a/src/compound-assignment-private/default/getter-setter.template
+++ b/src/compound-assignment-private/default/getter-setter.template
@@ -1,0 +1,59 @@
+// Copyright 2021 the V8 project authors; 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-
+esid: sec-assignment-operators-runtime-semantics-evaluation
+info: |
+  sec-assignment-operators-runtime-semantics-evaluation
+  AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+    1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+    2. Let _lval_ be ? GetValue(_lref_).
+    ...
+    7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+    8. Perform ? PutValue(_lref_, _r_).
+    9. Return _r_.
+
+  sec-property-accessors-runtime-semantics-evaluation
+  MemberExpression : MemberExpression `.` PrivateIdentifier
+
+    1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+    2. Let _baseValue_ be ? GetValue(_baseReference_).
+    3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+    4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+  PutValue (V, W)
+    ...
+    5.b. If IsPrivateReference(_V_) is *true*, then
+      i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+  PrivateSet (O, P, value)
+    ...
+    5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+    ...
+    5.c. Let _setter_ be _entry_.[[Set]].
+    d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+name: to an accessor property with getter and setter
+features: [class-fields-private]
+---*/
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return /*{lhs}*/;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field /*{operator}*/ /*{rhs}*/;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), /*{result}*/, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), /*{result}*/, "PutValue should call the setter with the result");

--- a/src/compound-assignment-private/default/getter.template
+++ b/src/compound-assignment-private/default/getter.template
@@ -1,0 +1,49 @@
+// Copyright 2021 the V8 project authors; 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-
+esid: sec-assignment-operators-runtime-semantics-evaluation
+info: |
+  sec-assignment-operators-runtime-semantics-evaluation
+  AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+    1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+    2. Let _lval_ be ? GetValue(_lref_).
+    ...
+    7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+    8. Perform ? PutValue(_lref_, _r_).
+    9. Return _r_.
+
+  sec-property-accessors-runtime-semantics-evaluation
+  MemberExpression : MemberExpression `.` PrivateIdentifier
+
+    1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+    2. Let _baseValue_ be ? GetValue(_baseReference_).
+    3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+    4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+  PutValue (V, W)
+    ...
+    5.b. If IsPrivateReference(_V_) is *true*, then
+      i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+  PrivateSet (O, P, value)
+    ...
+    5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+    b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+name: to an accessor property with getter
+features: [class-fields-private]
+---*/
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field /*{operator}*/ 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/src/compound-assignment-private/default/method.template
+++ b/src/compound-assignment-private/default/method.template
@@ -1,0 +1,47 @@
+// Copyright 2021 the V8 project authors; 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+path: language/expressions/compound-assignment/left-hand-side-private-reference-method-
+esid: sec-assignment-operators-runtime-semantics-evaluation
+info: |
+  sec-assignment-operators-runtime-semantics-evaluation
+  AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+    1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+    2. Let _lval_ be ? GetValue(_lref_).
+    ...
+    7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+    8. Perform ? PutValue(_lref_, _r_).
+    9. Return _r_.
+
+  sec-property-accessors-runtime-semantics-evaluation
+  MemberExpression : MemberExpression `.` PrivateIdentifier
+
+    1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+    2. Let _baseValue_ be ? GetValue(_baseReference_).
+    3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+    4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+  PutValue (V, W)
+    ...
+    5.b. If IsPrivateReference(_V_) is *true*, then
+      i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+  PrivateSet (O, P, value)
+    ...
+    4. Else if _entry_.[[Kind]] is ~method~, then
+      a. Throw a *TypeError* exception.
+
+name: to a private method
+features: [class-fields-private]
+---*/
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod /*{operator}*/ 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/src/compound-assignment-private/div.case
+++ b/src/compound-assignment-private/div.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound division assignment with target being a private reference
+---*/
+
+//- lhs
+1
+//- operator
+/=
+//- rhs
+2
+//- result
+0.5

--- a/src/compound-assignment-private/exp.case
+++ b/src/compound-assignment-private/exp.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound exponentiation assignment with target being a private reference
+---*/
+
+//- lhs
+10
+//- operator
+**=
+//- rhs
+3
+//- result
+1000

--- a/src/compound-assignment-private/lshift.case
+++ b/src/compound-assignment-private/lshift.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound left-shift assignment with target being a private reference
+---*/
+
+//- lhs
+0b0110
+//- operator
+<<=
+//- rhs
+4
+//- result
+0b01100000

--- a/src/compound-assignment-private/mod.case
+++ b/src/compound-assignment-private/mod.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound modulo assignment with target being a private reference
+---*/
+
+//- lhs
+3
+//- operator
+%=
+//- rhs
+2
+//- result
+1

--- a/src/compound-assignment-private/mult.case
+++ b/src/compound-assignment-private/mult.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound multiplication assignment with target being a private reference
+---*/
+
+//- lhs
+2
+//- operator
+*=
+//- rhs
+3
+//- result
+6

--- a/src/compound-assignment-private/nullish.case
+++ b/src/compound-assignment-private/nullish.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound nullish-coalescing assignment with target being a private reference
+---*/
+
+//- lhs
+null
+//- operator
+??=
+//- rhs
+1
+//- result
+1

--- a/src/compound-assignment-private/or.case
+++ b/src/compound-assignment-private/or.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound logical-or assignment with target being a private reference
+---*/
+
+//- lhs
+false
+//- operator
+||=
+//- rhs
+true
+//- result
+true

--- a/src/compound-assignment-private/rshift.case
+++ b/src/compound-assignment-private/rshift.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound right-shift assignment with target being a private reference
+---*/
+
+//- lhs
+0b1100
+//- operator
+>>>=
+//- rhs
+2
+//- result
+0b0011

--- a/src/compound-assignment-private/srshift.case
+++ b/src/compound-assignment-private/srshift.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound signed-right-shift assignment with target being a private reference
+---*/
+
+//- lhs
+0b1100
+//- operator
+>>=
+//- rhs
+2
+//- result
+0b0011

--- a/src/compound-assignment-private/sub.case
+++ b/src/compound-assignment-private/sub.case
@@ -1,0 +1,16 @@
+// Copyright 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+template: default
+desc: Compound subtraction assignment with target being a private reference
+---*/
+
+//- lhs
+3
+//- operator
+-=
+//- rhs
+2
+//- result
+1

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-add.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-add.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/add.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound addition assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 1;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field += 2;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 3, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 3, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-and.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-and.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/and.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound logical-and assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return true;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field &&= false;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), false, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), false, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-bitand.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-bitand.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitand.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound bitwise-and assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 0b0101;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field &= 0b1010;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0b0000, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 0b0000, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-bitor.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-bitor.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitor.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound bitwise-or assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 0b0101;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field |= 0b1010;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0b1111, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 0b1111, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-bitxor.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-bitxor.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitxor.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound bitwise-xor assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 0x1111;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field ^= 0x1010;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0x0101, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 0x0101, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-div.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-div.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/div.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound division assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 1;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field /= 2;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0.5, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 0.5, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-exp.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-exp.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/exp.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound exponentiation assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 10;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field **= 3;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 1000, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 1000, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-lshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-lshift.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/lshift.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound left-shift assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 0b0110;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field <<= 4;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0b01100000, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 0b01100000, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-mod.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-mod.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/mod.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound modulo assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 3;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field %= 2;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 1, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 1, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-mult.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-mult.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/mult.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound multiplication assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 2;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field *= 3;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 6, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 6, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-nullish.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-nullish.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/nullish.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound nullish-coalescing assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return null;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field ??= 1;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 1, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 1, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-or.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-or.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/or.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound logical-or assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return false;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field ||= true;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), true, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), true, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-rshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-rshift.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/rshift.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound right-shift assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 0b1100;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field >>>= 2;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0b0011, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 0b0011, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-srshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-srshift.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/srshift.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound signed-right-shift assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 0b1100;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field >>= 2;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0b0011, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 0b0011, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-sub.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-sub.js
@@ -1,0 +1,60 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/sub.case
+// - src/compound-assignment-private/default/getter-setter.template
+/*---
+description: Compound subtraction assignment with target being a private reference (to an accessor property with getter and setter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      ...
+      5.c. Let _setter_ be _entry_.[[Set]].
+      d. Perform ? Call(_setter_, _O_, « _value_ »).
+
+---*/
+
+
+class C {
+  #setterCalledWith;
+  get #field() {
+    return 3;
+  }
+  set #field(value) {
+    this.#setterCalledWith = value;
+  }
+  compoundAssignment() {
+    return this.#field -= 2;
+  }
+  setterCalledWithValue() {
+    return this.#setterCalledWith;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 1, "The expression should evaluate to the result");
+assert.sameValue(o.setterCalledWithValue(), 1, "PutValue should call the setter with the result");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-add.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-add.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/add.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound addition assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 1;
+  compoundAssignment() {
+    return this.#field += 2;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 3, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 3, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-and.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-and.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/and.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound logical-and assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = true;
+  compoundAssignment() {
+    return this.#field &&= false;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), false, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), false, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-bitand.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-bitand.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitand.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound bitwise-and assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 0b0101;
+  compoundAssignment() {
+    return this.#field &= 0b1010;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0b0000, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 0b0000, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-bitor.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-bitor.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitor.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound bitwise-or assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 0b0101;
+  compoundAssignment() {
+    return this.#field |= 0b1010;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0b1111, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 0b1111, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-bitxor.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-bitxor.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitxor.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound bitwise-xor assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 0x1111;
+  compoundAssignment() {
+    return this.#field ^= 0x1010;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0x0101, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 0x0101, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-div.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-div.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/div.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound division assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 1;
+  compoundAssignment() {
+    return this.#field /= 2;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0.5, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 0.5, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-exp.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-exp.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/exp.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound exponentiation assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 10;
+  compoundAssignment() {
+    return this.#field **= 3;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 1000, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 1000, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-lshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-lshift.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/lshift.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound left-shift assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 0b0110;
+  compoundAssignment() {
+    return this.#field <<= 4;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0b01100000, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 0b01100000, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-mod.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-mod.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/mod.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound modulo assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 3;
+  compoundAssignment() {
+    return this.#field %= 2;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 1, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 1, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-mult.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-mult.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/mult.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound multiplication assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 2;
+  compoundAssignment() {
+    return this.#field *= 3;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 6, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 6, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-nullish.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-nullish.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/nullish.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound nullish-coalescing assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = null;
+  compoundAssignment() {
+    return this.#field ??= 1;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 1, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 1, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-or.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-or.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/or.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound logical-or assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = false;
+  compoundAssignment() {
+    return this.#field ||= true;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), true, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), true, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-rshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-rshift.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/rshift.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound right-shift assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 0b1100;
+  compoundAssignment() {
+    return this.#field >>>= 2;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0b0011, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 0b0011, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-srshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-srshift.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/srshift.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound signed-right-shift assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 0b1100;
+  compoundAssignment() {
+    return this.#field >>= 2;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 0b0011, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 0b0011, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-sub.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-sub.js
@@ -1,0 +1,52 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/sub.case
+// - src/compound-assignment-private/default/data-property.template
+/*---
+description: Compound subtraction assignment with target being a private reference (to a field)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      3. If _entry_.[[Kind]] is ~field~, then
+        a. Set _entry_.[[Value]] to _value_.
+
+---*/
+
+
+class C {
+  #field = 3;
+  compoundAssignment() {
+    return this.#field -= 2;
+  }
+  fieldValue() {
+    return this.#field;
+  }
+}
+
+const o = new C();
+assert.sameValue(o.compoundAssignment(), 1, "The expression should evaluate to the result");
+assert.sameValue(o.fieldValue(), 1, "PutValue should store the result in the private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-add.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-add.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/add.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound addition assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod += 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-and.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-and.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/and.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound logical-and assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod &&= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-bitand.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-bitand.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitand.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound bitwise-and assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod &= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-bitor.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-bitor.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitor.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound bitwise-or assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod |= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-bitxor.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-bitxor.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitxor.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound bitwise-xor assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod ^= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-div.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-div.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/div.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound division assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod /= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-exp.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-exp.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/exp.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound exponentiation assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod **= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-lshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-lshift.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/lshift.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound left-shift assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod <<= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-mod.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-mod.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/mod.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound modulo assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod %= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-mult.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-mult.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/mult.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound multiplication assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod *= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-nullish.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-nullish.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/nullish.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound nullish-coalescing assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod ??= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-or.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-or.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/or.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound logical-or assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod ||= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-rshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-rshift.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/rshift.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound right-shift assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod >>>= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-srshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-srshift.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/srshift.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound signed-right-shift assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod >>= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-sub.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-sub.js
@@ -1,0 +1,48 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/sub.case
+// - src/compound-assignment-private/default/method.template
+/*---
+description: Compound subtraction assignment with target being a private reference (to a private method)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      4. Else if _entry_.[[Kind]] is ~method~, then
+        a. Throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  #privateMethod() {}
+  compoundAssignment() {
+    return this.#privateMethod -= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result in a method private reference");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-add.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-add.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/add.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound addition assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field += 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-and.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-and.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/and.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound logical-and assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field &&= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-bitand.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-bitand.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitand.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound bitwise-and assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field &= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-bitor.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-bitor.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitor.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound bitwise-or assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field |= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-bitxor.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-bitxor.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/bitxor.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound bitwise-xor assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field ^= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-div.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-div.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/div.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound division assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field /= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-exp.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-exp.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/exp.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound exponentiation assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field **= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-lshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-lshift.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/lshift.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound left-shift assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field <<= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-mod.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-mod.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/mod.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound modulo assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field %= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-mult.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-mult.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/mult.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound multiplication assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field *= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-nullish.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-nullish.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/nullish.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound nullish-coalescing assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field ??= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-or.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-or.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/or.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound logical-or assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field ||= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-rshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-rshift.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/rshift.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound right-shift assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field >>>= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-srshift.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-srshift.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/srshift.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound signed-right-shift assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field >>= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-sub.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-sub.js
@@ -1,0 +1,50 @@
+// This file was procedurally generated from the following sources:
+// - src/compound-assignment-private/sub.case
+// - src/compound-assignment-private/default/getter.template
+/*---
+description: Compound subtraction assignment with target being a private reference (to an accessor property with getter)
+esid: sec-assignment-operators-runtime-semantics-evaluation
+features: [class-fields-private]
+flags: [generated]
+info: |
+    sec-assignment-operators-runtime-semantics-evaluation
+    AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
+      1. Let _lref_ be the result of evaluating |LeftHandSideExpression|.
+      2. Let _lval_ be ? GetValue(_lref_).
+      ...
+      7. Let _r_ be ApplyStringOrNumericBinaryOperator(_lval_, _opText_, _rval_).
+      8. Perform ? PutValue(_lref_, _r_).
+      9. Return _r_.
+
+    sec-property-accessors-runtime-semantics-evaluation
+    MemberExpression : MemberExpression `.` PrivateIdentifier
+
+      1. Let _baseReference_ be the result of evaluating |MemberExpression|.
+      2. Let _baseValue_ be ? GetValue(_baseReference_).
+      3. Let _fieldNameString_ be the StringValue of |PrivateIdentifier|.
+      4. Return ! MakePrivateReference(_baseValue_, _fieldNameString_).
+
+    PutValue (V, W)
+      ...
+      5.b. If IsPrivateReference(_V_) is *true*, then
+        i. Return ? PrivateSet(_baseObj_, _V_.[[ReferencedName]], _W_).
+
+    PrivateSet (O, P, value)
+      ...
+      5.a. Assert: _entry_.[[Kind]] is ~accessor~.
+      b. If _entry_.[[Set]] is *undefined*, throw a *TypeError* exception.
+
+---*/
+
+
+class C {
+  get #field() {
+    return 1;
+  }
+  compoundAssignment() {
+    return this.#field -= 1;
+  }
+}
+
+const o = new C();
+assert.throws(TypeError, () => o.compoundAssignment(), "PutValue throws when storing the result if no setter");


### PR DESCRIPTION
This adds generated tests for each of the compound assignment operators, assigning to each type of private reference. I used https://chromium-review.googlesource.com/c/v8/v8/+/2652495/1/test/mjsunit/regress/regress-v8-11360.js as a starting point for the tests, and expanded that to cover all the operators.

Also two minor fixes to .editorconfig and CONTRIBUTING.md.

Closes: #2940