### PR TITLE
Fixed YAML in some new test metadata

### DIFF
--- a/test/built-ins/ShadowRealm/WrappedFunction/throws-typeerror-on-revoked-proxy.js
+++ b/test/built-ins/ShadowRealm/WrappedFunction/throws-typeerror-on-revoked-proxy.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-wrapped-function-exotic-objects-call-thisargument-argumentslist
 description: >
-  	WrappedFunctionCreate throws a TypeError the target is a revoked proxy.
+    WrappedFunctionCreate throws a TypeError the target is a revoked proxy.
 
 info: |
   WrappedFunctionCreate ( callerRealm: a Realm Record, Target: a function object, )

--- a/test/built-ins/ShadowRealm/prototype/evaluate/throws-typeerror-wrap-throwing.js
+++ b/test/built-ins/ShadowRealm/prototype/evaluate/throws-typeerror-wrap-throwing.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-wrappedfunctioncreate
 description: >
-  	WrappedFunctionCreate throws a TypeError if the accessing target's property may throw.
+    WrappedFunctionCreate throws a TypeError if the accessing target's property may throw.
 
 info: |
   WrappedFunctionCreate ( callerRealm: a Realm Record, Target: a function object, )


### PR DESCRIPTION
This closes #3451.

It coverts the tab character to spaces to avoid YAML parsing errors.