### PR TITLE
Add tests for Temporal.Instant strings at the edge of the range

### DIFF
--- a/test/built-ins/Temporal/Instant/compare/instant-string-limits.js
+++ b/test/built-ins/Temporal/Instant/compare/instant-string-limits.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.compare
+description: String arguments at the limit of the representable range
+features: [Temporal]
+---*/
+
+const minInstant = new Temporal.Instant(-86400_00000000_000_000_000n);
+const maxInstant = new Temporal.Instant(86400_00000000_000_000_000n);
+
+const minInstantStrings = [
+  "-271821-04-20T00:00Z",
+  "-271821-04-19T23:00-01:00",
+  "-271821-04-19T00:00:00.000000001-23:59:59.999999999",
+];
+for (const str of minInstantStrings) {
+  assert.sameValue(Temporal.Instant.compare(str, minInstant), 0, `instant string ${str} should be valid (first argument)`);
+  assert.sameValue(Temporal.Instant.compare(minInstant, str), 0, `instant string ${str} should be valid (second argument)`);
+}
+
+const maxInstantStrings = [
+  "+275760-09-13T00:00Z",
+  "+275760-09-13T01:00+01:00",
+  "+275760-09-13T23:59:59.999999999+23:59:59.999999999",
+];
+
+for (const str of maxInstantStrings) {
+  assert.sameValue(Temporal.Instant.compare(str, maxInstant), 0, `instant string ${str} should be valid (first argument)`);
+  assert.sameValue(Temporal.Instant.compare(maxInstant, str), 0, `instant string ${str} should be valid (second argument)`);
+}
+
+const outOfRangeInstantStrings = [
+  "-271821-04-19T23:59:59.999999999Z",
+  "-271821-04-19T23:00-00:59:59.999999999",
+  "-271821-04-19T00:00:00-23:59:59.999999999",
+  "-271821-04-19T00:00:00-24:00",
+  "+275760-09-13T00:00:00.000000001Z",
+  "+275760-09-13T01:00+00:59:59.999999999",
+  "+275760-09-14T00:00+23:59:59.999999999",
+  "+275760-09-14T00:00+24:00",
+];
+
+for (const str of outOfRangeInstantStrings) {
+  assert.throws(RangeError, () => Temporal.Instant.compare(str, minInstant), `instant string ${str} should not be valid (first argument)`);
+  assert.throws(RangeError, () => Temporal.Instant.compare(minInstant, str), `instant string ${str} should not be valid (second argument)`);
+}

--- a/test/built-ins/Temporal/Instant/from/instant-string-limits.js
+++ b/test/built-ins/Temporal/Instant/from/instant-string-limits.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.from
+description: String arguments at the limit of the representable range
+features: [Temporal]
+---*/
+
+const minInstant = new Temporal.Instant(-86400_00000000_000_000_000n);
+const maxInstant = new Temporal.Instant(86400_00000000_000_000_000n);
+
+const minInstantStrings = [
+  "-271821-04-20T00:00Z",
+  "-271821-04-19T23:00-01:00",
+  "-271821-04-19T00:00:00.000000001-23:59:59.999999999",
+];
+for (const str of minInstantStrings) {
+  assert.sameValue(Temporal.Instant.from(str).epochNanoseconds, minInstant.epochNanoseconds, `instant string ${str} should be valid`);
+}
+
+const maxInstantStrings = [
+  "+275760-09-13T00:00Z",
+  "+275760-09-13T01:00+01:00",
+  "+275760-09-13T23:59:59.999999999+23:59:59.999999999",
+];
+
+for (const str of maxInstantStrings) {
+  assert.sameValue(Temporal.Instant.from(str).epochNanoseconds, maxInstant.epochNanoseconds, `instant string ${str} should be valid`);
+}
+
+const outOfRangeInstantStrings = [
+  "-271821-04-19T23:59:59.999999999Z",
+  "-271821-04-19T23:00-00:59:59.999999999",
+  "-271821-04-19T00:00:00-23:59:59.999999999",
+  "-271821-04-19T00:00:00-24:00",
+  "+275760-09-13T00:00:00.000000001Z",
+  "+275760-09-13T01:00+00:59:59.999999999",
+  "+275760-09-14T00:00+23:59:59.999999999",
+  "+275760-09-14T00:00+24:00",
+];
+
+for (const str of outOfRangeInstantStrings) {
+  assert.throws(RangeError, () => Temporal.Instant.from(str), `instant string ${str} should not be valid`);
+}

