### PR TITLE
More follow-up on closed Temporal tests PRs

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.inleapyear
+description: An ISO 8601 date string should be converted as input
+info: |
+  4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]] or [[InitializedTemporalYearMonth]] internal slot, then
+    a. Set temporalDateLike to ? ToTemporalDate(temporalDateLike).
+  5. Return ! IsISOLeapYear(temporalDateLike.[[ISOYear]]).
+features: [Temporal]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+
+assert.sameValue(cal.inLeapYear("2019-03-18"), false);
+assert.sameValue(cal.inLeapYear("2020-03-18"), true);
+
+assert.sameValue(cal.inLeapYear("+002023-03-18"), false);
+assert.sameValue(cal.inLeapYear("+002024-03-18"), true);
+
+assert.sameValue(cal.inLeapYear("2019-03-18T13:00:00+00:00[UTC]"), false);
+assert.sameValue(cal.inLeapYear("2020-12-31T23:59:59+00:00[UTC]"), true);
+
+assert.sameValue(cal.inLeapYear("+002023-03-18T13:00:00+00:00[UTC]"), false);
+assert.sameValue(cal.inLeapYear("+002024-03-18T13:00:00+00:00[UTC]"), true);

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/basic.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/basic.js
@@ -8,10 +8,19 @@ features: [Temporal]
 ---*/
 
 const iso = Temporal.Calendar.from("iso8601");
-const res = false;
-assert.sameValue(iso.inLeapYear(Temporal.PlainDate.from("1994-11-05")), res, "PlainDate");
-assert.sameValue(iso.inLeapYear(Temporal.PlainDateTime.from("1994-11-05T08:15:30")), res, "PlainDateTime");
-assert.sameValue(iso.inLeapYear(Temporal.PlainYearMonth.from("1994-11")), res, "PlainYearMonth");
+let res = false;
+
+assert.sameValue(iso.inLeapYear(new Temporal.PlainDate(1994, 11, 5)), res, "PlainDate");
+assert.sameValue(iso.inLeapYear(new Temporal.PlainDateTime(1994, 11, 5, 8, 15, 30)), res, "PlainDateTime");
+assert.sameValue(iso.inLeapYear(new Temporal.PlainYearMonth(1994, 11)), res, "PlainYearMonth");
 assert.sameValue(iso.inLeapYear({ year: 1994, month: 11, day: 5 }), res, "property bag");
 assert.sameValue(iso.inLeapYear("1994-11-05"), res, "string");
+
+res = true;
+assert.sameValue(iso.inLeapYear(new Temporal.PlainDate(1996, 7, 15)), res, "PlainDate in leap year");
+assert.sameValue(iso.inLeapYear(new Temporal.PlainDateTime(1996, 7, 15, 5, 30, 13)), res, "PlainDateTime in leap year");
+assert.sameValue(iso.inLeapYear(new Temporal.PlainYearMonth(1996, 7)), res, "PlainYearMonth in leap year");
+assert.sameValue(iso.inLeapYear({ year: 1996, month: 7, day: 15 }), res, "property bag in leap year");
+assert.sameValue(iso.inLeapYear("1996-07-15"), res, "string in leap year");
+
 assert.throws(TypeError, () => iso.inLeapYear({ year: 2000 }), "property bag with missing properties");

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/branding.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/branding.js
@@ -11,12 +11,14 @@ const inLeapYear = Temporal.Calendar.prototype.inLeapYear;
 
 assert.sameValue(typeof inLeapYear, "function");
 
-assert.throws(TypeError, () => inLeapYear.call(undefined), "undefined");
-assert.throws(TypeError, () => inLeapYear.call(null), "null");
-assert.throws(TypeError, () => inLeapYear.call(true), "true");
-assert.throws(TypeError, () => inLeapYear.call(""), "empty string");
-assert.throws(TypeError, () => inLeapYear.call(Symbol()), "symbol");
-assert.throws(TypeError, () => inLeapYear.call(1), "1");
-assert.throws(TypeError, () => inLeapYear.call({}), "plain object");
-assert.throws(TypeError, () => inLeapYear.call(Temporal.Calendar), "Temporal.Calendar");
-assert.throws(TypeError, () => inLeapYear.call(Temporal.Calendar.prototype), "Temporal.Calendar.prototype");
+const arg = new Temporal.PlainDate(2021, 3, 4);
+
+assert.throws(TypeError, () => inLeapYear.call(undefined, arg), "undefined");
+assert.throws(TypeError, () => inLeapYear.call(null, arg), "null");
+assert.throws(TypeError, () => inLeapYear.call(true, arg), "true");
+assert.throws(TypeError, () => inLeapYear.call("", arg), "empty string");
+assert.throws(TypeError, () => inLeapYear.call(Symbol(), arg), "symbol");
+assert.throws(TypeError, () => inLeapYear.call(1, arg), "1");
+assert.throws(TypeError, () => inLeapYear.call({}, arg), "plain object");
+assert.throws(TypeError, () => inLeapYear.call(Temporal.Calendar, arg), "Temporal.Calendar");
+assert.throws(TypeError, () => inLeapYear.call(Temporal.Calendar.prototype, arg), "Temporal.Calendar.prototype");

