### PR TITLE
Tests for Temporal formatting the year appropriately as 4 or 6 digits

### DIFF
--- a/test/built-ins/Temporal/Instant/prototype/toJSON/year-format.js
+++ b/test/built-ins/Temporal/Instant/prototype/toJSON/year-format.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tojson
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+function epochNsInYear(year) {
+  // Return an epoch nanoseconds value near the middle of the given year
+  const avgNsPerYear = 31_556_952_000_000_000n;
+  return (year - 1970n) * avgNsPerYear + (avgNsPerYear / 2n);
+}
+
+let instance = new Temporal.Instant(epochNsInYear(-100000n));
+assert.sameValue(instance.toJSON(), "-100000-07-01T21:30:36Z", "large negative year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(-10000n));
+assert.sameValue(instance.toJSON(), "-010000-07-01T21:30:36Z", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(-9999n));
+assert.sameValue(instance.toJSON(), "-009999-07-02T03:19:48Z", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(-1000n));
+assert.sameValue(instance.toJSON(), "-001000-07-02T09:30:36Z", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(-999n));
+assert.sameValue(instance.toJSON(), "-000999-07-02T15:19:48Z", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(-1n));
+assert.sameValue(instance.toJSON(), "-000001-07-02T15:41:24Z", "year -1 formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(0n));
+assert.sameValue(instance.toJSON(), "0000-07-01T21:30:36Z", "year 0 formatted as 4-digit");
+
+instance = new Temporal.Instant(epochNsInYear(1n));
+assert.sameValue(instance.toJSON(), "0001-07-02T03:19:48Z", "year 1 formatted as 4-digit");
+
+instance = new Temporal.Instant(epochNsInYear(999n));
+assert.sameValue(instance.toJSON(), "0999-07-02T03:41:24Z", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.Instant(epochNsInYear(1000n));
+assert.sameValue(instance.toJSON(), "1000-07-02T09:30:36Z", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.Instant(epochNsInYear(9999n));
+assert.sameValue(instance.toJSON(), "9999-07-02T15:41:24Z", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.Instant(epochNsInYear(10000n));
+assert.sameValue(instance.toJSON(), "+010000-07-01T21:30:36Z", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(100000n));
+assert.sameValue(instance.toJSON(), "+100000-07-01T21:30:36Z", "large positive year formatted as 6-digit");

--- a/test/built-ins/Temporal/Instant/prototype/toString/year-format.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/year-format.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+function epochNsInYear(year) {
+  // Return an epoch nanoseconds value near the middle of the given year
+  const avgNsPerYear = 31_556_952_000_000_000n;
+  return (year - 1970n) * avgNsPerYear + (avgNsPerYear / 2n);
+}
+
+let instance = new Temporal.Instant(epochNsInYear(-100000n));
+assert.sameValue(instance.toString(), "-100000-07-01T21:30:36Z", "large negative year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(-10000n));
+assert.sameValue(instance.toString(), "-010000-07-01T21:30:36Z", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(-9999n));
+assert.sameValue(instance.toString(), "-009999-07-02T03:19:48Z", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(-1000n));
+assert.sameValue(instance.toString(), "-001000-07-02T09:30:36Z", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(-999n));
+assert.sameValue(instance.toString(), "-000999-07-02T15:19:48Z", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(-1n));
+assert.sameValue(instance.toString(), "-000001-07-02T15:41:24Z", "year -1 formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(0n));
+assert.sameValue(instance.toString(), "0000-07-01T21:30:36Z", "year 0 formatted as 4-digit");
+
+instance = new Temporal.Instant(epochNsInYear(1n));
+assert.sameValue(instance.toString(), "0001-07-02T03:19:48Z", "year 1 formatted as 4-digit");
+
+instance = new Temporal.Instant(epochNsInYear(999n));
+assert.sameValue(instance.toString(), "0999-07-02T03:41:24Z", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.Instant(epochNsInYear(1000n));
+assert.sameValue(instance.toString(), "1000-07-02T09:30:36Z", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.Instant(epochNsInYear(9999n));
+assert.sameValue(instance.toString(), "9999-07-02T15:41:24Z", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.Instant(epochNsInYear(10000n));
+assert.sameValue(instance.toString(), "+010000-07-01T21:30:36Z", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.Instant(epochNsInYear(100000n));
+assert.sameValue(instance.toString(), "+100000-07-01T21:30:36Z", "large positive year formatted as 6-digit");

--- a/test/built-ins/Temporal/PlainDate/prototype/toJSON/year-format.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toJSON/year-format.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tojson
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+let instance = new Temporal.PlainDate(-100000, 12, 3);
+assert.sameValue(instance.toJSON(), "-100000-12-03", "large negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(-10000, 4, 5);
+assert.sameValue(instance.toJSON(), "-010000-04-05", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(-9999, 6, 7);
+assert.sameValue(instance.toJSON(), "-009999-06-07", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(-1000, 8, 9);
+assert.sameValue(instance.toJSON(), "-001000-08-09", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(-999, 10, 9);
+assert.sameValue(instance.toJSON(), "-000999-10-09", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(-1, 8, 7);
+assert.sameValue(instance.toJSON(), "-000001-08-07", "year -1 formatted as 6-digit");
+
+instance = new Temporal.PlainDate(0, 6, 5);
+assert.sameValue(instance.toJSON(), "0000-06-05", "year 0 formatted as 4-digit");
+
+instance = new Temporal.PlainDate(1, 4, 3);
+assert.sameValue(instance.toJSON(), "0001-04-03", "year 1 formatted as 4-digit");
+
+instance = new Temporal.PlainDate(999, 2, 10);
+assert.sameValue(instance.toJSON(), "0999-02-10", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDate(1000, 1, 23);
+assert.sameValue(instance.toJSON(), "1000-01-23", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDate(9999, 4, 5);
+assert.sameValue(instance.toJSON(), "9999-04-05", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDate(10000, 6, 7);
+assert.sameValue(instance.toJSON(), "+010000-06-07", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(100000, 8, 9);
+assert.sameValue(instance.toJSON(), "+100000-08-09", "large positive year formatted as 6-digit");

--- a/test/built-ins/Temporal/PlainDate/prototype/toString/year-format.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toString/year-format.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tostring
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+let instance = new Temporal.PlainDate(-100000, 12, 3);
+assert.sameValue(instance.toString(), "-100000-12-03", "large negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(-10000, 4, 5);
+assert.sameValue(instance.toString(), "-010000-04-05", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(-9999, 6, 7);
+assert.sameValue(instance.toString(), "-009999-06-07", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(-1000, 8, 9);
+assert.sameValue(instance.toString(), "-001000-08-09", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(-999, 10, 9);
+assert.sameValue(instance.toString(), "-000999-10-09", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(-1, 8, 7);
+assert.sameValue(instance.toString(), "-000001-08-07", "year -1 formatted as 6-digit");
+
+instance = new Temporal.PlainDate(0, 6, 5);
+assert.sameValue(instance.toString(), "0000-06-05", "year 0 formatted as 4-digit");
+
+instance = new Temporal.PlainDate(1, 4, 3);
+assert.sameValue(instance.toString(), "0001-04-03", "year 1 formatted as 4-digit");
+
+instance = new Temporal.PlainDate(999, 2, 10);
+assert.sameValue(instance.toString(), "0999-02-10", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDate(1000, 1, 23);
+assert.sameValue(instance.toString(), "1000-01-23", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDate(9999, 4, 5);
+assert.sameValue(instance.toString(), "9999-04-05", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDate(10000, 6, 7);
+assert.sameValue(instance.toString(), "+010000-06-07", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.PlainDate(100000, 8, 9);
+assert.sameValue(instance.toString(), "+100000-08-09", "large positive year formatted as 6-digit");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toJSON/year-format.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toJSON/year-format.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tojson
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+let instance = new Temporal.PlainDateTime(-100000, 12, 3, 4, 56, 7, 890);
+assert.sameValue(instance.toJSON(), "-100000-12-03T04:56:07.89", "large negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(-10000, 4, 5, 6, 7, 8, 910);
+assert.sameValue(instance.toJSON(), "-010000-04-05T06:07:08.91", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(-9999, 6, 7, 8, 9, 10, 987);
+assert.sameValue(instance.toJSON(), "-009999-06-07T08:09:10.987", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(-1000, 8, 9, 10, 9, 8, 765);
+assert.sameValue(instance.toJSON(), "-001000-08-09T10:09:08.765", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(-999, 10, 9, 8, 7, 6, 543);
+assert.sameValue(instance.toJSON(), "-000999-10-09T08:07:06.543", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(-1, 8, 7, 6, 54, 32, 100);
+assert.sameValue(instance.toJSON(), "-000001-08-07T06:54:32.1", "year -1 formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(0, 6, 5, 4, 32, 10, 123);
+assert.sameValue(instance.toJSON(), "0000-06-05T04:32:10.123", "year 0 formatted as 4-digit");
+
+instance = new Temporal.PlainDateTime(1, 4, 3, 21, 0, 12, 345);
+assert.sameValue(instance.toJSON(), "0001-04-03T21:00:12.345", "year 1 formatted as 4-digit");
+
+instance = new Temporal.PlainDateTime(999, 2, 10, 12, 34, 56, 789);
+assert.sameValue(instance.toJSON(), "0999-02-10T12:34:56.789", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDateTime(1000, 1, 23, 4, 56, 7, 890);
+assert.sameValue(instance.toJSON(), "1000-01-23T04:56:07.89", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDateTime(9999, 4, 5, 6, 7, 8, 910);
+assert.sameValue(instance.toJSON(), "9999-04-05T06:07:08.91", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDateTime(10000, 6, 7, 8, 9, 10, 987);
+assert.sameValue(instance.toJSON(), "+010000-06-07T08:09:10.987", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(100000, 8, 9, 10, 9, 8, 765);
+assert.sameValue(instance.toJSON(), "+100000-08-09T10:09:08.765", "large positive year formatted as 6-digit");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/year-format.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/year-format.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+let instance = new Temporal.PlainDateTime(-100000, 12, 3, 4, 56, 7, 890);
+assert.sameValue(instance.toString(), "-100000-12-03T04:56:07.89", "large negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(-10000, 4, 5, 6, 7, 8, 910);
+assert.sameValue(instance.toString(), "-010000-04-05T06:07:08.91", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(-9999, 6, 7, 8, 9, 10, 987);
+assert.sameValue(instance.toString(), "-009999-06-07T08:09:10.987", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(-1000, 8, 9, 10, 9, 8, 765);
+assert.sameValue(instance.toString(), "-001000-08-09T10:09:08.765", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(-999, 10, 9, 8, 7, 6, 543);
+assert.sameValue(instance.toString(), "-000999-10-09T08:07:06.543", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(-1, 8, 7, 6, 54, 32, 100);
+assert.sameValue(instance.toString(), "-000001-08-07T06:54:32.1", "year -1 formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(0, 6, 5, 4, 32, 10, 123);
+assert.sameValue(instance.toString(), "0000-06-05T04:32:10.123", "year 0 formatted as 4-digit");
+
+instance = new Temporal.PlainDateTime(1, 4, 3, 21, 0, 12, 345);
+assert.sameValue(instance.toString(), "0001-04-03T21:00:12.345", "year 1 formatted as 4-digit");
+
+instance = new Temporal.PlainDateTime(999, 2, 10, 12, 34, 56, 789);
+assert.sameValue(instance.toString(), "0999-02-10T12:34:56.789", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDateTime(1000, 1, 23, 4, 56, 7, 890);
+assert.sameValue(instance.toString(), "1000-01-23T04:56:07.89", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDateTime(9999, 4, 5, 6, 7, 8, 910);
+assert.sameValue(instance.toString(), "9999-04-05T06:07:08.91", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainDateTime(10000, 6, 7, 8, 9, 10, 987);
+assert.sameValue(instance.toString(), "+010000-06-07T08:09:10.987", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.PlainDateTime(100000, 8, 9, 10, 9, 8, 765);
+assert.sameValue(instance.toString(), "+100000-08-09T10:09:08.765", "large positive year formatted as 6-digit");

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/year-format.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/toJSON/year-format.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.tojson
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+// For PlainMonthDay, the ISO reference year is only present in the string if
+// the calendar is not ISO 8601
+class NotISO extends Temporal.Calendar {
+  constructor() { super("iso8601"); }
+  toString() { return "not-iso"; }
+}
+const calendar = new NotISO();
+
+let instance = new Temporal.PlainMonthDay(12, 3, calendar, -100000);
+assert.sameValue(instance.toJSON(), "-100000-12-03[u-ca=not-iso]", "large negative year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(4, 5, calendar, -10000);
+assert.sameValue(instance.toJSON(), "-010000-04-05[u-ca=not-iso]", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(6, 7, calendar, -9999);
+assert.sameValue(instance.toJSON(), "-009999-06-07[u-ca=not-iso]", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(8, 9, calendar, -1000);
+assert.sameValue(instance.toJSON(), "-001000-08-09[u-ca=not-iso]", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(10, 9, calendar, -999);
+assert.sameValue(instance.toJSON(), "-000999-10-09[u-ca=not-iso]", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(8, 7, calendar, -1);
+assert.sameValue(instance.toJSON(), "-000001-08-07[u-ca=not-iso]", "year -1 formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(6, 5, calendar, 0);
+assert.sameValue(instance.toJSON(), "0000-06-05[u-ca=not-iso]", "year 0 formatted as 4-digit");
+
+instance = new Temporal.PlainMonthDay(4, 3, calendar, 1);
+assert.sameValue(instance.toJSON(), "0001-04-03[u-ca=not-iso]", "year 1 formatted as 4-digit");
+
+instance = new Temporal.PlainMonthDay(2, 10, calendar, 999);
+assert.sameValue(instance.toJSON(), "0999-02-10[u-ca=not-iso]", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainMonthDay(1, 23, calendar, 1000);
+assert.sameValue(instance.toJSON(), "1000-01-23[u-ca=not-iso]", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainMonthDay(4, 5, calendar, 9999);
+assert.sameValue(instance.toJSON(), "9999-04-05[u-ca=not-iso]", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainMonthDay(6, 7, calendar, 10000);
+assert.sameValue(instance.toJSON(), "+010000-06-07[u-ca=not-iso]", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(8, 9, calendar, 100000);
+assert.sameValue(instance.toJSON(), "+100000-08-09[u-ca=not-iso]", "large positive year formatted as 6-digit");

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/toString/year-format.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/toString/year-format.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.tostring
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+// For PlainMonthDay, the ISO reference year is only present in the string if
+// the calendar is not ISO 8601
+class NotISO extends Temporal.Calendar {
+  constructor() { super("iso8601"); }
+  toString() { return "not-iso"; }
+}
+const calendar = new NotISO();
+
+let instance = new Temporal.PlainMonthDay(12, 3, calendar, -100000);
+assert.sameValue(instance.toString(), "-100000-12-03[u-ca=not-iso]", "large negative year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(4, 5, calendar, -10000);
+assert.sameValue(instance.toString(), "-010000-04-05[u-ca=not-iso]", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(6, 7, calendar, -9999);
+assert.sameValue(instance.toString(), "-009999-06-07[u-ca=not-iso]", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(8, 9, calendar, -1000);
+assert.sameValue(instance.toString(), "-001000-08-09[u-ca=not-iso]", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(10, 9, calendar, -999);
+assert.sameValue(instance.toString(), "-000999-10-09[u-ca=not-iso]", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(8, 7, calendar, -1);
+assert.sameValue(instance.toString(), "-000001-08-07[u-ca=not-iso]", "year -1 formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(6, 5, calendar, 0);
+assert.sameValue(instance.toString(), "0000-06-05[u-ca=not-iso]", "year 0 formatted as 4-digit");
+
+instance = new Temporal.PlainMonthDay(4, 3, calendar, 1);
+assert.sameValue(instance.toString(), "0001-04-03[u-ca=not-iso]", "year 1 formatted as 4-digit");
+
+instance = new Temporal.PlainMonthDay(2, 10, calendar, 999);
+assert.sameValue(instance.toString(), "0999-02-10[u-ca=not-iso]", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainMonthDay(1, 23, calendar, 1000);
+assert.sameValue(instance.toString(), "1000-01-23[u-ca=not-iso]", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainMonthDay(4, 5, calendar, 9999);
+assert.sameValue(instance.toString(), "9999-04-05[u-ca=not-iso]", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainMonthDay(6, 7, calendar, 10000);
+assert.sameValue(instance.toString(), "+010000-06-07[u-ca=not-iso]", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.PlainMonthDay(8, 9, calendar, 100000);
+assert.sameValue(instance.toString(), "+100000-08-09[u-ca=not-iso]", "large positive year formatted as 6-digit");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/toJSON/year-format.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/toJSON/year-format.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.tojson
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+let instance = new Temporal.PlainYearMonth(-100000, 12);
+assert.sameValue(instance.toJSON(), "-100000-12", "large negative year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(-10000, 4);
+assert.sameValue(instance.toJSON(), "-010000-04", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(-9999, 6);
+assert.sameValue(instance.toJSON(), "-009999-06", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(-1000, 8);
+assert.sameValue(instance.toJSON(), "-001000-08", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(-999, 10);
+assert.sameValue(instance.toJSON(), "-000999-10", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(-1, 8);
+assert.sameValue(instance.toJSON(), "-000001-08", "year -1 formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(0, 6);
+assert.sameValue(instance.toJSON(), "0000-06", "year 0 formatted as 4-digit");
+
+instance = new Temporal.PlainYearMonth(1, 4);
+assert.sameValue(instance.toJSON(), "0001-04", "year 1 formatted as 4-digit");
+
+instance = new Temporal.PlainYearMonth(999, 2);
+assert.sameValue(instance.toJSON(), "0999-02", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainYearMonth(1000, 1);
+assert.sameValue(instance.toJSON(), "1000-01", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainYearMonth(9999, 4);
+assert.sameValue(instance.toJSON(), "9999-04", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainYearMonth(10000, 6);
+assert.sameValue(instance.toJSON(), "+010000-06", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(100000, 8);
+assert.sameValue(instance.toJSON(), "+100000-08", "large positive year formatted as 6-digit");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/toString/year-format.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/toString/year-format.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.tostring
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+let instance = new Temporal.PlainYearMonth(-100000, 12);
+assert.sameValue(instance.toString(), "-100000-12", "large negative year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(-10000, 4);
+assert.sameValue(instance.toString(), "-010000-04", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(-9999, 6);
+assert.sameValue(instance.toString(), "-009999-06", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(-1000, 8);
+assert.sameValue(instance.toString(), "-001000-08", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(-999, 10);
+assert.sameValue(instance.toString(), "-000999-10", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(-1, 8);
+assert.sameValue(instance.toString(), "-000001-08", "year -1 formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(0, 6);
+assert.sameValue(instance.toString(), "0000-06", "year 0 formatted as 4-digit");
+
+instance = new Temporal.PlainYearMonth(1, 4);
+assert.sameValue(instance.toString(), "0001-04", "year 1 formatted as 4-digit");
+
+instance = new Temporal.PlainYearMonth(999, 2);
+assert.sameValue(instance.toString(), "0999-02", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainYearMonth(1000, 1);
+assert.sameValue(instance.toString(), "1000-01", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainYearMonth(9999, 4);
+assert.sameValue(instance.toString(), "9999-04", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.PlainYearMonth(10000, 6);
+assert.sameValue(instance.toString(), "+010000-06", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.PlainYearMonth(100000, 8);
+assert.sameValue(instance.toString(), "+100000-08", "large positive year formatted as 6-digit");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toJSON/year-format.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toJSON/year-format.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tojson
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+function epochNsInYear(year) {
+  // Return an epoch nanoseconds value near the middle of the given year
+  const avgNsPerYear = 31_556_952_000_000_000n;
+  return (year - 1970n) * avgNsPerYear + (avgNsPerYear / 2n);
+}
+
+const utc = new Temporal.TimeZone("UTC");
+
+let instance = new Temporal.ZonedDateTime(epochNsInYear(-100000n), utc);
+assert.sameValue(instance.toJSON(), "-100000-07-01T21:30:36+00:00[UTC]", "large negative year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(-10000n), utc);
+assert.sameValue(instance.toJSON(), "-010000-07-01T21:30:36+00:00[UTC]", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(-9999n), utc);
+assert.sameValue(instance.toJSON(), "-009999-07-02T03:19:48+00:00[UTC]", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(-1000n), utc);
+assert.sameValue(instance.toJSON(), "-001000-07-02T09:30:36+00:00[UTC]", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(-999n), utc);
+assert.sameValue(instance.toJSON(), "-000999-07-02T15:19:48+00:00[UTC]", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(-1n), utc);
+assert.sameValue(instance.toJSON(), "-000001-07-02T15:41:24+00:00[UTC]", "year -1 formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(0n), utc);
+assert.sameValue(instance.toJSON(), "0000-07-01T21:30:36+00:00[UTC]", "year 0 formatted as 4-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(1n), utc);
+assert.sameValue(instance.toJSON(), "0001-07-02T03:19:48+00:00[UTC]", "year 1 formatted as 4-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(999n), utc);
+assert.sameValue(instance.toJSON(), "0999-07-02T03:41:24+00:00[UTC]", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(1000n), utc);
+assert.sameValue(instance.toJSON(), "1000-07-02T09:30:36+00:00[UTC]", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(9999n), utc);
+assert.sameValue(instance.toJSON(), "9999-07-02T15:41:24+00:00[UTC]", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(10000n), utc);
+assert.sameValue(instance.toJSON(), "+010000-07-01T21:30:36+00:00[UTC]", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(100000n), utc);
+assert.sameValue(instance.toJSON(), "+100000-07-01T21:30:36+00:00[UTC]", "large positive year formatted as 6-digit");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/year-format.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/year-format.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: Verify that the year is appropriately formatted as 4 or 6 digits
+features: [Temporal]
+---*/
+
+function epochNsInYear(year) {
+  // Return an epoch nanoseconds value near the middle of the given year
+  const avgNsPerYear = 31_556_952_000_000_000n;
+  return (year - 1970n) * avgNsPerYear + (avgNsPerYear / 2n);
+}
+
+const utc = new Temporal.TimeZone("UTC");
+
+let instance = new Temporal.ZonedDateTime(epochNsInYear(-100000n), utc);
+assert.sameValue(instance.toString(), "-100000-07-01T21:30:36+00:00[UTC]", "large negative year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(-10000n), utc);
+assert.sameValue(instance.toString(), "-010000-07-01T21:30:36+00:00[UTC]", "smallest 5-digit negative year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(-9999n), utc);
+assert.sameValue(instance.toString(), "-009999-07-02T03:19:48+00:00[UTC]", "largest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(-1000n), utc);
+assert.sameValue(instance.toString(), "-001000-07-02T09:30:36+00:00[UTC]", "smallest 4-digit negative year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(-999n), utc);
+assert.sameValue(instance.toString(), "-000999-07-02T15:19:48+00:00[UTC]", "largest 3-digit negative year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(-1n), utc);
+assert.sameValue(instance.toString(), "-000001-07-02T15:41:24+00:00[UTC]", "year -1 formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(0n), utc);
+assert.sameValue(instance.toString(), "0000-07-01T21:30:36+00:00[UTC]", "year 0 formatted as 4-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(1n), utc);
+assert.sameValue(instance.toString(), "0001-07-02T03:19:48+00:00[UTC]", "year 1 formatted as 4-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(999n), utc);
+assert.sameValue(instance.toString(), "0999-07-02T03:41:24+00:00[UTC]", "largest 3-digit positive year formatted as 4-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(1000n), utc);
+assert.sameValue(instance.toString(), "1000-07-02T09:30:36+00:00[UTC]", "smallest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(9999n), utc);
+assert.sameValue(instance.toString(), "9999-07-02T15:41:24+00:00[UTC]", "largest 4-digit positive year formatted as 4-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(10000n), utc);
+assert.sameValue(instance.toString(), "+010000-07-01T21:30:36+00:00[UTC]", "smallest 5-digit positive year formatted as 6-digit");
+
+instance = new Temporal.ZonedDateTime(epochNsInYear(100000n), utc);
+assert.sameValue(instance.toString(), "+100000-07-01T21:30:36+00:00[UTC]", "large positive year formatted as 6-digit");


### PR DESCRIPTION
https://github.com/tc39/proposal-temporal/pull/2090 is a normative change
that reached consensus at the March 2022 TC39 plenary meeting. This adds
tests that verify the change made to the formatting of years between 0 and
999 inclusive in all toString and toJSON methods of Temporal types that
can output an ISO year number in their return value.