### PR TITLE
add noStrict flag to yield-as-binding-id cases

### DIFF
--- a/src/decorator/decorator-call-expr-identifier-reference-yield.case
+++ b/src/decorator/decorator-call-expr-identifier-reference-yield.case
@@ -14,29 +14,18 @@ info: |
     DecoratorMemberExpression[?Yield, ?Await] . IdentifierName
 
   IdentifierReference[Yield, Await] :
-    Identifier
     [~Yield] yield
-    [~Await] await
+    ...
 
 template: syntax/valid
+flags: [noStrict]
 ---*/
 
 //- setup
 function decorator() {
   return () => {};
 }
-var _ = decorator;
-var \u{6F} = decorator;
-var \u2118 = decorator;
-var ZW_\u200C_NJ = decorator;
-var ZW_\u200D_J = decorator;
-var await = decorator;
+var yield = decorator;
 
 //- decorators
-@$()
-@_()
-@\u{6F}()
-@\u2118()
-@ZW_\u200C_NJ()
-@ZW_\u200D_J()
-@await()
+@yield()

--- a/src/decorator/decorator-call-expr-identifier-reference.case
+++ b/src/decorator/decorator-call-expr-identifier-reference.case
@@ -19,6 +19,7 @@ info: |
     [~Await] await
 
 template: syntax/valid
+flags: [noStrict]
 ---*/
 
 //- setup

--- a/src/decorator/decorator-member-expr-identifier-reference-yield.case
+++ b/src/decorator/decorator-member-expr-identifier-reference-yield.case
@@ -6,26 +6,14 @@ desc: >
   Decorator @ DecoratorMemberExpression
 info: |
   IdentifierReference[Yield, Await] :
-    Identifier
     [~Yield] yield
-    [~Await] await
+    ...
 template: syntax/valid
+flags: [noStrict]
 ---*/
 
 //- setup
-function $() {}
-function _() {}
-function \u{6F}() {}
-function \u2118() {}
-function ZW_\u200C_NJ() {}
-function ZW_\u200D_J() {}
-function await() {}
+function yield() {}
 
 //- decorators
-@$
-@_
-@\u{6F}
-@\u2118
-@ZW_\u200C_NJ
-@ZW_\u200D_J
-@await
+@yield

--- a/src/decorator/decorator-member-expr-identifier-reference.case
+++ b/src/decorator/decorator-member-expr-identifier-reference.case
@@ -10,6 +10,7 @@ info: |
     [~Yield] yield
     [~Await] await
 template: syntax/valid
+flags: [noStrict]
 ---*/
 
 //- setup

--- a/src/decorator/decorator-parenthesized-expr-identifier-reference-yield.case
+++ b/src/decorator/decorator-parenthesized-expr-identifier-reference-yield.case
@@ -23,23 +23,15 @@ info: |
     TemplateLiteral[?Yield, ?Await, ~Tagged]
     CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]
 
+  IdentifierReference[Yield, Await] :
+    [~Yield] yield
+    ...
 template: syntax/valid
+flags: [noStrict]
 ---*/
 
 //- setup
-function $() {}
-function _() {}
-function \u{6F}() {}
-function \u2118() {}
-function ZW_\u200C_NJ() {}
-function ZW_\u200D_J() {}
-function await() {}
+function yield() {}
 
 //- decorators
-@($)
-@(_)
-@(\u{6F})
-@(\u2118)
-@(ZW_\u200C_NJ)
-@(ZW_\u200D_J)
-@(await)
+@(yield)

--- a/src/decorator/decorator-parenthesized-expr-identifier-reference.case
+++ b/src/decorator/decorator-parenthesized-expr-identifier-reference.case
@@ -24,6 +24,7 @@ info: |
     CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]
 
 template: syntax/valid
+flags: [noStrict]
 ---*/
 
 //- setup

--- a/test/language/expressions/class/decorator/syntax/valid/decorator-call-expr-identifier-reference-yield.js
+++ b/test/language/expressions/class/decorator/syntax/valid/decorator-call-expr-identifier-reference-yield.js
@@ -1,15 +1,14 @@
 // This file was procedurally generated from the following sources:
