### PR TITLE
Fix generator clean fail on .DS_Store

### DIFF
--- a/tools/generation/generator.py
+++ b/tools/generation/generator.py
@@ -9,6 +9,11 @@ import glob, os, sys
 from lib.expander import Expander
 from lib.test import Test
 
+# base name of the files to be ignored
+ignored_files = [
+    '.DS_Store',
+]
+
 def print_error(*values):
     print('ERROR:', *values, file=sys.stderr)
 
@@ -35,6 +40,8 @@ def find_cases(location):
 def clean(args):
     for (subdir, _, fileNames) in os.walk(args.directory):
         for fileName in map(lambda x: os.path.join(subdir, x), fileNames):
+            if os.path.basename(fileName) in ignored_files:
+                continue
             test = Test(fileName)
             test.load()
             if test.is_generated():


### PR DESCRIPTION
.DS_Store is not a utf8 encoded text file. Reading it in utf8 encoding makes `./make.py clean` abort with the following exception:

```
./make.py clean
Running target: clean
> /bin/python tools/generation/generator.py clean test
Traceback (most recent call last):
  File "/workspace/tc39/test262/tools/generation/generator.py", line 103, in <module>
    args.func(args)
  File "/workspace/tc39/test262/tools/generation/generator.py", line 39, in clean
    test.load()
  File "/workspace/tc39/test262/tools/generation/lib/test.py", line 29, in load
    self.source = handle.read()
  File "/workspace/.pyenv/versions/3.10.3/lib/python3.10/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x86 in position 1097: invalid start byte
```