### PR TITLE
Fix Temporal.PlainDateTime.withPlainDate tests

### DIFF
--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-noniso.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-noniso.js
@@ -10,6 +10,8 @@ includes: [temporalHelpers.js]
 
 const cal = {
   id: 'thisisnotiso',
+  era() { return undefined; },
+  eraYear() { return undefined; },
   toString() { return "this is a string"; },
   year() { return 2008; },
   month() { return 9; },

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-id.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-id.js
@@ -13,6 +13,8 @@ const cal1 = {
 };
 const cal2 = {
   id: 'thisisnotiso',
+  era() { return undefined; },
+  eraYear() { return undefined; },
   toString() { return "this is a string"; },
   year() { return 2008; },
   month() { return 9; },

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-object.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-object.js
@@ -11,6 +11,8 @@ includes: [temporalHelpers.js]
 let calls = 0;
 const cal = {
   id: 'thisisnotiso',
+  era() { return undefined; },
+  eraYear() { return undefined; },
   toString() {
     ++calls;
     return "this is a string";

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar.js
@@ -10,6 +10,8 @@ includes: [temporalHelpers.js]
 
 const cal = {
   id: 'thisisnotiso',
+  era() { return undefined; },
+  eraYear() { return undefined; },
   toString() { return "this is a string"; },
   year() { return 2008; },
   month() { return 9; },

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-iso-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-iso-calendar.js
@@ -10,6 +10,8 @@ includes: [temporalHelpers.js]
 
 const cal = {
   id: "thisisnotiso",
+  era() { return undefined; },
+  eraYear() { return undefined; },
   toString() { return "this is a string"; },
   year() { return 2008; },
   month() { return 9; },


### PR DESCRIPTION
I suggested in #3517 that these lines should be removed but didn't realize
they must be present because TemporalHelpers.assertPlainDateTime is going
to access the 'era' and 'eraYear' properties.