### PR TITLE
Varied `TypedArray` helper

### DIFF
--- a/harness/testTypedArray.js
+++ b/harness/testTypedArray.js
@@ -8,6 +8,7 @@ defines:
   - floatArrayConstructors
   - intArrayConstructors
   - TypedArray
+  - createTypedArrayVariations
   - testWithTypedArrayConstructors
   - testWithAtomicsFriendlyTypedArrayConstructors
   - testWithNonAtomicsFriendlyTypedArrayConstructors
@@ -119,4 +120,28 @@ function testTypedArrayConversions(byteConversionValues, fn) {
       fn(TA, value, exp, initial);
     });
   });
+}
+
+function createTypedArrayVariations(TA, values) {
+  const rab = new ArrayBuffer(4 * TA.BYTES_PER_ELEMENT, { maxByteLength: 8 * TA.BYTES_PER_ELEMENT });
+
+  let nonresizable = new TA(values);
+  let fixedLength = new TA(rab, 0, values.length);
+  let lengthTracking = new TA(rab, 0);
+  let fixedLengthWithOffset = new TA(rab, 2 * TA.BYTES_PER_ELEMENT, (values.length / 2));
+  let lengthTrackingWithOffset = new TA(rab, 2 * TA.BYTES_PER_ELEMENT);
+
+  // Writes data to the buffer backing all the arrays
+  let ta_write = new TA(rab);
+  for (let i = 0; i < values.length; ++i) {
+    ta_write[i] = values[i];
+  }
+
+  return {
+    nonresizable,
+    fixedLength,
+    lengthTracking,
+    fixedLengthWithOffset,
+    lengthTrackingWithOffset,
+  }
 }

--- a/test/built-ins/TypedArray/prototype/at/returns-item.js
+++ b/test/built-ins/TypedArray/prototype/at/returns-item.js
@@ -29,10 +29,32 @@ assert.sameValue(
 
 testWithTypedArrayConstructors(TA => {
   assert.sameValue(typeof TA.prototype.at, 'function', 'The value of `typeof TA.prototype.at` is "function"');
-  let a = new TA([1, 2, 3, 4]);
 
-  assert.sameValue(a.at(0), 1, 'a.at(0) must return 1');
-  assert.sameValue(a.at(1), 2, 'a.at(1) must return 2');
-  assert.sameValue(a.at(2), 3, 'a.at(2) must return 3');
-  assert.sameValue(a.at(3), 4, 'a.at(3) must return 4');
+  const {
+    nonresizable,
+    fixedLength,
+    lengthTracking,
+    fixedLengthWithOffset,
+    lengthTrackingWithOffset
+  } = createTypedArrayVariations(TA, [1, 2, 3, 4]);
+
+  [
+    nonresizable,
+    fixedLength,
+    lengthTracking,
+  ].forEach((a) => {
+    assert.sameValue(a.at(0), 1, 'a.at(0) must return 1')
+    assert.sameValue(a.at(1), 2, 'a.at(1) must return 2')
+    assert.sameValue(a.at(2), 3, 'a.at(2) must return 3')
+    assert.sameValue(a.at(3), 4, 'a.at(3) must return 4')
+  });
+
+  [
+    fixedLengthWithOffset,
+    lengthTrackingWithOffset
+  ].forEach((a) => {
+    assert.sameValue(a.at(0), 3, 'a.at(2) must return 3')
+    assert.sameValue(a.at(1), 4, 'a.at(3) must return 4')
+  })
+
 });


### PR DESCRIPTION
As we discussed last week, I drafted out what adding a test helper for the different sorts of backing arrays might look like. 