-// - src/decorator/decorator-call-expr-identifier-reference.case
-// - src/decorator/syntax/valid/cls-decl-decorators-valid-syntax.template
+// - src/decorator/decorator-call-expr-identifier-reference-yield.case
+// - src/decorator/syntax/valid/cls-expr-decorators-valid-syntax.template
 /*---
-description: Decorator @ DecoratorCallExpression (Valid syntax for decorator on class.)
-esid: prod-ClassDeclaration
+description: Decorator @ DecoratorCallExpression (Valid syntax for decorator on class expression)
+esid: prod-ClassExpression
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
-    ClassDeclaration[Yield, Await, Default] :
-      DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
-      [+Default] DecoratorList[?Yield, ?Await]opt class ClassTail[?Yield, ?Await]
+    ClassExpression[Yield, Await] :
+      DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await]opt ClassTail[?Yield, ?Await]
 
     DecoratorList[Yield, Await] :
       DecoratorList[?Yield, ?Await]opt Decorator[?Yield, ?Await]
@@ -31,27 +30,15 @@ info: |
       DecoratorMemberExpression[?Yield, ?Await] . IdentifierName
 
     IdentifierReference[Yield, Await] :
-      Identifier
       [~Yield] yield
-      [~Await] await
+      ...
 
 ---*/
 function decorator() {
   return () => {};
 }
-var _ = decorator;
-var \u{6F} = decorator;
-var \u2118 = decorator;
-var ZW_\u200C_NJ = decorator;
-var ZW_\u200D_J = decorator;
-var await = decorator;
+var yield = decorator;
 
 
 
-@$()
-@_()
-@\u{6F}()
-@\u2118()
-@ZW_\u200C_NJ()
-@ZW_\u200D_J()
-@await() class C {}
+var C = @yield() class {};

--- a/test/language/expressions/class/decorator/syntax/valid/decorator-call-expr-identifier-reference.js
+++ b/test/language/expressions/class/decorator/syntax/valid/decorator-call-expr-identifier-reference.js
@@ -5,7 +5,7 @@
 description: Decorator @ DecoratorCallExpression (Valid syntax for decorator on class expression)
 esid: prod-ClassExpression
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
     ClassExpression[Yield, Await] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await]opt ClassTail[?Yield, ?Await]

--- a/test/language/expressions/class/decorator/syntax/valid/decorator-call-expr-identifier-reference.js
+++ b/test/language/expressions/class/decorator/syntax/valid/decorator-call-expr-identifier-reference.js
@@ -5,7 +5,7 @@
 description: Decorator @ DecoratorCallExpression (Valid syntax for decorator on class expression)
 esid: prod-ClassExpression
 features: [class, decorators]
-flags: [generated, noStrict]
+flags: [generated]
 info: |
     ClassExpression[Yield, Await] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await]opt ClassTail[?Yield, ?Await]
@@ -43,7 +43,6 @@ var \u{6F} = decorator;
 var \u2118 = decorator;
 var ZW_\u200C_NJ = decorator;
 var ZW_\u200D_J = decorator;
-var yield = decorator;
 var await = decorator;
 
 
@@ -54,5 +53,4 @@ var C = @$()
 @\u2118()
 @ZW_\u200C_NJ()
 @ZW_\u200D_J()
-@yield()
 @await() class {};

--- a/test/language/expressions/class/decorator/syntax/valid/decorator-member-expr-identifier-reference-yield.js
+++ b/test/language/expressions/class/decorator/syntax/valid/decorator-member-expr-identifier-reference-yield.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/decorator/decorator-member-expr-identifier-reference.case
+// - src/decorator/decorator-member-expr-identifier-reference-yield.case
 // - src/decorator/syntax/valid/cls-expr-decorators-valid-syntax.template
 /*---
 description: Decorator @ DecoratorMemberExpression (Valid syntax for decorator on class expression)
 esid: prod-ClassExpression
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
     ClassExpression[Yield, Await] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await]opt ClassTail[?Yield, ?Await]
@@ -22,25 +22,12 @@ info: |
 
 
     IdentifierReference[Yield, Await] :
-      Identifier
       [~Yield] yield
-      [~Await] await
+      ...
 
 ---*/
