### PR TITLE
Temporal: Adjust tests for non-integer/out-of-range values of fractionalSecondDigits

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-non-integer.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-non-integer.js
@@ -16,5 +16,11 @@ features: [Temporal]
 
 const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 650, 0);
 
-const string = duration.toString({ fractionalSecondDigits: 2.5 });
-assert.sameValue(string, "P1Y2M3W4DT5H6M7.98S", "fractionalSecondDigits 2.5 floors to 2");
+let string = duration.toString({ fractionalSecondDigits: 2.5 });
+assert.sameValue(string, "P1Y2M3W4DT5H6M7.98S", "fractionalSecondDigits 2.5 truncates to 2");
+
+string = duration.toString({ fractionalSecondDigits: 9.7 });
+assert.sameValue(string, "P1Y2M3W4DT5H6M7.987650000S", "fractionalSecondDigits 9.7 truncates to 9 and is not out of range");
+
+string = duration.toString({ fractionalSecondDigits: -0.6 });
+assert.sameValue(string, "P1Y2M3W4DT5H6M7S", "fractionalSecondDigits -0.6 truncates to 0 and is not out of range");

--- a/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-non-integer.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-non-integer.js
@@ -16,5 +16,11 @@ features: [Temporal]
 
 const instant = new Temporal.Instant(1_000_000_000_987_650_000n);
 
-const string = instant.toString({ fractionalSecondDigits: 2.5 });
-assert.sameValue(string, "2001-09-09T01:46:40.98Z", "fractionalSecondDigits 2.5 floors to 2");
+let string = instant.toString({ fractionalSecondDigits: 2.5 });
+assert.sameValue(string, "2001-09-09T01:46:40.98Z", "fractionalSecondDigits 2.5 truncates to 2");
+
+string = instant.toString({ fractionalSecondDigits: 9.7 });
+assert.sameValue(string, "2001-09-09T01:46:40.987650000Z", "fractionalSecondDigits 9.7 truncates to 9 and is not out of range");
+
+string = instant.toString({ fractionalSecondDigits: -0.6 });
+assert.sameValue(string, "2001-09-09T01:46:40Z", "fractionalSecondDigits -0.6 truncates to 0 and is not out of range");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-non-integer.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-non-integer.js
@@ -16,5 +16,11 @@ features: [Temporal]
 
 const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 650, 0);
 
-const string = datetime.toString({ fractionalSecondDigits: 2.5 });
-assert.sameValue(string, "2000-05-02T12:34:56.98", "fractionalSecondDigits 2.5 floors to 2");
+let string = datetime.toString({ fractionalSecondDigits: 2.5 });
+assert.sameValue(string, "2000-05-02T12:34:56.98", "fractionalSecondDigits 2.5 truncates to 2");
+
+string = datetime.toString({ fractionalSecondDigits: 9.7 });
+assert.sameValue(string, "2000-05-02T12:34:56.987650000", "fractionalSecondDigits 9.7 truncates to 9 and is not out of range");
+
+string = datetime.toString({ fractionalSecondDigits: -0.6 });
+assert.sameValue(string, "2000-05-02T12:34:56", "fractionalSecondDigits -0.6 truncates to 0 and is not out of range");

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-non-integer.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-non-integer.js
@@ -16,5 +16,11 @@ features: [Temporal]
 
 const time = new Temporal.PlainTime(12, 34, 56, 987, 650, 0);
 
-const string = time.toString({ fractionalSecondDigits: 2.5 });
-assert.sameValue(string, "12:34:56.98", "fractionalSecondDigits 2.5 floors to 2");
+let string = time.toString({ fractionalSecondDigits: 2.5 });
+assert.sameValue(string, "12:34:56.98", "fractionalSecondDigits 2.5 truncates to 2");
+
+string = time.toString({ fractionalSecondDigits: 9.7 });
+assert.sameValue(string, "12:34:56.987650000", "fractionalSecondDigits 9.7 truncates to 9 and is not out of range");
+
+string = time.toString({ fractionalSecondDigits: -0.6 });
+assert.sameValue(string, "12:34:56", "fractionalSecondDigits -0.6 truncates to 0 and is not out of range");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-non-integer.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/fractionalseconddigits-non-integer.js
@@ -16,5 +16,11 @@ features: [Temporal]
 
 const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_650_000n, "UTC");
 
-const string = datetime.toString({ fractionalSecondDigits: 2.5 });
-assert.sameValue(string, "2001-09-09T01:46:40.98+00:00[UTC]", "fractionalSecondDigits 2.5 floors to 2");
+let string = datetime.toString({ fractionalSecondDigits: 2.5 });
+assert.sameValue(string, "2001-09-09T01:46:40.98+00:00[UTC]", "fractionalSecondDigits 2.5 truncates to 2");
+
+string = datetime.toString({ fractionalSecondDigits: 9.7 });
+assert.sameValue(string, "2001-09-09T01:46:40.987650000+00:00[UTC]", "fractionalSecondDigits 9.7 truncates to 9 and is not out of range");
+
+string = datetime.toString({ fractionalSecondDigits: -0.6 });
+assert.sameValue(string, "2001-09-09T01:46:40+00:00[UTC]", "fractionalSecondDigits -0.6 truncates to 0 and is not out of range");


### PR DESCRIPTION
This implements the normative change in
https://github.com/tc39/proposal-temporal/pull/2297 which reached
consensus at the July 2022 TC39 meeting.

Values given as the fractionalSecondDigits option are now truncated to
integers before they are compared to the allowable range.