### PR TITLE
Fix DurationFormat default tests

### DIFF
--- a/test/intl402/DurationFormat/constructor-options-defaults.js
+++ b/test/intl402/DurationFormat/constructor-options-defaults.js
@@ -20,13 +20,14 @@ features: [Intl.DurationFormat]
 includes: [testIntl.js]
 ---*/
 
-testOption( Intl.DurationFormat, "years", "string", ["long", "short", "narrow"], "narrow");
-testOption( Intl.DurationFormat, "months", "string", ["long", "short", "narrow"], "narrow");
-testOption( Intl.DurationFormat, "weeks", "string", ["long", "short", "narrow"], "narrow");
-testOption( Intl.DurationFormat, "days", "string", ["long", "short", "narrow", "numeric", "2-digit"], "numeric");
-testOption( Intl.DurationFormat, "hours", "string", ["long", "short", "narrow", "numeric", "2-digit"], "numeric");
-testOption( Intl.DurationFormat, "minutes", "string", ["long", "short", "narrow", "numeric", "2-digit"], "numeric");
-testOption( Intl.DurationFormat, "milliseconds", "string", ["long", "short", "narrow", "numeric", "2-digit"], "numeric");
-testOption( Intl.DurationFormat, "microseconds", "string", ["long", "short", "narrow", "numeric", "2-digit"], "numeric");
-testOption( Intl.DurationFormat, "nanoseconds", "string", ["long", "short", "narrow", "numeric", "2-digit"], "numeric");
+testOption( Intl.DurationFormat, "years", "string", ["long", "short", "narrow"], "long");
+testOption( Intl.DurationFormat, "months", "string", ["long", "short", "narrow"], "long");
+testOption( Intl.DurationFormat, "weeks", "string", ["long", "short", "narrow"], "long");
+testOption( Intl.DurationFormat, "days", "string", ["long", "short", "narrow"], "long");
+testOption( Intl.DurationFormat, "hours", "string", ["long", "short", "narrow", "numeric", "2-digit"], "long");
+testOption( Intl.DurationFormat, "minutes", "string", ["long", "short", "narrow", "numeric", "2-digit"], "long");
+testOption( Intl.DurationFormat, "seconds", "string", ["long", "short", "narrow", "numeric", "2-digit"], "long");
+testOption( Intl.DurationFormat, "milliseconds", "string", ["long", "short", "narrow", "numeric"], "long");
+testOption( Intl.DurationFormat, "microseconds", "string", ["long", "short", "narrow", "numeric"], "long");
+testOption( Intl.DurationFormat, "nanoseconds", "string", ["long", "short", "narrow", "numeric"], "long");
 

--- a/test/intl402/DurationFormat/constructor-options-defaults.js
+++ b/test/intl402/DurationFormat/constructor-options-defaults.js
@@ -20,14 +20,14 @@ features: [Intl.DurationFormat]
 includes: [testIntl.js]
 ---*/
 
-testOption( Intl.DurationFormat, "years", "string", ["long", "short", "narrow"], "long");
-testOption( Intl.DurationFormat, "months", "string", ["long", "short", "narrow"], "long");
-testOption( Intl.DurationFormat, "weeks", "string", ["long", "short", "narrow"], "long");
-testOption( Intl.DurationFormat, "days", "string", ["long", "short", "narrow"], "long");
-testOption( Intl.DurationFormat, "hours", "string", ["long", "short", "narrow", "numeric", "2-digit"], "long");
-testOption( Intl.DurationFormat, "minutes", "string", ["long", "short", "narrow", "numeric", "2-digit"], "long");
-testOption( Intl.DurationFormat, "seconds", "string", ["long", "short", "narrow", "numeric", "2-digit"], "long");
-testOption( Intl.DurationFormat, "milliseconds", "string", ["long", "short", "narrow", "numeric"], "long");
-testOption( Intl.DurationFormat, "microseconds", "string", ["long", "short", "narrow", "numeric"], "long");
-testOption( Intl.DurationFormat, "nanoseconds", "string", ["long", "short", "narrow", "numeric"], "long");
+testOption( Intl.DurationFormat, "years", "string", ["long", "short", "narrow"], "short");
+testOption( Intl.DurationFormat, "months", "string", ["long", "short", "narrow"], "short");
+testOption( Intl.DurationFormat, "weeks", "string", ["long", "short", "narrow"], "short");
+testOption( Intl.DurationFormat, "days", "string", ["long", "short", "narrow"], "short");
+testOption( Intl.DurationFormat, "hours", "string", ["long", "short", "narrow", "numeric", "2-digit"], "short");
+testOption( Intl.DurationFormat, "minutes", "string", ["long", "short", "narrow", "numeric", "2-digit"], "short");
+testOption( Intl.DurationFormat, "seconds", "string", ["long", "short", "narrow", "numeric", "2-digit"], "short");
+testOption( Intl.DurationFormat, "milliseconds", "string", ["long", "short", "narrow", "numeric"], "short");
+testOption( Intl.DurationFormat, "microseconds", "string", ["long", "short", "narrow", "numeric"], "short");
+testOption( Intl.DurationFormat, "nanoseconds", "string", ["long", "short", "narrow", "numeric"], "short");
 

--- a/test/intl402/DurationFormat/constructor-options-style-valid.js
+++ b/test/intl402/DurationFormat/constructor-options-style-valid.js
@@ -7,13 +7,13 @@ description: Checks handling of valid values for the style option to the Duratio
 info: |
     InitializeDurationFormat (DurationFormat, locales, options)
     (...)
-    13. Let style be ? GetOption(options, "style", "string", « "long", "short", "narrow", "digital" », "long").
+    13. Let style be ? GetOption(options, "style", "string", « "long", "short", "narrow", "digital" », "short").
     14. Set durationFormat.[[Style]] to style.
 features: [Intl.DurationFormat]
 ---*/
 
 const validOptions = [
-  [undefined, "long"],
+  [undefined, "short"],
   ["long", "long"],
   ["short", "short"],
   ["narrow", "narrow"],

--- a/test/intl402/DurationFormat/prototype/format/basic-format-en.js
+++ b/test/intl402/DurationFormat/prototype/format/basic-format-en.js
@@ -23,4 +23,4 @@ const duration = {
 
 const df = new Intl.DurationFormat('en');
 
-assert.sameValue(df.format(duration), "1 year, 2 months, 3 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds, 8 microseconds, and 9 nanoseconds");
+assert.sameValue(df.format(duration), "1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns");


### PR DESCRIPTION
1. add the test for "seconds"
2. since the default value for "style" is "long", baseStyle for GetDurationUnitOptions is "long" and therefore the 
last argument in testOption should be "long"
3. the valid values for "days" does not contains  "numeric", and "2-digit". remove them. 
4. the valid values for "milliseconds", "microseconds" and "nanoseconds" does not contains "2-digit". remove it.

See https://tc39.es/proposal-intl-duration-format/#table-duration-components about the valid value
notice the last colum is for "Digital Default" while the baseStyle is "digital" but the set up does not set it that way, the default value for "style" is "long" as in
```
13. Let style be ? GetOption(options, "style", "string", « "long", "short", "narrow", "digital" », "long").
```
of https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat

@sffc @romulocintra  @ryzokuken  