### PR TITLE
Fixed #3545

### DIFF
--- a/test/built-ins/Temporal/Calendar/subclass.js
+++ b/test/built-ins/Temporal/Calendar/subclass.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal.calendar
 description: Test for Temporal.Calendar subclassing.
-flags: [Temporal]
+features: [Temporal]
 ---*/
 
 class CustomCalendar extends Temporal.Calendar {

--- a/test/built-ins/Temporal/Duration/subclass.js
+++ b/test/built-ins/Temporal/Duration/subclass.js
@@ -5,7 +5,7 @@
 esid: sec-temporal.duration
 description: Test for Temporal.Duration subclassing.
 includes: [temporalHelpers.js]
-flags: [Temporal]
+features: [Temporal]
 ---*/
 
 class CustomDuration extends Temporal.Duration {

--- a/test/built-ins/Temporal/Instant/subclass.js
+++ b/test/built-ins/Temporal/Instant/subclass.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal.instant
 description: Test for Temporal.Instant subclassing.
-flags: [Temporal]
+features: [Temporal]
 ---*/
 
 class CustomInstant extends Temporal.Instant {

--- a/test/built-ins/Temporal/PlainDate/subclass.js
+++ b/test/built-ins/Temporal/PlainDate/subclass.js
@@ -5,7 +5,7 @@
 esid: sec-temporal.plaindate
 description: Test for Temporal.PlainDate subclassing.
 includes: [temporalHelpers.js]
-flags: [Temporal]
+features: [Temporal]
 ---*/
 
 class CustomPlainDate extends Temporal.PlainDate {

--- a/test/built-ins/Temporal/PlainDateTime/subclass.js
+++ b/test/built-ins/Temporal/PlainDateTime/subclass.js
@@ -5,7 +5,7 @@
 esid: sec-temporal.plaindatetime
 description: Test for Temporal.PlainDateTime subclassing.
 includes: [temporalHelpers.js]
-flags: [Temporal]
+features: [Temporal]
 ---*/
 
 class CustomPlainDateTime extends Temporal.PlainDateTime {

--- a/test/built-ins/Temporal/PlainMonthDay/subclass.js
+++ b/test/built-ins/Temporal/PlainMonthDay/subclass.js
@@ -5,7 +5,7 @@
 esid: sec-temporal.plainmonthday
 description: Test for Temporal.PlainMonthDay subclassing.
 includes: [temporalHelpers.js]
-flags: [Temporal]
+features: [Temporal]
 ---*/
 
 class CustomPlainMonthDay extends Temporal.PlainMonthDay {

--- a/test/built-ins/Temporal/PlainTime/subclass.js
+++ b/test/built-ins/Temporal/PlainTime/subclass.js
@@ -5,7 +5,7 @@
 esid: sec-temporal.plaintime
 description: Test for Temporal.PlainTime subclassing.
 includes: [temporalHelpers.js]
-flags: [Temporal]
+features: [Temporal]
 ---*/
 
 class CustomPlainTime extends Temporal.PlainTime {

--- a/test/built-ins/Temporal/PlainYearMonth/subclass.js
+++ b/test/built-ins/Temporal/PlainYearMonth/subclass.js
@@ -5,7 +5,7 @@
 esid: sec-temporal.plainyearmonth
 description: Test for Temporal.PlainYearMonth subclassing.
 includes: [temporalHelpers.js]
-flags: [Temporal]
+features: [Temporal]
 ---*/
 
 class CustomPlainYearMonth extends Temporal.PlainYearMonth {

--- a/test/built-ins/Temporal/TimeZone/subclass.js
+++ b/test/built-ins/Temporal/TimeZone/subclass.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal.timezone
 description: Test for Temporal.TimeZone subclassing.
-flags: [Temporal]
+features: [Temporal]
 ---*/
 
 class CustomTimeZone extends Temporal.TimeZone {

--- a/test/built-ins/Temporal/ZonedDateTime/subclass.js
+++ b/test/built-ins/Temporal/ZonedDateTime/subclass.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal.zoneddatetime
 description: Test for Temporal.ZonedDateTime subclassing.
-flags: [Temporal]
+features: [Temporal]
 ---*/
 
 class CustomZonedDateTime extends Temporal.ZonedDateTime {


### PR DESCRIPTION
This pull request fixes #3545. It changes the typo of `flags: [Temporal]` to `features: [Temporal]`, added in https://github.com/tc39/test262/commit/6573cf954b81171b00b55bb7404d1ee46b5b0db6.