### PR TITLE
Correct spurious syntax errors

### DIFF
--- a/test/language/module-code/early-dup-lex.js
+++ b/test/language/module-code/early-dup-lex.js
@@ -15,4 +15,4 @@ negative:
 $DONOTEVALUATE();
 
 let x;
-const x;
+const x = 0;

--- a/test/language/statements/for/labelled-fn-stmt-const.js
+++ b/test/language/statements/for/labelled-fn-stmt-const.js
@@ -15,4 +15,4 @@ info: |
 
 $DONOTEVALUATE();
 
-for (const x; false; ) label1: label2: function f() {}
+for (const x = 0; false; ) label1: label2: function f() {}


### PR DESCRIPTION
Prior to this commit, two tests for specific early errors also included
syntactically invalid `const` declarations. Implementations which
produced the expected syntax error due to these invalid declarations
would pass the tests regardless of whether they produced the early
errors that the tests were written to verify.

Correct the `const` declarations so that the tests verify the parsing
rule that they were designed to verify.

---

Hat tip to @grassator for recognizing this problem in another test (see gh-3575).