### PR TITLE
Test improvements for Temporal toString methods with options for outputting seconds

### DIFF
--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -239,39 +239,6 @@ var TemporalHelpers = {
   },
 
   /*
-   * checkFractionalSecondDigitsOptionWrongType(temporalObject):
-   *
-   * Checks the string-or-number type handling of the fractionalSecondDigits
-   * option to the various types' toString() methods. temporalObject is an
-   * instance of the Temporal type under test.
-   */
-  checkFractionalSecondDigitsOptionWrongType(temporalObject) {
-    // null is not a number, and converts to the string "null", which is an invalid string value
-    assert.throws(RangeError, () => temporalObject.toString({ fractionalSecondDigits: null }), "null");
-    // Booleans are not numbers, and convert to the strings "true" or "false", which are invalid
-    assert.throws(RangeError, () => temporalObject.toString({ fractionalSecondDigits: true }), "true");
-    assert.throws(RangeError, () => temporalObject.toString({ fractionalSecondDigits: false }), "false");
-    // Symbols are not numbers and cannot convert to strings
-    assert.throws(TypeError, () => temporalObject.toString({ fractionalSecondDigits: Symbol() }), "symbol");
-    // BigInts are not numbers and convert to strings which are invalid
-    assert.throws(RangeError, () => temporalObject.toString({ fractionalSecondDigits: 2n }), "bigint");
-
-    // Objects are not numbers and prefer their toString() methods when converting to a string
-    assert.throws(RangeError, () => temporalObject.toString({ fractionalSecondDigits: {} }), "plain object");
-
-    const toStringExpected = temporalObject.toString({ fractionalSecondDigits: 'auto' });
-    const expected = [
-      "get fractionalSecondDigits.toString",
-      "call fractionalSecondDigits.toString",
-    ];
-    const actual = [];
-    const observer = TemporalHelpers.toPrimitiveObserver(actual, "auto", "fractionalSecondDigits");
-    const result = temporalObject.toString({ fractionalSecondDigits: observer });
-    assert.sameValue(result, toStringExpected, "object with toString");
-    assert.compareArray(actual, expected, "order of operations");
-  },
-
-  /*
    * checkPlainDateTimeConversionFastPath(func):
    *
    * ToTemporalDate and ToTemporalTime should both, if given a

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/options-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.calendar.prototype.dateadd
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.Calendar("iso8601");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.dateAdd(new Temporal.PlainDate(1976, 11, 18), new Temporal.Duration(1), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Calendar/prototype/dateFromFields/options-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateFromFields/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.calendar.prototype.datefromfields
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.Calendar("iso8601");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.dateFromFields({ year: 1976, month: 11, day: 18 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/options-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.calendar.prototype.dateuntil
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.Calendar("iso8601");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.dateUntil(new Temporal.PlainDate(1976, 11, 18), new Temporal.PlainDate(1984, 5, 31), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/options-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.calendar.prototype.monthdayfromfields
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.Calendar("iso8601");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.monthDayFromFields({ monthCode: "M12", day: 15 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Calendar/prototype/yearMonthFromFields/options-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearMonthFromFields/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.calendar.prototype.yearmonthfromfields
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.Calendar("iso8601");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.yearMonthFromFields({ year: 2000, monthCode: "M05" }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Duration/compare/options-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/compare/options-wrong-type.js
@@ -2,23 +2,21 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.duration.compare
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => Temporal.Duration.compare({ hours: 1 }, { minutes: 60 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Duration/prototype/add/options-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.duration.prototype.add
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.Duration(0, 0, 0, 0, 1);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.add({ hours: 1 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Duration/prototype/round/options-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/options-wrong-type.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
+esid: sec-temporal.duration.prototype.round
 description: TypeError thrown when options argument is missing or a non-string primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
@@ -16,7 +16,7 @@ const badOptions = [
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
+const instance = new Temporal.Duration(0, 0, 0, 0, 1);
 assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
   assert.throws(TypeError, () => instance.round(value),

--- a/test/built-ins/Temporal/Duration/prototype/round/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/smallestunit-invalid-string.js
@@ -8,4 +8,20 @@ features: [Temporal]
 ---*/
 
 const duration = new Temporal.Duration(0, 0, 0, 0, 12, 34, 56, 123, 987, 500);
-assert.throws(RangeError, () => duration.round({ smallestUnit: "other string" }));
+const badValues = [
+  "era",
+  "eraYear",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => duration.round({ smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
+}

--- a/test/built-ins/Temporal/Duration/prototype/subtract/options-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.duration.prototype.subtract
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.Duration(0, 0, 0, 0, 1);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.subtract({ hours: 1 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-auto.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-auto.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+description: auto value for fractionalSecondDigits option
+features: [Temporal]
+---*/
+
+const wholeSeconds = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7);
+const subSeconds = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 650);
+
+const tests = [
+  [wholeSeconds, "P1Y2M3W4DT5H6M7S"],
+  [subSeconds, "P1Y2M3W4DT5H6M7.98765S"],
+];
+
+for (const [duration, expected] of tests) {
+  assert.sameValue(duration.toString(), expected, "default is to emit seconds and drop trailing zeroes");
+  assert.sameValue(duration.toString({ fractionalSecondDigits: "auto" }), expected, "auto is the default");
+}

--- a/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-invalid-string.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-invalid-string.js
@@ -16,6 +16,7 @@ features: [Temporal]
 
 const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 650, 0);
 
-for (const fractionalSecondDigits of ["other string", "AUTO", "not-auto", "autos"]) {
-  assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits }));
+for (const fractionalSecondDigits of ["other string", "AUTO", "not-auto", "autos", "auto\0"]) {
+  assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits }),
+    `"${fractionalSecondDigits}" is not a valid value for fractionalSecondDigits`);
 }

--- a/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-number.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+description: Number for fractionalSecondDigits option
+features: [Temporal]
+---*/
+
+const wholeSeconds = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7);
+const subSeconds = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 650);
+
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 0 }), "P1Y2M3W4DT5H6M7S",
+  "truncates 4 decimal places to 0");
+assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 2 }), "P1Y2M3W4DT5H6M7.00S",
+  "pads whole seconds to 2 decimal places");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 2 }), "P1Y2M3W4DT5H6M7.98S",
+  "truncates 4 decimal places to 2");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 3 }), "P1Y2M3W4DT5H6M7.987S",
+  "truncates 4 decimal places to 3");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 6 }), "P1Y2M3W4DT5H6M7.987650S",
+  "pads 4 decimal places to 6");
+assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 7 }), "P1Y2M3W4DT5H6M7.0000000S",
+  "pads whole seconds to 7 decimal places");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 7 }), "P1Y2M3W4DT5H6M7.9876500S",
+  "pads 4 decimal places to 7");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 9 }), "P1Y2M3W4DT5H6M7.987650000S",
+  "pads 4 decimal places to 9");

--- a/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-out-of-range.js
@@ -16,7 +16,11 @@ features: [Temporal]
 
 const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 650, 0);
 
-assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: -Infinity }));
-assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: -1 }));
-assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: 10 }));
-assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: Infinity }));
+assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: -Infinity }),
+  "−∞ is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: -1 }),
+  "−1 is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: 10 }),
+  "10 is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: Infinity }),
+  "∞ is out of range for fractionalSecondDigits");

--- a/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-undefined.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-undefined.js
@@ -16,10 +16,21 @@ info: |
 features: [Temporal]
 ---*/
 
-const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 650, 0);
+const wholeSeconds = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7);
+const subSeconds = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 650);
 
-const explicit = duration.toString({ fractionalSecondDigits: undefined });
-assert.sameValue(explicit, "P1Y2M3W4DT5H6M7.98765S", "default fractionalSecondDigits is auto");
+const tests = [
+  [wholeSeconds, "P1Y2M3W4DT5H6M7S"],
+  [subSeconds, "P1Y2M3W4DT5H6M7.98765S"],
+];
 
-const implicit = duration.toString({});
-assert.sameValue(implicit, "P1Y2M3W4DT5H6M7.98765S", "default fractionalSecondDigits is auto");
+for (const [duration, expected] of tests) {
+  const explicit = duration.toString({ fractionalSecondDigits: undefined });
+  assert.sameValue(explicit, expected, "default fractionalSecondDigits is auto (property present but undefined)");
+
+  const implicit = duration.toString({});
+  assert.sameValue(implicit, expected, "default fractionalSecondDigits is auto (property not present)");
+
+  const lambda = duration.toString(() => {});
+  assert.sameValue(lambda, expected, "default fractionalSecondDigits is auto (property not present, function object)");
+}

--- a/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-wrong-type.js
@@ -22,4 +22,26 @@ features: [Temporal]
 ---*/
 
 const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 650, 0);
-TemporalHelpers.checkFractionalSecondDigitsOptionWrongType(duration);
+
+assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: null }),
+  "null is not a number and converts to the string 'null' which is not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: true }),
+  "true is not a number and converts to the string 'true' which is not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: false }),
+  "false is not a number and converts to the string 'false' which is not valid for fractionalSecondDigits");
+assert.throws(TypeError, () => duration.toString({ fractionalSecondDigits: Symbol() }),
+  "symbols are not numbers and cannot convert to strings");
+assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: 2n }),
+  "bigints are not numbers and convert to strings which are not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => duration.toString({ fractionalSecondDigits: {} }),
+  "plain objects are not numbers and convert to strings which are not valid for fractionalSecondDigits");
+
+const expected = [
+  "get fractionalSecondDigits.toString",
+  "call fractionalSecondDigits.toString",
+];
+const actual = [];
+const observer = TemporalHelpers.toPrimitiveObserver(actual, "auto", "fractionalSecondDigits");
+const result = duration.toString({ fractionalSecondDigits: observer });
+assert.sameValue(result, "P1Y2M3W4DT5H6M7.98765S", "object with toString uses toString return value");
+assert.compareArray(actual, expected, "object with toString calls toString and not valueOf");

--- a/test/built-ins/Temporal/Duration/prototype/toString/options-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.duration.prototype.tostring
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.Duration(0, 0, 0, 0, 1);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.toString(value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Duration/prototype/toString/roundingmode-ceil.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/roundingmode-ceil.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+description: ceil value for roundingMode option
+features: [Temporal]
+---*/
+
+const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 123, 987, 500);
+
+const result1 = duration.toString({ smallestUnit: "microsecond", roundingMode: "ceil" });
+assert.sameValue(result1, "P1Y2M3W4DT5H6M7.123988S",
+  "roundingMode is ceil (with 6 digits from smallestUnit)");
+
+const result2 = duration.toString({ fractionalSecondDigits: 6, roundingMode: "ceil" });
+assert.sameValue(result2, "P1Y2M3W4DT5H6M7.123988S",
+  "roundingMode is ceil (with 6 digits from fractionalSecondDigits)");
+
+const result3 = duration.toString({ smallestUnit: "millisecond", roundingMode: "ceil" });
+assert.sameValue(result3, "P1Y2M3W4DT5H6M7.124S",
+  "roundingMode is ceil (with 3 digits from smallestUnit)");
+
+const result4 = duration.toString({ fractionalSecondDigits: 3, roundingMode: "ceil" });
+assert.sameValue(result4, "P1Y2M3W4DT5H6M7.124S",
+  "roundingMode is ceil (with 3 digits from fractionalSecondDigits)");
+
+const result5 = duration.toString({ smallestUnit: "second", roundingMode: "ceil" });
+assert.sameValue(result5, "P1Y2M3W4DT5H6M8S",
+  "roundingMode is ceil (with 0 digits from smallestUnit)");
+
+const result6 = duration.toString({ fractionalSecondDigits: 0, roundingMode: "ceil" });
+assert.sameValue(result6, "P1Y2M3W4DT5H6M8S",
+  "roundingMode is ceil (with 0 digits from fractionalSecondDigits)");

--- a/test/built-ins/Temporal/Duration/prototype/toString/roundingmode-floor.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/roundingmode-floor.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+description: floor value for roundingMode option
+features: [Temporal]
+---*/
+
+const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 123, 987, 500);
+
+const result1 = duration.toString({ smallestUnit: "microsecond", roundingMode: "floor" });
+assert.sameValue(result1, "P1Y2M3W4DT5H6M7.123987S",
+  "roundingMode is floor (with 6 digits from smallestUnit)");
+
+const result2 = duration.toString({ fractionalSecondDigits: 6, roundingMode: "floor" });
+assert.sameValue(result2, "P1Y2M3W4DT5H6M7.123987S",
+  "roundingMode is floor (with 6 digits from fractionalSecondDigits)");
+
+const result3 = duration.toString({ smallestUnit: "millisecond", roundingMode: "floor" });
+assert.sameValue(result3, "P1Y2M3W4DT5H6M7.123S",
+  "roundingMode is floor (with 3 digits from smallestUnit)");
+
+const result4 = duration.toString({ fractionalSecondDigits: 3, roundingMode: "floor" });
+assert.sameValue(result4, "P1Y2M3W4DT5H6M7.123S",
+  "roundingMode is floor (with 3 digits from fractionalSecondDigits)");
+
+const result5 = duration.toString({ smallestUnit: "second", roundingMode: "floor" });
+assert.sameValue(result5, "P1Y2M3W4DT5H6M7S",
+  "roundingMode is floor (with 0 digits from smallestUnit)");
+
+const result6 = duration.toString({ fractionalSecondDigits: 0, roundingMode: "floor" });
+assert.sameValue(result6, "P1Y2M3W4DT5H6M7S",
+  "roundingMode is floor (with 0 digits from fractionalSecondDigits)");

--- a/test/built-ins/Temporal/Duration/prototype/toString/roundingmode-halfExpand.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/roundingmode-halfExpand.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+description: halfExpand value for roundingMode option
+features: [Temporal]
+---*/
+
+const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 123, 987, 500);
+
+const result1 = duration.toString({ smallestUnit: "microsecond", roundingMode: "halfExpand" });
+assert.sameValue(result1, "P1Y2M3W4DT5H6M7.123988S",
+  "roundingMode is halfExpand (with 6 digits from smallestUnit)");
+
+const result2 = duration.toString({ fractionalSecondDigits: 6, roundingMode: "halfExpand" });
+assert.sameValue(result2, "P1Y2M3W4DT5H6M7.123988S",
+  "roundingMode is halfExpand (with 6 digits from fractionalSecondDigits)");
+
+const result3 = duration.toString({ smallestUnit: "millisecond", roundingMode: "halfExpand" });
+assert.sameValue(result3, "P1Y2M3W4DT5H6M7.124S",
+  "roundingMode is halfExpand (with 3 digits from smallestUnit)");
+
+const result4 = duration.toString({ fractionalSecondDigits: 3, roundingMode: "halfExpand" });
+assert.sameValue(result4, "P1Y2M3W4DT5H6M7.124S",
+  "roundingMode is halfExpand (with 3 digits from fractionalSecondDigits)");
+
+const result5 = duration.toString({ smallestUnit: "second", roundingMode: "halfExpand" });
+assert.sameValue(result5, "P1Y2M3W4DT5H6M7S",
+  "roundingMode is halfExpand (with 0 digits from smallestUnit)");
+
+const result6 = duration.toString({ fractionalSecondDigits: 0, roundingMode: "halfExpand" });
+assert.sameValue(result6, "P1Y2M3W4DT5H6M7S",
+  "roundingMode is halfExpand (with 0 digits from fractionalSecondDigits)");