--- a/test/built-ins/Temporal/Instant/prototype/equals/instant-string-limits.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/instant-string-limits.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.equals
+description: String arguments at the limit of the representable range
+features: [Temporal]
+---*/
+
+const minInstant = new Temporal.Instant(-86400_00000000_000_000_000n);
+const maxInstant = new Temporal.Instant(86400_00000000_000_000_000n);
+
+const minInstantStrings = [
+  "-271821-04-20T00:00Z",
+  "-271821-04-19T23:00-01:00",
+  "-271821-04-19T00:00:00.000000001-23:59:59.999999999",
+];
+for (const str of minInstantStrings) {
+  assert.sameValue(minInstant.equals(str), true, `instant string ${str} should be valid`);
+}
+
+const maxInstantStrings = [
+  "+275760-09-13T00:00Z",
+  "+275760-09-13T01:00+01:00",
+  "+275760-09-13T23:59:59.999999999+23:59:59.999999999",
+];
+
+for (const str of maxInstantStrings) {
+  assert.sameValue(maxInstant.equals(str), true, `instant string ${str} should be valid`);
+}
+
+const outOfRangeInstantStrings = [
+  "-271821-04-19T23:59:59.999999999Z",
+  "-271821-04-19T23:00-00:59:59.999999999",
+  "-271821-04-19T00:00:00-23:59:59.999999999",
+  "-271821-04-19T00:00:00-24:00",
+  "+275760-09-13T00:00:00.000000001Z",
+  "+275760-09-13T01:00+00:59:59.999999999",
+  "+275760-09-14T00:00+23:59:59.999999999",
+  "+275760-09-14T00:00+24:00",
+];
+
+for (const str of outOfRangeInstantStrings) {
+  assert.throws(RangeError, () => minInstant.equals(str), `instant string ${str} should not be valid`);
+}

--- a/test/built-ins/Temporal/Instant/prototype/since/instant-string-limits.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/instant-string-limits.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: String arguments at the limit of the representable range
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const minInstant = new Temporal.Instant(-86400_00000000_000_000_000n);
+const maxInstant = new Temporal.Instant(86400_00000000_000_000_000n);
+
+const minInstantStrings = [
+  "-271821-04-20T00:00Z",
+  "-271821-04-19T23:00-01:00",
+  "-271821-04-19T00:00:00.000000001-23:59:59.999999999",
+];
+for (const str of minInstantStrings) {
+  TemporalHelpers.assertDuration(minInstant.since(str), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `instant string ${str} should be valid`);
+}
+
+const maxInstantStrings = [
+  "+275760-09-13T00:00Z",
+  "+275760-09-13T01:00+01:00",
+  "+275760-09-13T23:59:59.999999999+23:59:59.999999999",
+];
+
+for (const str of maxInstantStrings) {
+  TemporalHelpers.assertDuration(maxInstant.since(str), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `instant string ${str} should be valid`);
+}
+
+const outOfRangeInstantStrings = [
+  "-271821-04-19T23:59:59.999999999Z",
+  "-271821-04-19T23:00-00:59:59.999999999",
+  "-271821-04-19T00:00:00-23:59:59.999999999",
+  "-271821-04-19T00:00:00-24:00",
+  "+275760-09-13T00:00:00.000000001Z",
+  "+275760-09-13T01:00+00:59:59.999999999",
+  "+275760-09-14T00:00+23:59:59.999999999",
+  "+275760-09-14T00:00+24:00",
+];
+
+for (const str of outOfRangeInstantStrings) {
+  assert.throws(RangeError, () => minInstant.since(str), `instant string ${str} should not be valid`);
+}

