### PR TITLE
Make minimumFractionDigits = maximumFractionDigits

### DIFF
--- a/test/intl402/NumberFormat/constructor-roundingIncrement.js
+++ b/test/intl402/NumberFormat/constructor-roundingIncrement.js
@@ -39,7 +39,8 @@ for (const [value, expected] of values) {
     get roundingIncrement() {
       callOrder.push("roundingIncrement");
       return value;
-    }
+    },
+    minimumFractionDigits: 3
   });
   const resolvedOptions = nf.resolvedOptions();
   assert("roundingIncrement" in resolvedOptions, "has property for value " + value);

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-10.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-10.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 10, maximumFractionDigits: 2},
+  {roundingIncrement: 10, maximumFractionDigits: 2, minimumFractionDigits: 2},
   {
-    '1.100': '1.1',
-    '1.125': '1.1',
-    '1.150': '1.2',
-    '1.175': '1.2',
-    '1.200': '1.2',
+    '1.100': '1.10',
+    '1.125': '1.10',
+    '1.150': '1.20',
+    '1.175': '1.20',
+    '1.200': '1.20',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 10, maximumFractionDigits: 3},
+  {roundingIncrement: 10, maximumFractionDigits: 3, minimumFractionDigits: 3},
   {
-    '1.0100': '1.01',
-    '1.0125': '1.01',
-    '1.0150': '1.02',
-    '1.0175': '1.02',
-    '1.0200': '1.02',
+    '1.0100': '1.010',
+    '1.0125': '1.010',
+    '1.0150': '1.020',
+    '1.0175': '1.020',
+    '1.0200': '1.020',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-100.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-100.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 100, maximumFractionDigits: 3},
+  {roundingIncrement: 100, maximumFractionDigits: 3, minimumFractionDigits: 3},
   {
-    '1.100': '1.1',
-    '1.125': '1.1',
-    '1.150': '1.2',
-    '1.175': '1.2',
-    '1.200': '1.2',
+    '1.100': '1.100',
+    '1.125': '1.100',
+    '1.150': '1.200',
+    '1.175': '1.200',
+    '1.200': '1.200',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 100, maximumFractionDigits: 4},
+  {roundingIncrement: 100, maximumFractionDigits: 4, minimumFractionDigits: 4},
   {
-    '1.0100': '1.01',
-    '1.0125': '1.01',
-    '1.0150': '1.02',
-    '1.0175': '1.02',
-    '1.0200': '1.02',
+    '1.0100': '1.0100',
+    '1.0125': '1.0100',
+    '1.0150': '1.0200',
+    '1.0175': '1.0200',
+    '1.0200': '1.0200',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-1000.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-1000.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 1000, maximumFractionDigits: 4},
+  {roundingIncrement: 1000, maximumFractionDigits: 4, minimumFractionDigits: 4},
   {
-    '1.100': '1.1',
-    '1.125': '1.1',
-    '1.150': '1.2',
-    '1.175': '1.2',
-    '1.200': '1.2',
+    '1.100': '1.1000',
+    '1.125': '1.1000',
+    '1.150': '1.2000',
+    '1.175': '1.2000',
+    '1.200': '1.2000',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 1000, maximumFractionDigits: 5},
+  {roundingIncrement: 1000, maximumFractionDigits: 5, minimumFractionDigits: 5},
   {
-    '1.0100': '1.01',
-    '1.0125': '1.01',
-    '1.0150': '1.02',
-    '1.0175': '1.02',
-    '1.0200': '1.02',
+    '1.0100': '1.01000',
+    '1.0125': '1.01000',
+    '1.0150': '1.02000',
+    '1.0175': '1.02000',
+    '1.0200': '1.02000',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2.js
@@ -15,7 +15,7 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 2, maximumFractionDigits: 1},
+  {roundingIncrement: 2, maximumFractionDigits: 1, minimumFractionDigits: 1},
   {
     '1.20': '1.2',
     '1.25': '1.2',
@@ -28,7 +28,7 @@ testNumberFormat(
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 2, maximumFractionDigits: 2},
+  {roundingIncrement: 2, maximumFractionDigits: 2, minimumFractionDigits: 2},
   {
     '1.020': '1.02',
     '1.025': '1.02',

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-20.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-20.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 20, maximumFractionDigits: 2},
+  {roundingIncrement: 20, maximumFractionDigits: 2, minimumFractionDigits: 2},
   {
-    '1.20': '1.2',
-    '1.25': '1.2',
-    '1.30': '1.4',
-    '1.35': '1.4',
-    '1.40': '1.4',
+    '1.20': '1.20',
+    '1.25': '1.20',
+    '1.30': '1.40',
+    '1.35': '1.40',
+    '1.40': '1.40',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 20, maximumFractionDigits: 3},
+  {roundingIncrement: 20, maximumFractionDigits: 3, minimumFractionDigits: 3},
   {
-    '1.020': '1.02',
-    '1.025': '1.02',
-    '1.030': '1.04',
-    '1.035': '1.04',
-    '1.040': '1.04',
+    '1.020': '1.020',
+    '1.025': '1.020',
+    '1.030': '1.040',
+    '1.035': '1.040',
+    '1.040': '1.040',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-200.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-200.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 200, maximumFractionDigits: 3},
+  {roundingIncrement: 200, maximumFractionDigits: 3, minimumFractionDigits: 3},
   {
-    '1.20': '1.2',
-    '1.25': '1.2',
-    '1.30': '1.4',
-    '1.35': '1.4',
-    '1.40': '1.4',
+    '1.20': '1.200',
+    '1.25': '1.200',
+    '1.30': '1.400',
+    '1.35': '1.400',
+    '1.40': '1.400',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 200, maximumFractionDigits: 4},
+  {roundingIncrement: 200, maximumFractionDigits: 4, minimumFractionDigits: 4},
   {
-    '1.020': '1.02',
-    '1.025': '1.02',
-    '1.030': '1.04',
-    '1.035': '1.04',
-    '1.040': '1.04',
+    '1.020': '1.0200',
+    '1.025': '1.0200',
+    '1.030': '1.0400',
+    '1.035': '1.0400',
+    '1.040': '1.0400',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2000.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2000.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 2000, maximumFractionDigits: 4},
+  {roundingIncrement: 2000, maximumFractionDigits: 4, minimumFractionDigits: 4},
   {
-    '1.20': '1.2',
-    '1.25': '1.2',
-    '1.30': '1.4',
-    '1.35': '1.4',
-    '1.40': '1.4',
+    '1.20': '1.2000',
+    '1.25': '1.2000',
+    '1.30': '1.4000',
+    '1.35': '1.4000',
+    '1.40': '1.4000',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 2000, maximumFractionDigits: 5},
+  {roundingIncrement: 2000, maximumFractionDigits: 5, minimumFractionDigits: 5},
   {
-    '1.020': '1.02',
-    '1.025': '1.02',
-    '1.030': '1.04',
-    '1.035': '1.04',
-    '1.040': '1.04',
+    '1.020': '1.02000',
+    '1.025': '1.02000',
+    '1.030': '1.04000',
+    '1.035': '1.04000',
+    '1.040': '1.04000',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-25.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-25.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 25, maximumFractionDigits: 2, minimumFractionDigits: 1},
+  {roundingIncrement: 25, maximumFractionDigits: 2, minimumFractionDigits: 2},
   {
     '1.2500': '1.25',
     '1.3125': '1.25',
-    '1.3750': '1.5',
-    '1.4375': '1.5',
-    '1.5000': '1.5',
+    '1.3750': '1.50',
+    '1.4375': '1.50',
+    '1.5000': '1.50',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 25, maximumFractionDigits: 3},
+  {roundingIncrement: 25, maximumFractionDigits: 3, minimumFractionDigits: 3},
   {
     '1.02500': '1.025',
     '1.03125': '1.025',
-    '1.03750': '1.05',
-    '1.04375': '1.05',
-    '1.05000': '1.05',
+    '1.03750': '1.050',
+    '1.04375': '1.050',
+    '1.05000': '1.050',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-250.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-250.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 250, maximumFractionDigits: 3, minimumFractionDigits: 1},
+  {roundingIncrement: 250, maximumFractionDigits: 3, minimumFractionDigits: 3},
   {
-    '1.2500': '1.25',
-    '1.3125': '1.25',
-    '1.3750': '1.5',
-    '1.4375': '1.5',
-    '1.5000': '1.5',
+    '1.2500': '1.250',
+    '1.3125': '1.250',
+    '1.3750': '1.500',
+    '1.4375': '1.500',
+    '1.5000': '1.500',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 250, maximumFractionDigits: 4},
+  {roundingIncrement: 250, maximumFractionDigits: 4, minimumFractionDigits: 4},
   {
-    '1.02500': '1.025',
-    '1.03125': '1.025',
-    '1.03750': '1.05',
-    '1.04375': '1.05',
-    '1.05000': '1.05',
+    '1.02500': '1.0250',
+    '1.03125': '1.0250',
+    '1.03750': '1.0500',
+    '1.04375': '1.0500',
+    '1.05000': '1.0500',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2500.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-2500.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 2500, maximumFractionDigits: 4, minimumFractionDigits: 1},
+  {roundingIncrement: 2500, maximumFractionDigits: 4, minimumFractionDigits: 4},
   {
-    '1.2500': '1.25',
-    '1.3125': '1.25',
-    '1.3750': '1.5',
-    '1.4375': '1.5',
-    '1.5000': '1.5',
+    '1.2500': '1.2500',
+    '1.3125': '1.2500',
+    '1.3750': '1.5000',
+    '1.4375': '1.5000',
+    '1.5000': '1.5000',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 2500, maximumFractionDigits: 5},
+  {roundingIncrement: 2500, maximumFractionDigits: 5, minimumFractionDigits: 5},
   {
-    '1.02500': '1.025',
-    '1.03125': '1.025',
-    '1.03750': '1.05',
-    '1.04375': '1.05',
-    '1.05000': '1.05',
+    '1.02500': '1.02500',
+    '1.03125': '1.02500',
+    '1.03750': '1.05000',
+    '1.04375': '1.05000',
+    '1.05000': '1.05000',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5.js
@@ -28,12 +28,12 @@ testNumberFormat(
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 5, maximumFractionDigits: 2},
+  {roundingIncrement: 5, maximumFractionDigits: 2, minimumFractionDigits: 2},
   {
     '1.0500': '1.05',
     '1.0625': '1.05',
-    '1.0750': '1.1',
-    '1.0875': '1.1',
-    '1.1000': '1.1',
+    '1.0750': '1.10',
+    '1.0875': '1.10',
+    '1.1000': '1.10',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-50.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-50.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 50, maximumFractionDigits: 2, minimumFractionDigits: 1},
+  {roundingIncrement: 50, maximumFractionDigits: 2, minimumFractionDigits: 2},
   {
-    '1.500': '1.5',
-    '1.625': '1.5',
-    '1.750': '2.0',
-    '1.875': '2.0',
-    '2.000': '2.0',
+    '1.500': '1.50',
+    '1.625': '1.50',
+    '1.750': '2.00',
+    '1.875': '2.00',
+    '2.000': '2.00',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 50, maximumFractionDigits: 3},
+  {roundingIncrement: 50, maximumFractionDigits: 3, minimumFractionDigits: 3},
   {
-    '1.0500': '1.05',
-    '1.0625': '1.05',
-    '1.0750': '1.1',
-    '1.0875': '1.1',
-    '1.1000': '1.1',
+    '1.0500': '1.050',
+    '1.0625': '1.050',
+    '1.0750': '1.100',
+    '1.0875': '1.100',
+    '1.1000': '1.100',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-500.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-500.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 500, maximumFractionDigits: 3, minimumFractionDigits: 1},
+  {roundingIncrement: 500, maximumFractionDigits: 3, minimumFractionDigits: 3},
   {
-    '1.500': '1.5',
-    '1.625': '1.5',
-    '1.750': '2.0',
-    '1.875': '2.0',
-    '2.000': '2.0',
+    '1.500': '1.500',
+    '1.625': '1.500',
+    '1.750': '2.000',
+    '1.875': '2.000',
+    '2.000': '2.000',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 500, maximumFractionDigits: 4},
+  {roundingIncrement: 500, maximumFractionDigits: 4, minimumFractionDigits: 4},
   {
-    '1.0500': '1.05',
-    '1.0625': '1.05',
-    '1.0750': '1.1',
-    '1.0875': '1.1',
-    '1.1000': '1.1',
+    '1.0500': '1.0500',
+    '1.0625': '1.0500',
+    '1.0750': '1.1000',
+    '1.0875': '1.1000',
+    '1.1000': '1.1000',
   }
 );

--- a/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5000.js
+++ b/test/intl402/NumberFormat/prototype/format/format-rounding-increment-5000.js
@@ -15,25 +15,25 @@ var numberingSystems = ['arab', 'latn', 'thai', 'hanidec'];
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 5000, maximumFractionDigits: 4, minimumFractionDigits: 1},
+  {roundingIncrement: 5000, maximumFractionDigits: 4, minimumFractionDigits: 4},
   {
-    '1.500': '1.5',
-    '1.625': '1.5',
-    '1.750': '2.0',
-    '1.875': '2.0',
-    '2.000': '2.0',
+    '1.500': '1.5000',
+    '1.625': '1.5000',
+    '1.750': '2.0000',
+    '1.875': '2.0000',
+    '2.000': '2.0000',
   }
 );
 
 testNumberFormat(
   locales,
   numberingSystems,
-  {roundingIncrement: 5000, maximumFractionDigits: 5},
+  {roundingIncrement: 5000, maximumFractionDigits: 5, minimumFractionDigits: 5},
   {
-    '1.0500': '1.05',
-    '1.0625': '1.05',
-    '1.0750': '1.1',
-    '1.0875': '1.1',
-    '1.1000': '1.1',
+    '1.0500': '1.05000',
+    '1.0625': '1.05000',
+    '1.0750': '1.10000',
+    '1.0875': '1.10000',
+    '1.1000': '1.10000',
   }
 );


### PR DESCRIPTION
Make minimumFractionDigits equal to maximumFractionDigits while
roundingIncrement != 1 to sync with latest spec change in
https://github.com/tc39/proposal-intl-numberformat-v3/pull/85
which landed to spec text in Feb 22, 2022

@sffc @romulocintra 