### PR TITLE
use `isConstructor` assertion in "non-constructor" tests

### DIFF
--- a/test/built-ins/Array/prototype/concat/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/concat/create-species-non-ctor.js
@@ -18,8 +18,15 @@ info: |
        b. If C is null, let C be undefined.
     [...]
     9. If IsConstructor(C) is false, throw a TypeError exception.
-features: [Symbol.species]
+includes: [isConstructor.js]
+features: [Symbol.species, Reflect.construct]
 ---*/
+
+assert.sameValue(
+  isConstructor(parseInt),
+  false,
+  'precondition: isConstructor(parseInt) must return false'
+);
 
 var a = [];
 

--- a/test/built-ins/Array/prototype/filter/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/filter/create-species-non-ctor.js
@@ -19,8 +19,15 @@ info: |
        b. If C is null, let C be undefined.
     [...]
     9. If IsConstructor(C) is false, throw a TypeError exception.
-features: [Symbol.species]
+includes: [isConstructor.js]
+features: [Symbol.species, Reflect.construct]
 ---*/
+
+assert.sameValue(
+  isConstructor(parseInt),
+  false,
+  'precondition: isConstructor(parseInt) must return false'
+);
 
 var a = [];
 var callCount = 0;
@@ -33,5 +40,5 @@ a.constructor[Symbol.species] = parseInt;
 
 assert.throws(TypeError, function() {
   a.filter(cb);
-});
+}, 'a.filter(cb) throws a TypeError exception');
 assert.sameValue(callCount, 0);

--- a/test/built-ins/Array/prototype/map/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/map/create-species-non-ctor.js
@@ -19,8 +19,15 @@ info: |
        b. If C is null, let C be undefined.
     [...]
     9. If IsConstructor(C) is false, throw a TypeError exception.
-features: [Symbol.species]
+includes: [isConstructor.js]
+features: [Symbol.species, Reflect.construct]
 ---*/
+
+assert.sameValue(
+  isConstructor(parseInt),
+  false,
+  'precondition: isConstructor(parseInt) must return false'
+);
 
 var a = [];
 var callCount = 0;
@@ -33,5 +40,5 @@ a.constructor[Symbol.species] = parseInt;
 
 assert.throws(TypeError, function() {
   a.map(cb);
-});
+}, 'a.map(cb) throws a TypeError exception');
 assert.sameValue(callCount, 0);

--- a/test/built-ins/Array/prototype/slice/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/slice/create-species-non-ctor.js
@@ -19,8 +19,15 @@ info: |
        b. If C is null, let C be undefined.
     [...]
     9. If IsConstructor(C) is false, throw a TypeError exception.
-features: [Symbol.species]
+includes: [isConstructor.js]
+features: [Symbol.species, Reflect.construct]
 ---*/
+
+assert.sameValue(
+  isConstructor(parseInt),
+  false,
+  'precondition: isConstructor(parseInt) must return false'
+);
 
 var a = [];
 
@@ -29,4 +36,4 @@ a.constructor[Symbol.species] = parseInt;
 
 assert.throws(TypeError, function() {
   a.slice();
-});
+}, 'a.slice() throws a TypeError exception');

--- a/test/built-ins/Array/prototype/splice/create-species-non-ctor.js
+++ b/test/built-ins/Array/prototype/splice/create-species-non-ctor.js
@@ -19,8 +19,15 @@ info: |
        b. If C is null, let C be undefined.
     [...]
     9. If IsConstructor(C) is false, throw a TypeError exception.
-features: [Symbol.species]
+includes: [isConstructor.js]
+features: [Symbol.species, Reflect.construct]
 ---*/
+
+assert.sameValue(
+  isConstructor(parseInt),
+  false,
+  'precondition: isConstructor(parseInt) must return false'
+);
 
 var a = [];
 
@@ -29,4 +36,4 @@ a.constructor[Symbol.species] = parseInt;
 
 assert.throws(TypeError, function() {
   a.splice();
-});
+}, 'a.splice() throws a TypeError exception');

--- a/test/built-ins/RegExp/prototype/toString/S15.10.6.4_A6.js
+++ b/test/built-ins/RegExp/prototype/toString/S15.10.6.4_A6.js
@@ -5,9 +5,17 @@
 info: RegExp.prototype.toString has not prototype property
 es5id: 15.10.6.4_A6
 description: Checking RegExp.prototype.toString.prototype
+includes: [isConstructor.js]
+features: [Reflect.construct]
 ---*/
 assert.sameValue(
   RegExp.prototype.toString.prototype,
   undefined,
   'The value of RegExp.prototype.toString.prototype is expected to equal undefined'
+);
+
+assert.sameValue(
+  isConstructor(RegExp.prototype.toString),
+  false,
+  'isConstructor(RegExp.prototype.toString) must return false'
 );

--- a/test/built-ins/RegExp/prototype/toString/S15.10.6.4_A7.js
+++ b/test/built-ins/RegExp/prototype/toString/S15.10.6.4_A7.js
@@ -5,6 +5,8 @@
 info: RegExp.prototype.toString can't be used as constructor
 es5id: 15.10.6.4_A7
 description: Checking if creating the RegExp.prototype.toString object fails
+includes: [isConstructor.js]
+features: [Reflect.construct]
 ---*/
 
 var __FACTORY = RegExp.prototype.toString;
@@ -19,5 +21,11 @@ try {
     'The result of evaluating (e instanceof TypeError) is expected to be true'
   );
 }
+
+assert.sameValue(
+  isConstructor(RegExp.prototype.toString),
+  false,
+  'isConstructor(RegExp.prototype.toString) must return false'
+);
 
 // TODO: Convert to assert.throws() format.


### PR DESCRIPTION
A few of the "not constructor" tests weren't using isConstructor, and thus lacked the `Reflect.construct` feature flag.

At first I tried to make a new "non-constructor" feature flag, but it would change hundreds of files - and since these tests were missing an `isConstructor` precondition assertion anyways, this seemed more expedient.