-function $() {}
-function _() {}
-function \u{6F}() {}
-function \u2118() {}
-function ZW_\u200C_NJ() {}
-function ZW_\u200D_J() {}
-function await() {}
+function yield() {}
 
 
 
-var C = @$
-@_
-@\u{6F}
-@\u2118
-@ZW_\u200C_NJ
-@ZW_\u200D_J
-@await class {};
+var C = @yield class {};

--- a/test/language/expressions/class/decorator/syntax/valid/decorator-member-expr-identifier-reference.js
+++ b/test/language/expressions/class/decorator/syntax/valid/decorator-member-expr-identifier-reference.js
@@ -5,7 +5,7 @@
 description: Decorator @ DecoratorMemberExpression (Valid syntax for decorator on class expression)
 esid: prod-ClassExpression
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
     ClassExpression[Yield, Await] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await]opt ClassTail[?Yield, ?Await]

--- a/test/language/expressions/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference-yield.js
+++ b/test/language/expressions/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference-yield.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/decorator/decorator-parenthesized-expr-identifier-reference.case
+// - src/decorator/decorator-parenthesized-expr-identifier-reference-yield.case
 // - src/decorator/syntax/valid/cls-expr-decorators-valid-syntax.template
 /*---
 description: Decorator @ DecoratorParenthesizedExpression (Valid syntax for decorator on class expression)
 esid: prod-ClassExpression
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
     ClassExpression[Yield, Await] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await]opt ClassTail[?Yield, ?Await]
@@ -39,21 +39,13 @@ info: |
       TemplateLiteral[?Yield, ?Await, ~Tagged]
       CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]
 
+    IdentifierReference[Yield, Await] :
+      [~Yield] yield
+      ...
+
 ---*/
-function $() {}
-function _() {}
-function \u{6F}() {}
-function \u2118() {}
-function ZW_\u200C_NJ() {}
-function ZW_\u200D_J() {}
-function await() {}
+function yield() {}
 
 
 
-var C = @($)
-@(_)
-@(\u{6F})
-@(\u2118)
-@(ZW_\u200C_NJ)
-@(ZW_\u200D_J)
-@(await) class {};
+var C = @(yield) class {};

--- a/test/language/expressions/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference.js
+++ b/test/language/expressions/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference.js
@@ -5,7 +5,7 @@
 description: Decorator @ DecoratorParenthesizedExpression (Valid syntax for decorator on class expression)
 esid: prod-ClassExpression
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
     ClassExpression[Yield, Await] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await]opt ClassTail[?Yield, ?Await]

--- a/test/language/statements/class/decorator/syntax/valid/decorator-call-expr-identifier-reference-yield.js
+++ b/test/language/statements/class/decorator/syntax/valid/decorator-call-expr-identifier-reference-yield.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/decorator/decorator-call-expr-identifier-reference.case
+// - src/decorator/decorator-call-expr-identifier-reference-yield.case
 // - src/decorator/syntax/valid/cls-decl-decorators-valid-syntax.template
 /*---
 description: Decorator @ DecoratorCallExpression (Valid syntax for decorator on class.)
 esid: prod-ClassDeclaration
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
     ClassDeclaration[Yield, Await, Default] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
@@ -31,27 +31,15 @@ info: |
       DecoratorMemberExpression[?Yield, ?Await] . IdentifierName
 
     IdentifierReference[Yield, Await] :
-      Identifier
       [~Yield] yield
-      [~Await] await
+      ...
 
 ---*/
 function decorator() {
   return () => {};
 }