--- a/test/built-ins/Temporal/Duration/prototype/toString/roundingmode-trunc.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/roundingmode-trunc.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+description: trunc value for roundingMode option
+features: [Temporal]
+---*/
+
+const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 123, 987, 500);
+
+const result1 = duration.toString({ smallestUnit: "microsecond", roundingMode: "trunc" });
+assert.sameValue(result1, "P1Y2M3W4DT5H6M7.123987S",
+  "roundingMode is trunc (with 6 digits from smallestUnit)");
+
+const result2 = duration.toString({ fractionalSecondDigits: 6, roundingMode: "trunc" });
+assert.sameValue(result2, "P1Y2M3W4DT5H6M7.123987S",
+  "roundingMode is trunc (with 6 digits from fractionalSecondDigits)");
+
+const result3 = duration.toString({ smallestUnit: "millisecond", roundingMode: "trunc" });
+assert.sameValue(result3, "P1Y2M3W4DT5H6M7.123S",
+  "roundingMode is trunc (with 3 digits from smallestUnit)");
+
+const result4 = duration.toString({ fractionalSecondDigits: 3, roundingMode: "trunc" });
+assert.sameValue(result4, "P1Y2M3W4DT5H6M7.123S",
+  "roundingMode is trunc (with 3 digits from fractionalSecondDigits)");
+
+const result5 = duration.toString({ smallestUnit: "second", roundingMode: "trunc" });
+assert.sameValue(result5, "P1Y2M3W4DT5H6M7S",
+  "roundingMode is trunc (with 0 digits from smallestUnit)");
+
+const result6 = duration.toString({ fractionalSecondDigits: 0, roundingMode: "trunc" });
+assert.sameValue(result6, "P1Y2M3W4DT5H6M7S",
+  "roundingMode is trunc (with 0 digits from fractionalSecondDigits)");

--- a/test/built-ins/Temporal/Duration/prototype/toString/smallestunit-fractionalseconddigits.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/smallestunit-fractionalseconddigits.js
@@ -2,29 +2,28 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.tostring
+esid: sec-temporal.duration.prototype.tostring
 description: fractionalSecondDigits option is not used with smallestUnit present
 features: [Temporal]
 ---*/
 
-const time = new Temporal.PlainTime(12, 34, 56, 789, 999, 999);
+const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 789, 999, 999);
 const tests = [
-  ["minute", "12:34"],
-  ["second", "12:34:56"],
-  ["millisecond", "12:34:56.789"],
-  ["microsecond", "12:34:56.789999"],
-  ["nanosecond", "12:34:56.789999999"],
+  ["second", "P1Y2M3W4DT5H6M7S"],
+  ["millisecond", "P1Y2M3W4DT5H6M7.789S"],
+  ["microsecond", "P1Y2M3W4DT5H6M7.789999S"],
+  ["nanosecond", "P1Y2M3W4DT5H6M7.789999999S"],
 ];
 
 for (const [smallestUnit, expected] of tests) {
-  const string = time.toString({
+  const string = duration.toString({
     smallestUnit,
     get fractionalSecondDigits() { throw new Test262Error("should not get fractionalSecondDigits") }
   });
   assert.sameValue(string, expected, `smallestUnit: "${smallestUnit}" overrides fractionalSecondDigits`);
 }
 
-assert.throws(RangeError, () => time.toString({
+assert.throws(RangeError, () => duration.toString({
   smallestUnit: "hour",
   get fractionalSecondDigits() { throw new Test262Error("should not get fractionalSecondDigits") }
 }), "hour is an invalid smallestUnit but still overrides fractionalSecondDigits");

--- a/test/built-ins/Temporal/Duration/prototype/toString/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/smallestunit-invalid-string.js
@@ -8,7 +8,32 @@ features: [Temporal]
 ---*/
 
 const duration = new Temporal.Duration(0, 0, 0, 0, 12, 34, 56, 123, 987, 500);
-const values = ["eras", "years", "months", "weeks", "days", "hours", "minutes", "nonsense", "other string", "mill\u0131seconds", "SECONDS"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => duration.toString({ smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => duration.toString({ smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/Duration/prototype/toString/smallestunit-valid-units.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/smallestunit-valid-units.js
@@ -9,12 +9,37 @@ features: [Temporal]
 
 const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
 
-assert.sameValue(duration.toString({ smallestUnit: "second" }), "P1Y2M3W4DT5H6M7S");
-assert.sameValue(duration.toString({ smallestUnit: "millisecond" }), "P1Y2M3W4DT5H6M7.987S");
-assert.sameValue(duration.toString({ smallestUnit: "microsecond" }), "P1Y2M3W4DT5H6M7.987654S");
-assert.sameValue(duration.toString({ smallestUnit: "nanosecond" }), "P1Y2M3W4DT5H6M7.987654321S");
+function test(instance, expectations, description) {
+  for (const [smallestUnit, expectedResult] of expectations) {
+    assert.sameValue(instance.toString({ smallestUnit }), expectedResult,
+      `${description} with smallestUnit "${smallestUnit}"`);
+  }
+}
+
+test(
+  duration,
+  [
+    ["seconds", "P1Y2M3W4DT5H6M7S"],
+    ["milliseconds", "P1Y2M3W4DT5H6M7.987S"],
+    ["microseconds", "P1Y2M3W4DT5H6M7.987654S"],
+    ["nanoseconds", "P1Y2M3W4DT5H6M7.987654321S"],
+  ],
+  "subseconds toString"
+);
+
+test(
+  new Temporal.Duration(1, 2, 3, 4, 5, 6, 7),
+  [
+    ["seconds", "P1Y2M3W4DT5H6M7S"],
+    ["milliseconds", "P1Y2M3W4DT5H6M7.000S"],
+    ["microseconds", "P1Y2M3W4DT5H6M7.000000S"],
+    ["nanoseconds", "P1Y2M3W4DT5H6M7.000000000S"],
+  ],
+  "whole seconds toString"
+);
 
 const notValid = [
+  "era",
   "year",
   "month",
   "week",
@@ -24,5 +49,6 @@ const notValid = [
 ];
 
 notValid.forEach((smallestUnit) => {
-  assert.throws(RangeError, () => duration.toString({ smallestUnit }), smallestUnit);
+  assert.throws(RangeError, () => duration.toString({ smallestUnit }),
+    `"${smallestUnit}" is not a valid unit for the smallestUnit option`);
 });

--- a/test/built-ins/Temporal/Duration/prototype/total/options-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/options-wrong-type.js
@@ -1,13 +1,13 @@
-// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 esid: sec-temporal.duration.prototype.total
-description: TypeError thrown when options argument is missing or a primitive
+description: TypeError thrown when options argument is missing or a non-string primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const values = [
+const badOptions = [
   undefined,
   null,
   true,
@@ -17,7 +17,8 @@ const values = [
 ];
 
 const instance = new Temporal.Duration(0, 0, 0, 0, 1);
-assert.throws(TypeError, () => instance.total(), "TypeError on missing argument");
-values.forEach((value) => {
-  assert.throws(TypeError, () => instance.total(value), `TypeError on wrong argument type ${typeof(value)}`);
-});
+assert.throws(TypeError, () => instance.total(), "TypeError on missing options argument");
+for (const value of badOptions) {
+  assert.throws(TypeError, () => instance.total(value),
+    `TypeError on wrong options type ${typeof value}`);
+};

--- a/test/built-ins/Temporal/Instant/prototype/round/rounding-direction.js
+++ b/test/built-ins/Temporal/Instant/prototype/round/rounding-direction.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.round
+description: Rounding down is towards the Big Bang, not the epoch or 1 BCE
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(-65_261_246_399_500_000_000n);  // -000099-12-15T12:00:00.5Z
+assert.sameValue(
+  instance.round({ smallestUnit: "second", roundingMode: "floor" }).epochNanoseconds,
+  -65_261_246_400_000_000_000n,  // -000099-12-15T12:00:00Z
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE (roundingMode floor)"
+);
+assert.sameValue(
+  instance.round({ smallestUnit: "second", roundingMode: "trunc" }).epochNanoseconds,
+  -65_261_246_400_000_000_000n,  // -000099-12-15T12:00:00Z
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE (roundingMode trunc)"
+);
+assert.sameValue(
+  instance.round({ smallestUnit: "second", roundingMode: "ceil" }).epochNanoseconds,
+  -65_261_246_399_000_000_000n,  // -000099-12-15T12:00:01Z
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode ceil)"
+);
+assert.sameValue(
+  instance.round({ smallestUnit: "second", roundingMode: "halfExpand" }).epochNanoseconds,
+  -65_261_246_399_000_000_000n,  // -000099-12-15T12:00:01Z
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode halfExpand)"
+);

--- a/test/built-ins/Temporal/Instant/prototype/round/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/round/smallestunit-invalid-string.js
@@ -8,4 +8,28 @@ features: [Temporal]
 ---*/
 
 const instant = new Temporal.Instant(1_000_000_000_123_987_500n);
-assert.throws(RangeError, () => instant.round({ smallestUnit: "other string" }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => instant.round({ smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
+}

--- a/test/built-ins/Temporal/Instant/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/largestunit-invalid-string.js
@@ -9,7 +9,28 @@ features: [Temporal]
 
 const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
 const later = new Temporal.Instant(1_000_090_061_987_654_321n);
-const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/Instant/prototype/since/options-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.instant.prototype.since
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
 const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.since(new Temporal.Instant(3600_000_000_000n), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Instant/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/smallestunit-invalid-string.js
@@ -9,7 +9,28 @@ features: [Temporal]
 
 const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
 const later = new Temporal.Instant(1_000_090_061_987_654_321n);
-const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-auto.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-auto.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: auto value for fractionalSecondDigits option
+features: [BigInt, Temporal]
+---*/
+
+const zeroSeconds = new Temporal.Instant(0n);
+const wholeSeconds = new Temporal.Instant(30_000_000_000n);
+const subSeconds = new Temporal.Instant(30_123_400_000n);
+
+const tests = [
+  [zeroSeconds, "1970-01-01T00:00:00Z"],
+  [wholeSeconds, "1970-01-01T00:00:30Z"],
+  [subSeconds, "1970-01-01T00:00:30.1234Z"],
+];
+
+for (const [instant, expected] of tests) {
+  assert.sameValue(instant.toString(), expected, "default is to emit seconds and drop trailing zeroes");
+  assert.sameValue(instant.toString({ fractionalSecondDigits: "auto" }), expected, "auto is the default");
+}

--- a/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-invalid-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-invalid-string.js
@@ -10,10 +10,13 @@ info: |
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.instant.prototype.tostring step 6:
-      6. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      6. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
 const instant = new Temporal.Instant(1_000_000_000_987_650_000n);
 
-assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: "other string" }));
+for (const fractionalSecondDigits of ["other string", "AUTO", "not-auto", "autos", "auto\0"]) {
+  assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits }),
+    `"${fractionalSecondDigits}" is not a valid value for fractionalSecondDigits`);
+}

--- a/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-non-integer.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-non-integer.js
@@ -10,7 +10,7 @@ info: |
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.instant.prototype.tostring step 6:
-      6. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      6. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 

--- a/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-number.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-number.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: Number for fractionalSecondDigits option
+features: [BigInt, Temporal]
+---*/
+
+const zeroSeconds = new Temporal.Instant(0n);
+const wholeSeconds = new Temporal.Instant(30_000_000_000n);
+const subSeconds = new Temporal.Instant(30_123_400_000n);
+
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 0 }), "1970-01-01T00:00:30Z",
+  "truncates 4 decimal places to 0");
+assert.sameValue(zeroSeconds.toString({ fractionalSecondDigits: 2 }), "1970-01-01T00:00:00.00Z",
+  "pads zero seconds to 2 decimal places");
+assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 2 }), "1970-01-01T00:00:30.00Z",
+  "pads whole seconds to 2 decimal places");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 2 }), "1970-01-01T00:00:30.12Z",
+  "truncates 4 decimal places to 2");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 3 }), "1970-01-01T00:00:30.123Z",
+  "truncates 4 decimal places to 3");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 6 }), "1970-01-01T00:00:30.123400Z",
+  "pads 4 decimal places to 6");
+assert.sameValue(zeroSeconds.toString({ fractionalSecondDigits: 7 }), "1970-01-01T00:00:00.0000000Z",
+  "pads zero seconds to 7 decimal places");
+assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 7 }), "1970-01-01T00:00:30.0000000Z",
+  "pads whole seconds to 7 decimal places");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 7 }), "1970-01-01T00:00:30.1234000Z",
+  "pads 4 decimal places to 7");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 9 }), "1970-01-01T00:00:30.123400000Z",
+  "pads 4 decimal places to 9");

--- a/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-out-of-range.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-out-of-range.js
@@ -10,13 +10,17 @@ info: |
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.instant.prototype.tostring step 6:
-      6. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      6. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
 const instant = new Temporal.Instant(1_000_000_000_987_650_000n);
 
-assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: -1 }));
-assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: 10 }));
-assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: -Infinity }));
-assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: Infinity }));
+assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: -Infinity }),
+  "−∞ is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: -1 }),
+  "−1 is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: 10 }),
+  "10 is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: Infinity }),
+  "∞ is out of range for fractionalSecondDigits");

--- a/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-undefined.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-undefined.js
@@ -8,18 +8,31 @@ info: |
     sec-getoption step 3:
       3. If _value_ is *undefined*, return _fallback_.
     sec-getstringornumberoption step 2:
-      2. Let _value_ be ? GetOption(_options_, _property_, *"stringOrNumber"*, *undefined*, _fallback_).
+      2. Let _value_ be ? GetOption(_options_, _property_, « Number, String », *undefined*, _fallback_).
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.instant.prototype.tostring step 6:
-      6. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      6. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
-const instant = new Temporal.Instant(1_000_000_000_987_650_000n);
+const zeroSeconds = new Temporal.Instant(0n);
+const wholeSeconds = new Temporal.Instant(30_000_000_000n);
+const subSeconds = new Temporal.Instant(30_123_400_000n);
 
-const explicit = instant.toString({ fractionalSecondDigits: undefined });
-assert.sameValue(explicit, "2001-09-09T01:46:40.98765Z", "default fractionalSecondDigits is auto");
+const tests = [
+  [zeroSeconds, "1970-01-01T00:00:00Z"],
+  [wholeSeconds, "1970-01-01T00:00:30Z"],
+  [subSeconds, "1970-01-01T00:00:30.1234Z"],
+];
 
-const implicit = instant.toString({});
-assert.sameValue(implicit, "2001-09-09T01:46:40.98765Z", "default fractionalSecondDigits is auto");
+for (const [instant, expected] of tests) {
+  const explicit = instant.toString({ fractionalSecondDigits: undefined });
+  assert.sameValue(explicit, expected, "default fractionalSecondDigits is auto (property present but undefined)");
+
+  const implicit = instant.toString({});
+  assert.sameValue(implicit, expected, "default fractionalSecondDigits is auto (property not present)");
+
+  const lambda = instant.toString(() => {});
+  assert.sameValue(lambda, expected, "default fractionalSecondDigits is auto (property not present, function object)");
+}

--- a/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-wrong-type.js
@@ -22,4 +22,26 @@ features: [Temporal]
 ---*/
 
 const instant = new Temporal.Instant(1_000_000_000_987_650_000n);
