### PR TITLE
Temporal: Add test for rounding Duration relative to Feb 1 in a leap year

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/round/february-leap-year.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/february-leap-year.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: RangeError thrown when largestUnit option not one of the allowed string values
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+// Based on a test case by André Bargull <andre.bargull@gmail.com>
+
+// Note: February in a leap year.
+const relativeTo = new Temporal.PlainDate(1972, 2, 1);
+
+const options = {
+  largestUnit: "years",
+  relativeTo,
+};
+
+const twoDaysLessThanFourYears = new Temporal.Duration(3, 11, 0, 27);
+TemporalHelpers.assertDuration(
+  twoDaysLessThanFourYears.round(options),
+  3, 11, 0, 27, 0, 0, 0, 0, 0, 0,
+  "Two days less than four years starting in February in a leap year shouldn't balance up"
+);
+
+const oneDayLessThanFourYears = new Temporal.Duration(3, 11, 0, 28);
+TemporalHelpers.assertDuration(
+  oneDayLessThanFourYears.round(options),
+  3, 11, 0, 28, 0, 0, 0, 0, 0, 0,
+  "One day less than four years starting in February in a leap year shouldn't balance up"
+);
+
+const fourYears = new Temporal.Duration(3, 11, 0, 29);
+TemporalHelpers.assertDuration(
+  fourYears.round(options),
+  4, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  "Four years starting in February in a leap year should balance up"
+);


### PR DESCRIPTION
This implements the normative change in
https://github.com/tc39/proposal-temporal/pull/2344 which reached
consensus at the July 2022 TC39 meeting.

It adds a test that catches a corner case in Duration.prototype.round().