--- a/test/built-ins/Temporal/Instant/prototype/until/instant-string-limits.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/instant-string-limits.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: String arguments at the limit of the representable range
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const minInstant = new Temporal.Instant(-86400_00000000_000_000_000n);
+const maxInstant = new Temporal.Instant(86400_00000000_000_000_000n);
+
+const minInstantStrings = [
+  "-271821-04-20T00:00Z",
+  "-271821-04-19T23:00-01:00",
+  "-271821-04-19T00:00:00.000000001-23:59:59.999999999",
+];
+for (const str of minInstantStrings) {
+  TemporalHelpers.assertDuration(minInstant.until(str), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `instant string ${str} should be valid`);
+}
+
+const maxInstantStrings = [
+  "+275760-09-13T00:00Z",
+  "+275760-09-13T01:00+01:00",
+  "+275760-09-13T23:59:59.999999999+23:59:59.999999999",
+];
+
+for (const str of maxInstantStrings) {
+  TemporalHelpers.assertDuration(maxInstant.until(str), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `instant string ${str} should be valid`);
+}
+
+const outOfRangeInstantStrings = [
+  "-271821-04-19T23:59:59.999999999Z",
+  "-271821-04-19T23:00-00:59:59.999999999",
+  "-271821-04-19T00:00:00-23:59:59.999999999",
+  "-271821-04-19T00:00:00-24:00",
+  "+275760-09-13T00:00:00.000000001Z",
+  "+275760-09-13T01:00+00:59:59.999999999",
+  "+275760-09-14T00:00+23:59:59.999999999",
+  "+275760-09-14T00:00+24:00",
+];
+
+for (const str of outOfRangeInstantStrings) {
+  assert.throws(RangeError, () => minInstant.until(str), `instant string ${str} should not be valid`);
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/instant-string-limits.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/instant-string-limits.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getnexttransition
+description: String arguments at the limit of the representable range
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const minInstantStrings = [
+  "-271821-04-20T00:00Z",
+  "-271821-04-19T23:00-01:00",
+  "-271821-04-19T00:00:00.000000001-23:59:59.999999999",
+];
+for (const str of minInstantStrings) {
+  assert.sameValue(instance.getNextTransition(str), null, `instant string ${str} should be valid`);
+}
+
+const maxInstantStrings = [
+  "+275760-09-13T00:00Z",
+  "+275760-09-13T01:00+01:00",
+  "+275760-09-13T23:59:59.999999999+23:59:59.999999999",
+];
+
+for (const str of maxInstantStrings) {
+  assert.sameValue(instance.getNextTransition(str), null, `instant string ${str} should be valid`);
+}
+
+const outOfRangeInstantStrings = [
+  "-271821-04-19T23:59:59.999999999Z",
+  "-271821-04-19T23:00-00:59:59.999999999",
+  "-271821-04-19T00:00:00-23:59:59.999999999",
+  "-271821-04-19T00:00:00-24:00",
+  "+275760-09-13T00:00:00.000000001Z",
+  "+275760-09-13T01:00+00:59:59.999999999",
+  "+275760-09-14T00:00+23:59:59.999999999",
+  "+275760-09-14T00:00+24:00",
+];
+
+for (const str of outOfRangeInstantStrings) {
+  assert.throws(RangeError, () => instance.getNextTransition(str), `instant string ${str} should not be valid`);
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/instant-string-limits.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/instant-string-limits.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getoffsetnanosecondsfor
+description: String arguments at the limit of the representable range
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const minInstantStrings = [
+  "-271821-04-20T00:00Z",
+  "-271821-04-19T23:00-01:00",
+  "-271821-04-19T00:00:00.000000001-23:59:59.999999999",
+];
+for (const str of minInstantStrings) {
+  assert.sameValue(instance.getOffsetNanosecondsFor(str), 0, `instant string ${str} should be valid`);
+}
+
+const maxInstantStrings = [
+  "+275760-09-13T00:00Z",
+  "+275760-09-13T01:00+01:00",
+  "+275760-09-13T23:59:59.999999999+23:59:59.999999999",
+];
+
+for (const str of maxInstantStrings) {
+  assert.sameValue(instance.getOffsetNanosecondsFor(str), 0, `instant string ${str} should be valid`);
+}
+
+const outOfRangeInstantStrings = [
+  "-271821-04-19T23:59:59.999999999Z",
+  "-271821-04-19T23:00-00:59:59.999999999",
+  "-271821-04-19T00:00:00-23:59:59.999999999",
+  "-271821-04-19T00:00:00-24:00",
+  "+275760-09-13T00:00:00.000000001Z",
+  "+275760-09-13T01:00+00:59:59.999999999",
+  "+275760-09-14T00:00+23:59:59.999999999",
+  "+275760-09-14T00:00+24:00",
+];
+
+for (const str of outOfRangeInstantStrings) {
+  assert.throws(RangeError, () => instance.getOffsetNanosecondsFor(str), `instant string ${str} should not be valid`);
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/instant-string-limits.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/instant-string-limits.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getoffsetstringfor
+description: String arguments at the limit of the representable range
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const minInstantStrings = [
+  "-271821-04-20T00:00Z",
+  "-271821-04-19T23:00-01:00",
+  "-271821-04-19T00:00:00.000000001-23:59:59.999999999",
+];
+for (const str of minInstantStrings) {
+  assert.sameValue(instance.getOffsetStringFor(str), "+00:00", `instant string ${str} should be valid`);
+}
+
+const maxInstantStrings = [
+  "+275760-09-13T00:00Z",
+  "+275760-09-13T01:00+01:00",
+  "+275760-09-13T23:59:59.999999999+23:59:59.999999999",
+];
+
+for (const str of maxInstantStrings) {
+  assert.sameValue(instance.getOffsetStringFor(str), "+00:00", `instant string ${str} should be valid`);
+}
+
+const outOfRangeInstantStrings = [
+  "-271821-04-19T23:59:59.999999999Z",
+  "-271821-04-19T23:00-00:59:59.999999999",
+  "-271821-04-19T00:00:00-23:59:59.999999999",
+  "-271821-04-19T00:00:00-24:00",
+  "+275760-09-13T00:00:00.000000001Z",
+  "+275760-09-13T01:00+00:59:59.999999999",
+  "+275760-09-14T00:00+23:59:59.999999999",
+  "+275760-09-14T00:00+24:00",
+];
+
+for (const str of outOfRangeInstantStrings) {
+  assert.throws(RangeError, () => instance.getOffsetStringFor(str), `instant string ${str} should not be valid`);
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/instant-string-limits.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/instant-string-limits.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
+description: String arguments at the limit of the representable range
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const minInstantStrings = [
+  "-271821-04-20T00:00Z",
+  "-271821-04-19T23:00-01:00",
+  "-271821-04-19T00:00:00.000000001-23:59:59.999999999",
+];
+for (const str of minInstantStrings) {
+  TemporalHelpers.assertPlainDateTime(instance.getPlainDateTimeFor(str), -271821, 4, "M04", 20, 0, 0, 0, 0, 0, 0, `instant string ${str} should be valid`);
+}
+
+const maxInstantStrings = [
+  "+275760-09-13T00:00Z",
+  "+275760-09-13T01:00+01:00",
+  "+275760-09-13T23:59:59.999999999+23:59:59.999999999",
+];
+
+for (const str of maxInstantStrings) {
+  TemporalHelpers.assertPlainDateTime(instance.getPlainDateTimeFor(str), 275760, 9, "M09", 13, 0, 0, 0, 0, 0, 0, `instant string ${str} should be valid`);
+}
+
+const outOfRangeInstantStrings = [
+  "-271821-04-19T23:59:59.999999999Z",
+  "-271821-04-19T23:00-00:59:59.999999999",
+  "-271821-04-19T00:00:00-23:59:59.999999999",
+  "-271821-04-19T00:00:00-24:00",
+  "+275760-09-13T00:00:00.000000001Z",
+  "+275760-09-13T01:00+00:59:59.999999999",
+  "+275760-09-14T00:00+23:59:59.999999999",
+  "+275760-09-14T00:00+24:00",
+];
+
+for (const str of outOfRangeInstantStrings) {
+  assert.throws(RangeError, () => instance.getPlainDateTimeFor(str), `instant string ${str} should not be valid`);
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/instant-string-limits.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/instant-string-limits.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getprevioustransition
+description: String arguments at the limit of the representable range
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const minInstantStrings = [
+  "-271821-04-20T00:00Z",
+  "-271821-04-19T23:00-01:00",
+  "-271821-04-19T00:00:00.000000001-23:59:59.999999999",
+];
+for (const str of minInstantStrings) {
+  assert.sameValue(instance.getPreviousTransition(str), null, `instant string ${str} should be valid`);
+}
+
+const maxInstantStrings = [
+  "+275760-09-13T00:00Z",
+  "+275760-09-13T01:00+01:00",
+  "+275760-09-13T23:59:59.999999999+23:59:59.999999999",
+];
+
+for (const str of maxInstantStrings) {
+  assert.sameValue(instance.getPreviousTransition(str), null, `instant string ${str} should be valid`);
+}
+
+const outOfRangeInstantStrings = [
+  "-271821-04-19T23:59:59.999999999Z",
+  "-271821-04-19T23:00-00:59:59.999999999",
+  "-271821-04-19T00:00:00-23:59:59.999999999",
+  "-271821-04-19T00:00:00-24:00",
+  "+275760-09-13T00:00:00.000000001Z",
+  "+275760-09-13T01:00+00:59:59.999999999",
+  "+275760-09-14T00:00+23:59:59.999999999",
+  "+275760-09-14T00:00+24:00",
+];
+
+for (const str of outOfRangeInstantStrings) {
+  assert.throws(RangeError, () => instance.getPreviousTransition(str), `instant string ${str} should not be valid`);
+}


### PR DESCRIPTION
This adds tests for a normative change which reached consensus in the June
2022 TC39 meeting, ensuring that the representable range of
Temporal.Instant is always the same regardless of which time zone offset
is used when converting from a string.

See: https://github.com/tc39/proposal-temporal/pull/2189