### PR TITLE
Temporal: Add tests for variant time separators

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-time-separators.js
@@ -2,24 +2,26 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.dateadd
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.dateAdd(arg, new Temporal.Duration());
+
+  TemporalHelpers.assertPlainDate(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    2000, 5, "M05", 2,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-string-time-separators.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: Time separator in string argument can vary
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const date = new Temporal.PlainDate(2000, 5, 3);
+const tests = [
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
+];
+
+const instance = new Temporal.Calendar("iso8601");
+
+tests.forEach(([arg, description]) => {
+  TemporalHelpers.assertDuration(
+    instance.dateUntil(arg, date),
+    0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+    `variant time separators (${description}), first argument`
+  );
+
+  TemporalHelpers.assertDuration(
+    instance.dateUntil(date, arg),
+    0, 0, 0, -1, 0, 0, 0, 0, 0, 0,
+    `variant time separators (${description}), second argument`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.day
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.day(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    2,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.dayofweek
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.dayOfWeek(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    2,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.dayofyear
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.dayOfYear(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    123,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.daysinmonth
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.daysInMonth(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    31,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.daysinweek
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.daysInWeek(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    7,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.daysinyear
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.daysInYear(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    366,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.inleapyear
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.inLeapYear(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    true,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.month
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.month(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    5,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.monthcode
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.monthCode(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    "M05",
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.monthsinyear
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.monthsInYear(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    12,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.weekofyear
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.weekOfYear(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    18,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.year
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.year(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    2000,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Instant/compare/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Instant/compare/argument-string-time-separators.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.compare
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const epoch = new Temporal.Instant(0n);
+const tests = [
+  ["1970-01-01T00:00Z", "uppercase T"],
+  ["1970-01-01t00:00Z", "lowercase T"],
+  ["1970-01-01 00:00Z", "space between date and time"],
+];
+
+tests.forEach(([arg, description]) => {
+  assert.sameValue(
+    Temporal.Instant.compare(arg, epoch),
+    0,
+    `variant time separators (${description}), first argument`
+  );
+
+  assert.sameValue(
+    Temporal.Instant.compare(epoch, arg),
+    0,
+    `variant time separators (${description}), second argument`
+  );
+});

--- a/test/built-ins/Temporal/Instant/from/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Instant/from/argument-string-time-separators.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.from
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const tests = [
+  ["1970-01-01T00:00Z", "uppercase T"],
+  ["1970-01-01t00:00Z", "lowercase T"],
+  ["1970-01-01 00:00Z", "space between date and time"],
+];
+
+tests.forEach(([arg, description]) => {
+  const result = Temporal.Instant.from(arg);
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    0n,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/Instant/prototype/equals/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.instant.prototype.equals
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["1970-01-01T00:00Z", "uppercase T"],
+  ["1970-01-01t00:00Z", "lowercase T"],
+  ["1970-01-01 00:00Z", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Instant(0n);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    true,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Instant/prototype/since/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/argument-string-time-separators.js
@@ -2,24 +2,26 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.instant.prototype.since
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["1970-01-01T00:00Z", "uppercase T"],
+  ["1970-01-01t00:00Z", "lowercase T"],
+  ["1970-01-01 00:00Z", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Instant(0n);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/Instant/prototype/until/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/argument-string-time-separators.js
@@ -2,24 +2,26 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.instant.prototype.until
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["1970-01-01T00:00Z", "uppercase T"],
+  ["1970-01-01t00:00Z", "lowercase T"],
+  ["1970-01-01 00:00Z", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Instant(0n);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainDate/compare/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-string-time-separators.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.compare
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const date = new Temporal.PlainDate(2000, 5, 2);
+const tests = [
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
+];
+
+tests.forEach(([arg, description]) => {
+  assert.sameValue(
+    Temporal.PlainDate.compare(arg, date),
+    0,
+    `variant time separators (${description}), first argument`
+  );
+
+  assert.sameValue(
+    Temporal.PlainDate.compare(date, arg),
+    0,
+    `variant time separators (${description}), second argument`
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/from/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-string-time-separators.js
@@ -2,24 +2,24 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindate.from
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
 tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+  const result = Temporal.PlainDate.from(arg);
 
-  TemporalHelpers.assertPlainDateTime(
+  TemporalHelpers.assertPlainDate(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    2000, 5, "M05", 2,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindate.prototype.equals
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.PlainDate(2000, 5, 2);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    true,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-string-time-separators.js
@@ -2,24 +2,26 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindate.prototype.since
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.PlainDate(2000, 5, 2);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-separators.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplaindatetime
+description: Time separator in string argument can vary
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const tests = [
+  ["1976-11-18T12:34:56.987654321", "uppercase T"],
+  ["1976-11-18t12:34:56.987654321", "lowercase T"],
+  ["1976-11-18 12:34:56.987654321", "space between date and time"],
+  ["T12:34:56.987654321", "time-only uppercase T"],
+  ["t12:34:56.987654321", "time-only lowercase T"],
+];
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.toPlainDateTime(arg);
+
+  TemporalHelpers.assertPlainDateTime(
+    result,
+    2000, 5, "M05", 2, 12, 34, 56, 987, 654, 321,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-time-separators.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const tests = [
+  ["1976-11-18T12:34:56.987654321", "uppercase T"],
+  ["1976-11-18t12:34:56.987654321", "lowercase T"],
+  ["1976-11-18 12:34:56.987654321", "space between date and time"],
+  ["T12:34:56.987654321", "time-only uppercase T"],
+  ["t12:34:56.987654321", "time-only lowercase T"],
+];
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" });
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    957_270_896_987_654_321n,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-string-time-separators.js
@@ -2,24 +2,26 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindate.prototype.until
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.PlainDate(2000, 5, 2);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-string-time-separators.js
@@ -2,12 +2,12 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindatetime.compare
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
+const dateTime = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
 const tests = [
   ["1976-11-18T15:23", "uppercase T"],
   ["1976-11-18t15:23", "lowercase T"],
@@ -15,11 +15,15 @@ const tests = [
 ];
 
 tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+  assert.sameValue(
+    Temporal.PlainDateTime.compare(arg, dateTime),
+    0,
+    `variant time separators (${description}), first argument`
+  );
 
-  TemporalHelpers.assertPlainDateTime(
-    result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
-    `variant time separators (${description})`
+  assert.sameValue(
+    Temporal.PlainDateTime.compare(dateTime, arg),
+    0,
+    `variant time separators (${description}), second argument`
   );
 });

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-time-separators.js
@@ -2,10 +2,9 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindatetime.prototype.equals
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
@@ -14,12 +13,14 @@ const tests = [
   ["1976-11-18 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    true,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-string-time-separators.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindatetime.prototype.since
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
@@ -14,12 +14,14 @@ const tests = [
   ["1976-11-18 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-string-time-separators.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindatetime.prototype.until
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
@@ -14,12 +14,14 @@ const tests = [
   ["1976-11-18 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-time-separators.js
@@ -2,24 +2,26 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaindatetime.prototype.withplaindate
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
+
 tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+  const result = instance.withPlainDate(arg);
 
   TemporalHelpers.assertPlainDateTime(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    2000, 5, "M05", 2, 15, 23, 0, 0, 0, 0,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-separators.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaintime
+description: Time separator in string argument can vary
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const tests = [
+  ["1976-11-18T12:34:56.987654321", "uppercase T"],
+  ["1976-11-18t12:34:56.987654321", "lowercase T"],
+  ["1976-11-18 12:34:56.987654321", "space between date and time"],
+  ["T12:34:56.987654321", "time-only uppercase T"],
+  ["t12:34:56.987654321", "time-only lowercase T"],
+];
+
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.withPlainTime(arg);
+
+  TemporalHelpers.assertPlainDateTime(
+    result,
+    1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-string-time-separators.js
@@ -2,24 +2,24 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plainmonthday.from
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["1976-05-02T15:23", "uppercase T"],
+  ["1976-05-02t15:23", "lowercase T"],
+  ["1976-05-02 15:23", "space between date and time"],
 ];
 
 tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+  const result = Temporal.PlainMonthDay.from(arg);
 
-  TemporalHelpers.assertPlainDateTime(
+  TemporalHelpers.assertPlainMonthDay(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    "M05", 2,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plainmonthday.prototype.equals
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["1976-05-02T15:23", "uppercase T"],
+  ["1976-05-02t15:23", "lowercase T"],
+  ["1976-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.PlainMonthDay(5, 2);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    true,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainTime/compare/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainTime/compare/argument-string-time-separators.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.compare
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const tests = [
+  ["1976-11-18T12:34:56.987654321", "uppercase T"],
+  ["1976-11-18t12:34:56.987654321", "lowercase T"],
+  ["1976-11-18 12:34:56.987654321", "space between date and time"],
+  ["T12:34:56.987654321", "time-only uppercase T"],
+  ["t12:34:56.987654321", "time-only lowercase T"],
+];
+
+tests.forEach(([arg, description]) => {
+  assert.sameValue(
+    Temporal.PlainTime.compare(arg, plainTime),
+    0,
+    `variant time separators (${description}), first argument`
+  );
+
+  assert.sameValue(
+    Temporal.PlainTime.compare(plainTime, arg),
+    0,
+    `variant time separators (${description}), second argument`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/from/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-string-time-separators.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.from
+description: Time separator in string argument can vary
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const tests = [
+  ["1976-11-18T12:34:56.987654321", "uppercase T"],
+  ["1976-11-18t12:34:56.987654321", "lowercase T"],
+  ["1976-11-18 12:34:56.987654321", "space between date and time"],
+  ["T12:34:56.987654321", "time-only uppercase T"],
+  ["t12:34:56.987654321", "time-only lowercase T"],
+];
+
+tests.forEach(([arg, description]) => {
+  const result = Temporal.PlainTime.from(arg);
+
+  TemporalHelpers.assertPlainTime(
+    result,
+    12, 34, 56, 987, 654, 321,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-separators.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.equals
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const tests = [
+  ["1976-11-18T12:34:56.987654321", "uppercase T"],
+  ["1976-11-18t12:34:56.987654321", "lowercase T"],
+  ["1976-11-18 12:34:56.987654321", "space between date and time"],
+  ["T12:34:56.987654321", "time-only uppercase T"],
+  ["t12:34:56.987654321", "time-only lowercase T"],
+];
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
+    result,
+    true,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-separators.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: Time separator in string argument can vary
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const tests = [
+  ["1976-11-18T12:34:56.987654321", "uppercase T"],
+  ["1976-11-18t12:34:56.987654321", "lowercase T"],
+  ["1976-11-18 12:34:56.987654321", "space between date and time"],
+  ["T12:34:56.987654321", "time-only uppercase T"],
+  ["t12:34:56.987654321", "time-only lowercase T"],
+];
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-string-time-separators.js
@@ -2,24 +2,26 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plaintime.prototype.toplaindatetime
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
 tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+  const result = instance.toPlainDateTime(arg);
 
   TemporalHelpers.assertPlainDateTime(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    2000, 5, "M05", 2, 12, 34, 56, 987, 654, 321,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-time-separators.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const tests = [
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
+];
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" });
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    957_270_896_987_654_321n,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-separators.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: Time separator in string argument can vary
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const tests = [
+  ["1976-11-18T12:34:56.987654321", "uppercase T"],
+  ["1976-11-18t12:34:56.987654321", "lowercase T"],
+  ["1976-11-18 12:34:56.987654321", "space between date and time"],
+  ["T12:34:56.987654321", "time-only uppercase T"],
+  ["t12:34:56.987654321", "time-only lowercase T"],
+];
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-string-time-separators.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const yearMonth = new Temporal.PlainYearMonth(2019, 12);
+const tests = [
+  ["2019-12-15T15:23", "uppercase T"],
+  ["2019-12-15t15:23", "lowercase T"],
+  ["2019-12-15 15:23", "space between date and time"],
+];
+
+tests.forEach(([arg, description]) => {
+  assert.sameValue(
+    Temporal.PlainYearMonth.compare(arg, yearMonth),
+    0,
+    `variant time separators (${description}), first argument`
+  );
+
+  assert.sameValue(
+    Temporal.PlainYearMonth.compare(yearMonth, arg),
+    0,
+    `variant time separators (${description}), second argument`
+  );
+});

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-string-time-separators.js
@@ -2,24 +2,24 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plainyearmonth.from
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2019-12-15T15:23", "uppercase T"],
+  ["2019-12-15t15:23", "lowercase T"],
+  ["2019-12-15 15:23", "space between date and time"],
 ];
 
 tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+  const result = Temporal.PlainYearMonth.from(arg);
 
-  TemporalHelpers.assertPlainDateTime(
+  TemporalHelpers.assertPlainYearMonth(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    2019, 12, "M12",
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plainyearmonth.prototype.equals
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2019-12-15T15:23", "uppercase T"],
+  ["2019-12-15t15:23", "lowercase T"],
+  ["2019-12-15 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.PlainYearMonth(2019, 12);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    true,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-time-separators.js
@@ -2,24 +2,26 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plainyearmonth.prototype.since
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2019-12-15T15:23", "uppercase T"],
+  ["2019-12-15t15:23", "lowercase T"],
+  ["2019-12-15 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.PlainYearMonth(2019, 12);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-time-separators.js
@@ -2,24 +2,26 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.plainyearmonth.prototype.until
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2019-12-15T15:23", "uppercase T"],
+  ["2019-12-15t15:23", "lowercase T"],
+  ["2019-12-15 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.PlainYearMonth(2019, 12);
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-string-time-separators.js
@@ -2,10 +2,9 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.timezone.prototype.getinstantfor
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
@@ -14,12 +13,14 @@ const tests = [
   ["1976-11-18 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.TimeZone("UTC");
 
-  TemporalHelpers.assertPlainDateTime(
-    result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+tests.forEach(([arg, description]) => {
+  const result = instance.getInstantFor(arg);
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    217_178_580_000_000_000n,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.timezone.prototype.getnexttransition
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["1970-01-01T00:00Z", "uppercase T"],
+  ["1970-01-01t00:00Z", "lowercase T"],
+  ["1970-01-01 00:00Z", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.TimeZone("UTC");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.getNextTransition(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    null,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.timezone.prototype.getoffsetnanosecondsfor
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["1970-01-01T00:00Z", "uppercase T"],
+  ["1970-01-01t00:00Z", "lowercase T"],
+  ["1970-01-01 00:00Z", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.TimeZone("UTC");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.getOffsetNanosecondsFor(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    0,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.timezone.prototype.getoffsetstringfor
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["1970-01-01T00:00Z", "uppercase T"],
+  ["1970-01-01t00:00Z", "lowercase T"],
+  ["1970-01-01 00:00Z", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.TimeZone("UTC");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.getOffsetStringFor(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    "+00:00",
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-string-time-separators.js
@@ -2,24 +2,26 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
 description: Time separator in string argument can vary
 features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["1970-01-01T00:00Z", "uppercase T"],
+  ["1970-01-01t00:00Z", "lowercase T"],
+  ["1970-01-01 00:00Z", "space between date and time"],
 ];
 
+const instance = new Temporal.TimeZone("UTC");
+
 tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+  const result = instance.getPlainDateTimeFor(arg);
 
   TemporalHelpers.assertPlainDateTime(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    1970, 1, "M01", 1, 0, 0, 0, 0, 0, 0,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-string-time-separators.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
+includes: [compareArray.js]
 ---*/
 
 const tests = [
@@ -14,12 +14,14 @@ const tests = [
   ["1976-11-18 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.TimeZone("UTC");
 
-  TemporalHelpers.assertPlainDateTime(
-    result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+tests.forEach(([arg, description]) => {
+  const result = instance.getPossibleInstantsFor(arg);
+
+  assert.compareArray(
+    result.map(i => i.epochNanoseconds),
+    [217_178_580_000_000_000n],
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.timezone.prototype.getprevioustransition
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["1970-01-01T00:00Z", "uppercase T"],
+  ["1970-01-01t00:00Z", "lowercase T"],
+  ["1970-01-01 00:00Z", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.TimeZone("UTC");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.getPreviousTransition(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    null,
     `variant time separators (${description})`
   );
 });

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-string-time-separators.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const epoch = new Temporal.ZonedDateTime(0n, "UTC");
+const tests = [
+  ["1970-01-01T00:00+00:00[UTC]", "uppercase T"],
+  ["1970-01-01t00:00+00:00[UTC]", "lowercase T"],
+  ["1970-01-01 00:00+00:00[UTC]", "space between date and time"],
+];
+
+tests.forEach(([arg, description]) => {
+  assert.sameValue(
+    Temporal.ZonedDateTime.compare(arg, epoch),
+    0,
+    `variant time separators (${description}), first argument`
+  );
+
+  assert.sameValue(
+    Temporal.ZonedDateTime.compare(epoch, arg),
+    0,
+    `variant time separators (${description}), second argument`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-string-time-separators.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const tests = [
+  ["1970-01-01T00:00+00:00[UTC]", "uppercase T"],
+  ["1970-01-01t00:00+00:00[UTC]", "lowercase T"],
+  ["1970-01-01 00:00+00:00[UTC]", "space between date and time"],
+];
+
+tests.forEach(([arg, description]) => {
+  const result = Temporal.ZonedDateTime.from(arg);
+
+  assert.sameValue(
+    result.timeZone.toString(),
+    "UTC",
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-string-time-separators.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const tests = [
+  ["1970-01-01T00:00+00:00[UTC]", "uppercase T"],
+  ["1970-01-01t00:00+00:00[UTC]", "lowercase T"],
+  ["1970-01-01 00:00+00:00[UTC]", "space between date and time"],
+];
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
+    result,
+    true,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-string-time-separators.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: Time separator in string argument can vary
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const tests = [
+  ["1970-01-01T00:00+00:00[UTC]", "uppercase T"],
+  ["1970-01-01t00:00+00:00[UTC]", "lowercase T"],
+  ["1970-01-01 00:00+00:00[UTC]", "space between date and time"],
+];
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-string-time-separators.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: Time separator in string argument can vary
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const tests = [
+  ["1970-01-01T00:00+00:00[UTC]", "uppercase T"],
+  ["1970-01-01t00:00+00:00[UTC]", "lowercase T"],
+  ["1970-01-01 00:00+00:00[UTC]", "space between date and time"],
+];
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-string-time-separators.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const tests = [
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
+];
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.withPlainDate(arg);
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    957_225_600_000_000_000n,
+    `variant time separators (${description})`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-time-separators.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-time-separators.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaintime
+description: Time separator in string argument can vary
+features: [Temporal]
+---*/
+
+const tests = [
+  ["1976-11-18T12:34:56.987654321", "uppercase T"],
+  ["1976-11-18t12:34:56.987654321", "lowercase T"],
+  ["1976-11-18 12:34:56.987654321", "space between date and time"],
+  ["T12:34:56.987654321", "time-only uppercase T"],
+  ["t12:34:56.987654321", "time-only lowercase T"],
+];
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+tests.forEach(([arg, description]) => {
+  const result = instance.withPlainTime(arg);
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    45_296_987_654_321n,
+    `variant time separators (${description})`
+  );
+});

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-string-time-separators.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.era
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.era(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    undefined,
     `variant time separators (${description})`
   );
 });

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-string-time-separators.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-string-time-separators.js
@@ -2,24 +2,25 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindatetime.from
+esid: sec-temporal.calendar.prototype.erayear
 description: Time separator in string argument can vary
 features: [Temporal]
-includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["1976-11-18T15:23", "uppercase T"],
-  ["1976-11-18t15:23", "lowercase T"],
-  ["1976-11-18 15:23", "space between date and time"],
+  ["2000-05-02T15:23", "uppercase T"],
+  ["2000-05-02t15:23", "lowercase T"],
+  ["2000-05-02 15:23", "space between date and time"],
 ];
 
-tests.forEach(([arg, description]) => {
-  const result = Temporal.PlainDateTime.from(arg);
+const instance = new Temporal.Calendar("iso8601");
 
-  TemporalHelpers.assertPlainDateTime(
+tests.forEach(([arg, description]) => {
+  const result = instance.eraYear(arg);
+
+  assert.sameValue(
     result,
-    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    undefined,
     `variant time separators (${description})`
   );
 });


### PR DESCRIPTION
ISO strings may separate the time from the date with a case-insensitive T,
or a space. This adds tests to all entry points that take ISO strings, to
ensure that they accept an uppercase T, lowercase T, or space as the time
separator.

These tests are based on the one test for Temporal.PlainDateTime.from that
was already present.