-TemporalHelpers.checkFractionalSecondDigitsOptionWrongType(instant);
+
+assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: null }),
+  "null is not a number and converts to the string 'null' which is not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: true }),
+  "true is not a number and converts to the string 'true' which is not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: false }),
+  "false is not a number and converts to the string 'false' which is not valid for fractionalSecondDigits");
+assert.throws(TypeError, () => instant.toString({ fractionalSecondDigits: Symbol() }),
+  "symbols are not numbers and cannot convert to strings");
+assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: 2n }),
+  "bigints are not numbers and convert to strings which are not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => instant.toString({ fractionalSecondDigits: {} }),
+  "plain objects are not numbers and convert to strings which are not valid for fractionalSecondDigits");
+
+const expected = [
+  "get fractionalSecondDigits.toString",
+  "call fractionalSecondDigits.toString",
+];
+const actual = [];
+const observer = TemporalHelpers.toPrimitiveObserver(actual, "auto", "fractionalSecondDigits");
+const result = instant.toString({ fractionalSecondDigits: observer });
+assert.sameValue(result, "2001-09-09T01:46:40.98765Z", "object with toString uses toString return value");
+assert.compareArray(actual, expected, "object with toString calls toString and not valueOf");

--- a/test/built-ins/Temporal/Instant/prototype/toString/options-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.instant.prototype.tostring
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
 const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.toString(value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Instant/prototype/toString/rounding-cross-midnight.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/rounding-cross-midnight.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: Rounding can cross midnight
+features: [Temporal]
+---*/
+
+const instant = new Temporal.Instant(946_684_799_999_999_999n);  // one nanosecond before 2000-01-01T00:00:00
+for (const roundingMode of ["ceil", "halfExpand"]) {
+  assert.sameValue(instant.toString({ fractionalSecondDigits: 8, roundingMode }), "2000-01-01T00:00:00.00000000Z");
+}

--- a/test/built-ins/Temporal/Instant/prototype/toString/rounding-direction.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/rounding-direction.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: Rounding down is towards the Big Bang, not the epoch or 1 BCE
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(-65_261_246_399_500_000_000n);  // -000099-12-15T12:00:00.5Z
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "floor" }),
+  "-000099-12-15T12:00:00Z",
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE"
+);
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "trunc" }),
+  "-000099-12-15T12:00:00Z",
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE (roundingMode trunc)"
+);
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "ceil" }),
+  "-000099-12-15T12:00:01Z",
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode ceil)"
+);
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "halfExpand" }),
+  "-000099-12-15T12:00:01Z",
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode halfExpand)"
+);

--- a/test/built-ins/Temporal/Instant/prototype/toString/roundingmode-ceil.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/roundingmode-ceil.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: ceil value for roundingMode option
+features: [Temporal]
+---*/
+
+const instant = new Temporal.Instant(1_000_000_000_123_987_500n);
+
+const result1 = instant.toString({ smallestUnit: "microsecond", roundingMode: "ceil" });
+assert.sameValue(result1, "2001-09-09T01:46:40.123988Z",
+  "roundingMode is ceil (with 6 digits from smallestUnit)");
+
+const result2 = instant.toString({ fractionalSecondDigits: 6, roundingMode: "ceil" });
+assert.sameValue(result2, "2001-09-09T01:46:40.123988Z",
+  "roundingMode is ceil (with 6 digits from fractionalSecondDigits)");
+
+const result3 = instant.toString({ smallestUnit: "millisecond", roundingMode: "ceil" });
+assert.sameValue(result3, "2001-09-09T01:46:40.124Z",
+  "roundingMode is ceil (with 3 digits from smallestUnit)");
+
+const result4 = instant.toString({ fractionalSecondDigits: 3, roundingMode: "ceil" });
+assert.sameValue(result4, "2001-09-09T01:46:40.124Z",
+  "roundingMode is ceil (with 3 digits from fractionalSecondDigits)");
+
+const result5 = instant.toString({ smallestUnit: "second", roundingMode: "ceil" });
+assert.sameValue(result5, "2001-09-09T01:46:41Z",
+  "roundingMode is ceil (with 0 digits from smallestUnit)");
+
+const result6 = instant.toString({ fractionalSecondDigits: 0, roundingMode: "ceil" });
+assert.sameValue(result6, "2001-09-09T01:46:41Z",
+  "roundingMode is ceil (with 0 digits from fractionalSecondDigits)");
+
+const result7 = instant.toString({ smallestUnit: "minute", roundingMode: "ceil" });
+assert.sameValue(result7, "2001-09-09T01:47Z", "roundingMode is ceil (round to minute)");

--- a/test/built-ins/Temporal/Instant/prototype/toString/roundingmode-floor.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/roundingmode-floor.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: floor value for roundingMode option
+features: [Temporal]
+---*/
+
+const instant = new Temporal.Instant(1_000_000_000_123_987_500n);
+
+const result1 = instant.toString({ smallestUnit: "microsecond", roundingMode: "floor" });
+assert.sameValue(result1, "2001-09-09T01:46:40.123987Z",
+  "roundingMode is floor (with 6 digits from smallestUnit)");
+
+const result2 = instant.toString({ fractionalSecondDigits: 6, roundingMode: "floor" });
+assert.sameValue(result2, "2001-09-09T01:46:40.123987Z",
+  "roundingMode is floor (with 6 digits from fractionalSecondDigits)");
+
+const result3 = instant.toString({ smallestUnit: "millisecond", roundingMode: "floor" });
+assert.sameValue(result3, "2001-09-09T01:46:40.123Z",
+  "roundingMode is floor (with 3 digits from smallestUnit)");
+
+const result4 = instant.toString({ fractionalSecondDigits: 3, roundingMode: "floor" });
+assert.sameValue(result4, "2001-09-09T01:46:40.123Z",
+  "roundingMode is floor (with 3 digits from fractionalSecondDigits)");
+
+const result5 = instant.toString({ smallestUnit: "second", roundingMode: "floor" });
+assert.sameValue(result5, "2001-09-09T01:46:40Z",
+  "roundingMode is floor (with 0 digits from smallestUnit)");
+
+const result6 = instant.toString({ fractionalSecondDigits: 0, roundingMode: "floor" });
+assert.sameValue(result6, "2001-09-09T01:46:40Z",
+  "roundingMode is floor (with 0 digits from fractionalSecondDigits)");
+
+const result7 = instant.toString({ smallestUnit: "minute", roundingMode: "floor" });
+assert.sameValue(result7, "2001-09-09T01:46Z", "roundingMode is floor (round to minute)");

--- a/test/built-ins/Temporal/Instant/prototype/toString/roundingmode-halfExpand.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/roundingmode-halfExpand.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: halfExpand value for roundingMode option
+features: [Temporal]
+---*/
+
+const instant = new Temporal.Instant(1_000_000_000_123_987_500n);
+
+const result1 = instant.toString({ smallestUnit: "microsecond", roundingMode: "halfExpand" });
+assert.sameValue(result1, "2001-09-09T01:46:40.123988Z",
+  "roundingMode is halfExpand (with 6 digits from smallestUnit)");
+
+const result2 = instant.toString({ fractionalSecondDigits: 6, roundingMode: "halfExpand" });
+assert.sameValue(result2, "2001-09-09T01:46:40.123988Z",
+  "roundingMode is halfExpand (with 6 digits from fractionalSecondDigits)");
+
+const result3 = instant.toString({ smallestUnit: "millisecond", roundingMode: "halfExpand" });
+assert.sameValue(result3, "2001-09-09T01:46:40.124Z",
+  "roundingMode is halfExpand (with 3 digits from smallestUnit)");
+
+const result4 = instant.toString({ fractionalSecondDigits: 3, roundingMode: "halfExpand" });
+assert.sameValue(result4, "2001-09-09T01:46:40.124Z",
+  "roundingMode is halfExpand (with 3 digits from fractionalSecondDigits)");
+
+const result5 = instant.toString({ smallestUnit: "second", roundingMode: "halfExpand" });
+assert.sameValue(result5, "2001-09-09T01:46:40Z",
+  "roundingMode is halfExpand (with 0 digits from smallestUnit)");
+
+const result6 = instant.toString({ fractionalSecondDigits: 0, roundingMode: "halfExpand" });
+assert.sameValue(result6, "2001-09-09T01:46:40Z",
+  "roundingMode is halfExpand (with 0 digits from fractionalSecondDigits)");
+
+const result7 = instant.toString({ smallestUnit: "minute", roundingMode: "halfExpand" });
+assert.sameValue(result7, "2001-09-09T01:47Z", "roundingMode is halfExpand (round to minute)");

--- a/test/built-ins/Temporal/Instant/prototype/toString/roundingmode-trunc.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/roundingmode-trunc.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: trunc value for roundingMode option
+features: [Temporal]
+---*/
+
+const instant = new Temporal.Instant(1_000_000_000_123_987_500n);
+
+const result1 = instant.toString({ smallestUnit: "microsecond", roundingMode: "trunc" });
+assert.sameValue(result1, "2001-09-09T01:46:40.123987Z",
+  "roundingMode is trunc (with 6 digits from smallestUnit)");
+
+const result2 = instant.toString({ fractionalSecondDigits: 6, roundingMode: "trunc" });
+assert.sameValue(result2, "2001-09-09T01:46:40.123987Z",
+  "roundingMode is trunc (with 6 digits from fractionalSecondDigits)");
+
+const result3 = instant.toString({ smallestUnit: "millisecond", roundingMode: "trunc" });
+assert.sameValue(result3, "2001-09-09T01:46:40.123Z",
+  "roundingMode is trunc (with 3 digits from smallestUnit)");
+
+const result4 = instant.toString({ fractionalSecondDigits: 3, roundingMode: "trunc" });
+assert.sameValue(result4, "2001-09-09T01:46:40.123Z",
+  "roundingMode is trunc (with 3 digits from fractionalSecondDigits)");
+
+const result5 = instant.toString({ smallestUnit: "second", roundingMode: "trunc" });
+assert.sameValue(result5, "2001-09-09T01:46:40Z",
+  "roundingMode is trunc (with 0 digits from smallestUnit)");
+
+const result6 = instant.toString({ fractionalSecondDigits: 0, roundingMode: "trunc" });
+assert.sameValue(result6, "2001-09-09T01:46:40Z",
+  "roundingMode is trunc (with 0 digits from fractionalSecondDigits)");
+
+const result7 = instant.toString({ smallestUnit: "minute", roundingMode: "trunc" });
+assert.sameValue(result7, "2001-09-09T01:46Z", "roundingMode is trunc (round to minute)");

--- a/test/built-ins/Temporal/Instant/prototype/toString/smallestunit-fractionalseconddigits.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/smallestunit-fractionalseconddigits.js
@@ -2,29 +2,29 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.tostring
+esid: sec-temporal.instant.prototype.tostring
 description: fractionalSecondDigits option is not used with smallestUnit present
 features: [Temporal]
 ---*/
 
