### PR TITLE
Rename Array#groupBy and Array#groupByToMap to Array#group and Array#groupToMap

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -260,7 +260,7 @@ ShadowRealm
 # https://github.com/tc39/proposal-array-find-from-last
 array-find-from-last
 
-# Array.prototype.groupBy & Array.prototype.groupByToMap
+# Array.prototype.group & Array.prototype.groupToMap
 # https://github.com/tc39/proposal-array-grouping
 array-grouping
 

--- a/test/built-ins/Array/prototype/Symbol.unscopables/array-grouping.js
+++ b/test/built-ins/Array/prototype/Symbol.unscopables/array-grouping.js
@@ -8,8 +8,8 @@ info: |
     22.1.3.32 Array.prototype [ @@unscopables ]
 
     ...
-    10. Perform ! CreateDataPropertyOrThrow(unscopableList, "groupBy", true).
-    11. Perform ! CreateDataPropertyOrThrow(unscopableList, "groupByToMap", true).
+    10. Perform ! CreateDataPropertyOrThrow(unscopableList, "group", true).
+    11. Perform ! CreateDataPropertyOrThrow(unscopableList, "groupToMap", true).
     ...
 
 includes: [propertyHelper.js]
@@ -20,12 +20,12 @@ var unscopables = Array.prototype[Symbol.unscopables];
 
 assert.sameValue(Object.getPrototypeOf(unscopables), null);
 
-assert.sameValue(unscopables.groupBy, true, '`groupBy` property value');
-verifyEnumerable(unscopables, 'groupBy');
-verifyWritable(unscopables, 'groupBy');
-verifyConfigurable(unscopables, 'groupBy');
+assert.sameValue(unscopables.group, true, '`group` property value');
+verifyEnumerable(unscopables, 'group');
+verifyWritable(unscopables, 'group');
+verifyConfigurable(unscopables, 'group');
 
-assert.sameValue(unscopables.groupByToMap, true, '`groupByToMap` property value');
-verifyEnumerable(unscopables, 'groupByToMap');
-verifyWritable(unscopables, 'groupByToMap');
-verifyConfigurable(unscopables, 'groupByToMap');
+assert.sameValue(unscopables.groupToMap, true, '`groupToMap` property value');
+verifyEnumerable(unscopables, 'groupToMap');
+verifyWritable(unscopables, 'groupToMap');
+verifyConfigurable(unscopables, 'groupToMap');


### PR DESCRIPTION
TC39 decided to rename them to avoid web-compat issue[1].
This change follows to it.

[1]: https://github.com/tc39/proposal-array-grouping/pull/39