### PR TITLE
Add tests for Temporal.Instant.p*.subtract

### DIFF
--- a/test/built-ins/Temporal/Instant/prototype/add/basic.js
+++ b/test/built-ins/Temporal/Instant/prototype/add/basic.js
@@ -1,0 +1,72 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.add
+description: Basic functionality of Temporal.Instant.prototype.add()
+info: |
+  1. Let instant be the this value.
+  2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
+  3. Let duration be ? ToLimitedTemporalDuration(temporalDurationLike, « "years", "months", "weeks", "days" »).
+  4. Let ns be ? AddInstant(instant.[[EpochNanoseconds]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]]).
+  5. Return ! CreateTemporalInstant(ns).
+features: [Temporal]
+---*/
+
+const inst = new Temporal.Instant(50000n);
+
+let result = inst.add(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 3, 2, 1));
+assert.sameValue(
+  3052001n,
+  result.epochNanoseconds,
+  "add positive sub-seconds"
+);
+
+result = inst.add(new Temporal.Duration(0, 0, 0, 0, 0, 0, 4, 3, 2, 1));
+assert.sameValue(
+  BigInt(4 * 1e9) + 3052001n,
+  result.epochNanoseconds,
+  "add positive seconds"
+);
+
+result = inst.add(new Temporal.Duration(0, 0, 0, 0, 0, 5, 4, 3, 2, 1));
+assert.sameValue(
+  BigInt(5 * 60 + 4) * 1000000000n + 3052001n,
+  result.epochNanoseconds,
+  "add positive minutes"
+);
+
+result = inst.add(new Temporal.Duration(0, 0, 0, 0, 6, 5, 4, 3, 2, 1));
+assert.sameValue(
+  BigInt(6 * 3600 + 5 * 60 + 4) * 1000000000n + 3052001n,
+  result.epochNanoseconds,
+  "add positive hours"
+);
+
+result = inst.add(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, -3, -2, -1));
+assert.sameValue(
+  -2952001n,
+  result.epochNanoseconds,
+  "add negative sub-seconds"
+);
+
+result = inst.add(new Temporal.Duration(0, 0, 0, 0, 0, 0, -4, -3, -2, -1));
+assert.sameValue(
+  BigInt(-4 * 1e9) - 2952001n,
+  result.epochNanoseconds,
+  "add negative seconds"
+);
+
+result = inst.add(new Temporal.Duration(0, 0, 0, 0, 0, -5, -4, -3, -2, -1));
+assert.sameValue(
+  BigInt(5 * 60 + 4) * -1000000000n - 2952001n,
+  result.epochNanoseconds,
+  "add negative minutes"
+);
+
+result = inst.add(new Temporal.Duration(0, 0, 0, 0, -6, -5, -4, -3, -2, -1));
+assert.sameValue(
+  BigInt(6 * 3600 + 5 * 60 + 4) * -1000000000n - 2952001n,
+  result.epochNanoseconds,
+  "add negative hours"
+);

--- a/test/built-ins/Temporal/Instant/prototype/add/branding.js
+++ b/test/built-ins/Temporal/Instant/prototype/add/branding.js
@@ -11,12 +11,14 @@ const add = Temporal.Instant.prototype.add;
 
 assert.sameValue(typeof add, "function");
 
-assert.throws(TypeError, () => add.call(undefined), "undefined");
-assert.throws(TypeError, () => add.call(null), "null");
-assert.throws(TypeError, () => add.call(true), "true");
-assert.throws(TypeError, () => add.call(""), "empty string");
-assert.throws(TypeError, () => add.call(Symbol()), "symbol");
-assert.throws(TypeError, () => add.call(1), "1");
-assert.throws(TypeError, () => add.call({}), "plain object");
-assert.throws(TypeError, () => add.call(Temporal.Instant), "Temporal.Instant");
-assert.throws(TypeError, () => add.call(Temporal.Instant.prototype), "Temporal.Instant.prototype");
+const arg = new Temporal.Duration(0, 0, 0, 0, 5);
+
+assert.throws(TypeError, () => add.call(undefined, arg), "undefined");
+assert.throws(TypeError, () => add.call(null, arg), "null");
+assert.throws(TypeError, () => add.call(true, arg), "true");
+assert.throws(TypeError, () => add.call("", arg), "empty string");
+assert.throws(TypeError, () => add.call(Symbol(), arg), "symbol");
+assert.throws(TypeError, () => add.call(1, arg), "1");
+assert.throws(TypeError, () => add.call({}, arg), "plain object");
+assert.throws(TypeError, () => add.call(Temporal.Instant, arg), "Temporal.Instant");
+assert.throws(TypeError, () => add.call(Temporal.Instant.prototype, arg), "Temporal.Instant.prototype");

