### PR TITLE
Temporal: Test validation of overflow option for conversion fast paths

### DIFF
--- a/test/built-ins/Temporal/PlainDate/from/overflow-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDate/from/overflow-invalid-string.js
@@ -24,6 +24,8 @@ features: [Temporal]
 
 const validItems = [
   new Temporal.PlainDate(2000, 5, 2),
+  new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC"),
+  new Temporal.PlainDateTime(2000, 5, 2, 12),
   { year: 2000, month: 5, day: 2 },
   "2000-05-02",
 ];

--- a/test/built-ins/Temporal/PlainDateTime/from/overflow-invalid-string.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/overflow-invalid-string.js
@@ -28,6 +28,8 @@ features: [Temporal]
 
 const validValues = [
   new Temporal.PlainDateTime(2000, 5, 2, 12),
+  new Temporal.PlainDate(2000, 5, 2),
+  new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC"),
   { year: 2000, month: 5, day: 2, hour: 12 },
   "2000-05-02T12:00",
 ];


### PR DESCRIPTION
A normative change that reached consensus at the June 2022 TC39 meeting
was this small change to throw on an invalid value for the overflow option
in PlainDate.from() and PlainDateTime.from(), in the case of a fast-path
conversion.

See https://github.com/tc39/proposal-temporal/pull/2225