### PR TITLE
Add tests for proposal-duplicate-named-capturing-groups

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -276,6 +276,10 @@ regexp-v-flag
 # https://github.com/tc39/proposal-decorators
 decorators
 
+# Duplicate named capturing groups
+# https://github.com/tc39/proposal-duplicate-named-capturing-groups
+regexp-duplicate-named-groups
+
 ## Standard language features
 #
 # Language features that have been included in a published version of the

--- a/test/built-ins/RegExp/named-groups/duplicate-names-group-property-enumeration-order.js
+++ b/test/built-ins/RegExp/named-groups/duplicate-names-group-property-enumeration-order.js
@@ -1,0 +1,24 @@
+// Copyright 2022 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Enumeration order of the groups object with duplicate named capture groups
+esid: prod-GroupSpecifier
+features: [regexp-duplicate-named-groups]
+includes: [compareArray.js]
+---*/
+
+
+let regexp = /(?<y>a)(?<x>a)|(?<x>b)(?<y>b)/;
+
+assert.compareArray(
+  Object.keys(regexp.exec("aa").groups),
+  ["y", "x"],
+  "property enumeration order of the groups object is based on source order, not match order"
+);
+
+assert.compareArray(
+  Object.keys(regexp.exec("bb").groups),
+  ["y", "x"],
+  "property enumeration order of the groups object is based on source order, not match order"
+);

--- a/test/built-ins/RegExp/named-groups/duplicate-names-match-indices.js
+++ b/test/built-ins/RegExp/named-groups/duplicate-names-match-indices.js
@@ -1,0 +1,15 @@
+// Copyright 2022 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: match indices with duplicate named capture groups
+esid: sec-makematchindicesindexpairarray
+features: [regexp-duplicate-named-groups, regexp-match-indices]
+includes: [compareArray.js]
+---*/
+
+let indices = "..ab".match(/(?<x>a)|(?<x>b)/d).indices;
+assert.compareArray(indices.groups.x, [2, 3]);
+
+indices = "..ba".match(/(?<x>a)|(?<x>b)/d).indices;
+assert.compareArray(indices.groups.x, [2, 3]);

--- a/test/built-ins/RegExp/named-groups/duplicate-names-replace.js
+++ b/test/built-ins/RegExp/named-groups/duplicate-names-replace.js
@@ -1,0 +1,17 @@
+// Copyright 2022 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: String.prototype.replace behavior with duplicate named capture groups
+esid: prod-GroupSpecifier
+features: [regexp-duplicate-named-groups]
+---*/
+
+assert.sameValue("ab".replace(/(?<x>a)|(?<x>b)/, "[$<x>]"), "[a]b");
+assert.sameValue("ba".replace(/(?<x>a)|(?<x>b)/, "[$<x>]"), "[b]a");
+
+assert.sameValue("ab".replace(/(?<x>a)|(?<x>b)/, "[$<x>][$1][$2]"), "[a][a][]b");
+assert.sameValue("ba".replace(/(?<x>a)|(?<x>b)/, "[$<x>][$1][$2]"), "[b][][b]a");
+
+assert.sameValue("ab".replace(/(?<x>a)|(?<x>b)/g, "[$<x>]"), "[a][b]");
+assert.sameValue("ba".replace(/(?<x>a)|(?<x>b)/g, "[$<x>]"), "[b][a]");