-var _ = decorator;
-var \u{6F} = decorator;
-var \u2118 = decorator;
-var ZW_\u200C_NJ = decorator;
-var ZW_\u200D_J = decorator;
-var await = decorator;
+var yield = decorator;
 
 
 
-@$()
-@_()
-@\u{6F}()
-@\u2118()
-@ZW_\u200C_NJ()
-@ZW_\u200D_J()
-@await() class C {}
+@yield() class C {}

--- a/test/language/statements/class/decorator/syntax/valid/decorator-call-expr-identifier-reference.js
+++ b/test/language/statements/class/decorator/syntax/valid/decorator-call-expr-identifier-reference.js
@@ -5,7 +5,7 @@
 description: Decorator @ DecoratorCallExpression (Valid syntax for decorator on class.)
 esid: prod-ClassDeclaration
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
     ClassDeclaration[Yield, Await, Default] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]

--- a/test/language/statements/class/decorator/syntax/valid/decorator-member-expr-identifier-reference-yield.js
+++ b/test/language/statements/class/decorator/syntax/valid/decorator-member-expr-identifier-reference-yield.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/decorator/decorator-call-expr-identifier-reference.case
+// - src/decorator/decorator-member-expr-identifier-reference-yield.case
 // - src/decorator/syntax/valid/cls-decl-decorators-valid-syntax.template
 /*---
-description: Decorator @ DecoratorCallExpression (Valid syntax for decorator on class.)
+description: Decorator @ DecoratorMemberExpression (Valid syntax for decorator on class.)
 esid: prod-ClassDeclaration
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
     ClassDeclaration[Yield, Await, Default] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
@@ -22,36 +22,13 @@ info: |
     ...
 
 
-    DecoratorCallExpression[Yield, Await] :
-      DecoratorMemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
-
-    DecoratorMemberExpression[Yield, Await] :
-      IdentifierReference[?Yield, ?Await]
-      PrivateIdentifier
-      DecoratorMemberExpression[?Yield, ?Await] . IdentifierName
-
     IdentifierReference[Yield, Await] :
-      Identifier
       [~Yield] yield
-      [~Await] await
+      ...
 
 ---*/
-function decorator() {
-  return () => {};
-}
-var _ = decorator;
-var \u{6F} = decorator;
-var \u2118 = decorator;
-var ZW_\u200C_NJ = decorator;
-var ZW_\u200D_J = decorator;
-var await = decorator;
+function yield() {}
 
 
 
-@$()
-@_()
-@\u{6F}()
-@\u2118()
-@ZW_\u200C_NJ()
-@ZW_\u200D_J()
-@await() class C {}
+@yield class C {}

--- a/test/language/statements/class/decorator/syntax/valid/decorator-member-expr-identifier-reference.js
+++ b/test/language/statements/class/decorator/syntax/valid/decorator-member-expr-identifier-reference.js
@@ -5,7 +5,7 @@
 description: Decorator @ DecoratorMemberExpression (Valid syntax for decorator on class.)
 esid: prod-ClassDeclaration
 features: [class, decorators]
-flags: [generated, noStrict]
+flags: [generated]
 info: |
     ClassDeclaration[Yield, Await, Default] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
@@ -34,7 +34,6 @@ function \u{6F}() {}
 function \u2118() {}
 function ZW_\u200C_NJ() {}
 function ZW_\u200D_J() {}
-function yield() {}
 function await() {}
 
 
@@ -45,5 +44,4 @@ function await() {}
 @\u2118
 @ZW_\u200C_NJ
 @ZW_\u200D_J
-@yield
 @await class C {}

--- a/test/language/statements/class/decorator/syntax/valid/decorator-member-expr-identifier-reference.js
+++ b/test/language/statements/class/decorator/syntax/valid/decorator-member-expr-identifier-reference.js
@@ -5,7 +5,7 @@
 description: Decorator @ DecoratorMemberExpression (Valid syntax for decorator on class.)
 esid: prod-ClassDeclaration
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
     ClassDeclaration[Yield, Await, Default] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]