--- a/test/built-ins/Temporal/Instant/prototype/add/disallowed-duration-units.js
+++ b/test/built-ins/Temporal/Instant/prototype/add/disallowed-duration-units.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.add
+description: |
+  Temporal.Instant.prototype.add() throws RangeError when the duration has
+  non-zero years, months, weeks, or days.
+info: |
+  1. Let instant be the this value.
+  3. Let duration be ? ToLimitedTemporalDuration(temporalDurationLike, « "years", "months", "weeks", "days" »).
+features: [Temporal]
+---*/
+
+const inst = new Temporal.Instant(500000n);
+assert.throws(RangeError, () => inst.add(new Temporal.Duration(1)),
+    "should throw RangeError when the duration has non-zero years (positive)");
+assert.throws(RangeError, () => inst.add(new Temporal.Duration(0, 2)),
+    "should throw RangeError when the duration has non-zero months (positive)");
+assert.throws(RangeError, () => inst.add(new Temporal.Duration(0, 0, 3)),
+    "should throw RangeError when the duration has non-zero weeks (positive)");
+assert.throws(RangeError, () => inst.add(new Temporal.Duration(0, 0, 0, 4)),
+    "should throw RangeError when the duration has non-zero days (positive)");
+assert.throws(RangeError, () => inst.add(new Temporal.Duration(-1)),
+    "should throw RangeError when the duration has non-zero years (negative)");
+assert.throws(RangeError, () => inst.add(new Temporal.Duration(0, -2)),
+    "should throw RangeError when the duration has non-zero months (negative)");
+assert.throws(RangeError, () => inst.add(new Temporal.Duration(0, 0, -3)),
+    "should throw RangeError when the duration has non-zero weeks (negative)");
+assert.throws(RangeError, () => inst.add(new Temporal.Duration(0, 0, 0, -4)),
+    "should throw RangeError when the duration has non-zero days (negative)");

--- a/test/built-ins/Temporal/Instant/prototype/add/result-out-of-range.js
+++ b/test/built-ins/Temporal/Instant/prototype/add/result-out-of-range.js
@@ -9,8 +9,22 @@ features: [Temporal]
 
 const fields = ["hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds"];
 
-const instance = Temporal.Instant.fromEpochNanoseconds(8640000_000_000_000_000_000n);
+const latest = Temporal.Instant.fromEpochNanoseconds(8640000_000_000_000_000_000n);
 
 fields.forEach((field) => {
-  assert.throws(RangeError, () => instance.add({ [field]: 1 }));
+  assert.throws(
+    RangeError,
+    () => latest.add({ [field]: 1 }),
+    `adding ${field} with result out of range (positive)`
+  );
+});
+
+const earliest = Temporal.Instant.fromEpochNanoseconds(-8640000_000_000_000_000_000n);
+
+fields.forEach((field) => {
+  assert.throws(
+    RangeError,
+    () => earliest.add({ [field]: -1 }),
+    `adding ${field} with result out of range (negative)`
+  );
 });