-const time = new Temporal.PlainTime(12, 34, 56, 789, 999, 999);
+const instant = new Temporal.Instant(56_789_999_999n);
 const tests = [
-  ["minute", "12:34"],
-  ["second", "12:34:56"],
-  ["millisecond", "12:34:56.789"],
-  ["microsecond", "12:34:56.789999"],
-  ["nanosecond", "12:34:56.789999999"],
+  ["minute", "1970-01-01T00:00Z"],
+  ["second", "1970-01-01T00:00:56Z"],
+  ["millisecond", "1970-01-01T00:00:56.789Z"],
+  ["microsecond", "1970-01-01T00:00:56.789999Z"],
+  ["nanosecond", "1970-01-01T00:00:56.789999999Z"],
 ];
 
 for (const [smallestUnit, expected] of tests) {
-  const string = time.toString({
+  const string = instant.toString({
     smallestUnit,
     get fractionalSecondDigits() { throw new Test262Error("should not get fractionalSecondDigits") }
   });
   assert.sameValue(string, expected, `smallestUnit: "${smallestUnit}" overrides fractionalSecondDigits`);
 }
 
-assert.throws(RangeError, () => time.toString({
+assert.throws(RangeError, () => instant.toString({
   smallestUnit: "hour",
   get fractionalSecondDigits() { throw new Test262Error("should not get fractionalSecondDigits") }
 }), "hour is an invalid smallestUnit but still overrides fractionalSecondDigits");

--- a/test/built-ins/Temporal/Instant/prototype/toString/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/smallestunit-invalid-string.js
@@ -8,4 +8,30 @@ features: [Temporal]
 ---*/
 
 const instant = new Temporal.Instant(1_000_000_000_123_987_500n);
-assert.throws(RangeError, () => instant.toString({ smallestUnit: "other string" }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => instant.toString({ smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
+}

--- a/test/built-ins/Temporal/Instant/prototype/toString/smallestunit-valid-units.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/smallestunit-valid-units.js
@@ -9,11 +9,36 @@ features: [Temporal]
 
 const instant = new Temporal.Instant(1_000_000_000_123_456_789n);
 
-assert.sameValue(instant.toString({ smallestUnit: "minute" }), "2001-09-09T01:46Z");
-assert.sameValue(instant.toString({ smallestUnit: "second" }), "2001-09-09T01:46:40Z");
-assert.sameValue(instant.toString({ smallestUnit: "millisecond" }), "2001-09-09T01:46:40.123Z");
-assert.sameValue(instant.toString({ smallestUnit: "microsecond" }), "2001-09-09T01:46:40.123456Z");
-assert.sameValue(instant.toString({ smallestUnit: "nanosecond" }), "2001-09-09T01:46:40.123456789Z");
+function test(instance, expectations, description) {
+  for (const [smallestUnit, expectedResult] of expectations) {
+    assert.sameValue(instance.toString({ smallestUnit }), expectedResult,
+      `${description} with smallestUnit "${smallestUnit}"`);
+  }
+}
+
+test(
+  instant,
+  [
+    ["minute", "2001-09-09T01:46Z"],
+    ["second", "2001-09-09T01:46:40Z"],
+    ["millisecond", "2001-09-09T01:46:40.123Z"],
+    ["microsecond", "2001-09-09T01:46:40.123456Z"],
+    ["nanosecond", "2001-09-09T01:46:40.123456789Z"],
+  ],
+  "subseconds toString"
+);
+
+test(
+  new Temporal.Instant(999_999_960_000_000_000n),
+  [
+    ["minute", "2001-09-09T01:46Z"],
+    ["second", "2001-09-09T01:46:00Z"],
+    ["millisecond", "2001-09-09T01:46:00.000Z"],
+    ["microsecond", "2001-09-09T01:46:00.000000Z"],
+    ["nanosecond", "2001-09-09T01:46:00.000000000Z"],
+  ],
+  "whole minutes toString"
+);
 
 const notValid = [
   "era",
@@ -25,5 +50,6 @@ const notValid = [
 ];
 
 notValid.forEach((smallestUnit) => {
-  assert.throws(RangeError, () => instant.toString({ smallestUnit }), smallestUnit);
+  assert.throws(RangeError, () => instant.toString({ smallestUnit }),
+    `"${smallestUnit}" is not a valid unit for the smallestUnit option`);
 });

--- a/test/built-ins/Temporal/Instant/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/largestunit-invalid-string.js
@@ -9,7 +9,28 @@ features: [Temporal]
 
 const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
 const later = new Temporal.Instant(1_000_090_061_987_654_321n);
-const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/Instant/prototype/until/options-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.instant.prototype.until
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
 const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.until(new Temporal.Instant(3600_000_000_000n), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/Instant/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/smallestunit-invalid-string.js
@@ -9,7 +9,28 @@ features: [Temporal]
 
 const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
 const later = new Temporal.Instant(1_000_090_061_987_654_321n);
-const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/PlainDate/from/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/from/options-wrong-type.js
@@ -2,23 +2,21 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindate.from
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => Temporal.PlainDate.from({ year: 1976, month: 11, day: 18 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDate/prototype/add/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/add/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindate.prototype.add
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDate(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.add({ months: 1 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDate/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/largestunit-invalid-string.js
@@ -9,7 +9,30 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDate(2000, 5, 2);
 const later = new Temporal.PlainDate(2001, 6, 3);
-const values = ["era", "eraYear", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+  "month\0",
+  "YEAR",
+  "eras",
+  "eraYears",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+  "months\0",
+  "YEARS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/since/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindate.prototype.since
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDate(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.since(new Temporal.PlainDate(1976, 11, 18), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDate/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/smallestunit-invalid-string.js
@@ -9,7 +9,30 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDate(2000, 5, 2);
 const later = new Temporal.PlainDate(2001, 6, 3);
-const values = ["era", "eraYear", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+  "month\0",
+  "YEAR",
+  "eras",
+  "eraYears",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+  "months\0",
+  "YEARS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/subtract/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/subtract/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindate.prototype.subtract
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDate(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.subtract({ months: 1 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDate/prototype/toString/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toString/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindate.prototype.tostring
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDate(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.toString(value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDate/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/largestunit-invalid-string.js
@@ -9,7 +9,30 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDate(2000, 5, 2);
 const later = new Temporal.PlainDate(2001, 6, 3);
-const values = ["era", "eraYear", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+  "month\0",
+  "YEAR",
+  "eras",
+  "eraYears",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+  "months\0",
+  "YEARS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/until/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindate.prototype.until
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDate(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.until(new Temporal.PlainDate(1976, 11, 18), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDate/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/smallestunit-invalid-string.js
@@ -9,7 +9,30 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDate(2000, 5, 2);
 const later = new Temporal.PlainDate(2001, 6, 3);
-const values = ["era", "eraYear", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+  "month\0",
+  "YEAR",
+  "eras",
+  "eraYears",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+  "months\0",
+  "YEARS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/with/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/with/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindate.prototype.with
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDate(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.with({ day: 5 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDateTime/from/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/options-wrong-type.js
@@ -2,23 +2,21 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindatetime.from
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => Temporal.PlainDateTime.from({ year: 1976, month: 11, day: 18 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDateTime/prototype/add/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/add/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindatetime.prototype.add
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.add({ months: 1 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDateTime/prototype/round/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/round/options-wrong-type.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
+esid: sec-temporal.plaindatetime.prototype.round
 description: TypeError thrown when options argument is missing or a non-string primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
@@ -16,7 +16,7 @@ const badOptions = [
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
 assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
   assert.throws(TypeError, () => instance.round(value),

--- a/test/built-ins/Temporal/PlainDateTime/prototype/round/rounding-direction.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/round/rounding-direction.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.round
+description: Rounding down is towards the Big Bang, not the epoch or 1 BCE
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(-99, 12, 15, 12, 0, 0, 500);
+TemporalHelpers.assertPlainDateTime(
+  instance.round({ smallestUnit: "second", roundingMode: "floor" }),
+  -99, 12, "M12", 15, 12, 0, 0, 0, 0, 0,
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE (roundingMode floor)"
+);
+TemporalHelpers.assertPlainDateTime(
+  instance.round({ smallestUnit: "second", roundingMode: "trunc" }),
+  -99, 12, "M12", 15, 12, 0, 0, 0, 0, 0,
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE (roundingMode trunc)"
+);
+TemporalHelpers.assertPlainDateTime(
+  instance.round({ smallestUnit: "second", roundingMode: "ceil" }),
+  -99, 12, "M12", 15, 12, 0, 1, 0, 0, 0,
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode ceil)"
+);
+TemporalHelpers.assertPlainDateTime(
+  instance.round({ smallestUnit: "second", roundingMode: "halfExpand" }),
+  -99, 12, "M12", 15, 12, 0, 1, 0, 0, 0,
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode halfExpand)"
+);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/round/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/round/smallestunit-invalid-string.js
@@ -8,4 +8,26 @@ features: [Temporal]
 ---*/
 
 const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 123, 987, 500);
-assert.throws(RangeError, () => datetime.round({ smallestUnit: "other string" }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => datetime.round({ smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/largestunit-invalid-string.js
@@ -9,7 +9,20 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainDateTime(2001, 6, 3, 13, 35, 57, 987, 654, 321);
-const values = ["era", "eraYear", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindatetime.prototype.since
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.since(new Temporal.PlainDateTime(1976, 11, 18), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/smallestunit-invalid-string.js
@@ -9,7 +9,20 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainDateTime(2000, 5, 3, 13, 35, 57, 987, 654, 321);
-const values = ["era", "eraYear", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/subtract/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/subtract/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.subtract({ months: 1 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-auto.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-auto.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: auto value for fractionalSecondDigits option
+features: [Temporal]
+---*/
+
+const zeroSeconds = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
+const wholeSeconds = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30);
+const subSeconds = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 400);
+
+const tests = [
+  [zeroSeconds, "1976-11-18T15:23:00"],
+  [wholeSeconds, "1976-11-18T15:23:30"],
+  [subSeconds, "1976-11-18T15:23:30.1234"],
+];
+
+for (const [datetime, expected] of tests) {
+  assert.sameValue(datetime.toString(), expected, "default is to emit seconds and drop trailing zeroes");
+  assert.sameValue(datetime.toString({ fractionalSecondDigits: "auto" }), expected, "auto is the default");
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-invalid-string.js
@@ -10,10 +10,13 @@ info: |
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.plaindatetime.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
 const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 650, 0);
 
-assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: "other string" }));
+for (const fractionalSecondDigits of ["other string", "AUTO", "not-auto", "autos", "auto\0"]) {
+  assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits }),
+    `"${fractionalSecondDigits}" is not a valid value for fractionalSecondDigits`);
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-non-integer.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-non-integer.js
@@ -10,7 +10,7 @@ info: |
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.plaindatetime.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-number.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: Number for fractionalSecondDigits option
+features: [Temporal]
+---*/
+
+const zeroSeconds = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
+const wholeSeconds = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30);
+const subSeconds = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 400);
+
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 0 }), "1976-11-18T15:23:30",
+  "truncates 4 decimal places to 0");
+assert.sameValue(zeroSeconds.toString({ fractionalSecondDigits: 2 }), "1976-11-18T15:23:00.00",
+  "pads zero seconds to 2 decimal places");
+assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 2 }), "1976-11-18T15:23:30.00",
+  "pads whole seconds to 2 decimal places");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 2 }), "1976-11-18T15:23:30.12",
+  "truncates 4 decimal places to 2");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 3 }), "1976-11-18T15:23:30.123",
+  "truncates 4 decimal places to 3");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 6 }), "1976-11-18T15:23:30.123400",
+  "pads 4 decimal places to 6");
+assert.sameValue(zeroSeconds.toString({ fractionalSecondDigits: 7 }), "1976-11-18T15:23:00.0000000",
+  "pads zero seconds to 7 decimal places");
+assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 7 }), "1976-11-18T15:23:30.0000000",
+  "pads whole seconds to 7 decimal places");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 7 }), "1976-11-18T15:23:30.1234000",
+  "pads 4 decimal places to 7");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 9 }), "1976-11-18T15:23:30.123400000",
+  "pads 4 decimal places to 9");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-out-of-range.js
@@ -10,11 +10,17 @@ info: |
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.plaindatetime.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
 const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 650, 0);
 
-assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: -1 }));
-assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: 10 }));
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: -Infinity }),
+  "−∞ is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: -1 }),
+  "−1 is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: 10 }),
+  "10 is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: Infinity }),
+  "∞ is out of range for fractionalSecondDigits");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-undefined.js
@@ -8,17 +8,31 @@ info: |
     sec-getoption step 3:
       3. If _value_ is *undefined*, return _fallback_.
     sec-getstringornumberoption step 2:
-      2. Let _value_ be ? GetOption(_options_, _property_, *"stringOrNumber"*, *undefined*, _fallback_).
+      2. Let _value_ be ? GetOption(_options_, _property_, « Number, String », *undefined*, _fallback_).
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.plaindatetime.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
-const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 650, 0);
+const zeroSeconds = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
+const wholeSeconds = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30);
+const subSeconds = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 400);
 
-const explicit = datetime.toString({ fractionalSecondDigits: undefined });
-assert.sameValue(explicit, "2000-05-02T12:34:56.98765", "default fractionalSecondDigits is auto");
+const tests = [
+  [zeroSeconds, "1976-11-18T15:23:00"],
+  [wholeSeconds, "1976-11-18T15:23:30"],
+  [subSeconds, "1976-11-18T15:23:30.1234"],
+];
 
-// See options-undefined.js for {}
+for (const [datetime, expected] of tests) {
+  const explicit = datetime.toString({ fractionalSecondDigits: undefined });
+  assert.sameValue(explicit, expected, "default fractionalSecondDigits is auto (property present but undefined)");
+
+  const implicit = datetime.toString({});
+  assert.sameValue(implicit, expected, "default fractionalSecondDigits is auto (property not present)");
+
+  const lambda = datetime.toString(() => {});
+  assert.sameValue(lambda, expected, "default fractionalSecondDigits is auto (property not present, function object)");
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-wrong-type.js
@@ -22,4 +22,26 @@ features: [Temporal]
 ---*/
 
 const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 650, 0);
-TemporalHelpers.checkFractionalSecondDigitsOptionWrongType(datetime);
+
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: null }),
+  "null is not a number and converts to the string 'null' which is not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: true }),
+  "true is not a number and converts to the string 'true' which is not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: false }),
+  "false is not a number and converts to the string 'false' which is not valid for fractionalSecondDigits");
+assert.throws(TypeError, () => datetime.toString({ fractionalSecondDigits: Symbol() }),
+  "symbols are not numbers and cannot convert to strings");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: 2n }),
+  "bigints are not numbers and convert to strings which are not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: {} }),
+  "plain objects are not numbers and convert to strings which are not valid for fractionalSecondDigits");
+
+const expected = [
+  "get fractionalSecondDigits.toString",
+  "call fractionalSecondDigits.toString",
+];
+const actual = [];
+const observer = TemporalHelpers.toPrimitiveObserver(actual, "auto", "fractionalSecondDigits");
+const result = datetime.toString({ fractionalSecondDigits: observer });
+assert.sameValue(result, "2000-05-02T12:34:56.98765", "object with toString uses toString return value");
+assert.compareArray(actual, expected, "object with toString calls toString and not valueOf");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.toString(value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/rounding-cross-midnight.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/rounding-cross-midnight.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: Rounding can cross midnight
+features: [Temporal]
+---*/
+
+const plainDateTime = new Temporal.PlainDateTime(1999, 12, 31, 23, 59, 59, 999, 999, 999);  // one nanosecond before 2000-01-01T00:00:00
+for (const roundingMode of ["ceil", "halfExpand"]) {
+  assert.sameValue(plainDateTime.toString({ fractionalSecondDigits: 8, roundingMode }), "2000-01-01T00:00:00.00000000");
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/rounding-direction.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/rounding-direction.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: Rounding down is towards the Big Bang, not the epoch or 1 BCE
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(-99, 12, 15, 12, 0, 0, 500);
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "floor" }),
+  "-000099-12-15T12:00:00",
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE"
+);
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "trunc" }),
+  "-000099-12-15T12:00:00",
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE (roundingMode trunc)"
+);
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "ceil" }),
+  "-000099-12-15T12:00:01",
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode ceil)"
+);
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "halfExpand" }),
+  "-000099-12-15T12:00:01",
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode halfExpand)"
+);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-ceil.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-ceil.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: ceil value for roundingMode option
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 123, 987, 500);
+
+const result1 = datetime.toString({ smallestUnit: "microsecond", roundingMode: "ceil" });
+assert.sameValue(result1, "2000-05-02T12:34:56.123988",
+  "roundingMode is ceil (with 6 digits from smallestUnit)");
+
+const result2 = datetime.toString({ fractionalSecondDigits: 6, roundingMode: "ceil" });
+assert.sameValue(result2, "2000-05-02T12:34:56.123988",
+  "roundingMode is ceil (with 6 digits from fractionalSecondDigits)");
+
+const result3 = datetime.toString({ smallestUnit: "millisecond", roundingMode: "ceil" });
+assert.sameValue(result3, "2000-05-02T12:34:56.124",
+  "roundingMode is ceil (with 3 digits from smallestUnit)");
+
+const result4 = datetime.toString({ fractionalSecondDigits: 3, roundingMode: "ceil" });
+assert.sameValue(result4, "2000-05-02T12:34:56.124",
+  "roundingMode is ceil (with 3 digits from fractionalSecondDigits)");
+
+const result5 = datetime.toString({ smallestUnit: "second", roundingMode: "ceil" });
+assert.sameValue(result5, "2000-05-02T12:34:57",
+  "roundingMode is ceil (with 0 digits from smallestUnit)");
+
+const result6 = datetime.toString({ fractionalSecondDigits: 0, roundingMode: "ceil" });
+assert.sameValue(result6, "2000-05-02T12:34:57",
+  "roundingMode is ceil (with 0 digits from fractionalSecondDigits)");
+
+const result7 = datetime.toString({ smallestUnit: "minute", roundingMode: "ceil" });
+assert.sameValue(result7, "2000-05-02T12:35", "roundingMode is ceil (round to minute)");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-floor.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-floor.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: floor value for roundingMode option
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 123, 987, 500);
+
+const result1 = datetime.toString({ smallestUnit: "microsecond", roundingMode: "floor" });
+assert.sameValue(result1, "2000-05-02T12:34:56.123987",
+  "roundingMode is floor (with 6 digits from smallestUnit)");
+
+const result2 = datetime.toString({ fractionalSecondDigits: 6, roundingMode: "floor" });
+assert.sameValue(result2, "2000-05-02T12:34:56.123987",
+  "roundingMode is floor (with 6 digits from fractionalSecondDigits)");
+
+const result3 = datetime.toString({ smallestUnit: "millisecond", roundingMode: "floor" });
+assert.sameValue(result3, "2000-05-02T12:34:56.123",
+  "roundingMode is floor (with 3 digits from smallestUnit)");
+
+const result4 = datetime.toString({ fractionalSecondDigits: 3, roundingMode: "floor" });
+assert.sameValue(result4, "2000-05-02T12:34:56.123",
+  "roundingMode is floor (with 3 digits from fractionalSecondDigits)");
+
+const result5 = datetime.toString({ smallestUnit: "second", roundingMode: "floor" });
+assert.sameValue(result5, "2000-05-02T12:34:56",
+  "roundingMode is floor (with 0 digits from smallestUnit)");
+
+const result6 = datetime.toString({ fractionalSecondDigits: 0, roundingMode: "floor" });
+assert.sameValue(result6, "2000-05-02T12:34:56",
+  "roundingMode is floor (with 0 digits from fractionalSecondDigits)");
+
+const result7 = datetime.toString({ smallestUnit: "minute", roundingMode: "floor" });
+assert.sameValue(result7, "2000-05-02T12:34", "roundingMode is floor (round to minute)");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-halfExpand.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-halfExpand.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: halfExpand value for roundingMode option
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 123, 987, 500);
+
+const result1 = datetime.toString({ smallestUnit: "microsecond", roundingMode: "halfExpand" });
+assert.sameValue(result1, "2000-05-02T12:34:56.123988",
+  "roundingMode is halfExpand (with 6 digits from smallestUnit)");
+
+const result2 = datetime.toString({ fractionalSecondDigits: 6, roundingMode: "halfExpand" });
+assert.sameValue(result2, "2000-05-02T12:34:56.123988",
+  "roundingMode is halfExpand (with 6 digits from fractionalSecondDigits)");
+
+const result3 = datetime.toString({ smallestUnit: "millisecond", roundingMode: "halfExpand" });
+assert.sameValue(result3, "2000-05-02T12:34:56.124",
+  "roundingMode is halfExpand (with 3 digits from smallestUnit)");
+
+const result4 = datetime.toString({ fractionalSecondDigits: 3, roundingMode: "halfExpand" });
+assert.sameValue(result4, "2000-05-02T12:34:56.124",
+  "roundingMode is halfExpand (with 3 digits from fractionalSecondDigits)");
+
+const result5 = datetime.toString({ smallestUnit: "second", roundingMode: "halfExpand" });
+assert.sameValue(result5, "2000-05-02T12:34:56",
+  "roundingMode is halfExpand (with 0 digits from smallestUnit)");
+
+const result6 = datetime.toString({ fractionalSecondDigits: 0, roundingMode: "halfExpand" });
+assert.sameValue(result6, "2000-05-02T12:34:56",
+  "roundingMode is halfExpand (with 0 digits from fractionalSecondDigits)");
+
+const result7 = datetime.toString({ smallestUnit: "minute", roundingMode: "halfExpand" });
+assert.sameValue(result7, "2000-05-02T12:35", "roundingMode is halfExpand (round to minute)");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-trunc.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-trunc.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: trunc value for roundingMode option
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 123, 987, 500);
+
+const result1 = datetime.toString({ smallestUnit: "microsecond", roundingMode: "trunc" });
+assert.sameValue(result1, "2000-05-02T12:34:56.123987",
+  "roundingMode is trunc (with 6 digits from smallestUnit)");
+
+const result2 = datetime.toString({ fractionalSecondDigits: 6, roundingMode: "trunc" });
+assert.sameValue(result2, "2000-05-02T12:34:56.123987",
+  "roundingMode is trunc (with 6 digits from fractionalSecondDigits)");
+
+const result3 = datetime.toString({ smallestUnit: "millisecond", roundingMode: "trunc" });
+assert.sameValue(result3, "2000-05-02T12:34:56.123",
+  "roundingMode is trunc (with 3 digits from smallestUnit)");
+
+const result4 = datetime.toString({ fractionalSecondDigits: 3, roundingMode: "trunc" });
+assert.sameValue(result4, "2000-05-02T12:34:56.123",
+  "roundingMode is trunc (with 3 digits from fractionalSecondDigits)");
+
+const result5 = datetime.toString({ smallestUnit: "second", roundingMode: "trunc" });
+assert.sameValue(result5, "2000-05-02T12:34:56",
+  "roundingMode is trunc (with 0 digits from smallestUnit)");
+
+const result6 = datetime.toString({ fractionalSecondDigits: 0, roundingMode: "trunc" });
+assert.sameValue(result6, "2000-05-02T12:34:56",
+  "roundingMode is trunc (with 0 digits from fractionalSecondDigits)");
+
+const result7 = datetime.toString({ smallestUnit: "minute", roundingMode: "trunc" });
+assert.sameValue(result7, "2000-05-02T12:34", "roundingMode is trunc (round to minute)");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/smallestunit-fractionalseconddigits.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/smallestunit-fractionalseconddigits.js
@@ -2,29 +2,29 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.tostring
+esid: sec-temporal.plaindatetime.prototype.tostring
 description: fractionalSecondDigits option is not used with smallestUnit present
 features: [Temporal]
 ---*/
 
