### PR TITLE
CI: Bump esvu to 1.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "homepage": "https://github.com/tc39/test262#readme",
   "devDependencies": {
-    "esvu": "^1.0.0",
+    "esvu": "^1.2.9",
     "test262-harness": "^8.0.0"
   },
   "scripts": {


### PR DESCRIPTION
1.2.8 does not install graaljs correctly.