### PR TITLE
Fix false negative in for-in test

### DIFF
--- a/test/language/statements/for-in/S12.6.4_A7_T2.js
+++ b/test/language/statements/for-in/S12.6.4_A7_T2.js
@@ -28,7 +28,10 @@ for (var __key in __obj){
 	
 }
 
-assert.sameValue(__accum, "aa1ca3");
+assert(
+	__accum === "aa1ca3" || __accum === "ca3aa1",
+	"Unexpected value: '" + __accum + "'"
+);
 
 // erasator is the hash map terminator
 function erasator_T_1000(hash_map, charactr){

--- a/test/language/statements/for-in/S12.6.4_A7_T2.js
+++ b/test/language/statements/for-in/S12.6.4_A7_T2.js
@@ -13,7 +13,10 @@ description: >
 
 var __obj, __accum;
 
-__obj={aa:1,ba:2,ca:3};
+__obj = Object.create(null);
+__obj.aa = 1;
+__obj.ba = 2;
+__obj.ca = 3;
 
 __accum="";
 
@@ -25,23 +28,7 @@ for (var __key in __obj){
 	
 }
 
-
-//////////////////////////////////////////////////////////////////////////////
-//CHECK#1
-if (!((__accum.indexOf("aa1")!==-1)&&(__accum.indexOf("ca3")!==-1))) {
-	throw new Test262Error('#1: (__accum.indexOf("aa1")!==-1)&&(__accum.indexOf("ca3")!==-1)');
-}
-//
-//////////////////////////////////////////////////////////////////////////////
-
-//////////////////////////////////////////////////////////////////////////////
-//CHECK#2
-if (__accum.indexOf("ba2")!==-1) {
-	throw new Test262Error('#2: __accum.indexOf("ba2") === -1. Actual:  __accum.indexOf("ba2") ==='+ __accum.indexOf("ba2")  );
-}
-//
-//////////////////////////////////////////////////////////////////////////////
-
+assert.sameValue(__accum, "aa1ca3");
 
 // erasator is the hash map terminator
 function erasator_T_1000(hash_map, charactr){


### PR DESCRIPTION
As originally written, this test would spuriously pass when the deleted
property was incorrectly visited by enumation but correctly removed from
the object. In such cases, the accumulator string would take the form

    "aa1baundefinedca3"

And satisfy all conditions intended to highlight implementation errors.

Refactor the test to avoid false negative by using an object with a null
prototype and verifying the exact contents of the accumulator string.