### PR TITLE
Undefined options check in Temporal

### DIFF
--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -1035,6 +1035,44 @@ var TemporalHelpers = {
   },
 
   /*
+   * A custom calendar that asserts its ...FromFields() methods are called with
+   * the options parameter having the value undefined.
+   */
+  calendarFromFieldsUndefinedOptions() {
+    class CalendarFromFieldsUndefinedOptions extends Temporal.Calendar {
+      constructor() {
+        super("iso8601");
+        this.dateFromFieldsCallCount = 0;
+        this.monthDayFromFieldsCallCount = 0;
+        this.yearMonthFromFieldsCallCount = 0;
+      }
+
+      toString() {
+        return "from-fields-undef-options";
+      }
+
+      dateFromFields(fields, options) {
+        this.dateFromFieldsCallCount++;
+        assert.sameValue(options, undefined, "dateFromFields shouldn't be called with options");
+        return super.dateFromFields(fields, options);
+      }
+
+      yearMonthFromFields(fields, options) {
+        this.yearMonthFromFieldsCallCount++;
+        assert.sameValue(options, undefined, "yearMonthFromFields shouldn't be called with options");
+        return super.yearMonthFromFields(fields, options);
+      }
+
+      monthDayFromFields(fields, options) {
+        this.monthDayFromFieldsCallCount++;
+        assert.sameValue(options, undefined, "monthDayFromFields shouldn't be called with options");
+        return super.monthDayFromFields(fields, options);
+      }
+    }
+    return new CalendarFromFieldsUndefinedOptions();
+  },
+
+  /*
    * A custom calendar that modifies the fields object passed in to
    * dateFromFields, sabotaging its time properties.
    */

