### PR TITLE
Use ECMAScript version 11

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,4 @@
 {
     "predef": ["Intl"],
-    "esversion": 6
+    "esversion": 11
 }


### PR DESCRIPTION
We use BigInt syntax in a bunch of tests. This change
registers that fact with linters that use `.jshintrc`.