### PR TITLE
Adding first  maintainers group docs

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,18 @@
+# Test262 Maintainers Group
+
+Being part of the Test262 Maintainers Group comes with great power (merging things!) and the associated great responsibility (merging things!). Below is a list of the general responsibilities of Test262 maintainers and roughly how often the tasks are taken care of. Please remember, most maintainers do this in their free time or as one of many work tasks, and may therefore not respond as quickly as you hope.
+
+## Responsibilities
+- **Reviewing PRs** (1-2x/week)
+- **Reviewing test plans and helping guide contributors before PRs are submitted** (1-2x/week, as needed)
+- **Reviewing Stage 3 proposals and prioritizing related tests** (6x/yr, following TC39 plenaries)
+- **Fielding requests and suggestions for improvement from users(contributors, implementers, etc. TKTK link here to priority of constituencies TKTK)** (1x/month, at group meetings)
+- **Maintaining and evolving our list of values, tutorials, and other documentation** (ongoing, as needed)
+
+## How Are Decisions Made in the Maintainers Group
+
+.. TKTKTKTK ..
+
+## How Do I Become a Member of the Maintainers Group
+
+.. TKTKTKTK ..


### PR DESCRIPTION
Adds draft for maintainers group documentation. Please take a look and let me know what you think, @rwaldron @jugglinmike @ptomato.

I notice that https://github.com/tc39/test262/pull/3406 adds a `guides/` directory so this could probably be moved into that, once we put all these things together.