### PR TITLE
Temporal: test for out-of-range in Temporal.PlainMonthDay constructor

### DIFF
--- a/test/built-ins/Temporal/PlainMonthDay/refisoyear-out-of-range.js
+++ b/test/built-ins/Temporal/PlainMonthDay/refisoyear-out-of-range.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday
+description: referenceISOYear argument, if given, can cause RangeError
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+
+assert.throws(RangeError, () => new Temporal.PlainMonthDay(9, 14, calendar, 275760), "after the maximum ISO date");
+assert.throws(RangeError, () => new Temporal.PlainMonthDay(4, 18, calendar, -271821), "before the minimum ISO date")


### PR DESCRIPTION
The refISOYear argument in the Temporal.PlainMonthDay constructor can
cause a RangeError if it is outside the supported range for PlainDate.

This is part of a normative PR that reached consensus at the July 2022
TC39 plenary:
https://github.com/tc39/proposal-temporal/pull/2266