### PR TITLE
Temporal: Add test for Temporal.Duration.prototype.total

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/total/total-value-infinity.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/total-value-infinity.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: Returns ±∞ when total is not representable as a Number value.
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, Number.MAX_VALUE, 0);
+
+assert.sameValue(instance.total('nanoseconds'), Infinity);


### PR DESCRIPTION
This adds test for https://github.com/tc39/proposal-temporal/pull/2298 which is a normative change to the Temporal proposal that reached consensus at the July 2022 TC39 meeting.