### PR TITLE
Add cases to RegExp.prototype flags brand checking tests

### DIFF
--- a/test/built-ins/RegExp/prototype/dotAll/this-val-invalid-obj.js
+++ b/test/built-ins/RegExp/prototype/dotAll/this-val-invalid-obj.js
@@ -28,3 +28,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   dotAll.call(arguments);
 }, 'arguments object');
+
+assert.throws(TypeError, function() {
+  dotAll.call(() => {});
+}, 'function object');

--- a/test/built-ins/RegExp/prototype/dotAll/this-val-non-obj.js
+++ b/test/built-ins/RegExp/prototype/dotAll/this-val-non-obj.js
@@ -38,3 +38,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   dotAll.call(4);
 }, "number");
+
+assert.throws(TypeError, function() {
+  dotAll.call(4n);
+}, "bigint");

--- a/test/built-ins/RegExp/prototype/flags/this-val-non-obj.js
+++ b/test/built-ins/RegExp/prototype/flags/this-val-non-obj.js
@@ -35,3 +35,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   get.call(Symbol());
 }, 'symbol');
+
+assert.throws(TypeError, function() {
+  get.call(4n);
+}, 'bigint');

--- a/test/built-ins/RegExp/prototype/global/this-val-invalid-obj.js
+++ b/test/built-ins/RegExp/prototype/global/this-val-invalid-obj.js
@@ -24,3 +24,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   get.call(arguments);
 }, 'arguments object');
+
+assert.throws(TypeError, function() {
+  get.call(() => {});
+}, 'function object');

--- a/test/built-ins/RegExp/prototype/global/this-val-non-obj.js
+++ b/test/built-ins/RegExp/prototype/global/this-val-non-obj.js
@@ -35,3 +35,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   get.call(symbol);
 }, 'symbol');
+
+assert.throws(TypeError, function() {
+  get.call(4n);
+}, 'bigint');

--- a/test/built-ins/RegExp/prototype/hasIndices/this-val-invalid-obj.js
+++ b/test/built-ins/RegExp/prototype/hasIndices/this-val-invalid-obj.js
@@ -28,3 +28,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   hasIndices.call(arguments);
 }, 'arguments object');
+
+assert.throws(TypeError, function() {
+  hasIndices.call(() => {});
+}, 'function object');

--- a/test/built-ins/RegExp/prototype/hasIndices/this-val-non-obj.js
+++ b/test/built-ins/RegExp/prototype/hasIndices/this-val-non-obj.js
@@ -38,3 +38,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   hasIndices.call(4);
 }, "number");
+
+assert.throws(TypeError, function() {
+  hasIndices.call(4n);
+}, "bigint");

--- a/test/built-ins/RegExp/prototype/ignoreCase/this-val-invalid-obj.js
+++ b/test/built-ins/RegExp/prototype/ignoreCase/this-val-invalid-obj.js
@@ -24,3 +24,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   get.call(arguments);
 }, 'arguments object');
+
+assert.throws(TypeError, function() {
+  get.call(() => {});
+}, 'function object');

--- a/test/built-ins/RegExp/prototype/ignoreCase/this-val-non-obj.js
+++ b/test/built-ins/RegExp/prototype/ignoreCase/this-val-non-obj.js
@@ -35,3 +35,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   get.call(symbol);
 }, 'symbol');
+
+assert.throws(TypeError, function() {
+  get.call(4n);
+}, 'bigint');

--- a/test/built-ins/RegExp/prototype/multiline/this-val-invalid-obj.js
+++ b/test/built-ins/RegExp/prototype/multiline/this-val-invalid-obj.js
@@ -24,3 +24,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   get.call(arguments);
 }, 'arguments object');
+
+assert.throws(TypeError, function() {
+  get.call(() => {});
+}, 'function object');

--- a/test/built-ins/RegExp/prototype/multiline/this-val-non-obj.js
+++ b/test/built-ins/RegExp/prototype/multiline/this-val-non-obj.js
@@ -35,3 +35,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   get.call(symbol);
 }, 'symbol');
+
+assert.throws(TypeError, function() {
+  get.call(4n);
+}, 'bigint');

--- a/test/built-ins/RegExp/prototype/source/this-val-invalid-obj.js
+++ b/test/built-ins/RegExp/prototype/source/this-val-invalid-obj.js
@@ -24,3 +24,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   get.call(arguments);
 }, 'arguments object');
+
+assert.throws(TypeError, function() {
+  get.call(() => {});
+}, 'function object');

--- a/test/built-ins/RegExp/prototype/source/this-val-non-obj.js
+++ b/test/built-ins/RegExp/prototype/source/this-val-non-obj.js
@@ -35,3 +35,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   get.call(symbol);
 }, 'symbol');
+
+assert.throws(TypeError, function() {
+  get.call(4n);
+}, 'bigint');

--- a/test/built-ins/RegExp/prototype/sticky/this-val-invalid-obj.js
+++ b/test/built-ins/RegExp/prototype/sticky/this-val-invalid-obj.js
@@ -26,3 +26,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   sticky.call(arguments);
 }, 'arguments object');
+
+assert.throws(TypeError, function() {
+  sticky.call(() => {});
+}, 'function object');

--- a/test/built-ins/RegExp/prototype/sticky/this-val-non-obj.js
+++ b/test/built-ins/RegExp/prototype/sticky/this-val-non-obj.js
@@ -38,3 +38,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   sticky.call(4);
 });
+
+assert.throws(TypeError, function() {
+  sticky.call(4n);
+}, 'bigint');

--- a/test/built-ins/RegExp/prototype/unicode/this-val-invalid-obj.js
+++ b/test/built-ins/RegExp/prototype/unicode/this-val-invalid-obj.js
@@ -26,3 +26,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   unicode.call(arguments);
 }, 'arguments object');
+
+assert.throws(TypeError, function() {
+  unicode.call(() => {});
+}, 'function object');

--- a/test/built-ins/RegExp/prototype/unicode/this-val-non-obj.js
+++ b/test/built-ins/RegExp/prototype/unicode/this-val-non-obj.js
@@ -38,3 +38,7 @@ assert.throws(TypeError, function() {
 assert.throws(TypeError, function() {
   unicode.call(4);
 });
+
+assert.throws(TypeError, function() {
+  unicode.call(4n);
+}, 'bigint');


### PR DESCRIPTION
For completeness, as we are doing in newer brand checking tests such as
those of Temporal, call these getters with a function object and a bigint
as the receiver.

Suggested in https://github.com/tc39/test262/pull/3614/files#r929662337