### PR TITLE
Another batch of Temporal tests

### DIFF
--- a/test/built-ins/Temporal/Calendar/from/calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/from/calendar-number.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.from
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const arg = 19761118;
+
+const result = Temporal.Calendar.from(arg);
+assert.sameValue(result.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => Temporal.Calendar.from(arg),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/from/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/from/calendar-wrong-type.js
@@ -2,17 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.calendar.from
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +18,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Calendar.from(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Calendar.from(arg), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-number.js
@@ -2,15 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.dateadd
 description: A number is converted to a string, then to Temporal.PlainDate
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
+const result = instance.dateAdd(arg, new Temporal.Duration());
 TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
@@ -22,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.dateAdd(arg, new Temporal.Duration()),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.dateAdd(arg, new Temporal.Duration());
+TemporalHelpers.assertPlainDate(result1, 1976, 11, "M11", 18, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.dateAdd(arg, new Temporal.Duration());
+TemporalHelpers.assertPlainDate(result2, 1976, 11, "M11", 18, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.dateAdd(arg, new Temporal.Duration()),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.dateAdd(arg, new Temporal.Duration()),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.dateAdd(arg, new Temporal.Duration()), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.dateAdd(arg, new Temporal.Duration()), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.dateAdd(arg, new Temporal.Duration()), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.dateAdd(arg, new Temporal.Duration()), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.dateAdd(arg, new Temporal.Duration()), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-invalid.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-invalid.js
@@ -55,7 +55,7 @@ const instance = new Temporal.Calendar("iso8601");
 for (const arg of invalidStrings) {
   assert.throws(
     RangeError,
-    () => instance.dateAdd(arg),
+    () => instance.dateAdd(arg, new Temporal.Duration()),
     `"${arg}" should not be a valid ISO string for a PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-with-utc-designator.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-with-utc-designator.js
@@ -15,7 +15,7 @@ const instance = new Temporal.Calendar("iso8601");
 invalidStrings.forEach((arg) => {
   assert.throws(
     RangeError,
-    () => instance.dateAdd(arg),
+    () => instance.dateAdd(arg, new Temporal.Duration()),
     "String with UTC designator should not be valid as a PlainDate"
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.dateadd
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.dateAdd(arg, new Temporal.Duration()), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.dateAdd(arg, new Temporal.Duration()), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/year-zero.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/year-zero.js
@@ -12,6 +12,6 @@ const instance = new Temporal.Calendar("iso8601");
 
 assert.throws(
     RangeError,
-    () => { instance.dateAdd(arg); },
+    () => { instance.dateAdd(arg, new Temporal.Duration()); },
     "reject minus zero as extended year"
 );

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-number.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: A number is converted to a string, then to Temporal.PlainDate
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const arg = 19761118;
+
+const result1 = instance.dateUntil(arg, new Temporal.PlainDate(1976, 11, 19));
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDate (first argument)");
+const result2 = instance.dateUntil(new Temporal.PlainDate(1976, 11, 19), arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDate (second argument)");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 18)),
+    `Number ${arg} does not convert to a valid ISO string for PlainDate (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 18), arg),
+    `Number ${arg} does not convert to a valid ISO string for PlainDate (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-number.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.dateUntil(arg, new Temporal.PlainDate(1976, 11, 19));
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (first argument)");
+const result2 = instance.dateUntil(new Temporal.PlainDate(1976, 11, 19), arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (second argument)");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result3 = instance.dateUntil(arg, new Temporal.PlainDate(1976, 11, 19));
+TemporalHelpers.assertDuration(result3, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (nested property, first argument)");
+const result4 = instance.dateUntil(new Temporal.PlainDate(1976, 11, 19), arg);
+TemporalHelpers.assertDuration(result4, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (nested property, second argument)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (second argument)`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property, first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property, second argument)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg), `${description} does not convert to a valid ISO string (second argument)`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)), `${description} does not convert to a valid ISO string (nested property, first argument)`);
+  assert.throws(RangeError, () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg), `${description} does not convert to a valid ISO string (nested property, second argument)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)), `${description} is not a valid property bag and does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)), `${description} is not a valid property bag and does not convert to a string (nested property, first argument)`);
+  assert.throws(TypeError, () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg), `${description} is not a valid property bag and does not convert to a string (nested property, second argument)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)), `nested undefined calendar property is always a RangeError (first argument)`);
+assert.throws(RangeError, () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg), `nested undefined calendar property is always a RangeError (second argument)`);

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-wrong-type.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or property bag for PlainDate
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [undefined, "undefined"],
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [arg, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg), `${description} does not convert to a valid ISO string (first argument)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
+];
+
+for (const [arg, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)), `${description} is not a valid property bag and does not convert to a string (second argument)`);
+  assert.throws(TypeError, () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
+}

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.day
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.day(arg);
+assert.sameValue(result, 18, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.day(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.day
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.day(arg);
+assert.sameValue(result1, 18, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.day(arg);
+assert.sameValue(result2, 18, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.day(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.day(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.day
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.day(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.day(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.day(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.day(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.day(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.day
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.day(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.day(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.dayofweek
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.dayOfWeek(arg);
+assert.sameValue(result, 4, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.dayOfWeek(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofweek
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.dayOfWeek(arg);
+assert.sameValue(result1, 4, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.dayOfWeek(arg);
+assert.sameValue(result2, 4, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.dayOfWeek(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.dayOfWeek(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofweek
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.dayOfWeek(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.dayOfWeek(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.dayOfWeek(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.dayOfWeek(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.dayOfWeek(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.dayofweek
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.dayOfWeek(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.dayOfWeek(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.dayofyear
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.dayOfYear(arg);
+assert.sameValue(result, 323, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.dayOfYear(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofyear
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.dayOfYear(arg);
+assert.sameValue(result1, 323, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.dayOfYear(arg);
+assert.sameValue(result2, 323, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.dayOfYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.dayOfYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofyear
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.dayOfYear(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.dayOfYear(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.dayOfYear(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.dayOfYear(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.dayOfYear(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.dayofyear
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.dayOfYear(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.dayOfYear(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.daysinmonth
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.daysInMonth(arg);
+assert.sameValue(result, 30, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.daysInMonth(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinmonth
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.daysInMonth(arg);
+assert.sameValue(result1, 30, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.daysInMonth(arg);
+assert.sameValue(result2, 30, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.daysInMonth(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.daysInMonth(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinmonth
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.daysInMonth(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.daysInMonth(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.daysInMonth(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.daysInMonth(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.daysInMonth(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.daysinmonth
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.daysInMonth(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.daysInMonth(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.daysinweek
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.daysInWeek(arg);
+assert.sameValue(result, 7, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.daysInWeek(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinweek
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.daysInWeek(arg);
+assert.sameValue(result1, 7, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.daysInWeek(arg);
+assert.sameValue(result2, 7, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.daysInWeek(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.daysInWeek(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinweek
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.daysInWeek(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.daysInWeek(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.daysInWeek(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.daysInWeek(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.daysInWeek(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.daysinweek
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.daysInWeek(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.daysInWeek(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.daysinyear
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.daysInYear(arg);
+assert.sameValue(result, 366, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.daysInYear(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinyear
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.daysInYear(arg);
+assert.sameValue(result1, 366, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.daysInYear(arg);
+assert.sameValue(result2, 366, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.daysInYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.daysInYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinyear
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.daysInYear(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.daysInYear(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.daysInYear(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.daysInYear(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.daysInYear(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.daysinyear
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.daysInYear(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.daysInYear(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.inleapyear
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.inLeapYear(arg);
+assert.sameValue(result, true, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.inLeapYear(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.inleapyear
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.inLeapYear(arg);
+assert.sameValue(result1, true, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.inLeapYear(arg);
+assert.sameValue(result2, true, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.inLeapYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.inLeapYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.inleapyear
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.inLeapYear(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.inLeapYear(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.inLeapYear(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.inLeapYear(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.inLeapYear(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.inleapyear
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.inLeapYear(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.inLeapYear(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.month
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.month(arg);
+assert.sameValue(result, 11, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.month(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.month
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.month(arg);
+assert.sameValue(result1, 11, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.month(arg);
+assert.sameValue(result2, 11, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.month(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.month(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.month
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.month(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.month(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.month(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.month(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.month(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.month
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.month(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.month(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.monthcode
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.monthCode(arg);
+assert.sameValue(result, "M11", "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.monthCode(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthcode
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.monthCode(arg);
+assert.sameValue(result1, "M11", "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.monthCode(arg);
+assert.sameValue(result2, "M11", "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.monthCode(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.monthCode(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthcode
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.monthCode(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.monthCode(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.monthCode(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.monthCode(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.monthCode(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.monthcode
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.monthCode(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.monthCode(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.monthsinyear
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.monthsInYear(arg);
+assert.sameValue(result, 12, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.monthsInYear(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthsinyear
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.monthsInYear(arg);
+assert.sameValue(result1, 12, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.monthsInYear(arg);
+assert.sameValue(result2, 12, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.monthsInYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.monthsInYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthsinyear
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.monthsInYear(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.monthsInYear(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.monthsInYear(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.monthsInYear(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.monthsInYear(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.monthsinyear
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.monthsInYear(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.monthsInYear(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.weekofyear
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.weekOfYear(arg);
+assert.sameValue(result, 47, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.weekOfYear(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.weekofyear
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.weekOfYear(arg);
+assert.sameValue(result1, 47, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.weekOfYear(arg);
+assert.sameValue(result2, 47, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.weekOfYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.weekOfYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.weekofyear
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.weekOfYear(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.weekOfYear(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.weekOfYear(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.weekOfYear(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.weekOfYear(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.weekofyear
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.weekOfYear(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.weekOfYear(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.year
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.year(arg);
+assert.sameValue(result, 1976, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.year(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.year
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.year(arg);
+assert.sameValue(result1, 1976, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.year(arg);
+assert.sameValue(result2, 1976, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.year(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.year(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.year
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.year(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.year(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.year(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.year(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.year(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.year
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.year(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.year(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Duration/compare/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/compare/timezone-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => Temporal.Duration.compare(new Temporal.Duration(), new Temporal.Duration(), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-number.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: A number as relativeTo option is converted to a string, then to Temporal.PlainDate
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+const relativeTo = 20191101;
+
+const result = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
+TemporalHelpers.assertDuration(result, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "20191101 is a valid ISO string for relativeTo");
+
+const numbers = [
+  1,
+  -20191101,
+  1234567890,
+];
+
+for (const relativeTo of numbers) {
+  assert.throws(
+    RangeError,
+    () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }),
+    `Number ${relativeTo} does not convert to a valid ISO string for relativeTo`
+  );
+}

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: A number as calendar in relativeTo property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+const calendar = 19970327;
+
+let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+const result1 = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
+TemporalHelpers.assertDuration(result1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for relativeTo.calendar");
+
+relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+const result2 = instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
+TemporalHelpers.assertDuration(result2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for relativeTo.calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }),
+    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar`
+  );
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }),
+    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-wrong-type.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: >
+  Appropriate error thrown when relativeTo.calendar cannot be converted to a
+  calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), `${description} does not convert to a valid ISO string`);
+
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), `${description} is not a valid property bag and does not convert to a string`);
+
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-wrong-type.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: >
+  Appropriate error thrown when relativeTo cannot be converted to a valid
+  relativeTo string or property bag
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+const rangeErrorTests = [
+  [undefined, "undefined"],
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [relativeTo, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), `${description} does not convert to a valid ISO string`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+];
+
+for (const [relativeTo, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo }), `${description} is not a valid property bag and does not convert to a string`);
+}

--- a/test/built-ins/Temporal/Duration/prototype/add/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.Duration(1);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.add(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-number.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: A number as relativeTo option is converted to a string, then to Temporal.PlainDate
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+const relativeTo = 20191101;
+
+const result = instance.round({ largestUnit: "years", relativeTo });
+TemporalHelpers.assertDuration(result, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, "20191101 is a valid ISO string for relativeTo");
+
+const numbers = [
+  1,
+  -20191101,
+  1234567890,
+];
+
+for (const relativeTo of numbers) {
+  assert.throws(
+    RangeError,
+    () => instance.round({ largestUnit: "years", relativeTo }),
+    `Number ${relativeTo} does not convert to a valid ISO string for relativeTo`
+  );
+}

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: A number as calendar in relativeTo property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+const calendar = 19970327;
+
+let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+const result1 = instance.round({ largestUnit: "years", relativeTo });
+TemporalHelpers.assertDuration(result1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for relativeTo.calendar");
+
+relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+const result2 = instance.round({ largestUnit: "years", relativeTo });
+TemporalHelpers.assertDuration(result2, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for relativeTo.calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.round({ largestUnit: "years", relativeTo }),
+    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar`
+  );
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.round({ largestUnit: "years", relativeTo }),
+    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-wrong-type.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  Appropriate error thrown when relativeTo.calendar cannot be converted to a
+  calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.round({ largestUnit: "years", relativeTo }), `${description} does not convert to a valid ISO string`);
+
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.round({ largestUnit: "years", relativeTo }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.round({ largestUnit: "years", relativeTo }), `${description} is not a valid property bag and does not convert to a string`);
+
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.round({ largestUnit: "years", relativeTo }), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.round({ largestUnit: "years", relativeTo }), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-wrong-type.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  Appropriate error thrown when relativeTo cannot be converted to a valid
+  relativeTo string or property bag
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+const rangeErrorTests = [
+  [undefined, "undefined"],
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [relativeTo, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.round({ largestUnit: "years", relativeTo }), `${description} does not convert to a valid ISO string`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+];
+
+for (const [relativeTo, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.round({ largestUnit: "years", relativeTo }), `${description} is not a valid property bag and does not convert to a string`);
+}

--- a/test/built-ins/Temporal/Duration/prototype/round/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.Duration(1);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.round({ largestUnit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-number.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: A number as relativeTo option is converted to a string, then to Temporal.PlainDate
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+const relativeTo = 20191101;
+
+const result = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
+TemporalHelpers.assertDuration(result, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "20191101 is a valid ISO string for relativeTo");
+
+const numbers = [
+  1,
+  -20191101,
+  1234567890,
+];
+
+for (const relativeTo of numbers) {
+  assert.throws(
+    RangeError,
+    () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }),
+    `Number ${relativeTo} does not convert to a valid ISO string for relativeTo`
+  );
+}

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: A number as calendar in relativeTo property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+const calendar = 19970327;
+
+let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+const result1 = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
+TemporalHelpers.assertDuration(result1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for relativeTo.calendar");
+
+relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+const result2 = instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
+TemporalHelpers.assertDuration(result2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for relativeTo.calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }),
+    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar`
+  );
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }),
+    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-wrong-type.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: >
+  Appropriate error thrown when relativeTo.calendar cannot be converted to a
+  calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), `${description} does not convert to a valid ISO string`);
+
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), `${description} is not a valid property bag and does not convert to a string`);
+
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-wrong-type.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: >
+  Appropriate error thrown when relativeTo cannot be converted to a valid
+  relativeTo string or property bag
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+const rangeErrorTests = [
+  [undefined, "undefined"],
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [relativeTo, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), `${description} does not convert to a valid ISO string`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+];
+
+for (const [relativeTo, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo }), `${description} is not a valid property bag and does not convert to a string`);
+}

--- a/test/built-ins/Temporal/Duration/prototype/subtract/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.Duration(1);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.subtract(new Temporal.Duration(1), { relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-number.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: A number as relativeTo option is converted to a string, then to Temporal.PlainDate
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+const relativeTo = 20191101;
+
+const result = instance.total({ unit: "days", relativeTo });
+assert.sameValue(result, 367, "20191101 is a valid ISO string for relativeTo");
+
+const numbers = [
+  1,
+  -20191101,
+  1234567890,
+];
+
+for (const relativeTo of numbers) {
+  assert.throws(
+    RangeError,
+    () => instance.total({ unit: "days", relativeTo }),
+    `Number ${relativeTo} does not convert to a valid ISO string for relativeTo`
+  );
+}

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: A number as calendar in relativeTo property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+const calendar = 19970327;
+
+let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+const result1 = instance.total({ unit: "days", relativeTo });
+assert.sameValue(result1, 367, "19970327 is a valid ISO string for relativeTo.calendar");
+
+relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+const result2 = instance.total({ unit: "days", relativeTo });
+assert.sameValue(result2, 367, "19970327 is a valid ISO string for relativeTo.calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.total({ unit: "days", relativeTo }),
+    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar`
+  );
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.total({ unit: "days", relativeTo }),
+    `Number ${calendar} does not convert to a valid ISO string for relativeTo.calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-wrong-type.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  Appropriate error thrown when relativeTo.calendar cannot be converted to a
+  calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.total({ unit: "days", relativeTo }), `${description} does not convert to a valid ISO string`);
+
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.total({ unit: "days", relativeTo }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.total({ unit: "days", relativeTo }), `${description} is not a valid property bag and does not convert to a string`);
+
+  relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.total({ unit: "days", relativeTo }), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const relativeTo = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.total({ unit: "days", relativeTo }), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-wrong-type.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  Appropriate error thrown when relativeTo cannot be converted to a valid
+  relativeTo string or property bag
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+const rangeErrorTests = [
+  [undefined, "undefined"],
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [relativeTo, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.total({ unit: "days", relativeTo }), `${description} does not convert to a valid ISO string`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+];
+
+for (const [relativeTo, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.total({ unit: "days", relativeTo }), `${description} is not a valid property bag and does not convert to a string`);
+}

--- a/test/built-ins/Temporal/Duration/prototype/total/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.Duration(1);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone } }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.total({ unit: "months", relativeTo: { year: 2000, month: 5, day: 2, timeZone: { timeZone } } }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Instant/compare/argument-object-tostring.js
+++ b/test/built-ins/Temporal/Instant/compare/argument-object-tostring.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.compare
+description: Object is converted to a string, then to Temporal.Instant
+features: [Temporal]
+---*/
+
+const epoch = new Temporal.Instant(0n);
+
+const arg = {};
+assert.throws(RangeError, () => Temporal.Instant.compare(arg, epoch), "[object Object] is not a valid ISO string (first argument)");
+assert.throws(RangeError, () => Temporal.Instant.compare(epoch, arg), "[object Object] is not a valid ISO string (second argument)");
+
+arg.toString = function() {
+  return "1970-01-01T00:00Z";
+};
+const result1 = Temporal.Instant.compare(arg, epoch);
+assert.sameValue(result1, 0, "result of toString is interpreted as ISO string (first argument)");
+const result2 = Temporal.Instant.compare(epoch, arg);
+assert.sameValue(result2, 0, "result of toString is interpreted as ISO string (second argument)");

--- a/test/built-ins/Temporal/Instant/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/compare/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.equals
+esid: sec-temporal.instant.compare
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
   for Instant
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.Instant(0n);
+const other = new Temporal.Instant(0n);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -24,7 +24,8 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Instant.compare(arg, other), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => Temporal.Instant.compare(other, arg), `${description} does not convert to a valid ISO string (second argument)`);
 }
 
 const typeErrorTests = [
@@ -33,5 +34,6 @@ const typeErrorTests = [
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Instant.compare(arg, other), `${description} does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => Temporal.Instant.compare(other, arg), `${description} does not convert to a string (second argument)`);
 }

--- a/test/built-ins/Temporal/Instant/compare/instant-string-sub-minute-offset.js
+++ b/test/built-ins/Temporal/Instant/compare/instant-string-sub-minute-offset.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.compare
+description: Temporal.Instant string with sub-minute offset
+features: [Temporal]
+---*/
+
+const epoch = new Temporal.Instant(0n);
+const str = "1970-01-01T00:19:32.37+00:19:32.37";
+
+const result1 = Temporal.Instant.compare(str, epoch);
+assert.sameValue(result1, 0, "if present, sub-minute offset is accepted exactly (first argument)");
+
+const result2 = Temporal.Instant.compare(epoch, str);
+assert.sameValue(result2, 0, "if present, sub-minute offset is accepted exactly (second argument)");

--- a/test/built-ins/Temporal/Instant/from/argument-object-tostring.js
+++ b/test/built-ins/Temporal/Instant/from/argument-object-tostring.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.from
+description: Object is converted to a string, then to Temporal.Instant
+features: [Temporal]
+---*/
+
+const arg = {};
+assert.throws(RangeError, () => Temporal.Instant.from(arg), "[object Object] is not a valid ISO string");
+
+arg.toString = function() {
+  return "1970-01-01T00:00Z";
+};
+const result = Temporal.Instant.from(arg);
+assert.sameValue(result.epochNanoseconds, 0n, "result of toString is interpreted as ISO string");

--- a/test/built-ins/Temporal/Instant/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/from/argument-wrong-type.js
@@ -2,14 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.instant.from
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  for Instant
 features: [BigInt, Symbol, Temporal]
 ---*/
-
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -17,20 +15,21 @@ const rangeErrorTests = [
   [true, "boolean"],
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [{}, "plain object"],
+  [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Instant.from(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.Instant.prototype, "Temporal.Instant.prototype, object"],  // fails brand check in toString()
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Instant.from(arg), `${description} does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Instant/from/basic.js
+++ b/test/built-ins/Temporal/Instant/from/basic.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.from
+description: Basic functionality of Temporal.Instant.from
+features: [Temporal]
+---*/
+
+const baseValue = 217_178_580_000_000_000n;
+
+let instant = Temporal.Instant.from("1976-11-18T15:23Z");
+assert.sameValue(
+  instant.epochNanoseconds,
+  baseValue,
+  "ISO string with UTC designator and minutes precision"
+);
+
+instant = Temporal.Instant.from("1976-11-18T15:23:30Z");
+assert.sameValue(
+  instant.epochNanoseconds,
+  baseValue + 30_000_000_000n,
+  "ISO string with UTC designator and seconds precision"
+);
+
+instant = Temporal.Instant.from("1976-11-18T15:23:30.123Z");
+assert.sameValue(
+  instant.epochNanoseconds,
+  baseValue + 30_123_000_000n,
+  "ISO string with UTC designator and milliseconds precision"
+);
+
+instant = Temporal.Instant.from("1976-11-18T15:23:30.123456Z");
+assert.sameValue(
+  instant.epochNanoseconds,
+  baseValue + 30_123_456_000n,
+  "ISO string with UTC designator and microseconds precision"
+);
+
+instant = Temporal.Instant.from("1976-11-18T15:23:30.123456789Z");
+assert.sameValue(
+  instant.epochNanoseconds,
+  baseValue + 30_123_456_789n,
+  "ISO string with UTC designator and nanoseconds precision"
+);
+
+instant = Temporal.Instant.from("1976-11-18T15:23-01:00");
+assert.sameValue(
+  instant.epochNanoseconds,
+  baseValue + 3600_000_000_000n,
+  "ISO string with negative UTC offset"
+);
+
+instant = Temporal.Instant.from("1976-11-18T15:23+01:00");
+assert.sameValue(
+  instant.epochNanoseconds,
+  baseValue - 3600_000_000_000n,
+  "ISO string with positive UTC offset"
+);

--- a/test/built-ins/Temporal/Instant/from/instant-string-sub-minute-offset.js
+++ b/test/built-ins/Temporal/Instant/from/instant-string-sub-minute-offset.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.from
+description: Temporal.Instant string with sub-minute offset
+features: [Temporal]
+---*/
+
+const str = "1970-01-01T00:19:32.37+00:19:32.37";
+const result = Temporal.Instant.from(str);
+assert.sameValue(result.epochNanoseconds, 0n, "if present, sub-minute offset is accepted exactly");

--- a/test/built-ins/Temporal/Instant/prototype/equals/argument-object-tostring.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/argument-object-tostring.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.equals
+description: Object is converted to a string, then to Temporal.Instant
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const arg = {};
+assert.throws(RangeError, () => instance.equals(arg), "[object Object] is not a valid ISO string");
+
+arg.toString = function() {
+  return "1970-01-01T00:00Z";
+};
+const result = instance.equals(arg);
+assert.sameValue(result, true, "result of toString is interpreted as ISO string");

--- a/test/built-ins/Temporal/Instant/prototype/equals/instant-string-sub-minute-offset.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/instant-string-sub-minute-offset.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.equals
+description: Temporal.Instant string with sub-minute offset
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const str = "1970-01-01T00:19:32.37+00:19:32.37";
+const result = instance.equals(str);
+assert.sameValue(result, true, "if present, sub-minute offset is accepted exactly");

--- a/test/built-ins/Temporal/Instant/prototype/since/argument-object-tostring.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/argument-object-tostring.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: Object is converted to a string, then to Temporal.Instant
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const arg = {};
+assert.throws(RangeError, () => instance.since(arg), "[object Object] is not a valid ISO string");
+
+arg.toString = function() {
+  return "1970-01-01T00:00Z";
+};
+const result = instance.since(arg);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "result of toString is interpreted as ISO string");

--- a/test/built-ins/Temporal/Instant/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.instant.prototype.since
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  for Instant
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Instant(0n);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -17,20 +17,21 @@ const rangeErrorTests = [
   [true, "boolean"],
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [{}, "plain object"],
+  [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.Instant.prototype, "Temporal.Instant.prototype, object"],  // fails brand check in toString()
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.since(arg), `${description} does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Instant/prototype/since/instant-string-sub-minute-offset.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/instant-string-sub-minute-offset.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: Temporal.Instant string with sub-minute offset
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const str = "1970-01-01T00:19:32.37+00:19:32.37";
+const result = instance.since(str);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "if present, sub-minute offset is accepted exactly");

--- a/test/built-ins/Temporal/Instant/prototype/toString/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.toString({ timeZone }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toString({ timeZone: { timeZone } }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.toString({ timeZone }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toString({ timeZone: { timeZone } }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.toString({ timeZone: { timeZone } }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-number.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-number.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tozoneddatetime
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
+
+const arg = 19761118;
+
+const result = instance.toZonedDateTime({ calendar: arg, timeZone: "UTC" });
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => instance.toZonedDateTime({ calendar: arg, timeZone: "UTC" }),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-wrong-type.js
@@ -2,17 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.instant.prototype.tozoneddatetime
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
 
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +20,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toZonedDateTime({ calendar: arg, timeZone: "UTC" }), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toZonedDateTime({ calendar: arg, timeZone: "UTC" }), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tozoneddatetime
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.toZonedDateTime({ timeZone, calendar: "iso8601" }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toZonedDateTime({ timeZone: { timeZone }, calendar: "iso8601" }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.toZonedDateTime({ timeZone, calendar: "iso8601" }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toZonedDateTime({ timeZone: { timeZone }, calendar: "iso8601" }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.toZonedDateTime({ timeZone: { timeZone }, calendar: "iso8601" }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tozoneddatetimeiso
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.toZonedDateTimeISO(timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toZonedDateTimeISO({ timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.toZonedDateTimeISO(timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toZonedDateTimeISO({ timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.toZonedDateTimeISO({ timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Instant/prototype/until/argument-object-tostring.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/argument-object-tostring.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: Object is converted to a string, then to Temporal.Instant
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const arg = {};
+assert.throws(RangeError, () => instance.until(arg), "[object Object] is not a valid ISO string");
+
+arg.toString = function() {
+  return "1970-01-01T00:00Z";
+};
+const result = instance.until(arg);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "result of toString is interpreted as ISO string");

--- a/test/built-ins/Temporal/Instant/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.instant.prototype.until
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  for Instant
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Instant(0n);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -17,20 +17,21 @@ const rangeErrorTests = [
   [true, "boolean"],
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [{}, "plain object"],
+  [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.Instant.prototype, "Temporal.Instant.prototype, object"],  // fails brand check in toString()
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.until(arg), `${description} does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Instant/prototype/until/instant-string-sub-minute-offset.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/instant-string-sub-minute-offset.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: Temporal.Instant string with sub-minute offset
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const str = "1970-01-01T00:19:32.37+00:19:32.37";
+const result = instance.until(str);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "if present, sub-minute offset is accepted exactly");

--- a/test/built-ins/Temporal/Now/plainDate/calendar-number.js
+++ b/test/built-ins/Temporal/Now/plainDate/calendar-number.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.plaindate
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const arg = 19761118;
+
+const result = Temporal.Now.plainDate(arg);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => Temporal.Now.plainDate(arg),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/Now/plainDate/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDate/calendar-wrong-type.js
@@ -2,17 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.now.plaindate
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +18,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.plainDate(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.plainDate(arg), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Now/plainDate/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDate/timezone-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.plaindate
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.Now.plainDate("iso8601", timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.plainDate("iso8601", { timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.Now.plainDate("iso8601", timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.plainDate("iso8601", { timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => Temporal.Now.plainDate("iso8601", { timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Now/plainDateISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateISO/timezone-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.plaindateiso
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.Now.plainDateISO(timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.plainDateISO({ timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.Now.plainDateISO(timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.plainDateISO({ timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => Temporal.Now.plainDateISO({ timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Now/plainDateTime/calendar-number.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/calendar-number.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.plaindatetime
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const arg = 19761118;
+
+const result = Temporal.Now.plainDateTime(arg);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => Temporal.Now.plainDateTime(arg),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/Now/plainDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/calendar-wrong-type.js
@@ -2,17 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.now.plaindatetime
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +18,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.plainDateTime(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.plainDateTime(arg), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Now/plainDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/timezone-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.plaindatetime
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.Now.plainDateTime("iso8601", timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.plainDateTime("iso8601", { timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.Now.plainDateTime("iso8601", timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.plainDateTime("iso8601", { timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => Temporal.Now.plainDateTime("iso8601", { timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.plaindatetimeiso
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO(timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO({ timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.Now.plainDateTimeISO(timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.plainDateTimeISO({ timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => Temporal.Now.plainDateTimeISO({ timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Now/plainTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainTimeISO/timezone-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.plaintimeiso
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.Now.plainTimeISO(timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.plainTimeISO({ timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.Now.plainTimeISO(timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.plainTimeISO({ timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => Temporal.Now.plainTimeISO({ timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Now/zonedDateTime/calendar-number.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/calendar-number.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.zoneddatetime
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const arg = 19761118;
+
+const result = Temporal.Now.zonedDateTime(arg);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => Temporal.Now.zonedDateTime(arg),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/Now/zonedDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/calendar-wrong-type.js
@@ -2,17 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.now.zoneddatetime
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +18,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.zonedDateTime(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.zonedDateTime(arg), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/Now/zonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/timezone-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.zoneddatetime
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.Now.zonedDateTime("iso8601", timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.zonedDateTime("iso8601", { timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.Now.zonedDateTime("iso8601", timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.zonedDateTime("iso8601", { timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => Temporal.Now.zonedDateTime("iso8601", { timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.now.zoneddatetimeiso
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.Now.zonedDateTimeISO(timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.zonedDateTimeISO({ timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.Now.zonedDateTimeISO(timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.zonedDateTimeISO({ timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => Temporal.Now.zonedDateTimeISO({ timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/PlainDate/calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/calendar-number.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const arg = 19761118;
+
+const result = new Temporal.PlainDate(2000, 5, 2, arg);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => new Temporal.PlainDate(2000, 5, 2, arg),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/calendar-wrong-type.js
@@ -2,17 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.plaindate
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +18,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => new Temporal.PlainDate(2000, 5, 2, arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => new Temporal.PlainDate(2000, 5, 2, arg), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDate/compare/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-number.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.compare
+description: A number is converted to a string, then to Temporal.PlainDate
+features: [Temporal]
+---*/
+
+const arg = 19761118;
+
+const result1 = Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18));
+assert.sameValue(result1, 0, "19761118 is a valid ISO string for PlainDate (first argument)");
+const result2 = Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg);
+assert.sameValue(result2, 0, "19761118 is a valid ISO string for PlainDate (second argument)");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)),
+    `Number ${arg} does not convert to a valid ISO string for PlainDate (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg),
+    `Number ${arg} does not convert to a valid ISO string for PlainDate (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-number.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.compare
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18));
+assert.sameValue(result1, 0, "19970327 is a valid ISO string for calendar (first argument)");
+const result2 = Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg);
+assert.sameValue(result2, 0, "19970327 is a valid ISO string for calendar (first argument)");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result3 = Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18));
+assert.sameValue(result3, 0, "19970327 is a valid ISO string for calendar (nested property, first argument)");
+const result4 = Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg);
+assert.sameValue(result4, 0, "19970327 is a valid ISO string for calendar (nested property, first argument)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (second argument)`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property, first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property, second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.compare
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg), `${description} does not convert to a valid ISO string (second argument)`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)), `${description} does not convert to a valid ISO string (nested property, first argument)`);
+  assert.throws(RangeError, () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg), `${description} does not convert to a valid ISO string (nested property, second argument)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)), `${description} is not a valid property bag and does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)), `${description} is not a valid property bag and does not convert to a string (nested property, first argument)`);
+  assert.throws(TypeError, () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg), `${description} is not a valid property bag and does not convert to a string (nested property, second argument)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)), `nested undefined calendar property is always a RangeError (first argument)`);
+assert.throws(RangeError, () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg), `nested undefined calendar property is always a RangeError (second argument)`);

--- a/test/built-ins/Temporal/PlainDate/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-wrong-type.js
@@ -2,14 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.prototype.equals
+esid: sec-temporal.plaindate.compare
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
   or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
-
-const instance = new Temporal.PlainDate(2000, 5, 2);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,7 +19,8 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg), `${description} does not convert to a valid ISO string (second argument)`);
 }
 
 const typeErrorTests = [
@@ -32,5 +31,6 @@ const typeErrorTests = [
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)), `${description} is not a valid property bag and does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
 }

--- a/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-number.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = Temporal.PlainDate.from(arg);
+TemporalHelpers.assertPlainDate(result1, 1976, 11, "M11", 18, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = Temporal.PlainDate.from(arg);
+TemporalHelpers.assertPlainDate(result2, 1976, 11, "M11", 18, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.from(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.from(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => Temporal.PlainDate.from(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => Temporal.PlainDate.from(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => Temporal.PlainDate.from(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => Temporal.PlainDate.from(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => Temporal.PlainDate.from(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainDate/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-wrong-type.js
@@ -2,14 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaindate.from
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
-
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +19,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.PlainDate.from(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.PlainDate.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.plaindate.prototype.equals
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainDate(1976, 11, 18);
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.equals(arg);
+assert.sameValue(result, true, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.equals(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.equals
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(1976, 11, 18);
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.equals(arg);
+assert.sameValue(result1, true, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.equals(arg);
+assert.sameValue(result2, true, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.equals
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.equals(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.plaindate.prototype.since
 description: A number is converted to a string, then to Temporal.PlainDate
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainDate(1976, 11, 18);
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.since(arg);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.since(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(1976, 11, 18);
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.since(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.since(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.since(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaindate.prototype.since
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.PlainDate(2000, 5, 2);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.from
+esid: sec-temporal.plaindate.prototype.toplaindatetime
 description: A number is converted to a string, then to Temporal.PlainTime
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
 const arg = 123456.987654321;
 
-const result = Temporal.PlainTime.from(arg);
-TemporalHelpers.assertPlainTime(result, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
+const result = instance.toPlainDateTime(arg);
+TemporalHelpers.assertPlainDateTime(result, 2000, 5, "M05", 2, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -23,7 +25,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainTime.from(arg),
+    () => instance.toPlainDateTime(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainTime`
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-designator-required-for-disambiguation.js
@@ -32,7 +32,7 @@ ambiguousStrings.forEach((string) => {
   assert.throws(
     RangeError,
     () => instance.toPlainDateTime(arg),
-    'space is not accepted as a substitute for T prefix'
+    "space is not accepted as a substitute for T prefix"
   );
 });
 

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-wrong-type.js
@@ -2,17 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaindate.prototype.toplaindatetime
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainTime
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.PlainDate(2000, 5, 2);
 
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +20,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toPlainDateTime(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainTime, "Temporal.PlainTime, object"],
+  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toPlainDateTime(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/plaintime-propertybag-no-time-units.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/plaintime-propertybag-no-time-units.js
@@ -11,7 +11,7 @@ features: [Temporal]
 const instance = new Temporal.PlainDate(2000, 1, 1);
 
 const props = {};
-assert.throws(TypeError, () => instance.toPlainDateTime(props), "TypeError if at least one property is not present");
+assert.throws(TypeError, () => instance.toPlainDateTime(props), "TypeError if no properties are present");
 
 props.minute = 30;
 const result = instance.toPlainDateTime(props);

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/year-zero.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/year-zero.js
@@ -8,8 +8,8 @@ features: [Temporal, arrow-function]
 ---*/
 
 const invalidStrings = [
-  '-000000-12-07T03:24:30',
-  '-000000-12-07T03:24:30+01:00[UTC]'
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
 ];
 const instance = new Temporal.PlainDate(2000, 5, 2);
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.from
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
 description: A number is converted to a string, then to Temporal.PlainTime
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
 const arg = 123456.987654321;
 
-const result = Temporal.PlainTime.from(arg);
-TemporalHelpers.assertPlainTime(result, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
+const result = instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" });
+assert.sameValue(result.epochNanoseconds, 957270896_987_654_321n, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -23,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainTime.from(arg),
+    () => instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" }),
     `Number ${arg} does not convert to a valid ISO string for PlainTime`
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-time-designator-required-for-disambiguation.js
@@ -32,7 +32,7 @@ ambiguousStrings.forEach((string) => {
   assert.throws(
     RangeError,
     () => instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" }),
-    'space is not accepted as a substitute for T prefix'
+    "space is not accepted as a substitute for T prefix"
   );
 });
 

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-wrong-type.js
@@ -2,17 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainTime
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.PlainDate(2000, 5, 2);
 
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +20,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" }), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainTime, "Temporal.PlainTime, object"],
+  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" }), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/plaintime-propertybag-no-time-units.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/plaintime-propertybag-no-time-units.js
@@ -10,7 +10,7 @@ features: [Temporal]
 const instance = new Temporal.PlainDate(2000, 1, 1);
 
 const props = {};
-assert.throws(TypeError, () => instance.toZonedDateTime({ plainTime: props, timeZone: "UTC" }), "TypeError if at least one property is not present");
+assert.throws(TypeError, () => instance.toZonedDateTime({ plainTime: props, timeZone: "UTC" }), "TypeError if no properties are present");
 
 props.minute = 30;
 const result = instance.toZonedDateTime({ plainTime: props, timeZone: "UTC" });

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.toZonedDateTime(timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toZonedDateTime({ timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.toZonedDateTime(timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toZonedDateTime({ timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.toZonedDateTime({ timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/year-zero.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/year-zero.js
@@ -8,8 +8,8 @@ features: [Temporal, arrow-function]
 ---*/
 
 const invalidStrings = [
-  '-000000-12-07T03:24:30',
-  '-000000-12-07T03:24:30+01:00[UTC]'
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
 ];
 const instance = new Temporal.PlainDate(2000, 5, 2);
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.plaindate.prototype.until
 description: A number is converted to a string, then to Temporal.PlainDate
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainDate(1976, 11, 18);
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.until(arg);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.until(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(1976, 11, 18);
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.until(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.until(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.until(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaindate.prototype.until
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.PlainDate(2000, 5, 2);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-number.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-number.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.withcalendar
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(1976, 11, 18, { id: "replace-me" });
+
+const arg = 19761118;
+
+const result = instance.withCalendar(arg);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => instance.withCalendar(arg),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-wrong-type.js
@@ -2,17 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.plaindate.prototype.withcalendar
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const instance = new Temporal.PlainDate(1976, 11, 18, { id: "replace-me" });
 
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +20,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.withCalendar(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.withCalendar(arg), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/calendar-number.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const arg = 19761118;
+
+const result = new Temporal.PlainDateTime(2000, 5, 2, 15, 23, 30, 987, 654, 321, arg);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => new Temporal.PlainDateTime(2000, 5, 2, 15, 23, 30, 987, 654, 321, arg),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/calendar-wrong-type.js
@@ -2,17 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.plaindatetime
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +18,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => new Temporal.PlainDateTime(2000, 5, 2, 15, 23, 30, 987, 654, 321, arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => new Temporal.PlainDateTime(2000, 5, 2, 15, 23, 30, 987, 654, 321, arg), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-number.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: A number is converted to a string, then to Temporal.PlainDateTime
+features: [Temporal]
+---*/
+
+let arg = 19761118;
+
+const result1 = Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18));
+assert.sameValue(result1, 0, "19761118 is a valid ISO string for PlainDateTime (first argument)");
+const result2 = Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg);
+assert.sameValue(result2, 0, "19761118 is a valid ISO string for PlainDateTime (second argument)");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)),
+    `Number ${arg} does not convert to a valid ISO string for PlainDateTime (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg),
+    `Number ${arg} does not convert to a valid ISO string for PlainDateTime (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-number.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18));
+assert.sameValue(result1, 0, "19970327 is a valid ISO string for calendar (first argument)");
+const result2 = Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg);
+assert.sameValue(result2, 0, "19970327 is a valid ISO string for calendar (second argument)");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result3 = Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18));
+assert.sameValue(result3, 0, "19970327 is a valid ISO string for calendar (nested property, first argument)");
+const result4 = Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg);
+assert.sameValue(result4, 0, "19970327 is a valid ISO string for calendar (nested property, second argument)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (second argument)`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property, first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property, second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg), `${description} does not convert to a valid ISO string (second argument)`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)), `${description} does not convert to a valid ISO string (nested property, first argument)`);
+  assert.throws(RangeError, () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg), `${description} does not convert to a valid ISO string (nested property, second argument)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)), `${description} is not a valid property bag and does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)), `${description} is not a valid property bag and does not convert to a string (nested property, first argument)`);
+  assert.throws(TypeError, () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg), `${description} is not a valid property bag and does not convert to a string (nested property, second argument)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)), `nested undefined calendar property is always a RangeError (first argument)`);
+assert.throws(RangeError, () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg), `nested undefined calendar property is always a RangeError (second argument)`);

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or property bag for PlainDateTime
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [undefined, "undefined"],
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [arg, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg), `${description} does not convert to a valid ISO string (second argument)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
+  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+];
+
+for (const [arg, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)), `${description} is not a valid property bag and does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
+}

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-number.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = Temporal.PlainDateTime.from(arg);
+TemporalHelpers.assertPlainDateTime(result1, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = Temporal.PlainDateTime.from(arg);
+TemporalHelpers.assertPlainDateTime(result2, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.from(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.from(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => Temporal.PlainDateTime.from(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => Temporal.PlainDateTime.from(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => Temporal.PlainDateTime.from(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => Temporal.PlainDateTime.from(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => Temporal.PlainDateTime.from(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-wrong-type.js
@@ -2,14 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaindatetime.from
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
   or property bag for PlainDateTime
 features: [BigInt, Symbol, Temporal]
 ---*/
-
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,7 +19,7 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.PlainDateTime.from(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
@@ -32,5 +30,5 @@ const typeErrorTests = [
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.PlainDateTime.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindatetime.prototype.equals
 description: A number is converted to a string, then to Temporal.PlainDateTime
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainDateTime(1976, 11, 18);
+
 let arg = 19761118;
 
-const result = Temporal.PlainDateTime.from(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDateTime");
+const result = instance.equals(arg);
+assert.sameValue(result, true, "19761118 is a valid ISO string for PlainDateTime");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDateTime.from(arg),
+    () => instance.equals(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDateTime`
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(1976, 11, 18);
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.equals(arg);
+assert.sameValue(result1, true, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.equals(arg);
+assert.sameValue(result2, true, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.equals(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindatetime.prototype.since
 description: A number is converted to a string, then to Temporal.PlainDateTime
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainDateTime(1976, 11, 18);
+
 let arg = 19761118;
 
-const result = Temporal.PlainDateTime.from(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDateTime");
+const result = instance.since(arg);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDateTime");
 
 const numbers = [
   1,
@@ -22,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDateTime.from(arg),
+    () => instance.since(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDateTime`
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(1976, 11, 18);
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.since(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.since(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.since(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-wrong-type.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaindatetime.prototype.since
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
   or property bag for PlainDateTime
@@ -21,7 +21,7 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
@@ -32,5 +32,5 @@ const typeErrorTests = [
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tozoneddatetime
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.toZonedDateTime(timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toZonedDateTime({ timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.toZonedDateTime(timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toZonedDateTime({ timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.toZonedDateTime({ timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindatetime.prototype.until
 description: A number is converted to a string, then to Temporal.PlainDateTime
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainDateTime(1976, 11, 18);
+
 let arg = 19761118;
 
-const result = Temporal.PlainDateTime.from(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDateTime");
+const result = instance.until(arg);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDateTime");
 
 const numbers = [
   1,
@@ -22,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDateTime.from(arg),
+    () => instance.until(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDateTime`
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(1976, 11, 18);
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.until(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.until(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.until(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-wrong-type.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaindatetime.prototype.until
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
   or property bag for PlainDateTime
@@ -21,7 +21,7 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
@@ -32,5 +32,5 @@ const typeErrorTests = [
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-number.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withcalendar
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789, { id: "replace-me" });
+
+const arg = 19761118;
+
+const result = instance.withCalendar(arg);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => instance.withCalendar(arg),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-wrong-type.js
@@ -2,17 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.plaindatetime.prototype.withcalendar
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789, { id: "replace-me" });
 
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +20,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.withCalendar(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.withCalendar(arg), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.plaindatetime.prototype.withplaindate
 description: A number is converted to a string, then to Temporal.PlainDate
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.withPlainDate(arg);
+TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.withPlainDate(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaindate
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.withPlainDate(arg);
+TemporalHelpers.assertPlainDateTime(result1, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.withPlainDate(arg);
+TemporalHelpers.assertPlainDateTime(result2, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.withPlainDate(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.withPlainDate(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaindate
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.withPlainDate(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.withPlainDate(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.withPlainDate(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.withPlainDate(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.withPlainDate(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-wrong-type.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaindatetime.prototype.withplaindate
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.withPlainDate(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.withPlainDate(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-number.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.from
+esid: sec-temporal.plaindatetime.prototype.withplaintime
 description: A number is converted to a string, then to Temporal.PlainTime
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
+
 const arg = 123456.987654321;
 
-const result = Temporal.PlainTime.from(arg);
-TemporalHelpers.assertPlainTime(result, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
+const result = instance.withPlainTime(arg);
+TemporalHelpers.assertPlainDateTime(result, 2000, 5, "M05", 2, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -23,7 +25,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainTime.from(arg),
+    () => instance.withPlainTime(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainTime`
   );
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-wrong-type.js
@@ -2,17 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaindatetime.prototype.withplaintime
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainTime
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +20,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.withPlainTime(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainTime, "Temporal.PlainTime, object"],
+  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.withPlainTime(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/plaintime-propertybag-no-time-units.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/plaintime-propertybag-no-time-units.js
@@ -11,7 +11,7 @@ features: [Temporal]
 const instance = new Temporal.PlainDateTime(2000, 1, 1, 12, 30, 45, 123, 456, 789);
 
 const props = {};
-assert.throws(TypeError, () => instance.withPlainTime(props), "TypeError if at least one property is not present");
+assert.throws(TypeError, () => instance.withPlainTime(props), "TypeError if no properties are present");
 
 props.minute = 30;
 const result = instance.withPlainTime(props);

--- a/test/built-ins/Temporal/PlainMonthDay/calendar-number.js
+++ b/test/built-ins/Temporal/PlainMonthDay/calendar-number.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const arg = 19761118;
+
+const result = new Temporal.PlainMonthDay(12, 15, arg, 1972);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => new Temporal.PlainMonthDay(12, 15, arg, 1972),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/PlainMonthDay/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/calendar-wrong-type.js
@@ -2,17 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.plainmonthday
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +18,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => new Temporal.PlainMonthDay(12, 15, arg, 1972), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => new Temporal.PlainMonthDay(12, 15, arg, 1972), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-number.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-number.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: A number is converted to a string, then to Temporal.PlainMonthDay
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const arg = 1118;
+
+const result = Temporal.PlainMonthDay.from(arg);
+TemporalHelpers.assertPlainMonthDay(result, "M11", 18, "1118 is a valid ISO string for PlainMonthDay");
+
+const numbers = [
+  1,
+  -1118,
+  12345,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainMonthDay.from(arg),
+    `Number ${arg} does not convert to a valid ISO string for PlainMonthDay`
+  );
+}

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-number.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = 19970327;
+
+let arg = { monthCode: "M11", day: 18, calendar };
+const result1 = Temporal.PlainMonthDay.from(arg);
+TemporalHelpers.assertPlainMonthDay(result1, "M11", 18, "19970327 is a valid ISO string for calendar");
+
+arg = { monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = Temporal.PlainMonthDay.from(arg);
+TemporalHelpers.assertPlainMonthDay(result2, "M11", 18, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainMonthDay.from(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainMonthDay.from(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => Temporal.PlainMonthDay.from(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => Temporal.PlainMonthDay.from(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => Temporal.PlainMonthDay.from(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => Temporal.PlainMonthDay.from(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-wrong-type.js
@@ -2,14 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plainmonthday.from
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainMonthDay
 features: [BigInt, Symbol, Temporal]
 ---*/
-
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +19,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.PlainMonthDay.from(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainMonthDay, "Temporal.PlainMonthDay, object"],
+  [Temporal.PlainMonthDay.prototype, "Temporal.PlainMonthDay.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.PlainMonthDay.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-number.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-number.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: A number is converted to a string, then to Temporal.PlainMonthDay
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainMonthDay(11, 18);
+
+const arg = 1118;
+
+const result = instance.equals(arg);
+assert.sameValue(result, true, "1118 is a valid ISO string for PlainMonthDay");
+
+const numbers = [
+  1,
+  -1118,
+  12345,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `Number ${arg} does not convert to a valid ISO string for PlainMonthDay`
+  );
+}

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainMonthDay(11, 18);
+
+const calendar = 19970327;
+
+let arg = { monthCode: "M11", day: 18, calendar };
+const result1 = instance.equals(arg);
+assert.sameValue(result1, true, "19970327 is a valid ISO string for calendar");
+
+arg = { monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.equals(arg);
+assert.sameValue(result2, true, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainMonthDay(5, 2);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.equals(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-wrong-type.js
@@ -1,20 +1,36 @@
-// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 esid: sec-temporal.plainmonthday.prototype.equals
-description: Appropriate error thrown when argument cannot be converted to a valid string
-features: [Symbol, Temporal]
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or property bag for PlainMonthDay
+features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = Temporal.PlainMonthDay.from({ month: 5, day: 2 });
+const instance = new Temporal.PlainMonthDay(5, 2);
 
-assert.throws(RangeError, () => instance.equals(undefined), "undefined");
-assert.throws(RangeError, () => instance.equals(null), "null");
-assert.throws(RangeError, () => instance.equals(true), "true");
-assert.throws(RangeError, () => instance.equals(""), "empty string");
-assert.throws(TypeError, () => instance.equals(Symbol()), "symbol");
-assert.throws(RangeError, () => instance.equals(1), "1");
-assert.throws(TypeError, () => instance.equals({}), "plain object");
-assert.throws(TypeError, () => instance.equals(Temporal.PlainMonthDay), "Temporal.PlainMonthDay");
-assert.throws(TypeError, () => instance.equals(Temporal.PlainMonthDay.prototype), "Temporal.PlainMonthDay.prototype");
+const rangeErrorTests = [
+  [undefined, "undefined"],
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [arg, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainMonthDay, "Temporal.PlainMonthDay, object"],
+  [Temporal.PlainMonthDay.prototype, "Temporal.PlainMonthDay.prototype, object"],
+];
+
+for (const [arg, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+}

--- a/test/built-ins/Temporal/PlainTime/compare/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/compare/argument-number.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.compare
+description: A number is converted to a string, then to Temporal.PlainTime
+features: [Temporal]
+---*/
+
+const arg = 123456.987654321;
+
+const result1 = Temporal.PlainTime.compare(arg, new Temporal.PlainTime(12, 34, 56, 987, 654, 321));
+assert.sameValue(result1, 0, "123456.987654321 is a valid ISO string for PlainTime (first argument)");
+const result2 = Temporal.PlainTime.compare(new Temporal.PlainTime(12, 34, 56, 987, 654, 321), arg);
+assert.sameValue(result2, 0, "123456.987654321 is a valid ISO string for PlainTime (second argument)");
+
+const numbers = [
+  1,
+  -123456.987654321,
+  1234567,
+  123456.9876543219,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainTime.compare(arg, new Temporal.PlainTime(12, 34, 56, 987, 654, 321)),
+    `Number ${arg} does not convert to a valid ISO string for PlainTime (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainTime.compare(new Temporal.PlainTime(12, 34, 56, 987, 654, 321), arg),
+    `Number ${arg} does not convert to a valid ISO string for PlainTime (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/compare/argument-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.compare
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or property bag for PlainTime
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [undefined, "undefined"],
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [arg, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.PlainTime.compare(arg, new Temporal.PlainTime(12, 34, 56, 987, 654, 321)), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => Temporal.PlainTime.compare(new Temporal.PlainTime(12, 34, 56, 987, 654, 321), arg), `${description} does not convert to a valid ISO string (second argument)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.PlainTime, "Temporal.PlainTime, object"],
+  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
+];
+
+for (const [arg, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.PlainTime.compare(arg, new Temporal.PlainTime(12, 34, 56, 987, 654, 321)), `${description} is not a valid property bag and does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => Temporal.PlainTime.compare(new Temporal.PlainTime(12, 34, 56, 987, 654, 321), arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
+}

--- a/test/built-ins/Temporal/PlainTime/compare/plaintime-propertybag-no-time-units.js
+++ b/test/built-ins/Temporal/PlainTime/compare/plaintime-propertybag-no-time-units.js
@@ -8,7 +8,7 @@ features: [Temporal]
 ---*/
 
 const props = {};
-assert.throws(TypeError, () => Temporal.PlainTime.compare(props, new Temporal.PlainTime(0, 30)), "TypeError if at least one property is not present");
+assert.throws(TypeError, () => Temporal.PlainTime.compare(props, new Temporal.PlainTime(0, 30)), "TypeError if no properties are present");
 
 props.minute = 30;
 const result = Temporal.PlainTime.compare(props, new Temporal.PlainTime(0, 30));

--- a/test/built-ins/Temporal/PlainTime/from/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-string-time-designator-required-for-disambiguation.js
@@ -30,7 +30,7 @@ ambiguousStrings.forEach((string) => {
   assert.throws(
     RangeError,
     () => Temporal.PlainTime.from(arg),
-    'space is not accepted as a substitute for T prefix'
+    "space is not accepted as a substitute for T prefix"
   );
 });
 

--- a/test/built-ins/Temporal/PlainTime/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-wrong-type.js
@@ -2,14 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaintime.from
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainTime
 features: [BigInt, Symbol, Temporal]
 ---*/
-
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +19,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.PlainTime.from(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainTime, "Temporal.PlainTime, object"],
+  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.PlainTime.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainTime/from/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/from/year-zero.js
@@ -8,8 +8,8 @@ features: [Temporal, arrow-function]
 ---*/
 
 const invalidStrings = [
-  '-000000-12-07T03:24:30',
-  '-000000-12-07T03:24:30+01:00[UTC]'
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
 ];
 invalidStrings.forEach((arg) => {
   assert.throws(

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.from
+esid: sec-temporal.plaintime.prototype.equals
 description: A number is converted to a string, then to Temporal.PlainTime
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
 const arg = 123456.987654321;
 
-const result = Temporal.PlainTime.from(arg);
-TemporalHelpers.assertPlainTime(result, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
+const result = instance.equals(arg);
+assert.sameValue(result, true, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -23,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainTime.from(arg),
+    () => instance.equals(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainTime`
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-designator-required-for-disambiguation.js
@@ -32,7 +32,7 @@ ambiguousStrings.forEach((string) => {
   assert.throws(
     RangeError,
     () => instance.equals(arg),
-    'space is not accepted as a substitute for T prefix'
+    "space is not accepted as a substitute for T prefix"
   );
 });
 

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/plaintime-propertybag-no-time-units.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/plaintime-propertybag-no-time-units.js
@@ -10,7 +10,7 @@ features: [Temporal]
 const instance = new Temporal.PlainTime(0, 30, 0, 0, 0, 0);
 
 const props = {};
-assert.throws(TypeError, () => instance.equals(props), "TypeError if at least one property is not present");
+assert.throws(TypeError, () => instance.equals(props), "TypeError if no properties are present");
 
 props.minute = 30;
 const result = instance.equals(props);

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/year-zero.js
@@ -8,8 +8,8 @@ features: [Temporal, arrow-function]
 ---*/
 
 const invalidStrings = [
-  '-000000-12-07T03:24:30',
-  '-000000-12-07T03:24:30+01:00[UTC]'
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
 ];
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.from
+esid: sec-temporal.plaintime.prototype.since
 description: A number is converted to a string, then to Temporal.PlainTime
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
 const arg = 123456.987654321;
 
-const result = Temporal.PlainTime.from(arg);
-TemporalHelpers.assertPlainTime(result, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
+const result = instance.since(arg);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -23,7 +25,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainTime.from(arg),
+    () => instance.since(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainTime`
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-designator-required-for-disambiguation.js
@@ -32,7 +32,7 @@ ambiguousStrings.forEach((string) => {
   assert.throws(
     RangeError,
     () => instance.since(arg),
-    'space is not accepted as a substitute for T prefix'
+    "space is not accepted as a substitute for T prefix"
   );
 });
 

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaintime.prototype.since
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainTime
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainTime, "Temporal.PlainTime, object"],
+  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/since/plaintime-propertybag-no-time-units.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/plaintime-propertybag-no-time-units.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: Missing time units in property bag default to 0
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime(1, 0, 0, 0, 0, 1);
+
+const props = {};
+assert.throws(TypeError, () => instance.since(props), "TypeError if no properties are present");
+
+props.minute = 30;
+const result = instance.since(props);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 30, 0, 0, 0, 1, "missing time units default to 0");

--- a/test/built-ins/Temporal/PlainTime/prototype/since/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/year-zero.js
@@ -8,8 +8,8 @@ features: [Temporal, arrow-function]
 ---*/
 
 const invalidStrings = [
-  '-000000-12-07T03:24:30',
-  '-000000-12-07T03:24:30+01:00[UTC]'
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
 ];
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.plaintime.prototype.toplaindatetime
 description: A number is converted to a string, then to Temporal.PlainDate
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.toPlainDateTime(arg);
+TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.toPlainDateTime(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.toplaindatetime
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.toPlainDateTime(arg);
+TemporalHelpers.assertPlainDateTime(result1, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.toPlainDateTime(arg);
+TemporalHelpers.assertPlainDateTime(result2, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.toPlainDateTime(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.toPlainDateTime(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.toplaindatetime
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.toPlainDateTime(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.toPlainDateTime(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.toPlainDateTime(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.toPlainDateTime(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.toPlainDateTime(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaintime.prototype.toplaindatetime
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toPlainDateTime(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toPlainDateTime(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" });
+assert.sameValue(result.epochNanoseconds, 217_168_496_987_654_321n, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" });
+assert.sameValue(result1.epochNanoseconds, 217_168_496_987_654_321n, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" });
+assert.sameValue(result2.epochNanoseconds, 217_168_496_987_654_321n, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-invalid.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-invalid.js
@@ -55,7 +55,7 @@ const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 for (const arg of invalidStrings) {
   assert.throws(
     RangeError,
-    () => instance.toZonedDateTime({ plainDate: arg }),
+    () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }),
     `"${arg}" should not be a valid ISO string for a PlainDate`
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-with-utc-designator.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-with-utc-designator.js
@@ -15,7 +15,7 @@ const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 invalidStrings.forEach((arg) => {
   assert.throws(
     RangeError,
-    () => instance.toZonedDateTime({ plainDate: arg }),
+    () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }),
     "String with UTC designator should not be valid as a PlainDate"
   );
 });

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-wrong-type.js
@@ -2,17 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +20,17 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
+  [undefined, "undefined"],  // plainDate property is required
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.PlainTime();
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone: { timeZone } }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone: { timeZone } }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(2000, 5, 2), timeZone: { timeZone } }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/year-zero.js
@@ -12,6 +12,6 @@ const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
 assert.throws(
     RangeError,
-    () => { instance.toZonedDateTime({ plainDate: arg }); },
+    () => { instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }); },
     "reject minus zero as extended year"
 );

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-number.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.from
+esid: sec-temporal.plaintime.prototype.until
 description: A number is converted to a string, then to Temporal.PlainTime
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
 const arg = 123456.987654321;
 
-const result = Temporal.PlainTime.from(arg);
-TemporalHelpers.assertPlainTime(result, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
+const result = instance.until(arg);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -23,7 +25,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainTime.from(arg),
+    () => instance.until(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainTime`
   );
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-designator-required-for-disambiguation.js
@@ -32,7 +32,7 @@ ambiguousStrings.forEach((string) => {
   assert.throws(
     RangeError,
     () => instance.until(arg),
-    'space is not accepted as a substitute for T prefix'
+    "space is not accepted as a substitute for T prefix"
   );
 });
 

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plaintime.prototype.until
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainTime
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainTime, "Temporal.PlainTime, object"],
+  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/until/plaintime-propertybag-no-time-units.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/plaintime-propertybag-no-time-units.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: Missing time units in property bag default to 0
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime(1, 0, 0, 0, 0, 1);
+
+const props = {};
+assert.throws(TypeError, () => instance.until(props), "TypeError if no properties are present");
+
+props.minute = 30;
+const result = instance.until(props);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, -30, 0, 0, 0, -1, "missing time units default to 0");

--- a/test/built-ins/Temporal/PlainTime/prototype/until/year-zero.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/year-zero.js
@@ -8,8 +8,8 @@ features: [Temporal, arrow-function]
 ---*/
 
 const invalidStrings = [
-  '-000000-12-07T03:24:30',
-  '-000000-12-07T03:24:30+01:00[UTC]'
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
 ];
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/PlainYearMonth/calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/calendar-number.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const arg = 19761118;
+
+const result = new Temporal.PlainYearMonth(2000, 5, arg, 1);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => new Temporal.PlainYearMonth(2000, 5, arg, 1),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/calendar-wrong-type.js
@@ -2,17 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.plainyearmonth
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +18,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => new Temporal.PlainYearMonth(2000, 5, arg, 1), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => new Temporal.PlainYearMonth(2000, 5, arg, 1), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-number.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: A number is converted to a string, then to Temporal.PlainYearMonth
+features: [Temporal]
+---*/
+
+const arg = 201906;
+
+const result1 = Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6));
+assert.sameValue(result1, 0, "201906 is a valid ISO string for PlainYearMonth (first argument)");
+const result2 = Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg);
+assert.sameValue(result2, 0, "201906 is a valid ISO string for PlainYearMonth (second argument)");
+
+const numbers = [
+  1,
+  -201906,
+  1234567,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)),
+    `Number ${arg} does not convert to a valid ISO string for PlainYearMonth (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg),
+    `Number ${arg} does not convert to a valid ISO string for PlainYearMonth (first argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-number.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const calendar = 19970327;
+
+let arg = { year: 2019, monthCode: "M06", calendar };
+const result1 = Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6));
+assert.sameValue(result1, 0, "19970327 is a valid ISO string for calendar (first argument)");
+const result2 = Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg);
+assert.sameValue(result2, 0, "19970327 is a valid ISO string for calendar (second argument)");
+
+arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+const result3 = Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6));
+assert.sameValue(result3, 0, "19970327 is a valid ISO string for calendar (nested property, first argument)");
+const result4 = Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg);
+assert.sameValue(result4, 0, "19970327 is a valid ISO string for calendar (nested property, second argument)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 2019, monthCode: "M06", calendar };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (second argument)`
+  );
+  arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property, first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property, second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg), `${description} does not convert to a valid ISO string (second argument)`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)), `${description} does not convert to a valid ISO string (nested property, first argument)`);
+  assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg), `${description} does not convert to a valid ISO string (nested property, second argument)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)), `${description} is not a valid property bag and does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)), `${description} is not a valid property bag and does not convert to a string (nested property, first argument)`);
+  assert.throws(TypeError, () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg), `${description} is not a valid property bag and does not convert to a string (nested property, second argument)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)), `nested undefined calendar property is always a RangeError (first argument)`);
+assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg), `nested undefined calendar property is always a RangeError (second argument)`);

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-wrong-type.js
@@ -2,14 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plainyearmonth.prototype.equals
+esid: sec-temporal.plainyearmonth.compare
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
   or property bag for PlainYearMonth
 features: [BigInt, Symbol, Temporal]
 ---*/
-
-const instance = new Temporal.PlainYearMonth(2000, 5);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,7 +19,8 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg), `${description} does not convert to a valid ISO string (second argument)`);
 }
 
 const typeErrorTests = [
@@ -32,5 +31,6 @@ const typeErrorTests = [
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)), `${description} is not a valid property bag and does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
 }

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-number.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = 19970327;
+
+let arg = { year: 2019, monthCode: "M06", calendar };
+const result1 = Temporal.PlainYearMonth.from(arg);
+TemporalHelpers.assertPlainYearMonth(result1, 2019, 6, "M06", "19970327 is a valid ISO string for calendar");
+
+arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+const result2 = Temporal.PlainYearMonth.from(arg);
+TemporalHelpers.assertPlainYearMonth(result2, 2019, 6, "M06", "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 2019, monthCode: "M06", calendar };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.from(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.from(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => Temporal.PlainYearMonth.from(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => Temporal.PlainYearMonth.from(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => Temporal.PlainYearMonth.from(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => Temporal.PlainYearMonth.from(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => Temporal.PlainYearMonth.from(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-wrong-type.js
@@ -2,14 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plainyearmonth.from
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainYearMonth
 features: [BigInt, Symbol, Temporal]
 ---*/
-
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +19,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.PlainYearMonth.from(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainYearMonth, "Temporal.PlainYearMonth, object"],
+  [Temporal.PlainYearMonth.prototype, "Temporal.PlainYearMonth.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.PlainYearMonth.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plainyearmonth.from
+esid: sec-temporal.plainyearmonth.prototype.equals
 description: A number is converted to a string, then to Temporal.PlainYearMonth
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainYearMonth(2019, 6);
+
 const arg = 201906;
 
-const result = Temporal.PlainYearMonth.from(arg);
-TemporalHelpers.assertPlainYearMonth(result, 2019, 6, "M06", "201906 is a valid ISO string for PlainYearMonth");
+const result = instance.equals(arg);
+assert.sameValue(result, true, "201906 is a valid ISO string for PlainYearMonth");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainYearMonth.from(arg),
+    () => instance.equals(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainYearMonth`
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.equals
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2019, 6);
+
+const calendar = 19970327;
+
+let arg = { year: 2019, monthCode: "M06", calendar };
+const result1 = instance.equals(arg);
+assert.sameValue(result1, true, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+const result2 = instance.equals(arg);
+assert.sameValue(result2, true, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 2019, monthCode: "M06", calendar };
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.equals
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainYearMonth(2000, 5);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.equals(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plainyearmonth.from
+esid: sec-temporal.plainyearmonth.prototype.since
 description: A number is converted to a string, then to Temporal.PlainYearMonth
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainYearMonth(2019, 6);
+
 const arg = 201906;
 
-const result = Temporal.PlainYearMonth.from(arg);
-TemporalHelpers.assertPlainYearMonth(result, 2019, 6, "M06", "201906 is a valid ISO string for PlainYearMonth");
+const result = instance.since(arg);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "201906 is a valid ISO string for PlainYearMonth");
 
 const numbers = [
   1,
@@ -22,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainYearMonth.from(arg),
+    () => instance.since(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainYearMonth`
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2019, 6);
+
+const calendar = 19970327;
+
+let arg = { year: 2019, monthCode: "M06", calendar };
+const result1 = instance.since(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+const result2 = instance.since(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 2019, monthCode: "M06", calendar };
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainYearMonth(2000, 5);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.since(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plainyearmonth.prototype.since
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainYearMonth
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.PlainYearMonth(2000, 5);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainYearMonth, "Temporal.PlainYearMonth, object"],
+  [Temporal.PlainYearMonth.prototype, "Temporal.PlainYearMonth.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plainyearmonth.from
+esid: sec-temporal.plainyearmonth.prototype.until
 description: A number is converted to a string, then to Temporal.PlainYearMonth
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.PlainYearMonth(2019, 6);
+
 const arg = 201906;
 
-const result = Temporal.PlainYearMonth.from(arg);
-TemporalHelpers.assertPlainYearMonth(result, 2019, 6, "M06", "201906 is a valid ISO string for PlainYearMonth");
+const result = instance.until(arg);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "201906 is a valid ISO string for PlainYearMonth");
 
 const numbers = [
   1,
@@ -22,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainYearMonth.from(arg),
+    () => instance.until(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainYearMonth`
   );
 }

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2019, 6);
+
+const calendar = 19970327;
+
+let arg = { year: 2019, monthCode: "M06", calendar };
+const result1 = instance.until(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+const result2 = instance.until(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 2019, monthCode: "M06", calendar };
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.PlainYearMonth(2000, 5);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.until(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.plainyearmonth.prototype.until
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainYearMonth
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.PlainYearMonth(2000, 5);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainYearMonth, "Temporal.PlainYearMonth, object"],
+  [Temporal.PlainYearMonth.prototype, "Temporal.PlainYearMonth.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/TimeZone/from/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/from/timezone-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.from
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.TimeZone.from(timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.TimeZone.from({ timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.TimeZone.from(timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.TimeZone.from({ timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => Temporal.TimeZone.from({ timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-number.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.timezone.prototype.getinstantfor
 description: A number is converted to a string, then to Temporal.PlainDateTime
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.TimeZone("UTC");
+
 let arg = 19761118;
 
-const result = Temporal.PlainDateTime.from(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDateTime");
+const result = instance.getInstantFor(arg);
+assert.sameValue(result.epochNanoseconds, 217_123_200_000_000_000n, "19761118 is a valid ISO string for PlainDateTime");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDateTime.from(arg),
+    () => instance.getInstantFor(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDateTime`
   );
 }

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.getInstantFor(arg);
+assert.sameValue(result1.epochNanoseconds, 217_123_200_000_000_000n, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.getInstantFor(arg);
+assert.sameValue(result2.epochNanoseconds, 217_123_200_000_000_000n, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.getInstantFor(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.getInstantFor(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.TimeZone("UTC");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.getInstantFor(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.getInstantFor(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.getInstantFor(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.getInstantFor(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.getInstantFor(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.timezone.prototype.getinstantfor
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
   or property bag for PlainDateTime
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.TimeZone("UTC");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,7 +21,7 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.getInstantFor(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
@@ -32,5 +32,5 @@ const typeErrorTests = [
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.getInstantFor(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-object-tostring.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-object-tostring.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
+description: Object is converted to a string, then to Temporal.Instant
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const arg = {};
+assert.throws(RangeError, () => instance.getPlainDateTimeFor(arg), "[object Object] is not a valid ISO string");
+
+arg.toString = function() {
+  return "1970-01-01T00:00Z";
+};
+const result = instance.getPlainDateTimeFor(arg);
+TemporalHelpers.assertPlainDateTime(result, 1970, 1, "M01", 1, 0, 0, 0, 0, 0, 0, "result of toString is interpreted as ISO string");

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  for Instant
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.TimeZone("UTC");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -17,20 +17,21 @@ const rangeErrorTests = [
   [true, "boolean"],
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [{}, "plain object"],
+  [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.getPlainDateTimeFor(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.Instant.prototype, "Temporal.Instant.prototype, object"],  // fails brand check in toString()
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.getPlainDateTimeFor(arg), `${description} does not convert to a string`);
 }

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-number.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-number.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const arg = 19761118;
+
+const result = instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-wrong-type.js
@@ -2,17 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const instance = new Temporal.TimeZone("UTC");
 
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +20,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/instant-string-sub-minute-offset.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/instant-string-sub-minute-offset.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
+description: Temporal.Instant string with sub-minute offset
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const str = "1970-01-01T00:19:32.37+00:19:32.37";
+const result = instance.getPlainDateTimeFor(str);
+TemporalHelpers.assertPlainDateTime(result, 1970, 1, "M01", 1, 0, 0, 0, 0, 0, 0, "if present, sub-minute offset is accepted exactly");

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-number.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-number.js
@@ -2,16 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
 description: A number is converted to a string, then to Temporal.PlainDateTime
-includes: [temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.TimeZone("UTC");
+
 let arg = 19761118;
 
-const result = Temporal.PlainDateTime.from(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "19761118 is a valid ISO string for PlainDateTime");
+const result = instance.getPossibleInstantsFor(arg);
+assert.compareArray(result.map(i => i.epochNanoseconds), [217_123_200_000_000_000n], "19761118 is a valid ISO string for PlainDateTime");
 
 const numbers = [
   1,
@@ -22,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDateTime.from(arg),
+    () => instance.getPossibleInstantsFor(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDateTime`
   );
 }

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [compareArray.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.getPossibleInstantsFor(arg);
+assert.compareArray(result1.map(i => i.epochNanoseconds), [217_123_200_000_000_000n], "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.getPossibleInstantsFor(arg);
+assert.compareArray(result2.map(i => i.epochNanoseconds), [217_123_200_000_000_000n], "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.getPossibleInstantsFor(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.getPossibleInstantsFor(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.TimeZone("UTC");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.getPossibleInstantsFor(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.getPossibleInstantsFor(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.getPossibleInstantsFor(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.getPossibleInstantsFor(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.getPossibleInstantsFor(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
   or property bag for PlainDateTime
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.TimeZone("UTC");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,7 +21,7 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.getPossibleInstantsFor(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
@@ -32,5 +32,5 @@ const typeErrorTests = [
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.getPossibleInstantsFor(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/calendar-number.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const arg = 19761118;
+
+const result = new Temporal.ZonedDateTime(0n, "UTC", arg);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => new Temporal.ZonedDateTime(0n, "UTC", arg),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/calendar-wrong-type.js
@@ -2,17 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.zoneddatetime
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
-
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +18,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => new Temporal.ZonedDateTime(0n, "UTC", arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => new Temporal.ZonedDateTime(0n, "UTC", arg), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-number.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const calendar = 19970327;
+
+const timeZone = new Temporal.TimeZone("UTC");
+const datetime = new Temporal.ZonedDateTime(0n, timeZone);
+
+let arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
+const result1 = Temporal.ZonedDateTime.compare(arg, datetime);
+assert.sameValue(result1, 0, "19970327 is a valid ISO string for calendar (first argument)");
+const result2 = Temporal.ZonedDateTime.compare(datetime, arg);
+assert.sameValue(result2, 0, "19970327 is a valid ISO string for calendar (second argument)");
+
+arg = { year: 1970, monthCode: "M01", day: 1, calendar: { calendar }, timeZone };
+const result3 = Temporal.ZonedDateTime.compare(arg, datetime);
+assert.sameValue(result3, 0, "19970327 is a valid ISO string for calendar (nested property, first argument)");
+const result4 = Temporal.ZonedDateTime.compare(datetime, arg);
+assert.sameValue(result4, 0, "19970327 is a valid ISO string for calendar (nested property, second argument)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.compare(arg, datetime),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.compare(datetime, arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (second argument)`
+  );
+  arg = { year: 1970, monthCode: "M01", day: 1, calendar: { calendar }, timeZone };
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.compare(arg, datetime),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property, first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.compare(datetime, arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property, second argument)`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(arg, datetime), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(datetime, arg), `${description} does not convert to a valid ISO string (second argument)`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(arg, datetime), `${description} does not convert to a valid ISO string (nested property, first argument)`);
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(datetime, arg), `${description} does not convert to a valid ISO string (nested property, second argument)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.compare(arg, datetime), `${description} is not a valid property bag and does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.compare(datetime, arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.compare(arg, datetime), `${description} is not a valid property bag and does not convert to a string (nested property, first argument)`);
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.compare(datetime, arg), `${description} is not a valid property bag and does not convert to a string (nested property, second argument)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(arg, datetime), `nested undefined calendar property is always a RangeError (first argument)`);
+assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(datetime, arg), `nested undefined calendar property is always a RangeError (second argument)`);

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-wrong-type.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or property bag for ZonedDateTime
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const other = new Temporal.ZonedDateTime(0n, timeZone);
+
+const rangeErrorTests = [
+  [undefined, "undefined"],
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [arg, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(arg, other), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(other, arg), `${description} does not convert to a valid ISO string (second argument)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
+];
+
+for (const [arg, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.compare(arg, other), `${description} is not a valid property bag and does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.compare(other, arg), `${description} is not a valid property bag and does not convert to a string (second argument)`);
+}

--- a/test/built-ins/Temporal/ZonedDateTime/compare/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/timezone-wrong-type.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare({ year: 2020, month: 5, day: 2, timeZone }, datetime), `${description} does not convert to a valid ISO string (first argument)`);
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(datetime, { year: 2020, month: 5, day: 2, timeZone }), `${description} does not convert to a valid ISO string (second argument)`);
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }, datetime), `${description} does not convert to a valid ISO string (nested property, first argument)`);
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(datetime, { year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `${description} does not convert to a valid ISO string (nested property, second argument)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.compare({ year: 2020, month: 5, day: 2, timeZone }, datetime), `${description} is not a valid object and does not convert to a string (first argument)`);
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.compare(datetime, { year: 2020, month: 5, day: 2, timeZone }), `${description} is not a valid object and does not convert to a string (second argument)`);
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.compare({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }, datetime), `${description} is not a valid object and does not convert to a string (nested property, first argument)`);
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.compare(datetime, { year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `${description} is not a valid object and does not convert to a string (nested property, second argument)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => Temporal.ZonedDateTime.compare({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }, datetime), `undefined is always a RangeError as nested property (first argument)`);
+assert.throws(RangeError, () => Temporal.ZonedDateTime.compare(datetime, { year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `undefined is always a RangeError as nested property (second argument)`);

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const calendar = 19970327;
+
+const timeZone = new Temporal.TimeZone("UTC");
+
+let arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
+const result1 = Temporal.ZonedDateTime.from(arg);
+assert.sameValue(result1.calendar.id, "iso8601", "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1970, monthCode: "M01", day: 1, calendar: { calendar }, timeZone };
+const result2 = Temporal.ZonedDateTime.from(arg);
+assert.sameValue(result2.calendar.id, "iso8601", "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.from(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1970, monthCode: "M01", day: 1, calendar: { calendar }, timeZone };
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.from(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.from(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.from(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.from(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.from(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-wrong-type.js
@@ -2,14 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.zoneddatetime.from
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for ZonedDateTime
 features: [BigInt, Symbol, Temporal]
 ---*/
-
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -17,20 +15,21 @@ const rangeErrorTests = [
   [true, "boolean"],
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.from(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.from(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/from/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/timezone-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone: { timeZone } }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone: { timeZone } }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2000, month: 5, day: 2, timeZone: { timeZone } }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-number.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const calendar = 19970327;
+
+let arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
+const result1 = instance.equals(arg);
+assert.sameValue(result1, true, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1970, monthCode: "M01", day: 1, calendar: { calendar }, timeZone };
+const result2 = instance.equals(arg);
+assert.sameValue(result2, true, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1970, monthCode: "M01", day: 1, calendar: { calendar }, timeZone };
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.equals(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-wrong-type.js
@@ -2,14 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.zoneddatetime.prototype.equals
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for ZonedDateTime
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -17,6 +18,7 @@ const rangeErrorTests = [
   [true, "boolean"],
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
 ];
 
@@ -27,8 +29,8 @@ for (const [arg, description] of rangeErrorTests) {
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.equals({ year: 2020, month: 5, day: 2, timeZone }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.equals({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.equals({ year: 2020, month: 5, day: 2, timeZone }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.equals({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.equals({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-number.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const calendar = 19970327;
+
+let arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
+const result1 = instance.since(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1970, monthCode: "M01", day: 1, calendar: { calendar }, timeZone };
+const result2 = instance.since(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1970, monthCode: "M01", day: 1, calendar: { calendar }, timeZone };
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.since(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-wrong-type.js
@@ -2,14 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.equals
+esid: sec-temporal.zoneddatetime.prototype.since
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  for Instant
+  or property bag for ZonedDateTime
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.Instant(0n);
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -19,19 +20,19 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
-  [{}, "plain object"],
-  [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.since(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [Temporal.Instant.prototype, "Temporal.Instant.prototype, object"],  // fails brand check in toString()
+  [{}, "plain object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} does not convert to a string`);
+  assert.throws(TypeError, () => instance.since(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.since({ year: 2020, month: 5, day: 2, timeZone }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.since({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.since({ year: 2020, month: 5, day: 2, timeZone }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.since({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.since({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-number.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const calendar = 19970327;
+
+let arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
+const result1 = instance.until(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1970, monthCode: "M01", day: 1, calendar: { calendar }, timeZone };
+const result2 = instance.until(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1970, monthCode: "M01", day: 1, calendar, timeZone };
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1970, monthCode: "M01", day: 1, calendar: { calendar }, timeZone };
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.until(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-wrong-type.js
@@ -2,14 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.equals
+esid: sec-temporal.zoneddatetime.prototype.until
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  for Instant
+  or property bag for ZonedDateTime
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.Instant(0n);
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -19,19 +20,19 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
-  [{}, "plain object"],
-  [Temporal.Instant, "Temporal.Instant, object"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.until(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [Temporal.Instant.prototype, "Temporal.Instant.prototype, object"],  // fails brand check in toString()
+  [{}, "plain object"],
+  [Temporal.ZonedDateTime, "Temporal.ZonedDateTime, object"],
+  [Temporal.ZonedDateTime.prototype, "Temporal.ZonedDateTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} does not convert to a string`);
+  assert.throws(TypeError, () => instance.until(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.until({ year: 2020, month: 5, day: 2, timeZone }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.until({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.until({ year: 2020, month: 5, day: 2, timeZone }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.until({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.until({ year: 2020, month: 5, day: 2, timeZone: { timeZone } }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-number.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withcalendar
+description: A number is converted to a string, then to Temporal.Calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", { id: "replace-me" });
+
+const arg = 19761118;
+
+const result = instance.withCalendar(arg);
+assert.sameValue(result.calendar.id, "iso8601", "19761118 is a valid ISO string for Calendar");
+
+const numbers = [
+  1,
+  -19761118,
+  1234567890,
+];
+
+for (const arg of numbers) {
+  assert.throws(
+    RangeError,
+    () => instance.withCalendar(arg),
+    `Number ${arg} does not convert to a valid ISO string for Calendar`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-wrong-type.js
@@ -2,17 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.prototype.equals
+esid: sec-temporal.zoneddatetime.prototype.withcalendar
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainTime
+  or object for Calendar
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", { id: "replace-me" });
 
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +20,13 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.withCalendar(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
-  [{}, "plain object"],
-  [Temporal.PlainTime, "Temporal.PlainTime, object"],
-  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.withCalendar(arg), `${description} is not a valid object and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.withPlainDate(arg);
+assert.sameValue(result.epochNanoseconds, 217_129_600_000_000_000n, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.withPlainDate(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-propertybag-calendar-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.withPlainDate(arg);
+assert.sameValue(result1.epochNanoseconds, 217_129_600_000_000_000n, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.withPlainDate(arg);
+assert.sameValue(result2.epochNanoseconds, 217_129_600_000_000_000n, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.withPlainDate(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.withPlainDate(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.withPlainDate(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.withPlainDate(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.withPlainDate(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.withPlainDate(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.withPlainDate(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.withPlainDate(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.withPlainDate(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-number.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaintime.from
+esid: sec-temporal.zoneddatetime.prototype.withplaintime
 description: A number is converted to a string, then to Temporal.PlainTime
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
 const arg = 123456.987654321;
 
-const result = Temporal.PlainTime.from(arg);
-TemporalHelpers.assertPlainTime(result, 12, 34, 56, 987, 654, 321, "123456.987654321 is a valid ISO string for PlainTime");
+const result = instance.withPlainTime(arg);
+assert.sameValue(result.epochNanoseconds, 1000038896_987_654_321n, "123456.987654321 is a valid ISO string for PlainTime");
 
 const numbers = [
   1,
@@ -23,7 +24,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainTime.from(arg),
+    () => instance.withPlainTime(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainTime`
   );
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-time-designator-required-for-disambiguation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-time-designator-required-for-disambiguation.js
@@ -32,7 +32,7 @@ ambiguousStrings.forEach((string) => {
   assert.throws(
     RangeError,
     () => instance.withPlainTime(arg),
-    'space is not accepted as a substitute for T prefix'
+    "space is not accepted as a substitute for T prefix"
   );
 });
 

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-wrong-type.js
@@ -2,17 +2,16 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.zoneddatetime.prototype.withplaintime
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainTime
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 
 const rangeErrorTests = [
-  [undefined, "undefined"],
   [null, "null"],
   [true, "boolean"],
   ["", "empty string"],
@@ -21,16 +20,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.withPlainTime(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainTime, "Temporal.PlainTime, object"],
+  [Temporal.PlainTime.prototype, "Temporal.PlainTime.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.withPlainTime(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/plaintime-propertybag-no-time-units.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/plaintime-propertybag-no-time-units.js
@@ -10,7 +10,7 @@ features: [Temporal]
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 
 const props = {};
-assert.throws(TypeError, () => instance.withPlainTime(props), "TypeError if at least one property is not present");
+assert.throws(TypeError, () => instance.withPlainTime(props), "TypeError if no properties are present");
 
 props.minute = 30;
 const result = instance.withPlainTime(props);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/year-zero.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/year-zero.js
@@ -8,8 +8,8 @@ features: [Temporal, arrow-function]
 ---*/
 
 const invalidStrings = [
-  '-000000-12-07T03:24:30',
-  '-000000-12-07T03:24:30+01:00[UTC]'
+  "-000000-12-07T03:24:30",
+  "-000000-12-07T03:24:30+01:00[UTC]"
 ];
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 invalidStrings.forEach((arg) => {

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone/timezone-wrong-type.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withtimezone
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(0n, new Temporal.TimeZone("UTC"));
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => instance.withTimeZone(timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.withTimeZone({ timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => instance.withTimeZone(timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.withTimeZone({ timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => instance.withTimeZone({ timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/built-ins/Temporal/ZonedDateTime/timezone-string-multiple-offsets.js
+++ b/test/built-ins/Temporal/ZonedDateTime/timezone-string-multiple-offsets.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime
+description: Time zone strings with UTC offset fractional part are not confused with time fractional part
+features: [Temporal]
+---*/
+
+const timeZone = "2021-08-19T17:30:45.123456789+01:46[+01:45:30.987654321]";
+
+const result1 = new Temporal.ZonedDateTime(0n, timeZone);
+assert.sameValue(result1.timeZone.id, "+01:45:30.987654321", "Time zone string determined from bracket name");
+const result2 = new Temporal.ZonedDateTime(0n, { timeZone });
+assert.sameValue(result2.timeZone.id, "+01:45:30.987654321", "Time zone string determined from bracket name");

--- a/test/built-ins/Temporal/ZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/timezone-wrong-type.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime
+description: >
+  Appropriate error thrown when argument cannot be converted to a valid string
+  or object for TimeZone
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [19761118, "number that would convert to a valid ISO string in other contexts"],
+  [1n, "bigint"],
+];
+
+for (const [timeZone, description] of rangeErrorTests) {
+  assert.throws(RangeError, () => new Temporal.ZonedDateTime(0n, timeZone), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => new Temporal.ZonedDateTime(0n, { timeZone }), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+];
+
+for (const [timeZone, description] of typeErrorTests) {
+  assert.throws(TypeError, () => new Temporal.ZonedDateTime(0n, timeZone), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => new Temporal.ZonedDateTime(0n, { timeZone }), `${description} is not a valid object and does not convert to a string (nested property)`);
+}
+
+const timeZone = undefined;
+assert.throws(RangeError, () => new Temporal.ZonedDateTime(0n, { timeZone }), `undefined is always a RangeError as nested property`);

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-number.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.era
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.era(arg);
+assert.sameValue(result, undefined, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.era(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-propertybag-calendar-number.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.era
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.era(arg);
+assert.sameValue(result1, undefined, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.era(arg);
+assert.sameValue(result2, undefined, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.era(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.era(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-propertybag-calendar-wrong-type.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.era
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.era(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.era(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.era(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.era(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.era(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-wrong-type.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.era
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.era(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.era(arg), `${description} is not a valid property bag and does not convert to a string`);
 }

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-number.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-number.js
@@ -2,16 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.from
+esid: sec-temporal.calendar.prototype.erayear
 description: A number is converted to a string, then to Temporal.PlainDate
-includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
+const instance = new Temporal.Calendar("iso8601");
+
 const arg = 19761118;
 
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, "19761118 is a valid ISO string for PlainDate");
+const result = instance.eraYear(arg);
+assert.sameValue(result, undefined, "19761118 is a valid ISO string for PlainDate");
 
 const numbers = [
   1,
@@ -22,7 +23,7 @@ const numbers = [
 for (const arg of numbers) {
   assert.throws(
     RangeError,
-    () => Temporal.PlainDate.from(arg),
+    () => instance.eraYear(arg),
     `Number ${arg} does not convert to a valid ISO string for PlainDate`
   );
 }

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-propertybag-calendar-number.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-propertybag-calendar-number.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.erayear
+description: A number as calendar in a property bag is converted to a string, then to a calendar
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = 19970327;
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.eraYear(arg);
+assert.sameValue(result1, undefined, "19970327 is a valid ISO string for calendar");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.eraYear(arg);
+assert.sameValue(result2, undefined, "19970327 is a valid ISO string for calendar (nested property)");
+
+const numbers = [
+  1,
+  -19970327,
+  1234567890,
+];
+
+for (const calendar of numbers) {
+  let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+  assert.throws(
+    RangeError,
+    () => instance.eraYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar`
+  );
+  arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+  assert.throws(
+    RangeError,
+    () => instance.eraYear(arg),
+    `Number ${calendar} does not convert to a valid ISO string for calendar (nested property)`
+  );
+}

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-propertybag-calendar-wrong-type.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-propertybag-calendar-wrong-type.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.erayear
+description: >
+  Appropriate error thrown when a calendar property from a property bag cannot
+  be converted to a calendar object or string
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.Calendar("iso8601");
+
+const rangeErrorTests = [
+  [null, "null"],
+  [true, "boolean"],
+  ["", "empty string"],
+  [1, "number that doesn't convert to a valid ISO string"],
+  [1n, "bigint"],
+];
+
+for (const [calendar, description] of rangeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(RangeError, () => instance.eraYear(arg), `${description} does not convert to a valid ISO string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(RangeError, () => instance.eraYear(arg), `${description} does not convert to a valid ISO string (nested property)`);
+}
+
+const typeErrorTests = [
+  [Symbol(), "symbol"],
+  [{}, "plain object"],  // TypeError due to missing dateFromFields()
+  [Temporal.Calendar, "Temporal.Calendar, object"],  // ditto
+  [Temporal.Calendar.prototype, "Temporal.Calendar.prototype, object"],  // fails brand check in dateFromFields()
+];
+
+for (const [calendar, description] of typeErrorTests) {
+  let arg = { year: 2019, monthCode: "M11", day: 1, calendar };
+  assert.throws(TypeError, () => instance.eraYear(arg), `${description} is not a valid property bag and does not convert to a string`);
+
+  arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar } };
+  assert.throws(TypeError, () => instance.eraYear(arg), `${description} is not a valid property bag and does not convert to a string (nested property)`);
+}
+
+const arg = { year: 2019, monthCode: "M11", day: 1, calendar: { calendar: undefined } };
+assert.throws(RangeError, () => instance.eraYear(arg), `nested undefined calendar property is always a RangeError`);

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-wrong-type.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-wrong-type.js
@@ -2,14 +2,14 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.prototype.equals
+esid: sec-temporal.calendar.prototype.erayear
 description: >
   Appropriate error thrown when argument cannot be converted to a valid string
-  or property bag for PlainDateTime
+  or property bag for PlainDate
 features: [BigInt, Symbol, Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const instance = new Temporal.Calendar("iso8601");
 
 const rangeErrorTests = [
   [undefined, "undefined"],
@@ -21,16 +21,16 @@ const rangeErrorTests = [
 ];
 
 for (const [arg, description] of rangeErrorTests) {
-  assert.throws(RangeError, () => instance.equals(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.eraYear(arg), `${description} does not convert to a valid ISO string`);
 }
 
 const typeErrorTests = [
   [Symbol(), "symbol"],
   [{}, "plain object"],
-  [Temporal.PlainDateTime, "Temporal.PlainDateTime, object"],
-  [Temporal.PlainDateTime.prototype, "Temporal.PlainDateTime.prototype, object"],
+  [Temporal.PlainDate, "Temporal.PlainDate, object"],
+  [Temporal.PlainDate.prototype, "Temporal.PlainDate.prototype, object"],
 ];
 
 for (const [arg, description] of typeErrorTests) {
-  assert.throws(TypeError, () => instance.equals(arg), `${description} is not a valid property bag and does not convert to a string`);
+  assert.throws(TypeError, () => instance.eraYear(arg), `${description} is not a valid property bag and does not convert to a string`);
 }


### PR DESCRIPTION
Best reviewed commit by commit.

- A few fixups
- Basic tests for `Temporal.Instant.from`
- Add a few tests, similar to existing ones, to entry points that didn't have them yet
- Various tests for conversion of values to Temporal types