### PR TITLE
Test ISO strings with extended year -000000

### DIFF
--- a/test/built-ins/Date/parse/year-zero.js
+++ b/test/built-ins/Date/parse/year-zero.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-expanded-years
+description: Negative zero, as an extended year, is rejected
+info: |
+  The year 0 is considered positive and must be prefixed with a + sign. The
+  representation of the year 0 as -000000 is invalid.
+---*/
+
+const invalidStrings = [
+  "-000000-03-31T00:45Z",
+  "-000000-03-31T01:45",
+  "-000000-03-31T01:45:00+01:00"
+];
+
+for (const str of invalidStrings) {
+  assert.sameValue(Date.parse(str), NaN, "reject minus zero as extended year");
+}

--- a/test/built-ins/Date/year-zero.js
+++ b/test/built-ins/Date/year-zero.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-expanded-years
+description: Negative zero, as an extended year, is rejected
+info: |
+  The year 0 is considered positive and must be prefixed with a + sign. The
+  representation of the year 0 as -000000 is invalid.
+---*/
+
+const invalidStrings = [
+  "-000000-03-31T00:45Z",
+  "-000000-03-31T01:45",
+  "-000000-03-31T01:45:00+01:00"
+];
+
+for (const str of invalidStrings) {
+  assert.sameValue(+new Date(str), NaN, "reject minus zero as extended year");
+}


### PR DESCRIPTION
In Date.parse() and new Date(), representations of the year 0 as -000000
must not be accepted. In the case of Date.parse(), they should yield NaN,
and in the case of new Date(), they should yield an invalid Date object,
whose valueOf() is NaN.

See https://github.com/tc39/ecma262/pull/2550