### PR TITLE
Update RegExp.prototype.{match,replace} tests to expect Get(rx, "flags")

### DIFF
--- a/implementation-contributed/javascriptcore/es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.match].js
+++ b/implementation-contributed/javascriptcore/es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.match].js
@@ -7,7 +7,7 @@ var p = new Proxy({ exec: function() { return null; } }, { get: function(o, k) {
 RegExp.prototype[Symbol.match].call(p);
 p.global = true;
 RegExp.prototype[Symbol.match].call(p);
-return get + '' === "global,exec,global,unicode,exec";
+return get + '' === "flags,exec,flags,exec";
       
 }
 

--- a/implementation-contributed/javascriptcore/es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.replace].js
+++ b/implementation-contributed/javascriptcore/es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.replace].js
@@ -7,7 +7,7 @@ var p = new Proxy({ exec: function() { return null; } }, { get: function(o, k) {
 RegExp.prototype[Symbol.replace].call(p);
 p.global = true;
 RegExp.prototype[Symbol.replace].call(p);
-return get + '' === "global,exec,global,unicode,exec";
+return get + '' === "flags,exec,flags,exec";
       
 }
 

--- a/implementation-contributed/v8/mjsunit/regress/regress-799813.js
+++ b/implementation-contributed/v8/mjsunit/regress/regress-799813.js
@@ -9,6 +9,7 @@ function testAdvanceLastIndex(initial_last_index_value,
   let final_last_index_value;
 
   var customRegexp = {
+    get flags() { return "gu"; },
     get global() { return true; },
     get unicode() { return true; },
     get lastIndex() {

--- a/test/built-ins/RegExp/prototype/Symbol.match/flags-tostring-error.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/flags-tostring-error.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2022 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Errors thrown by converting `flags` to string are forwarded to the runtime
+esid: sec-regexp.prototype-@@match
+info: |
+    1. Let _rx_ be the *this* value.
+    2. If Type(_rx_) is not Object, throw a *TypeError* exception.
+    3. Let _S_ be ? ToString(_string_).
+    4. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
+features: [Symbol.match]
+---*/
+
+function CustomError() {}
+var toStringThrows = {
+  [Symbol.toPrimitive](hint) {
+    if (hint === 'string') {
+      throw new CustomError();
+    }
+    throw new Test262Error('@@toPrimitive should be called with hint "string"');
+  },
+  get toString() { throw new Test262Error('toString property should not be read'); },
+  get valueOf() { throw new Test262Error('valueOf property should not be read'); }
+};
+
+var re = /./;
+Object.defineProperties(re, {
+  flags: {
+    get() { return toStringThrows; }
+  },
+  global: {
+    get() { throw new Test262Error('global property should not be read'); }
+  },
+  unicode: {
+    get() { throw new Test262Error('unicode property should not be read'); }
+  }
+});
+
+assert.throws(CustomError, function() {
+  re[Symbol.match]('');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.match/g-get-exec-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/g-get-exec-err.js
@@ -23,7 +23,7 @@ info: |
 features: [Symbol.match]
 ---*/
 
-var r = { global: true };
+var r = { flags: 'g', global: true };
 Object.defineProperty(r, 'exec', {
   get: function() {
     throw new Test262Error();

--- a/test/built-ins/RegExp/prototype/Symbol.match/get-flags-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/get-flags-err.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2022 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Errors thrown by `flags` accessor are forwarded to the runtime
+esid: sec-regexp.prototype-@@match
+info: |
+    1. Let _rx_ be the *this* value.
+    2. If Type(_rx_) is not Object, throw a *TypeError* exception.
+    3. Let _S_ be ? ToString(_string_).
+    4. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
+features: [Symbol.match]
+---*/
+
+function CustomError() {}
+
+var obj = {
+  get flags() {
+    throw new CustomError();
+  },
+  get global() {
+    throw new Test262Error('global property should not be read');
+  },
+  get unicode() {
+    throw new Test262Error('unicode property should not be read');
+  }
+};
+
+assert.throws(CustomError, function() {
+  RegExp.prototype[Symbol.match].call(obj);
+});

--- a/test/built-ins/RegExp/prototype/Symbol.match/get-global-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/get-global-err.js
@@ -4,19 +4,25 @@
 /*---
 description: >
     Behavior when error is thrown during retrieval of `global` property
-es6id: 21.2.5.6
+esid: sec-regexp.prototype-@@match
 info: |
-    5. Let global be ToBoolean(Get(rx, "global")).
-    6. ReturnIfAbrupt(global).
+    1. Let _rx_ be the *this* value.
+    2. If Type(_rx_) is not Object, throw a *TypeError* exception.
+    3. Let _S_ be ? ToString(_string_).
+    4. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
+
+    sec-get-regexp.prototype.flags get RegExp.prototype.flags
+    6. Let _global_ be ToBoolean(? Get(_R_, *"global"*)).
 features: [Symbol.match]
 ---*/
 
-var obj = {
-  get global() {
+var re = /./;
+Object.defineProperty(re, 'global', {
+  get() {
     throw new Test262Error();
   }
-};
+});
 
 assert.throws(Test262Error, function() {
-  RegExp.prototype[Symbol.match].call(obj);
+  RegExp.prototype[Symbol.match].call(re);
 });

--- a/test/built-ins/RegExp/prototype/Symbol.match/get-unicode-error.js
+++ b/test/built-ins/RegExp/prototype/Symbol.match/get-unicode-error.js
@@ -3,15 +3,16 @@
 
 /*---
 description: >
-    Errors thrown by `unicode` accessor are forwarded to the runtime for global patterns
-es6id: 21.2.5.6
+    Errors thrown by `unicode` accessor are forwarded to the runtime
+esid: sec-regexp.prototype-@@match
 info: |
-    21.2.5.6 RegExp.prototype [ @@match ] ( string )
+    1. Let _rx_ be the *this* value.
+    2. If Type(_rx_) is not Object, throw a *TypeError* exception.
+    3. Let _S_ be ? ToString(_string_).
+    4. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
 
-    [...]
-    8. Else global is true,
-       a. Let fullUnicode be ToBoolean(Get(rx, "unicode")).
-       b. ReturnIfAbrupt(fullUnicode).
+    sec-get-regexp.prototype.flags get RegExp.prototype.flags
+    14. Let _unicode_ be ToBoolean(? Get(_R_, *"unicode"*)).
 features: [Symbol.match]
 ---*/
 
@@ -27,7 +28,9 @@ Object.defineProperty(globalRe, 'unicode', {
   get: accessor
 });
 
-nonGlobalRe[Symbol.match]('');
+assert.throws(Test262Error, function() {
+  nonGlobalRe[Symbol.match]('');
+});
 
 assert.throws(Test262Error, function() {
   globalRe[Symbol.match]('');

--- a/test/built-ins/RegExp/prototype/Symbol.replace/flags-tostring-error.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/flags-tostring-error.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+    Errors thrown by converting `flags` to string are forwarded to the runtime
+esid: sec-regexp.prototype-@@replace
+info: |
+    1. Let _rx_ be the *this* value.
+    2. If Type(_rx_) is not Object, throw a *TypeError* exception.
+    3. Let _S_ be ? ToString(_string_).
+    4. Let _lengthS_ be the number of code unit elements in _S_.
+    5. Let _functionalReplace_ be IsCallable(_replaceValue_).
+    6. If _functionalReplace_ is *false*, then
+      a. Set _replaceValue_ to ? ToString(_replaceValue_).
+        i. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
+features: [Symbol.replace]
+---*/
+
+function CustomError() {}
+var toStringThrows = {
+  [Symbol.toPrimitive](hint) {
+    if (hint === 'string') {
+      throw new CustomError();
+    }
+    throw new Test262Error('@@toPrimitive should be called with hint "string"');
+  },
+  get toString() { throw new Test262Error('toString property should not be read'); },
+  get valueOf() { throw new Test262Error('valueOf property should not be read'); }
+};
+
+var re = /./g;
+Object.defineProperties(re, {
+  flags: {
+    get() { return toStringThrows; }
+  },
+  global: {
+    get() { throw new Test262Error('global property should not be read'); }
+  },
+  unicode: {
+    get() { throw new Test262Error('unicode property should not be read'); }
+  }
+});
+
+assert.throws(CustomError, function() {
+  re[Symbol.replace]('');
+});

--- a/test/built-ins/RegExp/prototype/Symbol.replace/get-exec-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/get-exec-err.js
@@ -19,7 +19,7 @@ info: |
 features: [Symbol.replace]
 ---*/
 
-var r = { global: true };
+var r = { flags: 'g', global: true };
 Object.defineProperty(r, 'exec', {
   get: function() {
     throw new Test262Error();

--- a/test/built-ins/RegExp/prototype/Symbol.replace/get-flags-err.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/get-flags-err.js
@@ -1,9 +1,9 @@
-// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2022 Richard Gibson. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
 description: >
-    Behavior when error is thrown during retrieval of `global` property
+    Errors thrown by `flags` accessor are forwarded to the runtime
 esid: sec-regexp.prototype-@@replace
 info: |
     1. Let _rx_ be the *this* value.
@@ -14,19 +14,23 @@ info: |
     6. If _functionalReplace_ is *false*, then
       a. Set _replaceValue_ to ? ToString(_replaceValue_).
         i. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
-
-    sec-get-regexp.prototype.flags get RegExp.prototype.flags
-    6. Let _global_ be ToBoolean(? Get(_R_, *"global"*)).
 features: [Symbol.replace]
 ---*/
 
-var re = /./;
-Object.defineProperty(re, 'global', {
-  get() {
-    throw new Test262Error();
-  }
-});
+function CustomError() {}
 
-assert.throws(Test262Error, function() {
-  RegExp.prototype[Symbol.replace].call(re);
+var obj = {
+  get flags() {
+    throw new CustomError();
+  },
+  get global() {
+    throw new Test262Error('global property should not be read');
+  },
+  get unicode() {
+    throw new Test262Error('unicode property should not be read');
+  }
+};
+
+assert.throws(CustomError, function() {
+  RegExp.prototype[Symbol.replace].call(obj);
 });

--- a/test/built-ins/RegExp/prototype/Symbol.replace/get-unicode-error.js
+++ b/test/built-ins/RegExp/prototype/Symbol.replace/get-unicode-error.js
@@ -3,15 +3,20 @@
 
 /*---
 description: >
-    Errors thrown by `unicode` accessor are forwarded to the runtime for global patterns
-es6id: 21.2.5.8
+    Errors thrown by `unicode` accessor are forwarded to the runtime
+esid: sec-regexp.prototype-@@replace
 info: |
-    21.2.5.8 RegExp.prototype [ @@replace ] ( string, replaceValue )
+    1. Let _rx_ be the *this* value.
+    2. If Type(_rx_) is not Object, throw a *TypeError* exception.
+    3. Let _S_ be ? ToString(_string_).
+    4. Let _lengthS_ be the number of code unit elements in _S_.
+    5. Let _functionalReplace_ be IsCallable(_replaceValue_).
+    6. If _functionalReplace_ is *false*, then
+      a. Set _replaceValue_ to ? ToString(_replaceValue_).
+        i. Let _flags_ be ? ToString(? Get(_rx_, *"flags"*)).
 
-    [...]
-    10. If global is true, then
-        a. Let fullUnicode be ToBoolean(Get(rx, "unicode")).
-        b. ReturnIfAbrupt(fullUnicode).
+    sec-get-regexp.prototype.flags get RegExp.prototype.flags
+    14. Let _unicode_ be ToBoolean(? Get(_R_, *"unicode"*)).
 features: [Symbol.replace]
 ---*/
 
@@ -27,7 +32,9 @@ Object.defineProperty(globalRe, 'unicode', {
   get: accessor
 });
 
-nonGlobalRe[Symbol.replace]('', '');
+assert.throws(Test262Error, function() {
+  nonGlobalRe[Symbol.replace]('', '');
+});
 
 assert.throws(Test262Error, function() {
   globalRe[Symbol.replace]('', '');


### PR DESCRIPTION
This adds tests for https://github.com/tc39/ecma262/pull/2791 , which reached consensus at the July 2022 TC39 meeting.