### PR TITLE
Add tests for T time designator prefix not allowing space

### DIFF
--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-designator-required-for-disambiguation.js
@@ -27,6 +27,13 @@ ambiguousStrings.forEach((string) => {
   // The same string with a T prefix should not throw:
   arg = `T${string}`;
   instance.toPlainDateTime(arg);
+
+  arg = ` ${string}`;
+  assert.throws(
+    RangeError,
+    () => instance.toPlainDateTime(arg),
+    'space is not accepted as a substitute for T prefix'
+  );
 });
 
 // None of these should throw without a T prefix, because they are unambiguously time strings:

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-time-designator-required-for-disambiguation.js
@@ -27,6 +27,13 @@ ambiguousStrings.forEach((string) => {
   // The same string with a T prefix should not throw:
   arg = `T${string}`;
   instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" });
+
+  arg = ` ${string}`;
+  assert.throws(
+    RangeError,
+    () => instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" }),
+    'space is not accepted as a substitute for T prefix'
+  );
 });
 
 // None of these should throw without a T prefix, because they are unambiguously time strings:

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-designator-required-for-disambiguation.js
@@ -27,6 +27,13 @@ ambiguousStrings.forEach((string) => {
   // The same string with a T prefix should not throw:
   arg = `T${string}`;
   instance.withPlainTime(arg);
+
+  arg = ` ${string}`;
+  assert.throws(
+    RangeError,
+    () => instance.withPlainTime(arg),
+    'space is not accepted as a substitute for T prefix'
+  );
 });
 
 // None of these should throw without a T prefix, because they are unambiguously time strings:

--- a/test/built-ins/Temporal/PlainTime/compare/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainTime/compare/argument-string-time-designator-required-for-disambiguation.js
@@ -33,6 +33,18 @@ ambiguousStrings.forEach((string) => {
   arg = `T${string}`;
   Temporal.PlainTime.compare(arg, midnight);
   Temporal.PlainTime.compare(midnight, arg);
+
+  arg = ` ${string}`;
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainTime.compare(arg, midnight),
+    'space is not accepted as a substitute for T prefix (first argument)'
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainTime.compare(midnight, arg),
+    'space is not accepted as a substitute for T prefix (second argument)'
+  );
 });
 
 // None of these should throw without a T prefix, because they are unambiguously time strings:

--- a/test/built-ins/Temporal/PlainTime/from/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-string-time-designator-required-for-disambiguation.js
@@ -25,6 +25,13 @@ ambiguousStrings.forEach((string) => {
   // The same string with a T prefix should not throw:
   arg = `T${string}`;
   Temporal.PlainTime.from(arg);
+
+  arg = ` ${string}`;
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainTime.from(arg),
+    'space is not accepted as a substitute for T prefix'
+  );
 });
 
 // None of these should throw without a T prefix, because they are unambiguously time strings:

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-designator-required-for-disambiguation.js
@@ -27,6 +27,13 @@ ambiguousStrings.forEach((string) => {
   // The same string with a T prefix should not throw:
   arg = `T${string}`;
   instance.equals(arg);
+
+  arg = ` ${string}`;
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    'space is not accepted as a substitute for T prefix'
+  );
 });
 
 // None of these should throw without a T prefix, because they are unambiguously time strings:

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-designator-required-for-disambiguation.js
@@ -27,6 +27,13 @@ ambiguousStrings.forEach((string) => {
   // The same string with a T prefix should not throw:
   arg = `T${string}`;
   instance.since(arg);
+
+  arg = ` ${string}`;
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    'space is not accepted as a substitute for T prefix'
+  );
 });
 
 // None of these should throw without a T prefix, because they are unambiguously time strings:

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-designator-required-for-disambiguation.js
@@ -27,6 +27,13 @@ ambiguousStrings.forEach((string) => {
   // The same string with a T prefix should not throw:
   arg = `T${string}`;
   instance.until(arg);
+
+  arg = ` ${string}`;
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    'space is not accepted as a substitute for T prefix'
+  );
 });
 
 // None of these should throw without a T prefix, because they are unambiguously time strings:

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-time-designator-required-for-disambiguation.js
@@ -27,6 +27,13 @@ ambiguousStrings.forEach((string) => {
   // The same string with a T prefix should not throw:
   arg = `T${string}`;
   instance.withPlainTime(arg);
+
+  arg = ` ${string}`;
+  assert.throws(
+    RangeError,
+    () => instance.withPlainTime(arg),
+    'space is not accepted as a substitute for T prefix'
+  );
 });
 
 // None of these should throw without a T prefix, because they are unambiguously time strings:


### PR DESCRIPTION
Here's a test I should have included in #3395. It's allowed to replace the
"T" in the middle of an ISO string with a space, but not when the "T" is a
time designator prefix. This assertion ensures that implementations make
this distinction correctly.