-const time = new Temporal.PlainTime(12, 34, 56, 789, 999, 999);
+const datetime = new Temporal.PlainDateTime(1976, 11, 18, 12, 34, 56, 789, 999, 999);
 const tests = [
-  ["minute", "12:34"],
-  ["second", "12:34:56"],
-  ["millisecond", "12:34:56.789"],
-  ["microsecond", "12:34:56.789999"],
-  ["nanosecond", "12:34:56.789999999"],
+  ["minute", "1976-11-18T12:34"],
+  ["second", "1976-11-18T12:34:56"],
+  ["millisecond", "1976-11-18T12:34:56.789"],
+  ["microsecond", "1976-11-18T12:34:56.789999"],
+  ["nanosecond", "1976-11-18T12:34:56.789999999"],
 ];
 
 for (const [smallestUnit, expected] of tests) {
-  const string = time.toString({
+  const string = datetime.toString({
     smallestUnit,
     get fractionalSecondDigits() { throw new Test262Error("should not get fractionalSecondDigits") }
   });
   assert.sameValue(string, expected, `smallestUnit: "${smallestUnit}" overrides fractionalSecondDigits`);
 }
 
-assert.throws(RangeError, () => time.toString({
+assert.throws(RangeError, () => datetime.toString({
   smallestUnit: "hour",
   get fractionalSecondDigits() { throw new Test262Error("should not get fractionalSecondDigits") }
 }), "hour is an invalid smallestUnit but still overrides fractionalSecondDigits");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/smallestunit-invalid-string.js
@@ -8,4 +8,30 @@ features: [Temporal]
 ---*/
 
 const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 123, 987, 500);
-assert.throws(RangeError, () => datetime.toString({ smallestUnit: "other string" }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => datetime.toString({ smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/smallestunit-valid-units.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/smallestunit-valid-units.js
@@ -7,15 +7,41 @@ description: Valid units for the smallestUnit option
 features: [Temporal]
 ---*/
 
-const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 789, 999, 999);
+const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 123, 456, 789);
 
-assert.sameValue(datetime.toString({ smallestUnit: "minute" }), "2000-05-02T12:34");
-assert.sameValue(datetime.toString({ smallestUnit: "second" }), "2000-05-02T12:34:56");
-assert.sameValue(datetime.toString({ smallestUnit: "millisecond" }), "2000-05-02T12:34:56.789");
-assert.sameValue(datetime.toString({ smallestUnit: "microsecond" }), "2000-05-02T12:34:56.789999");
-assert.sameValue(datetime.toString({ smallestUnit: "nanosecond" }), "2000-05-02T12:34:56.789999999");
+function test(instance, expectations, description) {
+  for (const [smallestUnit, expectedResult] of expectations) {
+    assert.sameValue(instance.toString({ smallestUnit }), expectedResult,
+      `${description} with smallestUnit "${smallestUnit}"`);
+  }
+}
+
+test(
+  datetime,
+  [
+    ["minute", "2000-05-02T12:34"],
+    ["second", "2000-05-02T12:34:56"],
+    ["millisecond", "2000-05-02T12:34:56.123"],
+    ["microsecond", "2000-05-02T12:34:56.123456"],
+    ["nanosecond", "2000-05-02T12:34:56.123456789"],
+  ],
+  "subseconds toString"
+);
+
+test(
+  new Temporal.PlainDateTime(2000, 5, 2, 12, 34),
+  [
+    ["minute", "2000-05-02T12:34"],
+    ["second", "2000-05-02T12:34:00"],
+    ["millisecond", "2000-05-02T12:34:00.000"],
+    ["microsecond", "2000-05-02T12:34:00.000000"],
+    ["nanosecond", "2000-05-02T12:34:00.000000000"],
+  ],
+  "whole minutes toString"
+);
 
 const notValid = [
+  "era",
   "year",
   "month",
   "week",
@@ -24,5 +50,6 @@ const notValid = [
 ];
 
 notValid.forEach((smallestUnit) => {
-  assert.throws(RangeError, () => datetime.toString({ smallestUnit }), smallestUnit);
+  assert.throws(RangeError, () => datetime.toString({ smallestUnit }),
+    `"${smallestUnit}" is not a valid unit for the smallestUnit option`);
 });

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindatetime.prototype.tozoneddatetime
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.toZonedDateTime("UTC", value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/largestunit-invalid-string.js
@@ -9,7 +9,20 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainDateTime(2001, 6, 3, 13, 35, 57, 987, 654, 321);
-const values = ["era", "eraYear", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindatetime.prototype.until
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.until(new Temporal.PlainDateTime(1976, 11, 18), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/smallestunit-invalid-string.js
@@ -9,7 +9,20 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainDateTime(2000, 5, 3, 13, 35, 57, 987, 654, 321);
-const values = ["era", "eraYear", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/with/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/with/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaindatetime.prototype.with
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.with({ day: 5 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainMonthDay/from/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/options-wrong-type.js
@@ -2,23 +2,21 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plainmonthday.from
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => Temporal.PlainMonthDay.from({ monthCode: "M12", day: 15 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/toString/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/toString/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plainmonthday.prototype.tostring
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainMonthDay(5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.toString(value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/with/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/with/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plainmonthday.prototype.with
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainMonthDay(5, 2);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.with({ day: 5 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainTime/from/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/from/options-wrong-type.js
@@ -2,23 +2,21 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaintime.from
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => Temporal.PlainTime.from({ hour: 12, minute: 34 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainTime/prototype/round/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/round/options-wrong-type.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
+esid: sec-temporal.plaintime.prototype.round
 description: TypeError thrown when options argument is missing or a non-string primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
@@ -16,7 +16,7 @@ const badOptions = [
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
+const instance = new Temporal.PlainTime();
 assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
   assert.throws(TypeError, () => instance.round(value),

--- a/test/built-ins/Temporal/PlainTime/prototype/round/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/round/smallestunit-invalid-string.js
@@ -8,7 +8,28 @@ features: [Temporal]
 ---*/
 
 const time = new Temporal.PlainTime(12, 34, 56, 123, 987, 500);
-const values = ["era", "year", "month", "week", "day", "years", "months", "weeks", "days", "nonsense", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => time.round({ smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => time.round({ smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/largestunit-invalid-string.js
@@ -9,7 +9,28 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainTime(13, 35, 57, 987, 654, 321);
-const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/since/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaintime.prototype.since
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainTime();
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.since(new Temporal.PlainTime(12, 34, 56), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainTime/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/smallestunit-invalid-string.js
@@ -9,7 +9,28 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainTime(13, 35, 57, 987, 654, 321);
-const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-auto.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-auto.js
@@ -7,13 +7,17 @@ description: auto value for fractionalSecondDigits option
 features: [Temporal]
 ---*/
 
+const zeroSeconds = new Temporal.PlainTime(15, 23);
+const wholeSeconds = new Temporal.PlainTime(15, 23, 30);
+const subSeconds = new Temporal.PlainTime(15, 23, 30, 123, 400);
+
 const tests = [
-  ["15:23", "15:23:00"],
-  ["15:23:30", "15:23:30"],
-  ["15:23:30.1234", "15:23:30.1234"],
+  [zeroSeconds, "15:23:00"],
+  [wholeSeconds, "15:23:30"],
+  [subSeconds, "15:23:30.1234"],
 ];
 
-for (const [input, expected] of tests) {
-  const plainTime = Temporal.PlainTime.from(input);
-  assert.sameValue(plainTime.toString({ fractionalSecondDigits: "auto" }), expected);
+for (const [time, expected] of tests) {
+  assert.sameValue(time.toString(), expected, "default is to emit seconds and drop trailing zeroes");
+  assert.sameValue(time.toString({ fractionalSecondDigits: "auto" }), expected, "auto is the default");
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-invalid-string.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-invalid-string.js
@@ -10,12 +10,13 @@ info: |
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.plaintime.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
 const time = new Temporal.PlainTime(12, 34, 56, 987, 650, 0);
 
-for (const fractionalSecondDigits of ["other string", "AUTO", "not-auto", "autos"]) {
-  assert.throws(RangeError, () => time.toString({ fractionalSecondDigits }));
+for (const fractionalSecondDigits of ["other string", "AUTO", "not-auto", "autos", "auto\0"]) {
+  assert.throws(RangeError, () => time.toString({ fractionalSecondDigits }),
+    `"${fractionalSecondDigits}" is not a valid value for fractionalSecondDigits`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-non-integer.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-non-integer.js
@@ -10,7 +10,7 @@ info: |
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.plaintime.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-number.js
@@ -7,16 +7,27 @@ description: Number for fractionalSecondDigits option
 features: [Temporal]
 ---*/
 
-const t1 = Temporal.PlainTime.from("15:23");
-const t2 = Temporal.PlainTime.from("15:23:30");
-const t3 = Temporal.PlainTime.from("15:23:30.1234");
-assert.sameValue(t3.toString({ fractionalSecondDigits: 0 }), "15:23:30");
-assert.sameValue(t1.toString({ fractionalSecondDigits: 2 }), "15:23:00.00");
-assert.sameValue(t2.toString({ fractionalSecondDigits: 2 }), "15:23:30.00");
-assert.sameValue(t3.toString({ fractionalSecondDigits: 2 }), "15:23:30.12");
-assert.sameValue(t3.toString({ fractionalSecondDigits: 3 }), "15:23:30.123");
-assert.sameValue(t3.toString({ fractionalSecondDigits: 6 }), "15:23:30.123400");
-assert.sameValue(t1.toString({ fractionalSecondDigits: 7 }), "15:23:00.0000000");
-assert.sameValue(t2.toString({ fractionalSecondDigits: 7 }), "15:23:30.0000000");
-assert.sameValue(t3.toString({ fractionalSecondDigits: 7 }), "15:23:30.1234000");
-assert.sameValue(t3.toString({ fractionalSecondDigits: 9 }), "15:23:30.123400000");
+const zeroSeconds = new Temporal.PlainTime(15, 23);
+const wholeSeconds = new Temporal.PlainTime(15, 23, 30);
+const subSeconds = new Temporal.PlainTime(15, 23, 30, 123, 400);
+
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 0 }), "15:23:30",
+  "truncates 4 decimal places to 0");
+assert.sameValue(zeroSeconds.toString({ fractionalSecondDigits: 2 }), "15:23:00.00",
+  "pads zero seconds to 2 decimal places");
+assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 2 }), "15:23:30.00",
+  "pads whole seconds to 2 decimal places");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 2 }), "15:23:30.12",
+  "truncates 4 decimal places to 2");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 3 }), "15:23:30.123",
+  "truncates 4 decimal places to 3");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 6 }), "15:23:30.123400",
+  "pads 4 decimal places to 6");
+assert.sameValue(zeroSeconds.toString({ fractionalSecondDigits: 7 }), "15:23:00.0000000",
+  "pads zero seconds to 7 decimal places");
+assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 7 }), "15:23:30.0000000",
+  "pads whole seconds to 7 decimal places");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 7 }), "15:23:30.1234000",
+  "pads 4 decimal places to 7");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 9 }), "15:23:30.123400000",
+  "pads 4 decimal places to 9");

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-out-of-range.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-out-of-range.js
@@ -10,13 +10,17 @@ info: |
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.plaintime.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
 const time = new Temporal.PlainTime(12, 34, 56, 987, 650, 0);
 
-assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: -Infinity }));
-assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: -1 }));
-assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: 10 }));
-assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: Infinity }));
+assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: -Infinity }),
+  "−∞ is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: -1 }),
+  "−1 is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: 10 }),
+  "10 is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: Infinity }),
+  "∞ is out of range for fractionalSecondDigits");

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-undefined.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-undefined.js
@@ -8,29 +8,31 @@ info: |
     sec-getoption step 3:
       3. If _value_ is *undefined*, return _fallback_.
     sec-getstringornumberoption step 2:
