### PR TITLE
Temporal: Adjust and expand tests for observable calls to ToString(calendar)

### DIFF
--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/calendar-tostring.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/calendar-tostring.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.protoype.tostring
+esid: sec-temporal.plaindatetime.protoype.tostring
 description: Should call 'toString' on the calendar once unless calendarName == 'never'.
 features: [Temporal]
 ---*/
@@ -14,12 +14,12 @@ const customCalendar = {
     return "custom";
   }
 };
-const date = new Temporal.PlainDate(2000, 5, 2, customCalendar);
+const date = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, customCalendar);
 [
-  ["always", "2000-05-02[u-ca=custom]", 1],
-  ["auto", "2000-05-02[u-ca=custom]", 1],
-  ["never", "2000-05-02", 0],
-  [undefined, "2000-05-02[u-ca=custom]", 1],
+  ["always", "2000-05-02T12:34:56.987654321[u-ca=custom]", 1],
+  ["auto", "2000-05-02T12:34:56.987654321[u-ca=custom]", 1],
+  ["never", "2000-05-02T12:34:56.987654321", 0],
+  [undefined, "2000-05-02T12:34:56.987654321[u-ca=custom]", 1],
 ].forEach(([calendarName, expectedResult, expectedCalls]) => {
   calls = 0;
   const result = date.toString({ calendarName });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/calendar-tostring.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/calendar-tostring.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plaindate.protoype.tostring
+esid: sec-temporal.zoneddatetime.protoype.tostring
 description: Should call 'toString' on the calendar once unless calendarName == 'never'.
 features: [Temporal]
 ---*/
@@ -14,12 +14,12 @@ const customCalendar = {
     return "custom";
   }
 };
-const date = new Temporal.PlainDate(2000, 5, 2, customCalendar);
+const date = new Temporal.ZonedDateTime(3661_987_654_321n, "UTC", customCalendar);
 [
-  ["always", "2000-05-02[u-ca=custom]", 1],
-  ["auto", "2000-05-02[u-ca=custom]", 1],
-  ["never", "2000-05-02", 0],
-  [undefined, "2000-05-02[u-ca=custom]", 1],
+  ["always", "1970-01-01T01:01:01.987654321+00:00[UTC][u-ca=custom]", 1],
+  ["auto", "1970-01-01T01:01:01.987654321+00:00[UTC][u-ca=custom]", 1],
+  ["never", "1970-01-01T01:01:01.987654321+00:00[UTC]", 0],
+  [undefined, "1970-01-01T01:01:01.987654321+00:00[UTC][u-ca=custom]", 1],
 ].forEach(([calendarName, expectedResult, expectedCalls]) => {
   calls = 0;
   const result = date.toString({ calendarName });


### PR DESCRIPTION
This implements the normative change in
https://github.com/tc39/proposal-temporal/pull/2269 which reached
consensus at the July 2022 TC39 meeting.

There was already a test for PlainDate for this topic, which needs to be
adjusted to accommodate the normative change. Tests for PlainDateTime and
ZonedDateTime did not yet exist, so add new ones based on the PlainDate
test.