### PR TITLE
ShadowRealm: exportName is no longer be coerced to a string

### DIFF
--- a/test/built-ins/ShadowRealm/prototype/importValue/throws-if-exportname-not-string.js
+++ b/test/built-ins/ShadowRealm/prototype/importValue/throws-if-exportname-not-string.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-shadowrealm.prototype.importvalue
 description: >
-  ShadowRealm.prototype.importValue coerces exportName to string.
+  ShadowRealm.prototype.importValue throws if exportName is not a string.
 features: [ShadowRealm]
 ---*/
 
@@ -23,8 +23,8 @@ const exportName = {
   }
 };
 
-assert.throws(Test262Error, () => {
+assert.throws(TypeError, () => {
   r.importValue('', exportName);
 });
 
-assert.sameValue(count, 1);
+assert.sameValue(count, 0);


### PR DESCRIPTION
Fixes: https://github.com/tc39/test262/issues/3509
Normative Change: https://github.com/tc39/proposal-shadowrealm/pull/352