--- a/test/language/statements/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference-yield.js
+++ b/test/language/statements/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference-yield.js
@@ -1,11 +1,11 @@
 // This file was procedurally generated from the following sources:
-// - src/decorator/decorator-call-expr-identifier-reference.case
+// - src/decorator/decorator-parenthesized-expr-identifier-reference-yield.case
 // - src/decorator/syntax/valid/cls-decl-decorators-valid-syntax.template
 /*---
-description: Decorator @ DecoratorCallExpression (Valid syntax for decorator on class.)
+description: Decorator @ DecoratorParenthesizedExpression (Valid syntax for decorator on class.)
 esid: prod-ClassDeclaration
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
     ClassDeclaration[Yield, Await, Default] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
@@ -22,36 +22,31 @@ info: |
     ...
 
 
-    DecoratorCallExpression[Yield, Await] :
-      DecoratorMemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
+    DecoratorParenthesizedExpression[Yield, Await] :
+      ( Expression[+In, ?Yield, ?Await] )
 
-    DecoratorMemberExpression[Yield, Await] :
+    PrimaryExpression[Yield, Await] :
+      this
       IdentifierReference[?Yield, ?Await]
-      PrivateIdentifier
-      DecoratorMemberExpression[?Yield, ?Await] . IdentifierName
+      Literal
+      ArrayLiteral[?Yield, ?Await]
+      ObjectLiteral[?Yield, ?Await]
+      FunctionExpression
+      ClassExpression[?Yield, ?Await]
+      GeneratorExpression
+      AsyncFunctionExpression
+      AsyncGeneratorExpression
+      RegularExpressionLiteral
+      TemplateLiteral[?Yield, ?Await, ~Tagged]
+      CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]
 
     IdentifierReference[Yield, Await] :
-      Identifier
       [~Yield] yield
-      [~Await] await
+      ...
 
 ---*/
-function decorator() {
-  return () => {};
-}
-var _ = decorator;
-var \u{6F} = decorator;
-var \u2118 = decorator;
-var ZW_\u200C_NJ = decorator;
-var ZW_\u200D_J = decorator;
-var await = decorator;
+function yield() {}
 
 
 
-@$()
-@_()
-@\u{6F}()
-@\u2118()
-@ZW_\u200C_NJ()
-@ZW_\u200D_J()
-@await() class C {}
+@(yield) class C {}

--- a/test/language/statements/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference.js
+++ b/test/language/statements/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference.js
@@ -5,7 +5,7 @@
 description: Decorator @ DecoratorParenthesizedExpression (Valid syntax for decorator on class.)
 esid: prod-ClassDeclaration
 features: [class, decorators]
-flags: [generated]
+flags: [generated, noStrict]
 info: |
     ClassDeclaration[Yield, Await, Default] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]

--- a/test/language/statements/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference.js
+++ b/test/language/statements/class/decorator/syntax/valid/decorator-parenthesized-expr-identifier-reference.js
@@ -5,7 +5,7 @@
 description: Decorator @ DecoratorParenthesizedExpression (Valid syntax for decorator on class.)
 esid: prod-ClassDeclaration
 features: [class, decorators]
-flags: [generated, noStrict]
+flags: [generated]
 info: |
     ClassDeclaration[Yield, Await, Default] :
       DecoratorList[?Yield, ?Await]opt class BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
@@ -47,7 +47,6 @@ function \u{6F}() {}
 function \u2118() {}
 function ZW_\u200C_NJ() {}
 function ZW_\u200D_J() {}
-function yield() {}
 function await() {}
 
 
@@ -58,5 +57,4 @@ function await() {}
 @(\u2118)
 @(ZW_\u200C_NJ)
 @(ZW_\u200D_J)
-@(yield)
 @(await) class C {}


### PR DESCRIPTION
The test preparation code in recently added decorator tests contains `var yield` and `function yield() {}`. However, a BindingIdentifier must not be `yield` in strict mode, so I add `noStrict` flag to these cases.

Context: https://github.com/babel/babel/pull/14638