-      2. Let _value_ be ? GetOption(_options_, _property_, *"stringOrNumber"*, *undefined*, _fallback_).
+      2. Let _value_ be ? GetOption(_options_, _property_, « Number, String », *undefined*, _fallback_).
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.plaintime.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
+const zeroSeconds = new Temporal.PlainTime(15, 23);
+const wholeSeconds = new Temporal.PlainTime(15, 23, 30);
+const subSeconds = new Temporal.PlainTime(15, 23, 30, 123, 400);
+
 const tests = [
-  ["15:23", "15:23:00"],
-  ["15:23:30", "15:23:30"],
-  ["15:23:30.1234", "15:23:30.1234"],
+  [zeroSeconds, "15:23:00"],
+  [wholeSeconds, "15:23:30"],
+  [subSeconds, "15:23:30.1234"],
 ];
 
-for (const [input, expected] of tests) {
-  const time = Temporal.PlainTime.from(input);
-
+for (const [time, expected] of tests) {
   const explicit = time.toString({ fractionalSecondDigits: undefined });
-  assert.sameValue(explicit, expected, "default fractionalSecondDigits is auto");
+  assert.sameValue(explicit, expected, "default fractionalSecondDigits is auto (property present but undefined)");
 
   const implicit = time.toString({});
-  assert.sameValue(implicit, expected, "default fractionalSecondDigits is auto");
+  assert.sameValue(implicit, expected, "default fractionalSecondDigits is auto (property not present)");
 
   const lambda = time.toString(() => {});
-  assert.sameValue(lambda, expected, "default fractionalSecondDigits is auto");
+  assert.sameValue(lambda, expected, "default fractionalSecondDigits is auto (property not present, function object)");
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-wrong-type.js
@@ -22,4 +22,26 @@ features: [Temporal]
 ---*/
 
 const time = new Temporal.PlainTime(12, 34, 56, 987, 650, 0);
-TemporalHelpers.checkFractionalSecondDigitsOptionWrongType(time);
+
+assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: null }),
+  "null is not a number and converts to the string 'null' which is not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: true }),
+  "true is not a number and converts to the string 'true' which is not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: false }),
+  "false is not a number and converts to the string 'false' which is not valid for fractionalSecondDigits");
+assert.throws(TypeError, () => time.toString({ fractionalSecondDigits: Symbol() }),
+  "symbols are not numbers and cannot convert to strings");
+assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: 2n }),
+  "bigints are not numbers and convert to strings which are not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => time.toString({ fractionalSecondDigits: {} }),
+  "plain objects are not numbers and convert to strings which are not valid for fractionalSecondDigits");
+
+const expected = [
+  "get fractionalSecondDigits.toString",
+  "call fractionalSecondDigits.toString",
+];
+const actual = [];
+const observer = TemporalHelpers.toPrimitiveObserver(actual, "auto", "fractionalSecondDigits");
+const result = time.toString({ fractionalSecondDigits: observer });
+assert.sameValue(result, "12:34:56.98765", "object with toString uses toString return value");
+assert.compareArray(actual, expected, "object with toString calls toString and not valueOf");

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaintime.prototype.tostring
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainTime();
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.toString(value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/rounding-cross-midnight.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/rounding-cross-midnight.js
@@ -7,7 +7,7 @@ description: Rounding can cross midnight
 features: [Temporal]
 ---*/
 
-const plainTime = Temporal.PlainTime.from("23:59:59.999999999");
+const plainTime = new Temporal.PlainTime(23, 59, 59, 999, 999, 999);  // one nanosecond before 00:00:00
 for (const roundingMode of ["ceil", "halfExpand"]) {
   assert.sameValue(plainTime.toString({ fractionalSecondDigits: 8, roundingMode }), "00:00:00.00000000");
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-ceil.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-ceil.js
@@ -10,10 +10,28 @@ features: [Temporal]
 const time = new Temporal.PlainTime(12, 34, 56, 123, 987, 500);
 
 const result1 = time.toString({ smallestUnit: "microsecond", roundingMode: "ceil" });
-assert.sameValue(result1, "12:34:56.123988", "roundingMode is ceil");
+assert.sameValue(result1, "12:34:56.123988",
+  "roundingMode is ceil (with 6 digits from smallestUnit)");
 
-const result2 = time.toString({ smallestUnit: "millisecond", roundingMode: "ceil" });
-assert.sameValue(result2, "12:34:56.124", "roundingMode is ceil");
+const result2 = time.toString({ fractionalSecondDigits: 6, roundingMode: "ceil" });
+assert.sameValue(result2, "12:34:56.123988",
+  "roundingMode is ceil (with 6 digits from fractionalSecondDigits)");
 
-const result3 = time.toString({ smallestUnit: "second", roundingMode: "ceil" });
-assert.sameValue(result3, "12:34:57", "roundingMode is ceil");
+const result3 = time.toString({ smallestUnit: "millisecond", roundingMode: "ceil" });
+assert.sameValue(result3, "12:34:56.124",
+  "roundingMode is ceil (with 3 digits from smallestUnit)");
+
+const result4 = time.toString({ fractionalSecondDigits: 3, roundingMode: "ceil" });
+assert.sameValue(result4, "12:34:56.124",
+  "roundingMode is ceil (with 3 digits from fractionalSecondDigits)");
+
+const result5 = time.toString({ smallestUnit: "second", roundingMode: "ceil" });
+assert.sameValue(result5, "12:34:57",
+  "roundingMode is ceil (with 0 digits from smallestUnit)");
+
+const result6 = time.toString({ fractionalSecondDigits: 0, roundingMode: "ceil" });
+assert.sameValue(result6, "12:34:57",
+  "roundingMode is ceil (with 0 digits from fractionalSecondDigits)");
+
+const result7 = time.toString({ smallestUnit: "minute", roundingMode: "ceil" });
+assert.sameValue(result7, "12:35", "roundingMode is ceil (round to minute)");

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-floor.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-floor.js
@@ -10,10 +10,28 @@ features: [Temporal]
 const time = new Temporal.PlainTime(12, 34, 56, 123, 987, 500);
 
 const result1 = time.toString({ smallestUnit: "microsecond", roundingMode: "floor" });
-assert.sameValue(result1, "12:34:56.123987", "roundingMode is floor");
+assert.sameValue(result1, "12:34:56.123987",
+  "roundingMode is floor (with 6 digits from smallestUnit)");
 
-const result2 = time.toString({ smallestUnit: "millisecond", roundingMode: "floor" });
-assert.sameValue(result2, "12:34:56.123", "roundingMode is floor");
+const result2 = time.toString({ fractionalSecondDigits: 6, roundingMode: "floor" });
+assert.sameValue(result2, "12:34:56.123987",
+  "roundingMode is floor (with 6 digits from fractionalSecondDigits)");
 
-const result3 = time.toString({ smallestUnit: "second", roundingMode: "floor" });
-assert.sameValue(result3, "12:34:56", "roundingMode is floor");
+const result3 = time.toString({ smallestUnit: "millisecond", roundingMode: "floor" });
+assert.sameValue(result3, "12:34:56.123",
+  "roundingMode is floor (with 3 digits from smallestUnit)");
+
+const result4 = time.toString({ fractionalSecondDigits: 3, roundingMode: "floor" });
+assert.sameValue(result4, "12:34:56.123",
+  "roundingMode is floor (with 3 digits from fractionalSecondDigits)");
+
+const result5 = time.toString({ smallestUnit: "second", roundingMode: "floor" });
+assert.sameValue(result5, "12:34:56",
+  "roundingMode is floor (with 0 digits from smallestUnit)");
+
+const result6 = time.toString({ fractionalSecondDigits: 0, roundingMode: "floor" });
+assert.sameValue(result6, "12:34:56",
+  "roundingMode is floor (with 0 digits from fractionalSecondDigits)");
+
+const result7 = time.toString({ smallestUnit: "minute", roundingMode: "floor" });
+assert.sameValue(result7, "12:34", "roundingMode is floor (round to minute)");

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-halfExpand.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-halfExpand.js
@@ -10,10 +10,28 @@ features: [Temporal]
 const time = new Temporal.PlainTime(12, 34, 56, 123, 987, 500);
 
 const result1 = time.toString({ smallestUnit: "microsecond", roundingMode: "halfExpand" });
-assert.sameValue(result1, "12:34:56.123988", "roundingMode is halfExpand");
+assert.sameValue(result1, "12:34:56.123988",
+  "roundingMode is halfExpand (with 6 digits from smallestUnit)");
 
-const result2 = time.toString({ smallestUnit: "millisecond", roundingMode: "halfExpand" });
-assert.sameValue(result2, "12:34:56.124", "roundingMode is halfExpand");
+const result2 = time.toString({ fractionalSecondDigits: 6, roundingMode: "halfExpand" });
+assert.sameValue(result2, "12:34:56.123988",
+  "roundingMode is halfExpand (with 6 digits from fractionalSecondDigits)");
 
-const result3 = time.toString({ smallestUnit: "second", roundingMode: "halfExpand" });
-assert.sameValue(result3, "12:34:56", "roundingMode is halfExpand");
+const result3 = time.toString({ smallestUnit: "millisecond", roundingMode: "halfExpand" });
+assert.sameValue(result3, "12:34:56.124",
+  "roundingMode is halfExpand (with 3 digits from smallestUnit)");
+
+const result4 = time.toString({ fractionalSecondDigits: 3, roundingMode: "halfExpand" });
+assert.sameValue(result4, "12:34:56.124",
+  "roundingMode is halfExpand (with 3 digits from fractionalSecondDigits)");
+
+const result5 = time.toString({ smallestUnit: "second", roundingMode: "halfExpand" });
+assert.sameValue(result5, "12:34:56",
+  "roundingMode is halfExpand (with 0 digits from smallestUnit)");
+
+const result6 = time.toString({ fractionalSecondDigits: 0, roundingMode: "halfExpand" });
+assert.sameValue(result6, "12:34:56",
+  "roundingMode is halfExpand (with 0 digits from fractionalSecondDigits)");
+
+const result7 = time.toString({ smallestUnit: "minute", roundingMode: "halfExpand" });
+assert.sameValue(result7, "12:35", "roundingMode is halfExpand (round to minute)");

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-trunc.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-trunc.js
@@ -10,10 +10,28 @@ features: [Temporal]
 const time = new Temporal.PlainTime(12, 34, 56, 123, 987, 500);
 
 const result1 = time.toString({ smallestUnit: "microsecond", roundingMode: "trunc" });
-assert.sameValue(result1, "12:34:56.123987", "roundingMode is trunc");
+assert.sameValue(result1, "12:34:56.123987",
+  "roundingMode is trunc (with 6 digits from smallestUnit)");
 
-const result2 = time.toString({ smallestUnit: "millisecond", roundingMode: "trunc" });
-assert.sameValue(result2, "12:34:56.123", "roundingMode is trunc");
+const result2 = time.toString({ fractionalSecondDigits: 6, roundingMode: "trunc" });
+assert.sameValue(result2, "12:34:56.123987",
+  "roundingMode is trunc (with 6 digits from fractionalSecondDigits)");
 
-const result3 = time.toString({ smallestUnit: "second", roundingMode: "trunc" });
-assert.sameValue(result3, "12:34:56", "roundingMode is trunc");
+const result3 = time.toString({ smallestUnit: "millisecond", roundingMode: "trunc" });
+assert.sameValue(result3, "12:34:56.123",
+  "roundingMode is trunc (with 3 digits from smallestUnit)");
+
+const result4 = time.toString({ fractionalSecondDigits: 3, roundingMode: "trunc" });
+assert.sameValue(result4, "12:34:56.123",
+  "roundingMode is trunc (with 3 digits from fractionalSecondDigits)");
+
+const result5 = time.toString({ smallestUnit: "second", roundingMode: "trunc" });
+assert.sameValue(result5, "12:34:56",
+  "roundingMode is trunc (with 0 digits from smallestUnit)");
+
+const result6 = time.toString({ fractionalSecondDigits: 0, roundingMode: "trunc" });
+assert.sameValue(result6, "12:34:56",
+  "roundingMode is trunc (with 0 digits from fractionalSecondDigits)");
+
+const result7 = time.toString({ smallestUnit: "minute", roundingMode: "trunc" });
+assert.sameValue(result7, "12:34", "roundingMode is trunc (round to minute)");

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/smallestunit-invalid-string.js
@@ -8,6 +8,30 @@ features: [Temporal]
 ---*/
 
 const time = new Temporal.PlainTime(12, 34, 56, 123, 987, 500);
-for (const smallestUnit of ["era", "year", "month", "day", "hour", "nonsense", "other string", "m\u0131nute", "SECOND"]) {
-  assert.throws(RangeError, () => time.toString({ smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => time.toString({ smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/smallestunit-valid-units.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/smallestunit-valid-units.js
@@ -7,21 +7,41 @@ description: Valid units for the smallestUnit option
 features: [Temporal]
 ---*/
 
-const time = new Temporal.PlainTime(12, 34, 56, 789, 999, 999);
-assert.sameValue(time.toString({ smallestUnit: "minute" }), "12:34");
-assert.sameValue(time.toString({ smallestUnit: "second" }), "12:34:56");
-assert.sameValue(time.toString({ smallestUnit: "millisecond" }), "12:34:56.789");
-assert.sameValue(time.toString({ smallestUnit: "microsecond" }), "12:34:56.789999");
-assert.sameValue(time.toString({ smallestUnit: "nanosecond" }), "12:34:56.789999999");
+const time = new Temporal.PlainTime(12, 34, 56, 123, 456, 789);
 
-const time2 = new Temporal.PlainTime(12, 34);
-assert.sameValue(time2.toString({ smallestUnit: "minute" }), "12:34");
-assert.sameValue(time2.toString({ smallestUnit: "second" }), "12:34:00");
-assert.sameValue(time2.toString({ smallestUnit: "millisecond" }), "12:34:00.000");
-assert.sameValue(time2.toString({ smallestUnit: "microsecond" }), "12:34:00.000000");
-assert.sameValue(time2.toString({ smallestUnit: "nanosecond" }), "12:34:00.000000000");
+function test(instance, expectations, description) {
+  for (const [smallestUnit, expectedResult] of expectations) {
+    assert.sameValue(instance.toString({ smallestUnit }), expectedResult,
+      `${description} with smallestUnit "${smallestUnit}"`);
+  }
+}
+
+test(
+  time,
+  [
+    ["minute", "12:34"],
+    ["second", "12:34:56"],
+    ["millisecond", "12:34:56.123"],
+    ["microsecond", "12:34:56.123456"],
+    ["nanosecond", "12:34:56.123456789"],
+  ],
+  "subseconds toString"
+);
+
+test(
+  new Temporal.PlainTime(12, 34),
+  [
+    ["minute", "12:34"],
+    ["second", "12:34:00"],
+    ["millisecond", "12:34:00.000"],
+    ["microsecond", "12:34:00.000000"],
+    ["nanosecond", "12:34:00.000000000"],
+  ],
+  "whole minutes toString"
+);
 
 const notValid = [
+  "era",
   "year",
   "month",
   "week",
@@ -30,5 +50,6 @@ const notValid = [
 ];
 
 notValid.forEach((smallestUnit) => {
-  assert.throws(RangeError, () => time.toString({ smallestUnit }), smallestUnit);
+  assert.throws(RangeError, () => time.toString({ smallestUnit }),
+    `"${smallestUnit}" is not a valid unit for the smallestUnit option`);
 });

--- a/test/built-ins/Temporal/PlainTime/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/largestunit-invalid-string.js
@@ -9,7 +9,28 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainTime(13, 35, 57, 987, 654, 321);
-const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/until/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaintime.prototype.until
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainTime();
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.until(new Temporal.PlainTime(12, 34, 56), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainTime/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/smallestunit-invalid-string.js
@@ -9,7 +9,28 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainTime(13, 35, 57, 987, 654, 321);
-const values = ["era", "eraYear", "years", "months", "weeks", "days", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/with/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/with/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plaintime.prototype.with
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainTime();
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.with({ minute: 45 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainYearMonth/from/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/options-wrong-type.js
@@ -2,23 +2,21 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plainyearmonth.from
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M01" }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plainyearmonth.prototype.add
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainYearMonth(2019, 10);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.add({ months: 1 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/largestunit-invalid-string.js
@@ -9,7 +9,34 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2001, 6);
-const values = ["era", "eraYear", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+  "month\0",
+  "YEAR",
+  "eras",
+  "eraYears",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+  "months\0",
+  "YEARS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plainyearmonth.prototype.since
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainYearMonth(2019, 10);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.since(new Temporal.PlainYearMonth(1976, 11), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/smallestunit-invalid-string.js
@@ -9,7 +9,34 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2001, 6);
-const values = ["era", "eraYear", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+  "month\0",
+  "YEAR",
+  "eras",
+  "eraYears",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+  "months\0",
+  "YEARS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainYearMonth(2019, 10);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.subtract({ months: 1 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/toString/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/toString/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plainyearmonth.prototype.tostring
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainYearMonth(2019, 10);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.toString(value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/largestunit-invalid-string.js
@@ -9,7 +9,34 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2001, 6);
-const values = ["era", "eraYear", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+  "month\0",
+  "YEAR",
+  "eras",
+  "eraYears",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+  "months\0",
+  "YEARS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.plainyearmonth.prototype.until
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.PlainYearMonth(2019, 10);
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.until(new Temporal.PlainYearMonth(1976, 11), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/smallestunit-invalid-string.js
@@ -9,7 +9,34 @@ features: [Temporal]
 
 const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2001, 6);
-const values = ["era", "eraYear", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+  "month\0",
+  "YEAR",
+  "eras",
+  "eraYears",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+  "months\0",
+  "YEARS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/with/options-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/with/options-wrong-type.js
@@ -7,7 +7,7 @@ description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const values = [
+const badOptions = [
   null,
   true,
   "2021-01",
@@ -16,7 +16,8 @@ const values = [
   2n,
 ];
 
-const ym = Temporal.PlainYearMonth.from("2019-10");
-values.forEach((value) => {
-  assert.throws(TypeError, () => ym.with({ year: 2020 }, value), `TypeError on wrong argument type ${typeof value}`);
-});
+const instance = new Temporal.PlainYearMonth(2019, 10);
+for (const value of badOptions) {
+  assert.throws(TypeError, () => instance.with({ year: 2020 }, value),
+    `TypeError on wrong options type ${typeof value}`);
+};

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/options-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.TimeZone("UTC");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.getInstantFor(new Temporal.PlainDateTime(2019, 10, 29, 10, 46, 38), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/ZonedDateTime/from/options-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/options-wrong-type.js
@@ -2,23 +2,21 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.zoneddatetime.from
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.from({ year: 1976, month: 11, day: 18, timeZone: "UTC" }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/add/options-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/add/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.zoneddatetime.prototype.add
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.add({ years: 1 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/options-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/options-wrong-type.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
+esid: sec-temporal.zoneddatetime.prototype.round
 description: TypeError thrown when options argument is missing or a non-string primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
@@ -16,7 +16,7 @@ const badOptions = [
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
 assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
 for (const value of badOptions) {
   assert.throws(TypeError, () => instance.round(value),

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/rounding-direction.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/rounding-direction.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.round
+description: Rounding down is towards the Big Bang, not the epoch or 1 BCE
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(-65_261_246_399_500_000_000n, "UTC");  // -000099-12-15T12:00:00.5Z
+assert.sameValue(
+  instance.round({ smallestUnit: "second", roundingMode: "floor" }).epochNanoseconds,
+  -65_261_246_400_000_000_000n,  // -000099-12-15T12:00:00Z
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE (roundingMode floor)"
+);
+assert.sameValue(
+  instance.round({ smallestUnit: "second", roundingMode: "trunc" }).epochNanoseconds,
+  -65_261_246_400_000_000_000n,  // -000099-12-15T12:00:00Z
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE (roundingMode trunc)"
+);
+assert.sameValue(
+  instance.round({ smallestUnit: "second", roundingMode: "ceil" }).epochNanoseconds,
+  -65_261_246_399_000_000_000n,  // -000099-12-15T12:00:01Z
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode ceil)"
+);
+assert.sameValue(
+  instance.round({ smallestUnit: "second", roundingMode: "halfExpand" }).epochNanoseconds,
+  -65_261_246_399_000_000_000n,  // -000099-12-15T12:00:01Z
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode halfExpand)"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/smallestunit-invalid-string.js
@@ -8,4 +8,26 @@ features: [Temporal]
 ---*/
 
 const datetime = new Temporal.ZonedDateTime(1_000_000_000_123_987_500n, "UTC");
-assert.throws(RangeError, () => datetime.round({ smallestUnit: "other string" }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => datetime.round({ smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/largestunit-invalid-string.js
@@ -9,7 +9,20 @@ features: [Temporal]
 
 const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 const later = new Temporal.ZonedDateTime(1_000_090_061_987_654_321n, "UTC");
-const values = ["era", "eraYear", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/options-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.zoneddatetime.prototype.since
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.since(new Temporal.ZonedDateTime(3600_000_000_000n, "UTC"), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/smallestunit-invalid-string.js
@@ -9,7 +9,20 @@ features: [Temporal]
 
 const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 const later = new Temporal.ZonedDateTime(1_000_090_061_987_654_321n, "UTC");
-const values = ["era", "eraYear", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => later.since(earlier, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/options-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.subtract({ years: 1 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-auto.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-auto.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: auto value for fractionalSecondDigits option
+features: [BigInt, Temporal]
+---*/
+
+const zeroSeconds = new Temporal.ZonedDateTime(0n, "UTC");
+const wholeSeconds = new Temporal.ZonedDateTime(30_000_000_000n, "UTC");
+const subSeconds = new Temporal.ZonedDateTime(30_123_400_000n, "UTC");
+
+const tests = [
+  [zeroSeconds, "1970-01-01T00:00:00+00:00[UTC]"],
+  [wholeSeconds, "1970-01-01T00:00:30+00:00[UTC]"],
+  [subSeconds, "1970-01-01T00:00:30.1234+00:00[UTC]"],
+];
+
+for (const [datetime, expected] of tests) {
+  assert.sameValue(datetime.toString(), expected, "default is to emit seconds and drop trailing zeroes");
+  assert.sameValue(datetime.toString({ fractionalSecondDigits: "auto" }), expected, "auto is the default");
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-invalid-string.js
@@ -9,11 +9,14 @@ info: |
       4. If _stringValues_ is not *undefined* and _stringValues_ does not contain an element equal to _value_, throw a *RangeError* exception.
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
-    sec-temporal.instant.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+    sec-temporal.zoneddatetime.prototype.tostring step 4:
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
 const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_650_000n, "UTC");
 
-assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: "other string" }));
+for (const fractionalSecondDigits of ["other string", "AUTO", "not-auto", "autos", "auto\0"]) {
+  assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits }),
+    `"${fractionalSecondDigits}" is not a valid value for fractionalSecondDigits`);
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-non-integer.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-non-integer.js
@@ -10,7 +10,7 @@ info: |
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.zoneddatetime.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-number.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: Number for fractionalSecondDigits option
+features: [BigInt, Temporal]
+---*/
+
+const zeroSeconds = new Temporal.ZonedDateTime(0n, "UTC");
+const wholeSeconds = new Temporal.ZonedDateTime(30_000_000_000n, "UTC");
+const subSeconds = new Temporal.ZonedDateTime(30_123_400_000n, "UTC");
+
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 0 }), "1970-01-01T00:00:30+00:00[UTC]",
+  "truncates 4 decimal places to 0");
+assert.sameValue(zeroSeconds.toString({ fractionalSecondDigits: 2 }), "1970-01-01T00:00:00.00+00:00[UTC]",
+  "pads zero seconds to 2 decimal places");
+assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 2 }), "1970-01-01T00:00:30.00+00:00[UTC]",
+  "pads whole seconds to 2 decimal places");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 2 }), "1970-01-01T00:00:30.12+00:00[UTC]",
+  "truncates 4 decimal places to 2");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 3 }), "1970-01-01T00:00:30.123+00:00[UTC]",
+  "truncates 4 decimal places to 3");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 6 }), "1970-01-01T00:00:30.123400+00:00[UTC]",
+  "pads 4 decimal places to 6");
+assert.sameValue(zeroSeconds.toString({ fractionalSecondDigits: 7 }), "1970-01-01T00:00:00.0000000+00:00[UTC]",
+  "pads zero seconds to 7 decimal places");
+assert.sameValue(wholeSeconds.toString({ fractionalSecondDigits: 7 }), "1970-01-01T00:00:30.0000000+00:00[UTC]",
+  "pads whole seconds to 7 decimal places");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 7 }), "1970-01-01T00:00:30.1234000+00:00[UTC]",
+  "pads 4 decimal places to 7");
+assert.sameValue(subSeconds.toString({ fractionalSecondDigits: 9 }), "1970-01-01T00:00:30.123400000+00:00[UTC]",
+  "pads 4 decimal places to 9");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-out-of-range.js
@@ -10,11 +10,17 @@ info: |
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.zoneddatetime.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
 const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_650_000n, "UTC");
 
-assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: -1 }));
-assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: 10 }));
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: -Infinity }),
+  "−∞ is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: -1 }),
+  "−1 is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: 10 }),
+  "10 is out of range for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: Infinity }),
+  "∞ is out of range for fractionalSecondDigits");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-undefined.js
@@ -8,17 +8,31 @@ info: |
     sec-getoption step 3:
       3. If _value_ is *undefined*, return _fallback_.
     sec-getstringornumberoption step 2:
-      2. Let _value_ be ? GetOption(_options_, _property_, *"stringOrNumber"*, *undefined*, _fallback_).
+      2. Let _value_ be ? GetOption(_options_, _property_, « Number, String », *undefined*, _fallback_).
     sec-temporal-tosecondsstringprecision step 9:
       9. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
     sec-temporal.zoneddatetime.prototype.tostring step 4:
-      4. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+      4. Let _precision_ be ? ToSecondsStringPrecision(_options_).
 features: [Temporal]
 ---*/
 
-const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_650_000n, "UTC");
+const zeroSeconds = new Temporal.ZonedDateTime(0n, "UTC");
+const wholeSeconds = new Temporal.ZonedDateTime(30_000_000_000n, "UTC");
+const subSeconds = new Temporal.ZonedDateTime(30_123_400_000n, "UTC");
 
-const explicit = datetime.toString({ fractionalSecondDigits: undefined });
-assert.sameValue(explicit, "2001-09-09T01:46:40.98765+00:00[UTC]", "default fractionalSecondDigits is auto");
+const tests = [
+  [zeroSeconds, "1970-01-01T00:00:00+00:00[UTC]"],
+  [wholeSeconds, "1970-01-01T00:00:30+00:00[UTC]"],
+  [subSeconds, "1970-01-01T00:00:30.1234+00:00[UTC]"],
+];
 
-// See options-undefined.js for {}
+for (const [datetime, expected] of tests) {
+  const explicit = datetime.toString({ fractionalSecondDigits: undefined });
+  assert.sameValue(explicit, expected, "default fractionalSecondDigits is auto (property present but undefined)");
+
+  const implicit = datetime.toString({});
+  assert.sameValue(implicit, expected, "default fractionalSecondDigits is auto (property not present)");
+
+  const lambda = datetime.toString(() => {});
+  assert.sameValue(lambda, expected, "default fractionalSecondDigits is auto (property not present, function object)");
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-wrong-type.js
@@ -22,4 +22,26 @@ features: [Temporal]
 ---*/
 
 const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_650_000n, "UTC");
-TemporalHelpers.checkFractionalSecondDigitsOptionWrongType(datetime);
+
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: null }),
+  "null is not a number and converts to the string 'null' which is not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: true }),
+  "true is not a number and converts to the string 'true' which is not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: false }),
+  "false is not a number and converts to the string 'false' which is not valid for fractionalSecondDigits");
+assert.throws(TypeError, () => datetime.toString({ fractionalSecondDigits: Symbol() }),
+  "symbols are not numbers and cannot convert to strings");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: 2n }),
+  "bigints are not numbers and convert to strings which are not valid for fractionalSecondDigits");
+assert.throws(RangeError, () => datetime.toString({ fractionalSecondDigits: {} }),
+  "plain objects are not numbers and convert to strings which are not valid for fractionalSecondDigits");
+
+const expected = [
+  "get fractionalSecondDigits.toString",
+  "call fractionalSecondDigits.toString",
+];
+const actual = [];
+const observer = TemporalHelpers.toPrimitiveObserver(actual, "auto", "fractionalSecondDigits");
+const result = datetime.toString({ fractionalSecondDigits: observer });
+assert.sameValue(result, "2001-09-09T01:46:40.98765+00:00[UTC]", "object with toString uses toString return value");
+assert.compareArray(actual, expected, "object with toString calls toString and not valueOf");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/options-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.toString(value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/rounding-cross-midnight.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/rounding-cross-midnight.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: Rounding can cross midnight
+features: [Temporal]
+---*/
+
+const zonedDateTime = new Temporal.ZonedDateTime(946_684_799_999_999_999n, "UTC");  // one nanosecond before 2000-01-01T00:00:00
+for (const roundingMode of ["ceil", "halfExpand"]) {
+  assert.sameValue(zonedDateTime.toString({ fractionalSecondDigits: 8, roundingMode }), "2000-01-01T00:00:00.00000000+00:00[UTC]");
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/rounding-direction.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/rounding-direction.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: Rounding down is towards the Big Bang, not the epoch or 1 BCE
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(-65_261_246_399_500_000_000n, "UTC");  // -000099-12-15T12:00:00.5Z
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "floor" }),
+  "-000099-12-15T12:00:00+00:00[UTC]",
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE"
+);
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "trunc" }),
+  "-000099-12-15T12:00:00+00:00[UTC]",
+  "Rounding down is towards the Big Bang, not the epoch or 1 BCE (roundingMode trunc)"
+);
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "ceil" }),
+  "-000099-12-15T12:00:01+00:00[UTC]",
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode ceil)"
+);
+assert.sameValue(
+  instance.toString({ smallestUnit: "second", roundingMode: "halfExpand" }),
+  "-000099-12-15T12:00:01+00:00[UTC]",
+  "Rounding up is away from the Big Bang, not the epoch or 1 BCE (roundingMode halfExpand)"
+);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/roundingmode-ceil.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/roundingmode-ceil.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: ceil value for roundingMode option
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(1_000_000_000_123_987_500n, "UTC");
+
+const result1 = datetime.toString({ smallestUnit: "microsecond", roundingMode: "ceil" });
+assert.sameValue(result1, "2001-09-09T01:46:40.123988+00:00[UTC]",
+  "roundingMode is ceil (with 6 digits from smallestUnit)");
+
+const result2 = datetime.toString({ fractionalSecondDigits: 6, roundingMode: "ceil" });
+assert.sameValue(result2, "2001-09-09T01:46:40.123988+00:00[UTC]",
+  "roundingMode is ceil (with 6 digits from fractionalSecondDigits)");
+
+const result3 = datetime.toString({ smallestUnit: "millisecond", roundingMode: "ceil" });
+assert.sameValue(result3, "2001-09-09T01:46:40.124+00:00[UTC]",
+  "roundingMode is ceil (with 3 digits from smallestUnit)");
+
+const result4 = datetime.toString({ fractionalSecondDigits: 3, roundingMode: "ceil" });
+assert.sameValue(result4, "2001-09-09T01:46:40.124+00:00[UTC]",
+  "roundingMode is ceil (with 3 digits from fractionalSecondDigits)");
+
+const result5 = datetime.toString({ smallestUnit: "second", roundingMode: "ceil" });
+assert.sameValue(result5, "2001-09-09T01:46:41+00:00[UTC]",
+  "roundingMode is ceil (with 0 digits from smallestUnit)");
+
+const result6 = datetime.toString({ fractionalSecondDigits: 0, roundingMode: "ceil" });
+assert.sameValue(result6, "2001-09-09T01:46:41+00:00[UTC]",
+  "roundingMode is ceil (with 0 digits from fractionalSecondDigits)");
+
+const result7 = datetime.toString({ smallestUnit: "minute", roundingMode: "ceil" });
+assert.sameValue(result7, "2001-09-09T01:47+00:00[UTC]", "roundingMode is ceil (round to minute)");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/roundingmode-floor.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/roundingmode-floor.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: floor value for roundingMode option
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(1_000_000_000_123_987_500n, "UTC");
+
+const result1 = datetime.toString({ smallestUnit: "microsecond", roundingMode: "floor" });
+assert.sameValue(result1, "2001-09-09T01:46:40.123987+00:00[UTC]",
+  "roundingMode is floor (with 6 digits from smallestUnit)");
+
+const result2 = datetime.toString({ fractionalSecondDigits: 6, roundingMode: "floor" });
+assert.sameValue(result2, "2001-09-09T01:46:40.123987+00:00[UTC]",
+  "roundingMode is floor (with 6 digits from fractionalSecondDigits)");
+
+const result3 = datetime.toString({ smallestUnit: "millisecond", roundingMode: "floor" });
+assert.sameValue(result3, "2001-09-09T01:46:40.123+00:00[UTC]",
+  "roundingMode is floor (with 3 digits from smallestUnit)");
+
+const result4 = datetime.toString({ fractionalSecondDigits: 3, roundingMode: "floor" });
+assert.sameValue(result4, "2001-09-09T01:46:40.123+00:00[UTC]",
+  "roundingMode is floor (with 3 digits from fractionalSecondDigits)");
+
+const result5 = datetime.toString({ smallestUnit: "second", roundingMode: "floor" });
+assert.sameValue(result5, "2001-09-09T01:46:40+00:00[UTC]",
+  "roundingMode is floor (with 0 digits from smallestUnit)");
+
+const result6 = datetime.toString({ fractionalSecondDigits: 0, roundingMode: "floor" });
+assert.sameValue(result6, "2001-09-09T01:46:40+00:00[UTC]",
+  "roundingMode is floor (with 0 digits from fractionalSecondDigits)");
+
+const result7 = datetime.toString({ smallestUnit: "minute", roundingMode: "floor" });
+assert.sameValue(result7, "2001-09-09T01:46+00:00[UTC]", "roundingMode is floor (round to minute)");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/roundingmode-halfExpand.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/roundingmode-halfExpand.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: halfExpand value for roundingMode option
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(1_000_000_000_123_987_500n, "UTC");
+
+const result1 = datetime.toString({ smallestUnit: "microsecond", roundingMode: "halfExpand" });
+assert.sameValue(result1, "2001-09-09T01:46:40.123988+00:00[UTC]",
+  "roundingMode is halfExpand (with 6 digits from smallestUnit)");
+
+const result2 = datetime.toString({ fractionalSecondDigits: 6, roundingMode: "halfExpand" });
+assert.sameValue(result2, "2001-09-09T01:46:40.123988+00:00[UTC]",
+  "roundingMode is halfExpand (with 6 digits from fractionalSecondDigits)");
+
+const result3 = datetime.toString({ smallestUnit: "millisecond", roundingMode: "halfExpand" });
+assert.sameValue(result3, "2001-09-09T01:46:40.124+00:00[UTC]",
+  "roundingMode is halfExpand (with 3 digits from smallestUnit)");
+
+const result4 = datetime.toString({ fractionalSecondDigits: 3, roundingMode: "halfExpand" });
+assert.sameValue(result4, "2001-09-09T01:46:40.124+00:00[UTC]",
+  "roundingMode is halfExpand (with 3 digits from fractionalSecondDigits)");
+
+const result5 = datetime.toString({ smallestUnit: "second", roundingMode: "halfExpand" });
+assert.sameValue(result5, "2001-09-09T01:46:40+00:00[UTC]",
+  "roundingMode is halfExpand (with 0 digits from smallestUnit)");
+
+const result6 = datetime.toString({ fractionalSecondDigits: 0, roundingMode: "halfExpand" });
+assert.sameValue(result6, "2001-09-09T01:46:40+00:00[UTC]",
+  "roundingMode is halfExpand (with 0 digits from fractionalSecondDigits)");
+
+const result7 = datetime.toString({ smallestUnit: "minute", roundingMode: "halfExpand" });
+assert.sameValue(result7, "2001-09-09T01:47+00:00[UTC]", "roundingMode is halfExpand (round to minute)");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/roundingmode-trunc.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/roundingmode-trunc.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: trunc value for roundingMode option
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(1_000_000_000_123_987_500n, "UTC");
+
+const result1 = datetime.toString({ smallestUnit: "microsecond", roundingMode: "trunc" });
+assert.sameValue(result1, "2001-09-09T01:46:40.123987+00:00[UTC]",
+  "roundingMode is trunc (with 6 digits from smallestUnit)");
+
+const result2 = datetime.toString({ fractionalSecondDigits: 6, roundingMode: "trunc" });
+assert.sameValue(result2, "2001-09-09T01:46:40.123987+00:00[UTC]",
+  "roundingMode is trunc (with 6 digits from fractionalSecondDigits)");
+
+const result3 = datetime.toString({ smallestUnit: "millisecond", roundingMode: "trunc" });
+assert.sameValue(result3, "2001-09-09T01:46:40.123+00:00[UTC]",
+  "roundingMode is trunc (with 3 digits from smallestUnit)");
+
+const result4 = datetime.toString({ fractionalSecondDigits: 3, roundingMode: "trunc" });
+assert.sameValue(result4, "2001-09-09T01:46:40.123+00:00[UTC]",
+  "roundingMode is trunc (with 3 digits from fractionalSecondDigits)");
+
+const result5 = datetime.toString({ smallestUnit: "second", roundingMode: "trunc" });
+assert.sameValue(result5, "2001-09-09T01:46:40+00:00[UTC]",
+  "roundingMode is trunc (with 0 digits from smallestUnit)");
+
+const result6 = datetime.toString({ fractionalSecondDigits: 0, roundingMode: "trunc" });
+assert.sameValue(result6, "2001-09-09T01:46:40+00:00[UTC]",
+  "roundingMode is trunc (with 0 digits from fractionalSecondDigits)");
+
+const result7 = datetime.toString({ smallestUnit: "minute", roundingMode: "trunc" });
+assert.sameValue(result7, "2001-09-09T01:46+00:00[UTC]", "roundingMode is trunc (round to minute)");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/smallestunit-fractionalseconddigits.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/smallestunit-fractionalseconddigits.js
@@ -2,29 +2,29 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.tostring
+esid: sec-temporal.zoneddatetime.prototype.tostring
 description: fractionalSecondDigits option is not used with smallestUnit present
 features: [Temporal]
 ---*/
 
