### PR TITLE
Turn unimportant tabs into spaces in S12.6.4_A7_T2.js

### DIFF
--- a/test/language/statements/for-in/S12.6.4_A7_T2.js
+++ b/test/language/statements/for-in/S12.6.4_A7_T2.js
@@ -21,23 +21,23 @@ __obj.ca = 3;
 __accum="";
 
 for (var __key in __obj){
-	
+
     erasator_T_1000(__obj,"b");
   
-	__accum+=(__key+__obj[__key]);
+    __accum+=(__key+__obj[__key]);
 	
 }
 
 assert(
-	__accum === "aa1ca3" || __accum === "ca3aa1",
-	"Unexpected value: '" + __accum + "'"
+    __accum === "aa1ca3" || __accum === "ca3aa1",
+    "Unexpected value: '" + __accum + "'"
 );
 
 // erasator is the hash map terminator
 function erasator_T_1000(hash_map, charactr){
-	for (var key in hash_map){
-		if (key.indexOf(charactr)===0) {
-			delete hash_map[key];
-		};
-	}
+    for (var key in hash_map){
+        if (key.indexOf(charactr)===0) {
+            delete hash_map[key];
+        };
+    }
 }


### PR DESCRIPTION
This test currently has some tabs. Clean this up and make it use spaces instead.