### PR TITLE
Move testing of era/eraYear under intl402

### DIFF
--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-noniso.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-noniso.js
@@ -26,9 +26,8 @@ const shifted = pdt.withPlainDate(pd);
 TemporalHelpers.assertPlainDateTime(
   shifted,
   2008, 9, "M09", 6, 3, 24, 30, 0, 0, 0,
-  "calendar is changed if receiver has ISO calendar (1)",
-  "the era",
-  1909
+  "calendar is changed if receiver has ISO calendar (1)"
+  // Testing of era and eraYear should only be coded under intl402
 );
 
 assert.sameValue(

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-noniso.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-noniso.js
@@ -10,8 +10,6 @@ includes: [temporalHelpers.js]
 
 const cal = {
   id: 'thisisnotiso',
-  era() { return "the era"; },
-  eraYear() { return 1909; },
   toString() { return "this is a string"; },
   year() { return 2008; },
   month() { return 9; },

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-id.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-id.js
@@ -13,8 +13,6 @@ const cal1 = {
 };
 const cal2 = {
   id: 'thisisnotiso',
-  era() { return "the era"; },
-  eraYear() { return 1909; },
   toString() { return "this is a string"; },
   year() { return 2008; },
   month() { return 9; },

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-id.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-id.js
@@ -28,9 +28,8 @@ const shifted = pdt.withPlainDate(pd);
 TemporalHelpers.assertPlainDateTime(
   shifted,
   2008, 9, "M09", 6, 3, 24, 30, 0, 0, 0,
-  "calendar is changed with same id (1)",
-  "the era",
-  1909
+  "calendar is changed with same id (1)"
+  // Testing of era and eraYear should only be coded under intl402
 );
 
 assert.sameValue(

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-object.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-object.js
@@ -29,9 +29,8 @@ const shifted = pdt.withPlainDate(pd);
 TemporalHelpers.assertPlainDateTime(
   shifted,
   2008, 9, "M09", 6, 3, 24, 30, 0, 0, 0,
-  "calendar is unchanged with same calendars (1)",
-  "the era",
-  1909
+  "calendar is unchanged with same calendars (1)"
+  // Testing of era and eraYear should only be coded under intl402
 );
 
 assert.sameValue(

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-object.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-object.js
@@ -11,8 +11,6 @@ includes: [temporalHelpers.js]
 let calls = 0;
 const cal = {
   id: 'thisisnotiso',
-  era() { return "the era"; },
-  eraYear() { return 1909; },
   toString() {
     ++calls;
     return "this is a string";

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar.js
@@ -26,9 +26,8 @@ const shifted = pdt.withPlainDate(pd);
 TemporalHelpers.assertPlainDateTime(
   shifted,
   2008, 9, "M09", 6, 3, 24, 30, 0, 0, 0,
-  "calendar is unchanged if input has ISO calendar (1)",
-  "the era",
-  1909
+  "calendar is unchanged if input has ISO calendar (1)"
+  // Testing of era and eraYear should only be coded under intl402
 );
 
 assert.sameValue(

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar.js
@@ -10,8 +10,6 @@ includes: [temporalHelpers.js]
 
 const cal = {
   id: 'thisisnotiso',
-  era() { return "the era"; },
-  eraYear() { return 1909; },
   toString() { return "this is a string"; },
   year() { return 2008; },
   month() { return 9; },

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-iso-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-iso-calendar.js
@@ -10,8 +10,6 @@ includes: [temporalHelpers.js]
 
 const cal = {
   id: "thisisnotiso",
-  era() { return "the era"; },
-  eraYear() { return 1909; },
   toString() { return "this is a string"; },
   year() { return 2008; },
   month() { return 9; },

--- a/test/intl402/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-noniso.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-noniso.js
@@ -3,13 +3,13 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.withplaindate
-description: Original PDT calendar is preserved with ISO string
+description: PlainDate calendar is preserved with ISO PDT
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const cal = {
-  id: "thisisnotiso",
+  id: 'thisisnotiso',
   era() { return "the era"; },
   eraYear() { return 1909; },
   toString() { return "this is a string"; },
@@ -18,18 +18,21 @@ const cal = {
   monthCode() { return "M09"; },
   day() { return 6; }
 };
-const dt = new Temporal.PlainDateTime(1995, 12, 7, 3, 24, 30, 0, 0, 0, cal);
-const shifted = dt.withPlainDate("2010-11-12");
+const pdt = new Temporal.PlainDateTime(1995, 12, 7, 3, 24, 30, 0, 0, 0);
+assert.sameValue(pdt.calendar.toString(), "iso8601", "PlainDateTime with ISO calendar");
+const pd = new Temporal.PlainDate(2010, 11, 12, cal);
+const shifted = pdt.withPlainDate(pd);
 
 TemporalHelpers.assertPlainDateTime(
   shifted,
   2008, 9, "M09", 6, 3, 24, 30, 0, 0, 0,
-  "calendar is unchanged if input has ISO calendar (1)"
-  // Testing of era and eraYear should only be coded under intl402
+  "calendar is changed if receiver has ISO calendar (1)",
+  "the era",
+  1909
 );
 
 assert.sameValue(
   shifted.calendar,
   cal,
-  "calendar is unchanged if input has ISO calendar (2)"
+  "calendar is changed if receiver has ISO calendar (2)"
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-id.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-id.js
@@ -3,13 +3,16 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.withplaindate
-description: Original PDT calendar is preserved with ISO string
+description: PlainDate calendar is preserved when both calendars have the same id
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-const cal = {
-  id: "thisisnotiso",
+const cal1 = {
+  toString() { return "this is a string"; },
+};
+const cal2 = {
+  id: 'thisisnotiso',
   era() { return "the era"; },
   eraYear() { return 1909; },
   toString() { return "this is a string"; },
@@ -18,18 +21,20 @@ const cal = {
   monthCode() { return "M09"; },
   day() { return 6; }
 };
-const dt = new Temporal.PlainDateTime(1995, 12, 7, 3, 24, 30, 0, 0, 0, cal);
-const shifted = dt.withPlainDate("2010-11-12");
+const pdt = new Temporal.PlainDateTime(1995, 12, 7, 3, 24, 30, 0, 0, 0, cal1);
+const pd = new Temporal.PlainDate(2010, 11, 12, cal2);
+const shifted = pdt.withPlainDate(pd);
 
 TemporalHelpers.assertPlainDateTime(
   shifted,
   2008, 9, "M09", 6, 3, 24, 30, 0, 0, 0,
-  "calendar is unchanged if input has ISO calendar (1)"
-  // Testing of era and eraYear should only be coded under intl402
+  "calendar is changed with same id (1)",
+  "the era",
+  1909
 );
 
 assert.sameValue(
   shifted.calendar,
-  cal,
-  "calendar is unchanged if input has ISO calendar (2)"
+  cal2,
+  "calendar is changed with same id (2)"
 );

--- a/test/intl402/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-object.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-object.js
@@ -3,33 +3,40 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.withplaindate
-description: Original PDT calendar is preserved with ISO string
+description: PlainDate calendar is preserved when both calendars are the same object
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
+let calls = 0;
 const cal = {
-  id: "thisisnotiso",
+  id: 'thisisnotiso',
   era() { return "the era"; },
   eraYear() { return 1909; },
-  toString() { return "this is a string"; },
+  toString() {
+    ++calls;
+    return "this is a string";
+  },
   year() { return 2008; },
   month() { return 9; },
   monthCode() { return "M09"; },
   day() { return 6; }
 };
-const dt = new Temporal.PlainDateTime(1995, 12, 7, 3, 24, 30, 0, 0, 0, cal);
-const shifted = dt.withPlainDate("2010-11-12");
+const pdt = new Temporal.PlainDateTime(1995, 12, 7, 3, 24, 30, 0, 0, 0, cal);
+const pd = new Temporal.PlainDate(2010, 11, 12, cal);
+const shifted = pdt.withPlainDate(pd);
 
 TemporalHelpers.assertPlainDateTime(
   shifted,
   2008, 9, "M09", 6, 3, 24, 30, 0, 0, 0,
-  "calendar is unchanged if input has ISO calendar (1)"
-  // Testing of era and eraYear should only be coded under intl402
+  "calendar is unchanged with same calendars (1)",
+  "the era",
+  1909
 );
 
 assert.sameValue(
   shifted.calendar,
   cal,
-  "calendar is unchanged if input has ISO calendar (2)"
+  "calendar is unchanged with same calendars (2)"
 );
+assert.sameValue(calls, 0, "should not have called cal.toString()");

--- a/test/intl402/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar.js
@@ -3,13 +3,13 @@
 
 /*---
 esid: sec-temporal.plaindatetime.prototype.withplaindate
-description: Original PDT calendar is preserved with ISO string
+description: Original PDT calendar is preserved with ISO PlainDate
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const cal = {
-  id: "thisisnotiso",
+  id: 'thisisnotiso',
   era() { return "the era"; },
   eraYear() { return 1909; },
   toString() { return "this is a string"; },
@@ -18,14 +18,17 @@ const cal = {
   monthCode() { return "M09"; },
   day() { return 6; }
 };
-const dt = new Temporal.PlainDateTime(1995, 12, 7, 3, 24, 30, 0, 0, 0, cal);
-const shifted = dt.withPlainDate("2010-11-12");
+const pdt = new Temporal.PlainDateTime(1995, 12, 7, 3, 24, 30, 0, 0, 0, cal);
+const pd = new Temporal.PlainDate(2010, 11, 12);
+assert.sameValue(pd.calendar.toString(), "iso8601", "PlainDate with ISO calendar");
+const shifted = pdt.withPlainDate(pd);
 
 TemporalHelpers.assertPlainDateTime(
   shifted,
   2008, 9, "M09", 6, 3, 24, 30, 0, 0, 0,
-  "calendar is unchanged if input has ISO calendar (1)"
-  // Testing of era and eraYear should only be coded under intl402
+  "calendar is unchanged if input has ISO calendar (1)",
+  "the era",
+  1909
 );
 
 assert.sameValue(

--- a/test/intl402/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-iso-calendar.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-iso-calendar.js
@@ -24,8 +24,9 @@ const shifted = dt.withPlainDate("2010-11-12");
 TemporalHelpers.assertPlainDateTime(
   shifted,
   2008, 9, "M09", 6, 3, 24, 30, 0, 0, 0,
-  "calendar is unchanged if input has ISO calendar (1)"
-  // Testing of era and eraYear should only be coded under intl402
+  "calendar is unchanged if input has ISO calendar (1)",
+  "the era",
+  1909
 );
 
 assert.sameValue(


### PR DESCRIPTION
Temporal.PlainDateTime.prototype.ear and earYear are not defined in first 14 chapters and only defined under Chapter 15. Therefore they should always return undefined unless it is an intl implementation.

Copy the same test to intl402 and remove the non undefined value of era/eraYear from the built-ints version of test. 

Fix https://github.com/tc39/test262/issues/3516 
Also see https://github.com/tc39/proposal-temporal/issues/2169