--- a/test/built-ins/Temporal/Instant/prototype/subtract/basic.js
+++ b/test/built-ins/Temporal/Instant/prototype/subtract/basic.js
@@ -1,0 +1,72 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.subtract
+description: Basic functionality of Temporal.Instant.prototype.subtract()
+info: |
+  1. Let instant be the this value.
+  2. Perform ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
+  3. Let duration be ? ToLimitedTemporalDuration(temporalDurationLike, « "years", "months", "weeks", "days" »).
+  4. Let ns be ? AddInstant(instant.[[EpochNanoseconds]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]]).
+  5. Return ! CreateTemporalInstant(ns).
+features: [Temporal]
+---*/
+
+const inst = new Temporal.Instant(50000n);
+
+let result = inst.subtract(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 3, 2, 1));
+assert.sameValue(
+  -2952001n,
+  result.epochNanoseconds,
+  "subtract positive sub-seconds"
+);
+
+result = inst.subtract(new Temporal.Duration(0, 0, 0, 0, 0, 0, 4, 3, 2, 1));
+assert.sameValue(
+  BigInt(-4 * 1e9) - 2952001n,
+  result.epochNanoseconds,
+  "subtract positive seconds"
+);
+
+result = inst.subtract(new Temporal.Duration(0, 0, 0, 0, 0, 5, 4, 3, 2, 1));
+assert.sameValue(
+  BigInt(5 * 60 + 4) * -1000000000n - 2952001n,
+  result.epochNanoseconds,
+  "subtract positive minutes"
+);
+
+result = inst.subtract(new Temporal.Duration(0, 0, 0, 0, 6, 5, 4, 3, 2, 1));
+assert.sameValue(
+  BigInt(6 * 3600 + 5 * 60 + 4) * -1000000000n - 2952001n,
+  result.epochNanoseconds,
+  "subtract positive hours"
+);
+
+result = inst.subtract(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, -3, -2, -1));
+assert.sameValue(
+  3052001n,
+  result.epochNanoseconds,
+  "subtract negative sub-seconds"
+);
+
+result = inst.subtract(new Temporal.Duration(0, 0, 0, 0, 0, 0, -4, -3, -2, -1));
+assert.sameValue(
+  BigInt(4 * 1e9) + 3052001n,
+  result.epochNanoseconds,
+  "subtract negative seconds"
+);
+
+result = inst.subtract(new Temporal.Duration(0, 0, 0, 0, 0, -5, -4, -3, -2, -1));
+assert.sameValue(
+  BigInt(5 * 60 + 4) * 1000000000n + 3052001n,
+  result.epochNanoseconds,
+  "subtract negative minutes"
+);
+
+result = inst.subtract(new Temporal.Duration(0, 0, 0, 0, -6, -5, -4, -3, -2, -1));
+assert.sameValue(
+  BigInt(6 * 3600 + 5 * 60 + 4) * 1000000000n + 3052001n,
+  result.epochNanoseconds,
+  "subtract negative hours"
+);

--- a/test/built-ins/Temporal/Instant/prototype/subtract/branding.js
+++ b/test/built-ins/Temporal/Instant/prototype/subtract/branding.js
@@ -11,12 +11,14 @@ const subtract = Temporal.Instant.prototype.subtract;
 
 assert.sameValue(typeof subtract, "function");
 
-assert.throws(TypeError, () => subtract.call(undefined), "undefined");
-assert.throws(TypeError, () => subtract.call(null), "null");
-assert.throws(TypeError, () => subtract.call(true), "true");
-assert.throws(TypeError, () => subtract.call(""), "empty string");
-assert.throws(TypeError, () => subtract.call(Symbol()), "symbol");
-assert.throws(TypeError, () => subtract.call(1), "1");
-assert.throws(TypeError, () => subtract.call({}), "plain object");
-assert.throws(TypeError, () => subtract.call(Temporal.Instant), "Temporal.Instant");
-assert.throws(TypeError, () => subtract.call(Temporal.Instant.prototype), "Temporal.Instant.prototype");
+const arg = new Temporal.Duration(0, 0, 0, 0, 5);
+
+assert.throws(TypeError, () => subtract.call(undefined, arg), "undefined");
+assert.throws(TypeError, () => subtract.call(null, arg), "null");
+assert.throws(TypeError, () => subtract.call(true, arg), "true");
+assert.throws(TypeError, () => subtract.call("", arg), "empty string");
+assert.throws(TypeError, () => subtract.call(Symbol(), arg), "symbol");
+assert.throws(TypeError, () => subtract.call(1, arg), "1");
+assert.throws(TypeError, () => subtract.call({}, arg), "plain object");
+assert.throws(TypeError, () => subtract.call(Temporal.Instant, arg), "Temporal.Instant");
+assert.throws(TypeError, () => subtract.call(Temporal.Instant.prototype, arg), "Temporal.Instant.prototype");

