### PR TITLE
Fix wrong error for a lexical redeclaration test

### DIFF
--- a/test/language/statements/for/head-const-bound-names-in-stmt.js
+++ b/test/language/statements/for/head-const-bound-names-in-stmt.js
@@ -17,6 +17,6 @@ es6id: 13.7.4
 
 $DONOTEVALUATE();
 
-for (const x; false; ) {
+for (const x = 0; false; ) {
   var x;
 }


### PR DESCRIPTION
The test as originally specified fails in all compatible parsers, but for the wrong reason. Below is an excerpt from V8, but all parser I tested behave the same:

```js
for (const x; false; ) {
           ^
SyntaxError: Missing initializer in const declaration
```

After the change the error is the assumed:

```js
  var x;
      ^
SyntaxError: Identifier 'x' has already been declared
```