### PR TITLE
Test primitive retval of Iterator and AsyncIterator getters

### DIFF
--- a/test/built-ins/AsyncIteratorPrototype/Symbol.asyncIterator/return-val.js
+++ b/test/built-ins/AsyncIteratorPrototype/Symbol.asyncIterator/return-val.js
@@ -10,11 +10,22 @@ features: [Symbol.asyncIterator, async-iteration]
 ---*/
 
 async function* generator() {}
-var AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(generator.prototype))
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(generator.prototype))
+const getAsyncIterator = AsyncIteratorPrototype[Symbol.asyncIterator];
 
-var thisValue = {};
+const thisValues = [
+    {},
+    Symbol(),
+    4,
+    4n,
+    true,
+    undefined,
+    null,
+];
 
-assert.sameValue(
-  AsyncIteratorPrototype[Symbol.asyncIterator].call(thisValue),
-  thisValue
-);
+for (const thisValue of thisValues) {
+    assert.sameValue(
+        getAsyncIterator.call(thisValue),
+        thisValue
+    );
+}

--- a/test/built-ins/IteratorPrototype/Symbol.iterator/return-val.js
+++ b/test/built-ins/IteratorPrototype/Symbol.iterator/return-val.js
@@ -1,19 +1,32 @@
 // Copyright (C) 2015 the V8 project authors. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-es6id: 25.1.2.1
-description: Descriptor for `name` property
+esid: sec-%iteratorprototype%-@@iterator
+description: Return value of @@iterator on IteratorPrototype
 info: |
+  %IteratorPrototype% [ @@iterator ] ( )
     1. Return the this value.
 features: [Symbol.iterator]
 ---*/
 
-var IteratorPrototype = Object.getPrototypeOf(
+const IteratorPrototype = Object.getPrototypeOf(
   Object.getPrototypeOf([][Symbol.iterator]())
 );
-var thisValue = {};
+const getIterator = IteratorPrototype[Symbol.iterator];
 
-assert.sameValue(
-  IteratorPrototype[Symbol.iterator].call(thisValue),
-  thisValue
-);
+const thisValues = [
+    {},
+    Symbol(),
+    4,
+    4n,
+    true,
+    undefined,
+    null,
+];
+
+for (const thisValue of thisValues) {
+    assert.sameValue(
+        getIterator.call(thisValue),
+        thisValue
+    );
+}


### PR DESCRIPTION
The existing test passed an object for a `this` value. This commit checks that
primitive values are returned verbatim, without any conversion.

Resolve #3489.