### PR TITLE
Remove undefined to sync to PR 113 of proposal-intl-duration-format

### DIFF
--- a/test/intl402/DurationFormat/constructor-options-fractionalDigits-valid.js
+++ b/test/intl402/DurationFormat/constructor-options-fractionalDigits-valid.js
@@ -12,7 +12,6 @@ features: [Intl.DurationFormat]
 ---*/
 
 const validOptions = [
-  undefined,
   0,
   1,
   5,


### PR DESCRIPTION
undefined is no longer value output for resolvedOptions().fractionalDigits

https://github.com/tc39/proposal-intl-duration-format/pull/113