--- a/test/built-ins/RegExp/named-groups/duplicate-names.js
+++ b/test/built-ins/RegExp/named-groups/duplicate-names.js
@@ -17,3 +17,6 @@ assert.compareArray(["bb", undefined, "bb"], "bb".match(/(?:(?<x>a)|(?<x>b))\k<x
 let matchResult = "aabb".match(/(?:(?:(?<x>a)|(?<x>b))\k<x>){2}/);
 assert.compareArray(["aabb", undefined, "bb"], matchResult);
 assert.sameValue(matchResult.groups.x, "bb");
+
+let notMatched = "abab".match(/(?:(?:(?<x>a)|(?<x>b))\k<x>){2}/);
+assert.sameValue(null, notMatched);

--- a/test/built-ins/RegExp/named-groups/duplicate-names.js
+++ b/test/built-ins/RegExp/named-groups/duplicate-names.js
@@ -19,4 +19,4 @@ assert.compareArray(["aabb", undefined, "bb"], matchResult);
 assert.sameValue(matchResult.groups.x, "bb");
 
 let notMatched = "abab".match(/(?:(?:(?<x>a)|(?<x>b))\k<x>){2}/);
-assert.sameValue(null, notMatched);
+assert.sameValue(notMatched, null);

--- a/test/built-ins/RegExp/named-groups/duplicate-names.js
+++ b/test/built-ins/RegExp/named-groups/duplicate-names.js
@@ -1,0 +1,19 @@
+// Copyright 2022 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Matching behavior with duplicate named capture groups
+esid: prod-GroupSpecifier
+features: [regexp-duplicate-named-groups]
+includes: [compareArray.js]
+---*/
+
+assert.compareArray(["b", "b"], "bab".match(/(?<x>a)|(?<x>b)/));
+assert.compareArray(["b", "b"], "bab".match(/(?<x>b)|(?<x>a)/));
+
+assert.compareArray(["aa", "aa", undefined], "aa".match(/(?:(?<x>a)|(?<x>b))\k<x>/));
+assert.compareArray(["bb", undefined, "bb"], "bb".match(/(?:(?<x>a)|(?<x>b))\k<x>/));
+
+let matchResult = "aabb".match(/(?:(?:(?<x>a)|(?<x>b))\k<x>){2}/);
+assert.compareArray(["aabb", undefined, "bb"], matchResult);
+assert.sameValue(matchResult.groups.x, "bb");

--- a/test/language/literals/regexp/named-groups/invalid-duplicate-groupspecifier-2-u.js
+++ b/test/language/literals/regexp/named-groups/invalid-duplicate-groupspecifier-2-u.js
@@ -2,10 +2,11 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: GroupSpecifiers must be unique.
+description: GroupSpecifiers within one alternative must be unique.
 info: |
-  It is a Syntax Error if Pattern contains multiple GroupSpecifiers
-  whose enclosed RegExpIdentifierNames have the same StringValue.
+  It is a Syntax Error if |Pattern| contains two distinct |GroupSpecifier|s
+  _x_ and _y_ for which CapturingGroupName(_x_) is the same as
+  CapturingGroupName(_y_) and such that CanBothParticipate(_x_, _y_) is *true*.
 esid: sec-patterns-static-semantics-early-errors
 negative:
   phase: parse

--- a/test/language/literals/regexp/named-groups/invalid-duplicate-groupspecifier-2.js
+++ b/test/language/literals/regexp/named-groups/invalid-duplicate-groupspecifier-2.js
@@ -2,10 +2,11 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: GroupSpecifiers must be unique.
+description: GroupSpecifiers within one alternative must be unique.
 info: |
-  It is a Syntax Error if Pattern contains multiple GroupSpecifiers
-  whose enclosed RegExpIdentifierNames have the same StringValue.
+  It is a Syntax Error if |Pattern| contains two distinct |GroupSpecifier|s
+  _x_ and _y_ for which CapturingGroupName(_x_) is the same as
+  CapturingGroupName(_y_) and such that CanBothParticipate(_x_, _y_) is *true*.
 esid: sec-patterns-static-semantics-early-errors
 negative:
   phase: parse

--- a/test/language/literals/regexp/named-groups/invalid-duplicate-groupspecifier-u.js
+++ b/test/language/literals/regexp/named-groups/invalid-duplicate-groupspecifier-u.js
@@ -2,10 +2,11 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: GroupSpecifiers must be unique.
+description: GroupSpecifiers within one alternative must be unique.
 info: |
-  It is a Syntax Error if Pattern contains multiple GroupSpecifiers
-  whose enclosed RegExpIdentifierNames have the same StringValue.
+  It is a Syntax Error if |Pattern| contains two distinct |GroupSpecifier|s
+  _x_ and _y_ for which CapturingGroupName(_x_) is the same as
+  CapturingGroupName(_y_) and such that CanBothParticipate(_x_, _y_) is *true*.
 esid: sec-patterns-static-semantics-early-errors
 negative:
   phase: parse

--- a/test/language/literals/regexp/named-groups/invalid-duplicate-groupspecifier.js
+++ b/test/language/literals/regexp/named-groups/invalid-duplicate-groupspecifier.js
@@ -2,10 +2,11 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: GroupSpecifiers must be unique.
+description: GroupSpecifiers within one alternative must be unique.
 info: |
-  It is a Syntax Error if Pattern contains multiple GroupSpecifiers
-  whose enclosed RegExpIdentifierNames have the same StringValue.
+  It is a Syntax Error if |Pattern| contains two distinct |GroupSpecifier|s
+  _x_ and _y_ for which CapturingGroupName(_x_) is the same as
+  CapturingGroupName(_y_) and such that CanBothParticipate(_x_, _y_) is *true*.
 esid: sec-patterns-static-semantics-early-errors
 negative:
   phase: parse


### PR DESCRIPTION
This adds simple tests for https://github.com/tc39/proposal-duplicate-named-capturing-groups, which achieved stage 3 at the July 2022 meeting. No existing tests were invalidated, but some needed their descriptions updated.
