### PR TITLE
Sync test to PR29 of numberformat-v3

### DIFF
--- a/test/intl402/NumberFormat/test-option-useGrouping-extended.js
+++ b/test/intl402/NumberFormat/test-option-useGrouping-extended.js
@@ -7,10 +7,7 @@ esid: sec-initializenumberformat
 description: Tests that the option useGrouping is processed correctly.
 info: |
   The "Intl.NumberFormat v3" proposal contradicts the behavior required by the
-  latest revision of ECMA402. Likewise, this test contradicts
-  test-option-useGrouping.js. Until the proposal is included in a published
-  standard (when the tests' discrepancies can be resolved), implementations
-  should only expect to pass one of these two tests.
+  latest revision of ECMA402.
 features: [Intl.NumberFormat-v3]
 ---*/
 

--- a/test/intl402/NumberFormat/test-option-useGrouping.js
+++ b/test/intl402/NumberFormat/test-option-useGrouping.js
@@ -7,10 +7,7 @@ es5id: 11.1.1_34
 description: Tests that the option useGrouping is processed correctly.
 info: |
   The "Intl.NumberFormat v3" proposal contradicts the behavior required by the
-  latest revision of ECMA402. Likewise, this test contradicts
-  test-option-useGrouping-extended.js. Until the proposal is included in a
-  published standard (when the tests' discrepancies can be resolved),
-  implementations should only expect to pass one of these two tests.
+  latest revision of ECMA402. 
 author: Norbert Lindenberg
 features: [Intl.NumberFormat-v3]
 ---*/
@@ -32,5 +29,5 @@ for (let falsy of [0, null, ""]) {
 }
 
 for (let truthy of [42, "MIN2", {}]) {
-  assert.throws(RangeError, () => { resolveUseGrouping(truthy); }, "Invalid truthy value");
+  assert.sameValue(resolveUseGrouping(truthy), "auto");
 }


### PR DESCRIPTION
Sync the test to
https://github.com/tc39/proposal-intl-numberformat-v3/pull/92 and remove unnecessary wording no longer true after that PR landed.