--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -1312,10 +1312,10 @@ var TemporalHelpers = {
         if (this._shiftNanoseconds > 0) {
           if (this._isBeforeShift(instant)) return [instant];
           if (instant.epochNanoseconds < this._epoch2) return [];
-          return [instant.add(this._shift)];
+          return [instant.subtract(this._shift)];
         }
         if (instant.epochNanoseconds < this._epoch2) return [instant];
-        const shifted = instant.add(this._shift);
+        const shifted = instant.subtract(this._shift);
         if (this._isBeforeShift(instant)) return [instant, shifted];
         return [shifted];
       }

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.dateAdd({ year: 2000, month: 5, day: 2, calendar }, new Temporal.Duration(1));
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.dateUntil({ year: 2000, month: 5, day: 2, calendar }, { year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 2);

--- a/test/built-ins/Temporal/Calendar/prototype/day/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.day
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.day({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofweek
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.dayOfWeek({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofyear
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.dayOfYear({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinmonth
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.daysInMonth({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinweek
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.daysInWeek({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinyear
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.daysInYear({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.inleapyear
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.inLeapYear({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/month/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.month
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.month({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthcode
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.monthCode({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthsinyear
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.monthsInYear({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.weekofyear
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.weekOfYear({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Calendar/prototype/year/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.year
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.year({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/Duration/compare/calendar-dateadd-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Duration/compare/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const relativeTo = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+const duration1 = new Temporal.Duration(0, 0, 1);
+const duration2 = new Temporal.Duration(0, 0, 1);
+Temporal.Duration.compare(duration1, duration2, { relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 4);
+// one call in CalculateOffsetShift for each duration argument, plus one in
+// UnbalanceDurationRelative for each duration argument

--- a/test/built-ins/Temporal/Duration/prototype/round/calendar-dateadd-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const relativeTo = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+// Rounding with smallestUnit a calendar unit.
+// The calls come from these paths:
+// Duration.round() ->
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   BalanceDurationRelative ->
+//     MoveRelativeDate -> calendar.dateAdd() (2x)
+//     calendar.dateAdd()
+//   MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   BalanceDuration ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+
+const instance1 = new Temporal.Duration(1, 1, 1, 1, 1);
+instance1.round({ smallestUnit: "days", relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 9, "rounding with calendar smallestUnit");
+
+// Rounding with a non-default largestUnit to cover the path in
+// UnbalanceDurationRelative where larger units are converted into smaller
+// units; and with a smallestUnit larger than days to cover the path in
+// RoundDuration where days are converted into larger units.
+// The calls come from these paths:
+// Duration.round() ->
+//   UnbalanceDurationRelative -> MoveRelativeDate -> calendar.dateAdd()
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     MoveRelativeDate -> calendar.dateAdd() (5x)
+//   BalanceDurationRelative
+//     MoveRelativeDate -> calendar.dateAdd()
+//   MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+
+calendar.dateAddCallCount = 0;
+
+const instance2 = new Temporal.Duration(0, 1, 1, 1);
+instance2.round({ largestUnit: "weeks", smallestUnit: "weeks", relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 9, "rounding with non-default largestUnit and calendar smallestUnit");
+
+// Rounding with smallestUnit a non-calendar unit, and having the resulting time
+// difference be longer than a calendar day, covering the paths that go through
+// AdjustRoundedDurationDays.
+// The calls come from these paths:
+// Duration.round() ->
+//   AdjustRoundedDurationDays ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     AddDuration ->
+//       AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//       NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+//   BalanceDuration ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+
+calendar.dateAddCallCount = 0;
+
+const instance3 = new Temporal.Duration(0, 0, 0, 0, 23, 59, 59, 999, 999, 999);
+instance3.round({ largestUnit: "days", smallestUnit: "hours", roundingMode: "ceil", relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 7, "rounding with time difference exceeding calendar day");

--- a/test/built-ins/Temporal/Duration/prototype/total/calendar-dateadd-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const relativeTo = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+// Total of a calendar unit where larger calendar units have to be converted
+// down, to cover the path that goes through UnbalanceDurationRelative
+// The calls come from these paths:
+// Duration.total() ->
+//   UnbalanceDurationRelative -> MoveRelativeDate -> calendar.dateAdd() (3x)
+//   BalanceDuration ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+
+const instance1 = new Temporal.Duration(1, 1, 1, 1, 1);
+instance1.total({ unit: "days", relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 8, "converting larger calendar units down");
+
+// Total of a calendar unit where smaller calendar units have to be converted
+// up, to cover the path that goes through MoveRelativeZonedDateTime
+// The calls come from these paths:
+// Duration.total() ->
+//   MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   BalanceDuration ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     MoveRelativeDate -> calendar.dateAdd()
+
+calendar.dateAddCallCount = 0;
+
+const instance2 = new Temporal.Duration(0, 0, 1, 1);
+instance2.total({ unit: "weeks", relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 6, "converting smaller calendar units up");

--- a/test/built-ins/Temporal/PlainDate/compare/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/compare/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.compare
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+Temporal.PlainDate.compare({ year: 2000, month: 5, day: 2, calendar }, { year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 2);

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.equals
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainDate(2000, 5, 2, calendar);
+instance.equals({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/PlainDate/prototype/since/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainDate(2000, 5, 2, calendar);
+instance.since({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/calendar-monthdayfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/calendar-monthdayfromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplainmonthday
+description: >
+    Calendar.monthDayFromFields method is called with undefined as the options
+    value when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainDate(2000, 5, 2, calendar);
+instance.toPlainMonthDay();
+assert.sameValue(calendar.monthDayFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/calendar-yearmonthfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/calendar-yearmonthfromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplainyearmonth
+description: >
+    Calendar.yearMonthFromFields method is called with undefined as the options
+    value when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainDate(2000, 5, 2, calendar);
+instance.toPlainYearMonth();
+assert.sameValue(calendar.yearMonthFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/PlainDate/prototype/until/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainDate(2000, 5, 2, calendar);
+instance.until({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toPlainMonthDay/calendar-monthdayfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toPlainMonthDay/calendar-monthdayfromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.toplainmonthday
+description: >
+    Calendar.monthDayFromFields method is called with undefined as the options
+    value when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+instance.toPlainMonthDay();
+assert.sameValue(calendar.monthDayFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toPlainYearMonth/calendar-yearmonthfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toPlainYearMonth/calendar-yearmonthfromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.toplainyearmonth
+description: >
+    Calendar.yearMonthFromFields method is called with undefined as the options
+    value when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+instance.toPlainYearMonth();
+assert.sameValue(calendar.yearMonthFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaindate
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+instance.withPlainDate({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/PlainMonthDay/from/calendar-monthdayfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/calendar-monthdayfromfields-called-with-options-undefined.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: >
+    Calendar.monthDayFromFields method is called with undefined as the options
+    value when call originates internally
+features: [Temporal]
+---*/
+
+const realMonthDayFromFields = Temporal.Calendar.prototype.monthDayFromFields;
+let monthDayFromFieldsCallCount = 0;
+Temporal.Calendar.prototype.monthDayFromFields = function (fields, options) {
+  monthDayFromFieldsCallCount++;
+  assert.sameValue(options, undefined, "monthDayFromFields shouldn't be called with options");
+  return realMonthDayFromFields.call(this, fields, options);
+}
+
+Temporal.PlainMonthDay.from("2000-05-02");
+assert.sameValue(monthDayFromFieldsCallCount, 1);
+
+Temporal.Calendar.prototype.monthDayFromFields = realMonthDayFromFields;

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/calendar-monthdayfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/calendar-monthdayfromfields-called-with-options-undefined.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: >
+    Calendar.monthDayFromFields method is called with undefined as the options
+    value when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainMonthDay(5, 2, calendar);
+instance.equals({ monthCode: "M05", day: 3, calendar });
+assert.sameValue(calendar.monthDayFromFieldsCallCount, 1);
+
+// Test again, but overriding the global Temporal.Calendar.prototype method so
+// we can observe the call to monthDayFromFields() on the ISO8601 calendar
+// that occurs when we parse the string
+
+const realMonthDayFromFields = Temporal.Calendar.prototype.monthDayFromFields;
+let monthDayFromFieldsCallCount = 0;
+Temporal.Calendar.prototype.monthDayFromFields = function (fields, options) {
+  monthDayFromFieldsCallCount++;
+  assert.sameValue(options, undefined, "monthDayFromFields shouldn't be called with options");
+  return realMonthDayFromFields.call(this, fields, options);
+}
+
+instance.equals("2000-05-03");
+assert.sameValue(monthDayFromFieldsCallCount, 1);
+
+Temporal.Calendar.prototype.monthDayFromFields = realMonthDayFromFields;

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.toplaindatetime
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321, calendar);
+instance.toPlainDateTime({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321, calendar);
+instance.toZonedDateTime({ plainDate: { year: 2000, month: 5, day: 3, calendar }, timeZone: new Temporal.TimeZone("UTC") });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/PlainYearMonth/compare/calendar-yearmonthfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/calendar-yearmonthfromfields-called-with-options-undefined.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: >
+    Calendar.yearMonthFromFields method is called with undefined as the options
+    value when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+Temporal.PlainYearMonth.compare({ year: 2000, month: 5, calendar }, { year: 2000, month: 6, calendar });
+assert.sameValue(calendar.yearMonthFromFieldsCallCount, 2);
+
+// Test again, but overriding the global Temporal.Calendar.prototype method so
+// we can observe the call to yearMonthFromFields() on the ISO8601 calendar
+// that occurs when we parse the string
+
+const realYearMonthFromFields = Temporal.Calendar.prototype.yearMonthFromFields;
+let yearMonthFromFieldsCallCount = 0;
+Temporal.Calendar.prototype.yearMonthFromFields = function (fields, options) {
+  yearMonthFromFieldsCallCount++;
+  assert.sameValue(options, undefined, "yearMonthFromFields shouldn't be called with options");
+  return realYearMonthFromFields.call(this, fields, options);
+}
+
+Temporal.PlainYearMonth.compare("2000-05-01", "2000-06-01");
+assert.sameValue(yearMonthFromFieldsCallCount, 2);
+
+Temporal.Calendar.prototype.yearMonthFromFields = realYearMonthFromFields;

--- a/test/built-ins/Temporal/PlainYearMonth/from/calendar-yearmonthfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/calendar-yearmonthfromfields-called-with-options-undefined.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: >
+    Calendar.yearMonthFromFields method is called with undefined as the options
+    value when call originates internally
+features: [Temporal]
+---*/
+
+const realYearMonthFromFields = Temporal.Calendar.prototype.yearMonthFromFields;
+let yearMonthFromFieldsCallCount = 0;
+Temporal.Calendar.prototype.yearMonthFromFields = function (fields, options) {
+  yearMonthFromFieldsCallCount++;
+  assert.sameValue(options, undefined, "yearMonthFromFields shouldn't be called with options");
+  return realYearMonthFromFields.call(this, fields, options);
+}
+
+Temporal.PlainYearMonth.from("2000-05-01");
+assert.sameValue(yearMonthFromFieldsCallCount, 1);
+
+Temporal.Calendar.prototype.yearMonthFromFields = realYearMonthFromFields;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/calendar-yearmonthfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/calendar-yearmonthfromfields-called-with-options-undefined.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.equals
+description: >
+    Calendar.yearMonthFromFields method is called with undefined as the options
+    value when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+let calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+let instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+instance.equals({ year: 2000, month: 6, calendar });
+assert.sameValue(calendar.yearMonthFromFieldsCallCount, 1);
+
+// Test again, but overriding the global Temporal.Calendar.prototype method so
+// we can observe the call to yearMonthFromFields() on the ISO8601 calendar
+// that occurs when we parse the string
+
+const realYearMonthFromFields = Temporal.Calendar.prototype.yearMonthFromFields;
+let yearMonthFromFieldsCallCount = 0;
+Temporal.Calendar.prototype.yearMonthFromFields = function (fields, options) {
+  yearMonthFromFieldsCallCount++;
+  assert.sameValue(options, undefined, "yearMonthFromFields shouldn't be called with options");
+  return realYearMonthFromFields.call(this, fields, options);
+}
+
+calendar = new Temporal.Calendar("iso8601");
+instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+instance.equals("2000-06-01");
+assert.sameValue(yearMonthFromFieldsCallCount, 1);
+
+Temporal.Calendar.prototype.yearMonthFromFields = realYearMonthFromFields;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+instance.since({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 2);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/calendar-yearmonthfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/calendar-yearmonthfromfields-called-with-options-undefined.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+    Calendar.yearMonthFromFields method is called with undefined as the options
+    value when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+let calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+let instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+instance.since({ year: 2000, month: 6, calendar });
+assert.sameValue(calendar.yearMonthFromFieldsCallCount, 1);
+
+// Test again, but overriding the global Temporal.Calendar.prototype method so
+// we can observe the call to yearMonthFromFields() on the ISO8601 calendar
+// that occurs when we parse the string
+
+const realYearMonthFromFields = Temporal.Calendar.prototype.yearMonthFromFields;
+let yearMonthFromFieldsCallCount = 0;
+Temporal.Calendar.prototype.yearMonthFromFields = function (fields, options) {
+  yearMonthFromFieldsCallCount++;
+  assert.sameValue(options, undefined, "yearMonthFromFields shouldn't be called with options");
+  return realYearMonthFromFields.call(this, fields, options);
+}
+
+calendar = new Temporal.Calendar("iso8601");
+instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+instance.since("2000-06-01");
+assert.sameValue(yearMonthFromFieldsCallCount, 1);
+
+Temporal.Calendar.prototype.yearMonthFromFields = realYearMonthFromFields;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+instance.until({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 2);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/calendar-yearmonthfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/calendar-yearmonthfromfields-called-with-options-undefined.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+    Calendar.yearMonthFromFields method is called with undefined as the options
+    value when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+let calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+let instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+instance.until({ year: 2000, month: 6, calendar });
+assert.sameValue(calendar.yearMonthFromFieldsCallCount, 1);
+
+// Test again, but overriding the global Temporal.Calendar.prototype method so
+// we can observe the call to yearMonthFromFields() on the ISO8601 calendar
+// that occurs when we parse the string
+
+const realYearMonthFromFields = Temporal.Calendar.prototype.yearMonthFromFields;
+let yearMonthFromFieldsCallCount = 0;
+Temporal.Calendar.prototype.yearMonthFromFields = function (fields, options) {
+  yearMonthFromFieldsCallCount++;
+  assert.sameValue(options, undefined, "yearMonthFromFields shouldn't be called with options");
+  return realYearMonthFromFields.call(this, fields, options);
+}
+
+calendar = new Temporal.Calendar("iso8601");
+instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+instance.until("2000-06-01");
+assert.sameValue(yearMonthFromFieldsCallCount, 1);
+
+Temporal.Calendar.prototype.yearMonthFromFields = realYearMonthFromFields;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/calendar-dateadd-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const earlier = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+// Basic difference with largestUnit larger than days.
+// The calls come from these paths:
+// ZonedDateTime.since() -> DifferenceZonedDateTime ->
+//   AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+
+const later1 = new Temporal.ZonedDateTime(1_213_200_000_000_000n, timeZone, calendar);
+later1.since(earlier, { largestUnit: "weeks" });
+assert.sameValue(calendar.dateAddCallCount, 2, "basic difference with largestUnit >days");
+
+// Basic difference with largestUnit equal to days, to cover the second path in
+// AddZonedDateTime.
+// The calls come from these paths:
+// ZonedDateTime.since() -> DifferenceZonedDateTime -> NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+
+calendar.dateAddCallCount = 0;
+
+later1.since(earlier, { largestUnit: "days" });
+assert.sameValue(calendar.dateAddCallCount, 2, "basic difference with largestUnit days");
+
+// Difference with rounding, with smallestUnit a calendar unit.
+// The calls come from these paths:
+// ZonedDateTime.since() ->
+//   DifferenceZonedDateTime ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     MoveRelativeDate -> calendar.dateAdd()
+
+calendar.dateAddCallCount = 0;
+
+later1.since(earlier, { smallestUnit: "weeks" });
+assert.sameValue(calendar.dateAddCallCount, 5, "rounding difference with calendar smallestUnit");
+
+// Difference with rounding, with smallestUnit a non-calendar unit, and having
+// the resulting time difference be longer than a calendar day, covering the
+// paths that go through AdjustRoundedDurationDays. (The path through
+// AdjustRoundedDurationDays -> AddDuration that's covered in the corresponding
+// test in until() only happens in one direction.)
+// The calls come from these paths:
+// ZonedDateTime.since() ->
+//   DifferenceZonedDateTime -> NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (3x)
+//   AdjustRoundedDurationDays ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (3x)
+
+calendar.dateAddCallCount = 0;
+
+const later2 = new Temporal.ZonedDateTime(86_399_999_999_999n, timeZone, calendar);
+later2.since(earlier, { largestUnit: "days", smallestUnit: "hours", roundingMode: "ceil" });
+assert.sameValue(calendar.dateAddCallCount, 6, "rounding difference with non-calendar smallestUnit and time difference longer than a calendar day");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainMonthDay/calendar-monthdayfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainMonthDay/calendar-monthdayfromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.toplainmonthday
+description: >
+    Calendar.monthDayFromFields method is called with undefined as the options
+    value when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", calendar);
+instance.toPlainMonthDay();
+assert.sameValue(calendar.monthDayFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainYearMonth/calendar-yearmonthfromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainYearMonth/calendar-yearmonthfromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.toplainyearmonth
+description: >
+    Calendar.yearMonthFromFields method is called with undefined as the options
+    value when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", calendar);
+instance.toPlainYearMonth();
+assert.sameValue(calendar.yearMonthFromFieldsCallCount, 1);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/calendar-dateadd-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const earlier = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+// Basic difference with largestUnit larger than days.
+// The calls come from these paths:
+// ZonedDateTime.until() -> DifferenceZonedDateTime ->
+//   AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+
+const later1 = new Temporal.ZonedDateTime(1_213_200_000_000_000n, timeZone, calendar);
+earlier.until(later1, { largestUnit: "weeks" });
+assert.sameValue(calendar.dateAddCallCount, 2, "basic difference with largestUnit >days");
+
+// Basic difference with largestUnit equal to days, to cover the second path in
+// AddZonedDateTime.
+// The calls come from these paths:
+// ZonedDateTime.until() -> DifferenceZonedDateTime -> NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+
+calendar.dateAddCallCount = 0;
+
+earlier.until(later1, { largestUnit: "days" });
+assert.sameValue(calendar.dateAddCallCount, 2, "basic difference with largestUnit days");
+
+// Difference with rounding, with smallestUnit a calendar unit.
+// The calls come from these paths:
+// ZonedDateTime.until() ->
+//   DifferenceZonedDateTime ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     MoveRelativeDate -> calendar.dateAdd()
+
+calendar.dateAddCallCount = 0;
+
+earlier.until(later1, { smallestUnit: "weeks" });
+assert.sameValue(calendar.dateAddCallCount, 5, "rounding difference with calendar smallestUnit");
+
+// Difference with rounding, with smallestUnit a non-calendar unit, and having
+// the resulting time difference be longer than a calendar day, covering the
+// paths that go through AdjustRoundedDurationDays.
+// The calls come from these paths:
+// ZonedDateTime.until() ->
+//   DifferenceZonedDateTime -> NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   AdjustRoundedDurationDays ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     AddDuration ->
+//       AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//       DifferenceZonedDateTime -> NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+
+calendar.dateAddCallCount = 0;
+
+const later2 = new Temporal.ZonedDateTime(86_399_999_999_999n, timeZone, calendar);
+earlier.until(later2, { largestUnit: "days", smallestUnit: "hours", roundingMode: "ceil" });
+assert.sameValue(calendar.dateAddCallCount, 5, "rounding difference with non-calendar smallestUnit and time difference longer than a calendar day");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", calendar);
+instance.withPlainDate({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/harness/temporalHelpers-one-shift-time-zone.js
+++ b/test/harness/temporalHelpers-one-shift-time-zone.js
@@ -1,0 +1,80 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Verify the time zone arithmetic used in TemporalHelpers.oneShiftTimeZone()
+  against known cases in the implementation's time zone database
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+function checkTimeZoneArithmetic(shiftInstant, shiftNs, realTimeZoneName, shiftWallTime) {
+  // No need to test this on hosts that don't provide an Intl object. It's
+  // sufficient that the logic is tested on at least one host.
+  if (typeof globalThis.Intl === "undefined")
+    return;
+
+  const tz = TemporalHelpers.oneShiftTimeZone(shiftInstant, shiftNs);
+  const realTz = new Temporal.TimeZone(realTimeZoneName);
+
+  assert.sameValue(
+    tz.getOffsetNanosecondsFor(shiftInstant),
+    realTz.getOffsetNanosecondsFor(shiftInstant),
+    'offset at shift instant'
+  );
+  const minus1 = shiftInstant.subtract({ hours: 1 });
+  assert.sameValue(
+    tz.getOffsetNanosecondsFor(minus1),
+    realTz.getOffsetNanosecondsFor(minus1),
+    'offset at 1 hour before shift'
+  );
+  const plus1 = shiftInstant.add({ hours: 1 });
+  assert.sameValue(
+    tz.getOffsetNanosecondsFor(plus1),
+    realTz.getOffsetNanosecondsFor(plus1),
+    'offset at 1 hour after shift'
+  );
+
+  assert.compareArray(
+    tz.getPossibleInstantsFor(shiftWallTime).map((i) => i.epochNanoseconds),
+    realTz.getPossibleInstantsFor(shiftWallTime).map((i) => i.epochNanoseconds),
+    'possible instants for wall time'
+  );
+  const before1 = shiftWallTime.subtract({ hours: 1 });
+  assert.compareArray(
+    tz.getPossibleInstantsFor(before1).map((i) => i.epochNanoseconds),
+    realTz.getPossibleInstantsFor(before1).map((i) => i.epochNanoseconds),
+    'possible instants for 1 hour before wall time'
+  );
+  const after1 = shiftWallTime.add({ hours: 1 });
+  assert.compareArray(
+    tz.getPossibleInstantsFor(after1).map((i) => i.epochNanoseconds),
+    realTz.getPossibleInstantsFor(after1).map((i) => i.epochNanoseconds),
+    'possible instants for 1 hour after wall time'
+  );
+}
+
+// Check a positive DST shift from +00:00 to +01:00
+checkTimeZoneArithmetic(
+  new Temporal.Instant(1616893200000000000n),
+  3600e9,
+  'Europe/London',
+  new Temporal.PlainDateTime(2021, 3, 28, 1)
+);
+
+// Check a negative DST shift from +00:00 to -01:00
+checkTimeZoneArithmetic(
+  new Temporal.Instant(1635642000000000000n),
+  -3600e9,
+  'Atlantic/Azores',
+  new Temporal.PlainDateTime(2021, 10, 31, 1)
+);
+
+// Check the no-shift case
+checkTimeZoneArithmetic(
+  new Temporal.Instant(0n),
+  0,
+  'UTC',
+  new Temporal.PlainDateTime(1970, 1, 1)
+);

--- a/test/intl402/Temporal/Calendar/prototype/era/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.era
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.era({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/calendar-datefromfields-called-with-options-undefined.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/calendar-datefromfields-called-with-options-undefined.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.erayear
+description: >
+    Calendar.dateFromFields method is called with undefined as the options value
+    when call originates internally
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarFromFieldsUndefinedOptions();
+calendar.eraYear({ year: 2000, month: 5, day: 3, calendar });
+assert.sameValue(calendar.dateFromFieldsCallCount, 1);


### PR DESCRIPTION
This adds tests for https://github.com/tc39/proposal-temporal/pull/2028, which achieved consensus at the March 2022 TC39 meeting.

Additionally includes a bug fix in one of the custom time zones used for testing time zone arithmetic in absence of Intl in the implementation.