-const time = new Temporal.PlainTime(12, 34, 56, 789, 999, 999);
+const datetime = new Temporal.ZonedDateTime(56_789_999_999n, "UTC");
 const tests = [
-  ["minute", "12:34"],
-  ["second", "12:34:56"],
-  ["millisecond", "12:34:56.789"],
-  ["microsecond", "12:34:56.789999"],
-  ["nanosecond", "12:34:56.789999999"],
+  ["minute", "1970-01-01T00:00+00:00[UTC]"],
+  ["second", "1970-01-01T00:00:56+00:00[UTC]"],
+  ["millisecond", "1970-01-01T00:00:56.789+00:00[UTC]"],
+  ["microsecond", "1970-01-01T00:00:56.789999+00:00[UTC]"],
+  ["nanosecond", "1970-01-01T00:00:56.789999999+00:00[UTC]"],
 ];
 
 for (const [smallestUnit, expected] of tests) {
-  const string = time.toString({
+  const string = datetime.toString({
     smallestUnit,
     get fractionalSecondDigits() { throw new Test262Error("should not get fractionalSecondDigits") }
   });
   assert.sameValue(string, expected, `smallestUnit: "${smallestUnit}" overrides fractionalSecondDigits`);
 }
 
-assert.throws(RangeError, () => time.toString({
+assert.throws(RangeError, () => datetime.toString({
   smallestUnit: "hour",
   get fractionalSecondDigits() { throw new Test262Error("should not get fractionalSecondDigits") }
 }), "hour is an invalid smallestUnit but still overrides fractionalSecondDigits");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/smallestunit-invalid-string.js
@@ -8,4 +8,30 @@ features: [Temporal]
 ---*/
 
 const datetime = new Temporal.ZonedDateTime(1_000_000_000_123_987_500n, "UTC");
-assert.throws(RangeError, () => datetime.toString({ smallestUnit: "other string" }));
+const badValues = [
+  "era",
+  "eraYear",
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => datetime.toString({ smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/smallestunit-valid-units.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/smallestunit-valid-units.js
@@ -9,13 +9,39 @@ features: [Temporal]
 
 const datetime = new Temporal.ZonedDateTime(1_000_000_000_123_456_789n, "UTC");
 
-assert.sameValue(datetime.toString({ smallestUnit: "minute" }), "2001-09-09T01:46+00:00[UTC]");
-assert.sameValue(datetime.toString({ smallestUnit: "second" }), "2001-09-09T01:46:40+00:00[UTC]");
-assert.sameValue(datetime.toString({ smallestUnit: "millisecond" }), "2001-09-09T01:46:40.123+00:00[UTC]");
-assert.sameValue(datetime.toString({ smallestUnit: "microsecond" }), "2001-09-09T01:46:40.123456+00:00[UTC]");
-assert.sameValue(datetime.toString({ smallestUnit: "nanosecond" }), "2001-09-09T01:46:40.123456789+00:00[UTC]");
+function test(instance, expectations, description) {
+  for (const [smallestUnit, expectedResult] of expectations) {
+    assert.sameValue(instance.toString({ smallestUnit }), expectedResult,
+      `${description} with smallestUnit "${smallestUnit}"`);
+  }
+}
+
+test(
+  datetime,
+  [
+    ["minute", "2001-09-09T01:46+00:00[UTC]"],
+    ["second", "2001-09-09T01:46:40+00:00[UTC]"],
+    ["millisecond", "2001-09-09T01:46:40.123+00:00[UTC]"],
+    ["microsecond", "2001-09-09T01:46:40.123456+00:00[UTC]"],
+    ["nanosecond", "2001-09-09T01:46:40.123456789+00:00[UTC]"],
+  ],
+  "subseconds toString"
+);
+
+test(
+  new Temporal.ZonedDateTime(999_999_960_000_000_000n, "UTC"),
+  [
+    ["minute", "2001-09-09T01:46+00:00[UTC]"],
+    ["second", "2001-09-09T01:46:00+00:00[UTC]"],
+    ["millisecond", "2001-09-09T01:46:00.000+00:00[UTC]"],
+    ["microsecond", "2001-09-09T01:46:00.000000+00:00[UTC]"],
+    ["nanosecond", "2001-09-09T01:46:00.000000000+00:00[UTC]"],
+  ],
+  "whole minutes toString"
+);
 
 const notValid = [
+  "era",
   "year",
   "month",
   "week",
@@ -24,5 +50,6 @@ const notValid = [
 ];
 
 notValid.forEach((smallestUnit) => {
-  assert.throws(RangeError, () => datetime.toString({ smallestUnit }), smallestUnit);
+  assert.throws(RangeError, () => datetime.toString({ smallestUnit }),
+    `"${smallestUnit}" is not a valid unit for the smallestUnit option`);
 });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/largestunit-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/largestunit-invalid-string.js
@@ -9,7 +9,20 @@ features: [Temporal]
 
 const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 const later = new Temporal.ZonedDateTime(1_000_090_061_987_654_321n, "UTC");
-const values = ["era", "eraYear", "other string"];
-for (const largestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { largestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string"
+];
+for (const largestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { largestUnit }),
+    `"${largestUnit}" is not a valid value for largestUnit`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/options-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.zoneddatetime.prototype.until
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.until(new Temporal.ZonedDateTime(3600_000_000_000n, "UTC"), value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/smallestunit-invalid-string.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/smallestunit-invalid-string.js
@@ -9,7 +9,20 @@ features: [Temporal]
 
 const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 const later = new Temporal.ZonedDateTime(1_000_090_061_987_654_321n, "UTC");
-const values = ["era", "eraYear", "other string"];
-for (const smallestUnit of values) {
-  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }));
+const badValues = [
+  "era",
+  "eraYear",
+  "millisecond\0",
+  "mill\u0131second",
+  "SECOND",
+  "eras",
+  "eraYears",
+  "milliseconds\0",
+  "mill\u0131seconds",
+  "SECONDS",
+  "other string",
+];
+for (const smallestUnit of badValues) {
+  assert.throws(RangeError, () => earlier.until(later, { smallestUnit }),
+    `"${smallestUnit}" is not a valid value for smallest unit`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/with/options-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/with/options-wrong-type.js
@@ -2,23 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.round
-description: TypeError thrown when options argument is missing or a non-string primitive
+esid: sec-temporal.zoneddatetime.prototype.with
+description: TypeError thrown when options argument is a primitive
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const badOptions = [
-  undefined,
   null,
   true,
+  "some string",
   Symbol(),
   1,
   2n,
 ];
 
-const instance = new Temporal.Instant(0n);
-assert.throws(TypeError, () => instance.round(), "TypeError on missing options argument");
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
 for (const value of badOptions) {
-  assert.throws(TypeError, () => instance.round(value),
+  assert.throws(TypeError, () => instance.with({ day: 5 }, value),
     `TypeError on wrong options type ${typeof value}`);
 };

--- a/test/intl402/Temporal/Instant/prototype/toString/timezone-offset.js
+++ b/test/intl402/Temporal/Instant/prototype/toString/timezone-offset.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: The time zone offset part of the string serialization (Intl time zones)
+features: [BigInt, Temporal]
+---*/
+
+const instant = new Temporal.Instant(0n);
+
+function test(timeZoneIdentifier, expected, description) {
+  const timeZone = new Temporal.TimeZone(timeZoneIdentifier);
+  assert.sameValue(instant.toString({ timeZone }), expected, description);
+}
+
+test("Europe/Berlin", "1970-01-01T01:00:00+01:00", "positive offset");
+test("America/New_York", "1969-12-31T19:00:00-05:00", "negative offset");
+test("Africa/Monrovia", "1969-12-31T23:15:30-00:45", "sub-minute offset");


### PR DESCRIPTION
This PR collects some improvements to `toString()` methods of Temporal objects, regarding the options for output of seconds and subseconds, and some improvements to tests for `smallestUnit` and `largestUnit` options in general.

Consists mostly of making similar tests consistent with each other, and adding better assertion messages.

Best reviewed commit by commit. There is more explanation in each commit message.