### PR TITLE
Tests for Temporal time zones with legacy IANA names

### DIFF
--- a/test/intl402/Temporal/TimeZone/from/etc-timezone.js
+++ b/test/intl402/Temporal/TimeZone/from/etc-timezone.js
@@ -1,0 +1,79 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.from
+description: Some Etc/GMT{+/-}{0}N timezones are valid, but not all
+features: [Temporal]
+---*/
+
+// "Etc/GMT-0" through "Etc/GMT-14" are OK
+
+assert.sameValue(
+  Temporal.TimeZone.from("Etc/GMT-0").toString(),
+  "UTC", // if the offset is -0, we say "UTC" rather than "GMT"
+  "Etc/GMT-0 is a valid timezone"
+);
+
+[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14].forEach((n) => {
+  const tz = "Etc/GMT-" + n;
+  const instance = Temporal.TimeZone.from(tz);
+  assert.sameValue(
+    instance.toString(),
+    tz,
+    tz + " is a valid timezone"
+  );
+});
+
+const gmtMinus24TZ = "Etc/GMT-24";
+assert.throws(
+  RangeError,
+  () => Temporal.TimeZone.from(gmtMinus24TZ),
+  gmtMinus24TZ + " is an invalid timezone"
+);
+
+// "Etc/GMT-0N" is not OK (1 ≤ N ≤ 9)
+[1, 2, 3, 4, 5, 6, 7, 8, 9].forEach((n) => {
+  const tz = "Etc/GMT-0" + n;
+  assert.throws(
+    RangeError,
+    () => Temporal.TimeZone.from(tz),
+    tz + " is an invalid timezone"
+  );
+});
+
+// "Etc/GMT+0N" is not OK (0 ≤ N ≤ 9)
+[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].forEach((n) => {
+  const tz = "Etc/GMT+0" + n;
+  assert.throws(
+    RangeError,
+    () => Temporal.TimeZone.from(tz),
+    tz + " is an invalid timezone"
+    );
+});
+
+// Etc/GMT+0" through "Etc/GMT+12" are OK
+
+// zero is handled in its own way (say "UTC" rather than "GMT"):
+assert.sameValue(
+  Temporal.TimeZone.from("Etc/GMT+0").toString(),
+  "UTC", // if the offset is +0, we say "UTC" rather than "GMT"
+  "Etc/GMT+0 is a valid timezone"
+);
+
+[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].forEach((n) => {
+  const tz = "Etc/GMT+" + n;
+  const instance = Temporal.TimeZone.from(tz);
+  assert.sameValue(
+    instance.toString(),
+    tz,
+    tz + " is a valid timezone"
+  );
+});
+
+const gmtPlus24TZ = "Etc/GMT+24";
+assert.throws(
+  RangeError,
+  () => Temporal.TimeZone.from(gmtPlus24TZ),
+  gmtPlus24TZ + " is an invalid timezone"
+);

--- a/test/intl402/Temporal/TimeZone/from/iana-legacy-names.js
+++ b/test/intl402/Temporal/TimeZone/from/iana-legacy-names.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone
+description: IANA legacy names must be supported
+features: [Temporal]
+---*/
+
+const legacyNames = [
+  ["Etc/GMT0", "UTC"],
+  ["GMT0", "UTC"],
+  ["GMT-0", "UTC"],
+  ["GMT+0", "UTC"],
+  ["EST5EDT", "EST5EDT"],
+  ["CST6CDT", "CST6CDT"],
+  ["MST7MDT", "MST7MDT"],
+  ["PST8PDT", "PST8PDT"],
+];
+
+legacyNames.forEach(([arg, expectedID]) => {
+  const tz = Temporal.TimeZone.from(arg);
+  assert.sameValue(tz.toString(), expectedID, `"${arg}" is a supported name for the "${expectedID}" time zone`);
+});

--- a/test/intl402/Temporal/TimeZone/iana-legacy-names.js
+++ b/test/intl402/Temporal/TimeZone/iana-legacy-names.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone
+description: IANA legacy names must be supported
+features: [Temporal]
+---*/
+
+const legacyNames = [
+  ["Etc/GMT0", "UTC"],
+  ["GMT0", "UTC"],
+  ["GMT-0", "UTC"],
+  ["GMT+0", "UTC"],
+  ["EST5EDT", "EST5EDT"],
+  ["CST6CDT", "CST6CDT"],
+  ["MST7MDT", "MST7MDT"],
+  ["PST8PDT", "PST8PDT"],
+];
+
+legacyNames.forEach(([arg, expectedID]) => {
+  const tz = new Temporal.TimeZone(arg);
+  assert.sameValue(tz.toString(), expectedID, `"${arg}" is a supported name for the "${expectedID}" time zone`);
+});


### PR DESCRIPTION
This adds tests for https://github.com/tc39/proposal-temporal/pull/2292 which is a normative change to the Temporal proposal that reached consensus at the July 2022 TC39 meeting.