--- a/test/built-ins/Temporal/Instant/prototype/subtract/disallowed-duration-units.js
+++ b/test/built-ins/Temporal/Instant/prototype/subtract/disallowed-duration-units.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.subtract
+description: |
+  Temporal.Instant.prototype.subtract() throws RangeError when the duration has
+  non-zero years, months, weeks or days.
+info: |
+  1. Let instant be the this value.
+  3. Let duration be ? ToLimitedTemporalDuration(temporalDurationLike, « "years", "months", "weeks", "days" »).
+features: [Temporal]
+---*/
+
+let i1 = new Temporal.Instant(500000n);
+assert.throws(RangeError, () => i1.subtract(new Temporal.Duration(1)),
+    "should throw RangeError when the duration has non-zero years (positive)");
+assert.throws(RangeError, () => i1.subtract(new Temporal.Duration(0, 2)),
+    "should throw RangeError when the duration has non-zero months (positive)");
+assert.throws(RangeError, () => i1.subtract(new Temporal.Duration(0, 0, 3)),
+    "should throw RangeError when the duration has non-zero weeks (positive)");
+assert.throws(RangeError, () => i1.subtract(new Temporal.Duration(0, 0, 0, 4)),
+    "should throw RangeError when the duration has non-zero days (positive)");
+assert.throws(RangeError, () => i1.subtract(new Temporal.Duration(-1)),
+    "should throw RangeError when the duration has non-zero years (negative)");
+assert.throws(RangeError, () => i1.subtract(new Temporal.Duration(0, -2)),
+    "should throw RangeError when the duration has non-zero months (negative)");
+assert.throws(RangeError, () => i1.subtract(new Temporal.Duration(0, 0, -3)),
+    "should throw RangeError when the duration has non-zero weeks (negative)");
+assert.throws(RangeError, () => i1.subtract(new Temporal.Duration(0, 0, 0, -4)),
+    "should throw RangeError when the duration has non-zero days (negative)");

--- a/test/built-ins/Temporal/Instant/prototype/subtract/result-out-of-range.js
+++ b/test/built-ins/Temporal/Instant/prototype/subtract/result-out-of-range.js
@@ -2,15 +2,29 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.add
+esid: sec-temporal.instant.prototype.subtract
 description: RangeError thrown if result is outside representable range
 features: [Temporal]
 ---*/
 
 const fields = ["hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds"];
 
-const instance = Temporal.Instant.fromEpochNanoseconds(-8640000_000_000_000_000_000n);
+const earliest = Temporal.Instant.fromEpochNanoseconds(-8640000_000_000_000_000_000n);
 
 fields.forEach((field) => {
-  assert.throws(RangeError, () => instance.subtract({ [field]: 1 }));
+  assert.throws(
+    RangeError,
+    () => earliest.subtract({ [field]: 1 }),
+    `subtracting ${field} with result out of range (negative)`
+  );
+});
+
+const latest = Temporal.Instant.fromEpochNanoseconds(8640000_000_000_000_000_000n);
+
+fields.forEach((field) => {
+  assert.throws(
+    RangeError,
+    () => latest.subtract({ [field]: -1 }),
+    `subtracting ${field} with result out of range (positive)`
+  );
 });


### PR DESCRIPTION
This was originally @FrankYFTang's PR #3076 which was closed without being merged. I'm following up as promised. I rebased it, added assertion messages, did some reformatting, and combined with some existing tests.