### PR TITLE
Update tests which used negative day lengths

### DIFF
--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/smallest-unit-day-daylength-too-large.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/smallest-unit-day-daylength-too-large.js
@@ -9,7 +9,8 @@ info: |
   Temporal.ZonedDateTime.prototype.round ( roundTo )
   ...
   18. Let dayLengthNs be ℝ(endNs - startNs).
-  ...
+  19. If dayLengthNs ≤ 0, then
+    a. Throw a RangeError exception.
   20. Let roundResult be ! RoundISODateTime(temporalDateTime.[[ISOYear]],
       temporalDateTime.[[ISOMonth]], temporalDateTime.[[ISODay]], temporalDateTime.[[ISOHour]],
       temporalDateTime.[[ISOMinute]], temporalDateTime.[[ISOSecond]],
@@ -74,12 +75,10 @@ const oneDay = 24n * 60n * 60n * 1000n * 1000n * 1000n
 {
   let tz = new TimeZone(minInstant);
   let zoned = new Temporal.ZonedDateTime(0n, tz);
-  let result = zoned.round({ smallestUnit: "days" });
-  assert(zoned.equals(result));
+  assert.throws(RangeError, () => zoned.round({ smallestUnit: "days" }));
 }
 {
   let tz = new TimeZone(minInstant);
   let zoned = new Temporal.ZonedDateTime(maxInstant - oneDay, tz);
-  let result = zoned.round({ smallestUnit: "days" });
-  assert(zoned.equals(result));
+  assert.throws(RangeError, () => zoned.round({ smallestUnit: "days" }));
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/smallest-unit-day-daylength-zero-or-negative.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/smallest-unit-day-daylength-zero-or-negative.js
@@ -9,7 +9,7 @@ info: |
   Temporal.ZonedDateTime.prototype.round ( roundTo )
   ...
   18. Let dayLengthNs be ℝ(endNs - startNs).
-  19. If dayLengthNs is 0, then
+  19. If dayLengthNs ≤ 0, then
     a. Throw a RangeError exception.
   20. Let roundResult be ! RoundISODateTime(temporalDateTime.[[ISOYear]],
       temporalDateTime.[[ISOMonth]], temporalDateTime.[[ISODay]], temporalDateTime.[[ISOHour]],
@@ -62,6 +62,5 @@ class TimeZone extends Temporal.TimeZone {
 {
   let tz = new TimeZone(-1n);
   let zoned = new Temporal.ZonedDateTime(0n, tz);
-  let result = zoned.round({ smallestUnit: "days" });
-  assert(zoned.equals(result));
+  assert.throws(RangeError, () => zoned.round({ smallestUnit: "days" }));
 }


### PR DESCRIPTION
Negative day lengths are no longer valid after <https://github.com/tc39/proposal-temporal/pull/2261>.