### PR TITLE
Temporal: tests for out-of-range time zone transitions

### DIFF
--- a/test/intl402/Temporal/TimeZone/prototype/getNextTransition/transition-at-instant-boundaries.js
+++ b/test/intl402/Temporal/TimeZone/prototype/getNextTransition/transition-at-instant-boundaries.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getnexttransition
+description: >
+  Test transitions at the instant boundaries.
+features: [Temporal, Intl-enumeration]
+---*/
+
+const min = new Temporal.Instant(-86_40000_00000_00000_00000n);
+const max = new Temporal.Instant(86_40000_00000_00000_00000n);
+
+for (let id of Intl.supportedValuesOf("timeZone")) {
+  let tz = new Temporal.TimeZone(id);
+
+  // If there's any next transition, it should be after |min|.
+  let next = tz.getNextTransition(min);
+  if (next) {
+    assert(next.epochNanoseconds > min.epochNanoseconds);
+  }
+
+  // There shouldn't be any next transition after |max|.
+  next = tz.getNextTransition(max);
+  assert.sameValue(next, null);
+}

--- a/test/intl402/Temporal/TimeZone/prototype/getPreviousTransition/transition-at-instant-boundaries.js
+++ b/test/intl402/Temporal/TimeZone/prototype/getPreviousTransition/transition-at-instant-boundaries.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getprevioustransition
+description: >
+  Test transitions at the instant boundaries.
+features: [Temporal, Intl-enumeration]
+---*/
+
+const min = new Temporal.Instant(-86_40000_00000_00000_00000n);
+const max = new Temporal.Instant(86_40000_00000_00000_00000n);
+
+for (let id of Intl.supportedValuesOf("timeZone")) {
+  let tz = new Temporal.TimeZone(id);
+
+  // If there's any previous transition, it should be before |max|.
+  let prev = tz.getPreviousTransition(max);
+  if (prev) {
+    assert(prev.epochNanoseconds < max.epochNanoseconds);
+  }
+
+  // There shouldn't be any previous transition before |min|.
+  prev = tz.getPreviousTransition(min);
+  assert.sameValue(prev, null);
+}


### PR DESCRIPTION
This normative change reached consensus in the July 2022 TC39 meeting:
https://github.com/tc39/proposal-temporal/pull/2351

(Taken from @anba's tests in #3599)