--- a/test/built-ins/Temporal/Calendar/prototype/mergeFields/basic.js
+++ b/test/built-ins/Temporal/Calendar/prototype/mergeFields/basic.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// Copyright (C) 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.mergefields
+description: >
+  Temporal.Calendar.prototype.mergeFields will merge own data properties on its
+  arguments
+info: |
+  1. Let calendar be the this value.
+  2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
+  3. Assert: calendar.[[Identifier]] is "iso8601".
+  4. Set fields to ? ToObject(fields).
+  5. Set additionalFields to ? ToObject(additionalFields).
+  6. Return ? DefaultMergeFields(fields, additionalFields).
+features: [Temporal]
+includes: [deepEqual.js]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2 }, { c: 3, d: 4 }),
+  { a: 1, b: 2, c: 3, d: 4 },
+  "properties are merged"
+);
+
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2 }, { b: 3, c: 4 }),
+  { a: 1, b: 3, c: 4 },
+  "property in additionalFields should overwrite one in fields"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/mergeFields/iso8601-calendar-month-monthCode.js
+++ b/test/built-ins/Temporal/Calendar/prototype/mergeFields/iso8601-calendar-month-monthCode.js
@@ -1,0 +1,99 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.mergefields
+description: >
+  The default mergeFields algorithm from the ISO 8601 calendar should correctly
+  merge the month and monthCode properties
+info: |
+  1. Let calendar be the this value.
+  2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
+  3. Assert: calendar.[[Identifier]] is "iso8601".
+  4. Set fields to ? ToObject(fields).
+  5. Set additionalFields to ? ToObject(additionalFields).
+  6. Return ? DefaultMergeFields(fields, additionalFields).
+features: [Temporal]
+includes: [deepEqual.js]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, month: 7 }, { b: 3, c: 4 }),
+  { a: 1, b: 3, c: 4, month: 7 },
+  "month is copied from fields"
+);
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, monthCode: "M08" }, { b: 3, c: 4 }),
+  { a: 1, b: 3, c: 4, monthCode: "M08" },
+  "monthCode is copied from fields"
+);
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, month: 7, monthCode: "M08" }, { b: 3, c: 4 }),
+  { a: 1, b: 3, c: 4, month: 7, monthCode: "M08" },
+  "both month and monthCode are copied from fields, no validation is performed"
+);
+
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2 }, { b: 3, c: 4, month: 5 }),
+  { a: 1, b: 3, c: 4, month: 5 },
+  "month is copied from additionalFields"
+);
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2 }, { b: 3, c: 4, monthCode: "M06" }),
+  { a: 1, b: 3, c: 4, monthCode: "M06" },
+  "monthCode is copied from additionalFields"
+);
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2 }, { b: 3, c: 4, month: 5, monthCode: "M06" }),
+  { a: 1, b: 3, c: 4, month: 5, monthCode: "M06" },
+  "both month and monthCode are copied from additionalFields, no validation is performed"
+);
+
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, month: 7 }, { b: 3, c: 4, month: 5 }),
+  { a: 1, b: 3, c: 4, month: 5 },
+  "month from additionalFields overrides month from fields"
+);
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, monthCode: "M07" }, { b: 3, c: 4, monthCode: "M05" }),
+  { a: 1, b: 3, c: 4, monthCode: "M05" },
+  "monthCode from additionalFields overrides monthCode from fields"
+);
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, monthCode: "M07" }, { b: 3, c: 4, month: 6 }),
+  { a: 1, b: 3, c: 4, month: 6 },
+  "month's presence on additionalFields blocks monthCode from fields"
+);
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, month: 7 }, { b: 3, c: 4, monthCode: "M06" }),
+  { a: 1, b: 3, c: 4, monthCode: "M06"},
+  "monthCode's presence on additionalFields blocks month from fields"
+);
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, month: 7, monthCode: "M08" },{ b: 3, c: 4, month: 5 }),
+  { a: 1, b: 3, c: 4, month: 5 },
+  "month's presence on additionalFields blocks both month and monthCode from fields"
+);
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, month: 7, monthCode: "M08" }, { b: 3, c: 4, monthCode: "M06" }),
+  { a: 1, b: 3, c: 4, monthCode: "M06" },
+  "monthCode's presence on additionalFields blocks both month and monthCode from fields"
+);
+
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, month: 7 }, { b: 3, c: 4, month: 5, monthCode: "M06" }),
+  { a: 1, b: 3, c: 4, month: 5, monthCode: "M06" },
+  "both month and monthCode are copied from additionalFields even when fields has month"
+);
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, monthCode: "M07" }, { b: 3, c: 4, month: 5, monthCode: "M06" }),
+  { a: 1, b: 3, c: 4, month: 5, monthCode: "M06" },
+  "both month and monthCode are copied from additionalFields even when fields has monthCode"
+);
+assert.deepEqual(
+  cal.mergeFields({ a: 1, b: 2, month: 7, monthCode: "M08" }, { b: 3, c: 4, month: 5, monthCode: "M06" }),
+  { a: 1, b: 3, c: 4, month: 5, monthCode: "M06" },
+  "both month and monthCode are copied from additionalFields even when fields has both month and monthCode"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/mergeFields/non-string-properties.js
+++ b/test/built-ins/Temporal/Calendar/prototype/mergeFields/non-string-properties.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// Copyright (C) 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.mergefields
+description: Only string keys from the arguments are merged
+info: |
+  1. Let calendar be the this value.
+  2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
+  3. Assert: calendar.[[Identifier]] is "iso8601".
+  4. Set fields to ? ToObject(fields).
+  5. Set additionalFields to ? ToObject(additionalFields).
+  6. Return ? DefaultMergeFields(fields, additionalFields).
+features: [Temporal]
+includes: [deepEqual.js]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+
+assert.deepEqual(
+  cal.mergeFields({ 1: 2 }, { 3: 4 }),
+  { "1": 2, "3": 4 },
+  "number keys are actually string keys and are merged as such"
+);
+assert.deepEqual(
+  cal.mergeFields({ 1n: 2 }, { 2n: 4 }),
+  { "1": 2, "2": 4 },
+  "bigint keys are actually string keys and are merged as such"
+);
+
+const foo = Symbol("foo");
+const bar = Symbol("bar");
+assert.deepEqual(cal.mergeFields({ [foo]: 1 }, { [bar]: 2 }), {}, "symbol keys are not merged");

--- a/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/basic.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/basic.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthdayfromfields
+description: Temporal.Calendar.prototype.monthDayFromFields will return correctly with valid data.
+info: |
+  1. Let calendar be the this value.
+  2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
+  3. Assert: calendar.[[Identifier]] is "iso8601".
+  4. If Type(fields) is not Object, throw a TypeError exception.
+  5. Set options to ? GetOptionsObject(options).
+  6. Let result be ? ISOMonthDayFromFields(fields, options).
+  7. Return ? CreateTemporalMonthDay(result.[[Month]], result.[[Day]], calendar, result.[[ReferenceISOYear]]).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+
+let result = cal.monthDayFromFields({ year: 2021, month: 7, day: 3 });
+TemporalHelpers.assertPlainMonthDay(result, "M07", 3, "month 7, day 3, with year");
+result = cal.monthDayFromFields({ year: 2021, month: 12, day: 31 });
+TemporalHelpers.assertPlainMonthDay(result, "M12", 31, "month 12, day 31, with year");
+result = cal.monthDayFromFields({ monthCode: "M07", day: 3 });
+TemporalHelpers.assertPlainMonthDay(result, "M07", 3, "monthCode M07, day 3");
+result = cal.monthDayFromFields({ monthCode: "M12", day: 31 });
+TemporalHelpers.assertPlainMonthDay(result, "M12", 31, "monthCode M12, day 31");
+
+["constrain", "reject"].forEach(function (overflow) {
+  const opt = { overflow };
+  result = cal.monthDayFromFields({ year: 2021, month: 7, day: 3 }, opt);
+  TemporalHelpers.assertPlainMonthDay(result, "M07", 3, "month 7, day 3, with year");
+  result = cal.monthDayFromFields({ year: 2021, month: 12, day: 31 }, opt);
+  TemporalHelpers.assertPlainMonthDay(result, "M12", 31, "month 12, day 31, with year");
+  result = cal.monthDayFromFields({ monthCode: "M07", day: 3 }, opt);
+  TemporalHelpers.assertPlainMonthDay(result, "M07", 3, "monthCode M07, day 3");
+  result = cal.monthDayFromFields({ monthCode: "M12", day: 31 }, opt);
+  TemporalHelpers.assertPlainMonthDay(result, "M12", 31, "monthCode M12, day 31");
+});

--- a/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/fields-missing-properties.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/fields-missing-properties.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthdayfromfields
+description: Temporal.Calendar.prototype.monthDayFromFields will throw TypeError with incorrect input data type.
+info: |
+  1. Let calendar be the this value.
+  2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
+  3. Assert: calendar.[[Identifier]] is "iso8601".
+  4. If Type(fields) is not Object, throw a TypeError exception.
+  5. Set options to ? GetOptionsObject(options).
+  6. Let result be ? ISOMonthDayFromFields(fields, options).
+  7. Return ? CreateTemporalMonthDay(result.[[Month]], result.[[Day]], calendar, result.[[ReferenceISOYear]]).
+features: [Temporal]
+---*/
+
+let cal = new Temporal.Calendar("iso8601")
+
+assert.throws(TypeError, () => cal.monthDayFromFields({}), "at least one correctly spelled property is required");
+assert.throws(TypeError, () => cal.monthDayFromFields({ monthCode: "M12" }), "day is required with monthCode");
+assert.throws(TypeError, () => cal.monthDayFromFields({ year: 2021, month: 12 }), "day is required with year and month");
+assert.throws(TypeError, () => cal.monthDayFromFields({ month: 1, day: 17 }), "year is required if month is present");
+assert.throws(TypeError, () => cal.monthDayFromFields({ year: 2021, day: 17 }), "either month or monthCode is required");

--- a/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/fields-not-object.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/fields-not-object.js
@@ -7,7 +7,7 @@ description: Throw a TypeError if the fields is not an object
 features: [Symbol, Temporal]
 ---*/
 
-const tests = [undefined, null, false, "string", Symbol("sym"), Math.PI, 42n];
+const tests = [undefined, null, true, false, "string", Symbol("sym"), Math.PI, Infinity, NaN, 42n];
 const iso = Temporal.Calendar.from("iso8601");
 for (const fields of tests) {
   assert.throws(TypeError, () => iso.monthDayFromFields(fields, {}));

--- a/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/monthcode-invalid.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/monthcode-invalid.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthdayfromfields
+description: Throw RangeError for an out-of-range, conflicting, or ill-formed monthCode
+info: |
+  1. Let calendar be the this value.
+  2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
+  3. Assert: calendar.[[Identifier]] is "iso8601".
+  4. If Type(fields) is not Object, throw a TypeError exception.
+  5. Set options to ? GetOptionsObject(options).
+  6. Let result be ? ISOMonthDayFromFields(fields, options).
+  7. Return ? CreateTemporalMonthDay(result.[[Month]], result.[[Day]], calendar, result.[[ReferenceISOYear]]).
+features: [Temporal]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+
+["m1", "M1", "m01"].forEach((monthCode) => {
+  assert.throws(RangeError, () => cal.monthDayFromFields({ monthCode, day: 17 }),
+    `monthCode '${monthCode}' is not well-formed`);
+});
+
+assert.throws(RangeError, () => cal.monthDayFromFields({ year: 2021, month: 12, monthCode: "M11", day: 17 }),
+  "monthCode and month conflict");
+
+["M00", "M19", "M99", "M13"].forEach((monthCode) => {
+  assert.throws(RangeError, () => cal.monthDayFromFields({ monthCode, day: 17 }),
+    `monthCode '${monthCode}' is not valid for ISO 8601 calendar`);
+});

--- a/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/overflow-constrain.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/overflow-constrain.js
@@ -1,0 +1,91 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthdayfromfields
+description: Temporal.Calendar.prototype.monthDayFromFields will return correctly with data and overflow set to 'constrain'.
+info: |
+  1. Let calendar be the this value.
+  2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
+  3. Assert: calendar.[[Identifier]] is "iso8601".
+  4. If Type(fields) is not Object, throw a TypeError exception.
+  5. Set options to ? GetOptionsObject(options).
+  6. Let result be ? ISOMonthDayFromFields(fields, options).
+  7. Return ? CreateTemporalMonthDay(result.[[Month]], result.[[Day]], calendar, result.[[ReferenceISOYear]]).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+const opt = { overflow: "constrain" };
+
+let result = cal.monthDayFromFields({ year: 2021, month: 1, day: 133 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M01", 31, "day is constrained to 31 in month 1");
+result = cal.monthDayFromFields({ year: 2021, month: 2, day: 133 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M02", 28, "day is constrained to 28 in month 2 (year 2021)");
+result = cal.monthDayFromFields({ year: 2021, month: 3, day: 9033 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M03", 31, "day is constrained to 31 in month 3");
+result = cal.monthDayFromFields({ year: 2021, month: 4, day: 50 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M04", 30, "day is constrained to 30 in month 4");
+result = cal.monthDayFromFields({ year: 2021, month: 5, day: 77 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M05", 31, "day is constrained to 31 in month 5");
+result = cal.monthDayFromFields({ year: 2021, month: 6, day: 33 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M06", 30, "day is constrained to 30 in month 6");
+result = cal.monthDayFromFields({ year: 2021, month: 7, day: 33 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M07", 31, "day is constrained to 31 in month 7");
+result = cal.monthDayFromFields({ year: 2021, month: 8, day: 300 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M08", 31, "day is constrained to 31 in month 8");
+result = cal.monthDayFromFields({ year: 2021, month: 9, day: 400 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M09", 30, "day is constrained to 30 in month 9");
+result = cal.monthDayFromFields({ year: 2021, month: 10, day: 400 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M10", 31, "day is constrained to 31 in month 10");
+result = cal.monthDayFromFields({ year: 2021, month: 11, day: 400 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M11", 30, "day is constrained to 30 in month 11");
+result = cal.monthDayFromFields({ year: 2021, month: 12, day: 500 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M12", 31, "day is constrained to 31 in month 12");
+
+assert.throws(
+  RangeError,
+  () => cal.monthDayFromFields({ year: 2021, month: -99999, day: 1 }, opt),
+  "negative month -99999 is out of range even with overflow constrain"
+)
+assert.throws(
+  RangeError,
+  () => cal.monthDayFromFields({ year: 2021, month: -1, day: 1 }, opt),
+  "negative month -1 is out of range even with overflow constrain"
+)
+assert.throws(
+  RangeError,
+  () => cal.monthDayFromFields({ year: 2021, month: 0, day: 1 }, opt),
+  "month zero is out of range even with overflow constrain"
+)
+
+result = cal.monthDayFromFields({ year: 2021, month: 13, day: 1 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M12", 1, "month 13 is constrained to 12");
+result = cal.monthDayFromFields({ year: 2021, month: 999999, day: 500 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M12", 31, "month 999999 is constrained to 12 and day constrained to 31");
+
+result = cal.monthDayFromFields({ monthCode: "M01", day: 133 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M01", 31, "day is constrained to 31 in monthCode M01");
+result = cal.monthDayFromFields({ monthCode: "M02", day: 133 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M02", 29, "day is constrained to 29 in monthCode M02");
+result = cal.monthDayFromFields({ monthCode: "M03", day: 9033 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M03", 31, "day is constrained to 31 in monthCode M03");
+result = cal.monthDayFromFields({ monthCode: "M04", day: 50 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M04", 30, "day is constrained to 30 in monthCode M04");
+result = cal.monthDayFromFields({ monthCode: "M05", day: 77 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M05", 31, "day is constrained to 31 in monthCode M05");
+result = cal.monthDayFromFields({ monthCode: "M06", day: 33 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M06", 30, "day is constrained to 30 in monthCode M06");
+result = cal.monthDayFromFields({ monthCode: "M07", day: 33 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M07", 31, "day is constrained to 31 in monthCode M07");
+result = cal.monthDayFromFields({ monthCode: "M08", day: 300 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M08", 31, "day is constrained to 31 in monthCode M08");
+result = cal.monthDayFromFields({ monthCode: "M09", day: 400 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M09", 30, "day is constrained to 30 in monthCode M09");
+result = cal.monthDayFromFields({ monthCode: "M10", day: 400 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M10", 31, "day is constrained to 31 in monthCode M10");
+result = cal.monthDayFromFields({ monthCode: "M11", day: 400 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M11", 30, "day is constrained to 30 in monthCode M11");
+result = cal.monthDayFromFields({ monthCode: "M12", day: 500 }, opt);
+TemporalHelpers.assertPlainMonthDay(result, "M12", 31, "day is constrained to 31 in monthCode M12");

--- a/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/overflow-reject.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/overflow-reject.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthdayfromfields
+description: Throw RangeError for input data out of range with overflow reject
+info: |
+  1. Let calendar be the this value.
+  2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
+  3. Assert: calendar.[[Identifier]] is "iso8601".
+  4. If Type(fields) is not Object, throw a TypeError exception.
+  5. Set options to ? GetOptionsObject(options).
+  6. Let result be ? ISOMonthDayFromFields(fields, options).
+  7. Return ? CreateTemporalMonthDay(result.[[Month]], result.[[Day]], calendar, result.[[ReferenceISOYear]]).
+features: [Temporal]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+
+[-1, 0, 13, 9995].forEach((month) => {
+  assert.throws(
+    RangeError,
+    () => cal.monthDayFromFields({year: 2021, month, day: 5}, { overflow: "reject" }),
+    `Month ${month} is out of range for 2021 with overflow: reject`
+  );
+});
+
+[-1, 0, 32, 999].forEach((day) => {
+  assert.throws(
+    RangeError,
+    () => cal.monthDayFromFields({ year: 2021, month: 12, day }, { overflow: "reject" }),
+    `Day ${day} is out of range for 2021-12 with overflow: reject`
+  );
+  assert.throws(
+    RangeError,
+    () => cal.monthDayFromFields({ monthCode: "M12", day }, { overflow: "reject" }),
+    `Day ${day} is out of range for 2021-M12 with overflow: reject`
+  );
+});
+
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M01", day: 32 }, { overflow: "reject" }), "Day 32 is out of range for monthCode M01");
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M02", day: 30 }, { overflow: "reject" }), "Day 30 is out of range for monthCode M02");
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M03", day: 32 }, { overflow: "reject" }), "Day 32 is out of range for monthCode M03");
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M04", day: 31 }, { overflow: "reject" }), "Day 31 is out of range for monthCode M04");
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M05", day: 32 }, { overflow: "reject" }), "Day 32 is out of range for monthCode M05");
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M06", day: 31 }, { overflow: "reject" }), "Day 31 is out of range for monthCode M06");
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M07", day: 32 }, { overflow: "reject" }), "Day 32 is out of range for monthCode M07");
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M08", day: 32 }, { overflow: "reject" }), "Day 32 is out of range for monthCode M08");
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M09", day: 31 }, { overflow: "reject" }), "Day 31 is out of range for monthCode M09");
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M10", day: 32 }, { overflow: "reject" }), "Day 32 is out of range for monthCode M10");
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M11", day: 31 }, { overflow: "reject" }), "Day 31 is out of range for monthCode M11");
+assert.throws(RangeError, () => cal.monthDayFromFields(
+    { monthCode: "M12", day: 32 }, { overflow: "reject" }), "Day 32 is out of range for monthCode M12");

--- a/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/reference-year-1972.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/reference-year-1972.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthdayfromfields
+description: Use a leap year as the reference year if monthCode is given
+info: |
+  sec-temporal-isomonthdayfromfields:
+  12. If _monthCode_ is *undefined*, then
+    a. Let _result_ be ? RegulateISODate(_year_, _month_, _day_, _overflow_).
+  13. Else,
+    a. Let _result_ be ? RegulateISODate(_referenceISOYear_, _month_, _day_, _overflow_).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+
+let result = cal.monthDayFromFields({ year: 2021, monthCode: "M02", day: 29 });
+TemporalHelpers.assertPlainMonthDay(result, "M02", 29, "year is ignored and reference year should be a leap year if monthCode is given");
+
+result = cal.monthDayFromFields({ year: 2021, month: 2, day: 29 }, { overflow: "constrain" });
+TemporalHelpers.assertPlainMonthDay(result, "M02", 28, "year should not be ignored if monthCode is not given");

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthsinyear
+description: An ISO 8601 date string should be converted as input
+info: |
+  a. Perform ? ToTemporalDate(temporalDateLike).
+  5. Return 12𝔽.
+features: [Temporal]
+---*/
+
+let cal = new Temporal.Calendar("iso8601");
+
+assert.sameValue(cal.monthsInYear("3456-12-20"), 12);
+assert.sameValue(cal.monthsInYear("+000998-01-28"), 12);
+assert.sameValue(cal.monthsInYear("3456-12-20T03:04:05+00:00[UTC]"), 12);
+assert.sameValue(cal.monthsInYear("+000998-01-28T03:04:05+00:00[UTC]"), 12);

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/basic.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/basic.js
@@ -9,9 +9,9 @@ features: [Temporal]
 
 const iso = Temporal.Calendar.from("iso8601");
 const res = 12;
-assert.sameValue(iso.monthsInYear(Temporal.PlainDate.from("1994-11-05")), res, "PlainDate");
-assert.sameValue(iso.monthsInYear(Temporal.PlainDateTime.from("1994-11-05T08:15:30")), res, "PlainDateTime");
-assert.sameValue(iso.monthsInYear(Temporal.PlainYearMonth.from("1994-11")), res, "PlainYearMonth");
+assert.sameValue(iso.monthsInYear(new Temporal.PlainDate(1994, 11, 5)), res, "PlainDate");
+assert.sameValue(iso.monthsInYear(new Temporal.PlainDateTime(1994, 11, 5, 8, 15, 30)), res, "PlainDateTime");
+assert.sameValue(iso.monthsInYear(new Temporal.PlainYearMonth(1994, 11)), res, "PlainYearMonth");
 assert.sameValue(iso.monthsInYear({ year: 1994, month: 11, day: 5 }), res, "property bag");
 assert.sameValue(iso.monthsInYear("1994-11-05"), res, "string");
 assert.throws(TypeError, () => iso.monthsInYear({ year: 2000 }), "property bag with missing properties");

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/branding.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/branding.js
@@ -11,12 +11,14 @@ const monthsInYear = Temporal.Calendar.prototype.monthsInYear;
 
 assert.sameValue(typeof monthsInYear, "function");
 
-assert.throws(TypeError, () => monthsInYear.call(undefined), "undefined");
-assert.throws(TypeError, () => monthsInYear.call(null), "null");
-assert.throws(TypeError, () => monthsInYear.call(true), "true");
-assert.throws(TypeError, () => monthsInYear.call(""), "empty string");
-assert.throws(TypeError, () => monthsInYear.call(Symbol()), "symbol");
-assert.throws(TypeError, () => monthsInYear.call(1), "1");
-assert.throws(TypeError, () => monthsInYear.call({}), "plain object");
-assert.throws(TypeError, () => monthsInYear.call(Temporal.Calendar), "Temporal.Calendar");
-assert.throws(TypeError, () => monthsInYear.call(Temporal.Calendar.prototype), "Temporal.Calendar.prototype");
+const arg = new Temporal.PlainDate(2021, 3, 4);
+
+assert.throws(TypeError, () => monthsInYear.call(undefined, arg), "undefined");
+assert.throws(TypeError, () => monthsInYear.call(null, arg), "null");
+assert.throws(TypeError, () => monthsInYear.call(true, arg), "true");
+assert.throws(TypeError, () => monthsInYear.call("", arg), "empty string");
+assert.throws(TypeError, () => monthsInYear.call(Symbol(), arg), "symbol");
+assert.throws(TypeError, () => monthsInYear.call(1, arg), "1");
+assert.throws(TypeError, () => monthsInYear.call({}, arg), "plain object");
+assert.throws(TypeError, () => monthsInYear.call(Temporal.Calendar, arg), "Temporal.Calendar");
+assert.throws(TypeError, () => monthsInYear.call(Temporal.Calendar.prototype, arg), "Temporal.Calendar.prototype");

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-plaindate.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-plaindate.js
@@ -1,0 +1,76 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.weekofyear
+description: >
+  Temporal.Calendar.prototype.weekOfYear will take Temporal.PlainDate object
+  and return the week of year of that date.
+info: |
+  4. Let temporalDate be ? ToTemporalDate(temporalDateLike).
+  5. Return 𝔽(! ToISOWeekOfYear(temporalDate.[[ISOYear]], temporalDate.[[ISOMonth]], temporalDate.[[ISODay]])).
+features: [Temporal]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+
+// The following week numbers are taken from the table "Examples of contemporary
+// dates around New Year's Day" from
+// https://en.wikipedia.org/wiki/ISO_week_date#Relation_with_the_Gregorian_calendar
+
+let d = new Temporal.PlainDate(1977, 1, 1);
+assert.sameValue(cal.weekOfYear(d), 53, "1977-01-01 is in w53");
+
+d = new Temporal.PlainDate(1977, 1, 2);
+assert.sameValue(cal.weekOfYear(d), 53, "1977-01-02 is in w53");
+
+d = new Temporal.PlainDate(1977, 12, 31);
+assert.sameValue(cal.weekOfYear(d), 52, "1977-12-31 is in w52");
+
+d = new Temporal.PlainDate(1978, 1, 1);
+assert.sameValue(cal.weekOfYear(d), 52, "1978-01-01 is in w52");
+
+d = new Temporal.PlainDate(1978, 1, 2);
+assert.sameValue(cal.weekOfYear(d), 1, "1978-01-02 is in w01");
+
+d = new Temporal.PlainDate(1978, 12, 31);
+assert.sameValue(cal.weekOfYear(d), 52, "1978-12-31 is in w52");
+
+d = new Temporal.PlainDate(1979, 1, 1);
+assert.sameValue(cal.weekOfYear(d), 1, "1979-01-01 is in w01");
+
+d = new Temporal.PlainDate(1979, 12, 30);
+assert.sameValue(cal.weekOfYear(d), 52, "1979-12-30 is in w52");
+
+d = new Temporal.PlainDate(1979, 12, 31);
+assert.sameValue(cal.weekOfYear(d), 1, "1979-12-31 is in w01");
+
+d = new Temporal.PlainDate(1980, 1, 1);
+assert.sameValue(cal.weekOfYear(d), 1, "1980-01-01 is in w01");
+
+d = new Temporal.PlainDate(1980, 12, 28);
+assert.sameValue(cal.weekOfYear(d), 52, "1980-12-28 is in w52");
+
+d = new Temporal.PlainDate(1980, 12, 29);
+assert.sameValue(cal.weekOfYear(d), 1, "1980-12-29 is in w01");
+
+d = new Temporal.PlainDate(1980, 12, 30);
+assert.sameValue(cal.weekOfYear(d), 1, "1980-12-30 is in w01");
+
+d = new Temporal.PlainDate(1980, 12, 31);
+assert.sameValue(cal.weekOfYear(d), 1, "1980-12-31 is in w01");
+
+d = new Temporal.PlainDate(1981, 1, 1);
+assert.sameValue(cal.weekOfYear(d), 1, "1981-01-01 is in w01");
+
+d = new Temporal.PlainDate(1981, 12, 31);
+assert.sameValue(cal.weekOfYear(d), 53, "1981-12-31 is in w53");
+
+d = new Temporal.PlainDate(1982, 1, 1);
+assert.sameValue(cal.weekOfYear(d), 53, "1982-01-01 is in w53");
+
+d = new Temporal.PlainDate(1982, 1, 2);
+assert.sameValue(cal.weekOfYear(d), 53, "1982-01-02 is in w53");
+
+d = new Temporal.PlainDate(1982, 1, 3);
+assert.sameValue(cal.weekOfYear(d), 53, "1982-01-03 is in w53");

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-plaindatetime.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-plaindatetime.js
@@ -1,0 +1,76 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.weekofyear
+description: >
+  Temporal.Calendar.prototype.weekOfYear will take Temporal.PlainDateTime object
+  and return the week of year of that date.
+info: |
+  4. Let temporalDate be ? ToTemporalDate(temporalDateLike).
+  5. Return 𝔽(! ToISOWeekOfYear(temporalDate.[[ISOYear]], temporalDate.[[ISOMonth]], temporalDate.[[ISODay]])).
+features: [Temporal]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+
+// The following week numbers are taken from the table "Examples of contemporary
+// dates around New Year's Day" from
+// https://en.wikipedia.org/wiki/ISO_week_date#Relation_with_the_Gregorian_calendar
+
+let dt = new Temporal.PlainDateTime(1977, 1, 1, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 53, "1977-01-01 is in w53");
+
+dt = new Temporal.PlainDateTime(1977, 1, 2, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 53, "1977-01-02 is in w53");
+
+dt = new Temporal.PlainDateTime(1977, 12, 31, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 52, "1977-12-31 is in w52");
+
+dt = new Temporal.PlainDateTime(1978, 1, 1, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 52, "1978-01-01 is in w52");
+
+dt = new Temporal.PlainDateTime(1978, 1, 2, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 1, "1978-01-02 is in w01");
+
+dt = new Temporal.PlainDateTime(1978, 12, 31, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 52, "1978-12-31 is in w52");
+
+dt = new Temporal.PlainDateTime(1979, 1, 1, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 1, "1979-01-01 is in w01");
+
+dt = new Temporal.PlainDateTime(1979, 12, 30, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 52, "1979-12-30 is in w52");
+
+dt = new Temporal.PlainDateTime(1979, 12, 31, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 1, "1979-12-31 is in w01");
+
+dt = new Temporal.PlainDateTime(1980, 1, 1, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 1, "1980-01-01 is in w01");
+
+dt = new Temporal.PlainDateTime(1980, 12, 28, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 52, "1980-12-28 is in w52");
+
+dt = new Temporal.PlainDateTime(1980, 12, 29, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 1, "1980-12-29 is in w01");
+
+dt = new Temporal.PlainDateTime(1980, 12, 30, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 1, "1980-12-30 is in w01");
+
+dt = new Temporal.PlainDateTime(1980, 12, 31, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 1, "1980-12-31 is in w01");
+
+dt = new Temporal.PlainDateTime(1981, 1, 1, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 1, "1981-01-01 is in w01");
+
+dt = new Temporal.PlainDateTime(1981, 12, 31, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 53, "1981-12-31 is in w53");
+
+dt = new Temporal.PlainDateTime(1982, 1, 1, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 53, "1982-01-01 is in w53");
+
+dt = new Temporal.PlainDateTime(1982, 1, 2, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 53, "1982-01-02 is in w53");
+
+dt = new Temporal.PlainDateTime(1982, 1, 3, 9, 8);
+assert.sameValue(cal.weekOfYear(dt), 53, "1982-01-03 is in w53");

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.weekofyear
+description: >
+  Temporal.Calendar.prototype.weekOfYear will take an ISO 8601 date string and
+  return the week of year of that date.
+info: |
+  4. Let temporalDate be ? ToTemporalDate(temporalDateLike).
+  5. Return 𝔽(! ToISOWeekOfYear(temporalDate.[[ISOYear]], temporalDate.[[ISOMonth]], temporalDate.[[ISODay]])).
+features: [Temporal]
+---*/
+
+const cal = new Temporal.Calendar("iso8601");
+
+// The following week numbers are taken from the table "Examples of contemporary
+// dates around New Year's Day" from
+// https://en.wikipedia.org/wiki/ISO_week_date#Relation_with_the_Gregorian_calendar
+
+assert.sameValue(cal.weekOfYear("1977-01-01"), 53, "1977-01-01 is in w53");
+assert.sameValue(cal.weekOfYear("1977-01-02"), 53, "1977-01-02 is in w53");
+assert.sameValue(cal.weekOfYear("1977-12-31"), 52, "1977-12-31 is in w52");
+assert.sameValue(cal.weekOfYear("1978-01-01"), 52, "1978-01-01 is in w52");
+assert.sameValue(cal.weekOfYear("1978-01-02"), 1, "1978-01-02 is in w01");
+assert.sameValue(cal.weekOfYear("1978-12-31"), 52, "1978-12-31 is in w52");
+assert.sameValue(cal.weekOfYear("1979-01-01"), 1, "1979-01-01 is in w01");
+assert.sameValue(cal.weekOfYear("1979-12-30"), 52, "1979-12-30 is in w52");
+assert.sameValue(cal.weekOfYear("1979-12-31"), 1, "1979-12-31 is in w01");
+assert.sameValue(cal.weekOfYear("1980-01-01"), 1, "1980-01-01 is in w01");
+assert.sameValue(cal.weekOfYear("1980-12-28"), 52, "1980-12-28 is in w52");
+assert.sameValue(cal.weekOfYear("1980-12-29"), 1, "1980-12-29 is in w01");
+assert.sameValue(cal.weekOfYear("1980-12-30"), 1, "1980-12-30 is in w01");
+assert.sameValue(cal.weekOfYear("1980-12-31"), 1, "1980-12-31 is in w01");
+assert.sameValue(cal.weekOfYear("1981-01-01"), 1, "1981-01-01 is in w01");
+assert.sameValue(cal.weekOfYear("1981-12-31"), 53, "1981-12-31 is in w53");
+assert.sameValue(cal.weekOfYear("1982-01-01"), 53, "1982-01-01 is in w53");
+assert.sameValue(cal.weekOfYear("1982-01-02"), 53, "1982-01-02 is in w53");
+assert.sameValue(cal.weekOfYear("1982-01-03"), 53, "1982-01-03 is in w53");

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/branding.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/branding.js
@@ -11,12 +11,14 @@ const weekOfYear = Temporal.Calendar.prototype.weekOfYear;
 
 assert.sameValue(typeof weekOfYear, "function");
 
-assert.throws(TypeError, () => weekOfYear.call(undefined), "undefined");
-assert.throws(TypeError, () => weekOfYear.call(null), "null");
-assert.throws(TypeError, () => weekOfYear.call(true), "true");
-assert.throws(TypeError, () => weekOfYear.call(""), "empty string");
-assert.throws(TypeError, () => weekOfYear.call(Symbol()), "symbol");
-assert.throws(TypeError, () => weekOfYear.call(1), "1");
-assert.throws(TypeError, () => weekOfYear.call({}), "plain object");
-assert.throws(TypeError, () => weekOfYear.call(Temporal.Calendar), "Temporal.Calendar");
-assert.throws(TypeError, () => weekOfYear.call(Temporal.Calendar.prototype), "Temporal.Calendar.prototype");
+const arg = new Temporal.PlainDate(2021, 7, 20);
+
+assert.throws(TypeError, () => weekOfYear.call(undefined, arg), "undefined");
+assert.throws(TypeError, () => weekOfYear.call(null, arg), "null");
+assert.throws(TypeError, () => weekOfYear.call(true, arg), "true");
+assert.throws(TypeError, () => weekOfYear.call("", arg), "empty string");
+assert.throws(TypeError, () => weekOfYear.call(Symbol(), arg), "symbol");
+assert.throws(TypeError, () => weekOfYear.call(1, arg), "1");
+assert.throws(TypeError, () => weekOfYear.call({}, arg), "plain object");
+assert.throws(TypeError, () => weekOfYear.call(Temporal.Calendar, arg), "Temporal.Calendar");
+assert.throws(TypeError, () => weekOfYear.call(Temporal.Calendar.prototype, arg), "Temporal.Calendar.prototype");


### PR DESCRIPTION
Similar to #3438, this was originally PRs #3056, #3057, #3058, #3059, #3060 by @FrankYFTang which were closed without being merged. I'm following up as promised. I rebased the PRs, added assertion messages, did some reformatting, and combined with some existing tests. In a few places I added more test cases.