### PR TITLE
Fix useGrouping tests based on the latest Intl.NumberFormat v3 change

### DIFF
--- a/test/intl402/NumberFormat/test-option-useGrouping-extended.js
+++ b/test/intl402/NumberFormat/test-option-useGrouping-extended.js
@@ -1,4 +1,5 @@
 // Copyright 2021 the V8 project authors. All rights reserved.
+// Copyright 2022 Apple Inc. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -36,18 +37,7 @@ assert.sameValue(render({notation: 'compact', useGrouping: false}), false, 'comp
 assert.sameValue(render({notation: 'compact', useGrouping: null}), false, 'compact, null');
 assert.sameValue(render({notation: 'compact', useGrouping: 'min2'}), 'min2', 'compact, "min2"');
 
-assert.throws(RangeError, function() {
-  new Intl.NumberFormat(undefined, {useGrouping: 'undefined'});
-}, '"undefined"');
-
-assert.throws(RangeError, function() {
-  new Intl.NumberFormat(undefined, {useGrouping: 'false'});
-}, '"false"');
-
-assert.throws(RangeError, function() {
-  new Intl.NumberFormat(undefined, {useGrouping: 'true'});
-}, '"true"');
-
-assert.throws(RangeError, function() {
-  new Intl.NumberFormat(undefined, {useGrouping: 'min3'});
-}, '"min3"');
+assert.sameValue(render({useGrouping: 'undefined'}), 'auto', 'use fallback value');
+assert.sameValue(render({useGrouping: 'false'}), 'auto', 'use fallback value');
+assert.sameValue(render({useGrouping: 'true'}), 'auto', 'use fallback value');
+assert.sameValue(render({useGrouping: 'min3'}), 'auto', 'use fallback value');


### PR DESCRIPTION
Based on discussion[1], useGrouping computation in Intl.NumberFormat v3 is updated[2] to keep web compatibility.
This change fixes the existing test which is testing the previous behavior.

[1]: https://github.com/tc39/proposal-intl-numberformat-v3/issues/74
[2]: https://github.com/tc39/proposal-intl-numberformat-v3/commit/d13bd63f8fdf3f00c0a2ec15a235f34cc0fcbb08