### PR TITLE
Meta: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+**/* @tc39/test262-maintainers
+test/staging/* @tc39/test262-staging @tc39/test262-maintainers


### PR DESCRIPTION
This requires @tc39/test262-maintainers approval for everything, but also allows @tc39/test262-staging approval for the `test/staging` directory.