### PR TITLE
Temporal: Add calendar strings to instant string tests

### DIFF
--- a/test/built-ins/Temporal/Instant/compare/instant-string.js
+++ b/test/built-ins/Temporal/Instant/compare/instant-string.js
@@ -32,3 +32,15 @@ assert.sameValue(Temporal.Instant.compare(epoch, str), 0, "date-time + Z + IANA 
 str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 assert.sameValue(Temporal.Instant.compare(str, hourBefore), 0, "date-time + offset + IANA annotation ignores the IANA annotation (first argument)");
 assert.sameValue(Temporal.Instant.compare(hourBefore, str), 0, "date-time + offset + IANA annotation ignores the IANA annotation (second argument)");
+
+str = "1970-01-01T00:00Z[u-ca=hebrew]";
+assert.sameValue(Temporal.Instant.compare(str, epoch), 0, "date-time + Z + Calendar ignores the Calendar (first argument)");
+assert.sameValue(Temporal.Instant.compare(epoch, str), 0, "date-time + Z + Calendar ignores the Calendar (second argument)");
+
+str = "1970-01-01T00:00+01:00[u-ca=hebrew]";
+assert.sameValue(Temporal.Instant.compare(str, hourBefore), 0, "date-time + offset + Calendar ignores the Calendar (first argument)");
+assert.sameValue(Temporal.Instant.compare(hourBefore, str), 0, "date-time + offset + Calendar ignores the Calendar (second argument)");
+
+str = "1970-01-01T00:00+01:00[Etc/Ignored][u-ca=hebrew]";
+assert.sameValue(Temporal.Instant.compare(str, hourBefore), 0, "date-time + offset + IANA annotation + Calendar ignores the IANA annotation and the Calendar (first argument)");
+assert.sameValue(Temporal.Instant.compare(hourBefore, str), 0, "date-time + offset + IANA annotation + Calendar ignores the IANA annotation and the Calendar (second argument)");

--- a/test/built-ins/Temporal/Instant/from/instant-string.js
+++ b/test/built-ins/Temporal/Instant/from/instant-string.js
@@ -27,3 +27,15 @@ assert.sameValue(result3.epochNanoseconds, 0n, "date-time + Z + IANA annotation 
 str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 const result4 = Temporal.Instant.from(str);
 assert.sameValue(result4.epochNanoseconds, -3600_000_000_000n, "date-time + offset + IANA annotation ignores the IANA annotation");
+
+str = "1970-01-01T00:00Z[u-ca=hebrew]";
+const result6 = Temporal.Instant.from(str);
+assert.sameValue(result6.epochNanoseconds, 0n, "date-time + Z + Calendar ignores the Calendar");
+
+str = "1970-01-01T00:00+01:00[u-ca=hebrew]";
+const result7 = Temporal.Instant.from(str);
+assert.sameValue(result7.epochNanoseconds, -3600_000_000_000n, "date-time + offset + Calendar ignores the Calendar");
+
+str = "1970-01-01T00:00+01:00[Etc/Ignored][u-ca=hebrew]";
+const result8 = Temporal.Instant.from(str);
+assert.sameValue(result8.epochNanoseconds, -3600_000_000_000n, "date-time + offset + IANA annotation + Calendar ignores the Calendar and IANA annotation");

--- a/test/built-ins/Temporal/Instant/prototype/equals/instant-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/instant-string.js
@@ -29,3 +29,15 @@ assert.sameValue(result3, true, "date-time + Z + IANA annotation ignores the IAN
 str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 const result4 = instance.equals(str);
 assert.sameValue(result4, false, "date-time + offset + IANA annotation ignores the IANA annotation");
+
+str = "1970-01-01T00:00Z[u-ca=hebrew]";
+const result6 = instance.equals(str);
+assert.sameValue(result6, true, "date-time + Z + Calendar ignores the Calendar");
+
+str = "1970-01-01T00:00+01:00[u-ca=hebrew]";
+const result5 = instance.equals(str);
+assert.sameValue(result5, false, "date-time + offset + Calendar ignores the Calendar");
+
+str = "1970-01-01T00:00+01:00[Etc/Ignored][u-ca=hebrew]";
+const result7 = instance.equals(str);
+assert.sameValue(result7, false, "date-time + offset + IANA annotation + Calendar ignores the Calendar and IANA annotation");

--- a/test/built-ins/Temporal/Instant/prototype/since/instant-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/instant-string.js
@@ -30,3 +30,15 @@ TemporalHelpers.assertDuration(result3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time
 str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 const result4 = instance.since(str);
 TemporalHelpers.assertDuration(result4, 0, 0, 0, 0, 0, 0, 3600, 0, 0, 0, "date-time + offset + IANA annotation ignores the IANA annotation");
+
+str = "1970-01-01T00:00Z[u-ca=hebrew]";
+const result6 = instance.since(str);
+TemporalHelpers.assertDuration(result6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + Z + Calendar ignores the Calendar");
+
+str = "1970-01-01T00:00+01:00[u-ca=hebrew]";
+const result5 = instance.since(str);
+TemporalHelpers.assertDuration(result5, 0, 0, 0, 0, 0, 0, 3600, 0, 0, 0, "date-time + offset + Calendar ignores the Calendar");
+
+str = "1970-01-01T00:00+01:00[Etc/Ignored][u-ca=hebrew]";
+const result7 = instance.since(str);
+TemporalHelpers.assertDuration(result7, 0, 0, 0, 0, 0, 0, 3600, 0, 0, 0, "date-time + offset + IANA annotation + Calendar ignores the Calendar and IANA annotation");

--- a/test/built-ins/Temporal/Instant/prototype/until/instant-string.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/instant-string.js
@@ -30,3 +30,15 @@ TemporalHelpers.assertDuration(result3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time
 str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 const result4 = instance.until(str);
 TemporalHelpers.assertDuration(result4, 0, 0, 0, 0, 0, 0, -3600, 0, 0, 0, "date-time + offset + IANA annotation ignores the IANA annotation");
+
+str = "1970-01-01T00:00Z[u-ca=hebrew]";
+const result6 = instance.until(str);
+TemporalHelpers.assertDuration(result6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "date-time + Z + Calendar ignores the Calendar");
+
+str = "1970-01-01T00:00+01:00[u-ca=hebrew]";
+const result5 = instance.until(str);
+TemporalHelpers.assertDuration(result5, 0, 0, 0, 0, 0, 0, -3600, 0, 0, 0, "date-time + offset + Calendar ignores the Calendar");
+
+str = "1970-01-01T00:00+01:00[Etc/Ignored][u-ca=hebrew]";
+const result7 = instance.until(str);
+TemporalHelpers.assertDuration(result7, 0, 0, 0, 0, 0, 0, -3600, 0, 0, 0, "date-time + offset + IANA annotation + Calendar ignores the Calendar and IANA annotation");

--- a/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/instant-string.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/instant-string.js
@@ -21,6 +21,9 @@ const valids = [
   "1970-01-01T00:00+01:00",
   "1970-01-01T00:00Z[UTC]",
   "1970-01-01T00:00+01:00[UTC]",
+  "1970-01-01T00:00Z[u-ca=hebrew]",
+  "1970-01-01T00:00+01:00[u-ca=hebrew]",
+  "1970-01-01T00:00+01:00[Etc/Ignored][u-ca=hebrew]",
 ];
 for (const str of valids) {
   const result = instance.getNextTransition(str);

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/instant-string.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/instant-string.js
@@ -21,6 +21,9 @@ const valids = [
   "1970-01-01T00:00+01:00",
   "1970-01-01T00:00Z[UTC]",
   "1970-01-01T00:00+01:00[UTC]",
+  "1970-01-01T00:00Z[u-ca=hebrew]",
+  "1970-01-01T00:00+01:00[u-ca=hebrew]",
+  "1970-01-01T00:00+01:00[Etc/Ignored][u-ca=hebrew]",
 ];
 for (const str of valids) {
   const result = instance.getOffsetNanosecondsFor(str);

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/instant-string.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/instant-string.js
@@ -21,6 +21,9 @@ const valids = [
   "1970-01-01T00:00+01:00",
   "1970-01-01T00:00Z[UTC]",
   "1970-01-01T00:00+01:00[UTC]",
+  "1970-01-01T00:00Z[u-ca=hebrew]",
+  "1970-01-01T00:00+01:00[u-ca=hebrew]",
+  "1970-01-01T00:00+01:00[Etc/Ignored][u-ca=hebrew]",
 ];
 for (const str of valids) {
   const result = instance.getOffsetStringFor(str);

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/instant-string.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/instant-string.js
@@ -30,3 +30,15 @@ TemporalHelpers.assertPlainDateTime(result3, 1970, 1, "M01", 1, 0, 0, 0, 0, 0, 0
 str = "1970-01-01T00:00+01:00[Etc/Ignored]";
 const result4 = instance.getPlainDateTimeFor(str);
 TemporalHelpers.assertPlainDateTime(result4, 1969, 12, "M12", 31, 23, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation ignores the IANA annotation");
+
+str = "1970-01-01T00:00Z[u-ca=hebrew]";
+const result6 = instance.getPlainDateTimeFor(str);
+TemporalHelpers.assertPlainDateTime(result6, 1970, 1, "M01", 1, 0, 0, 0, 0, 0, 0, "date-time + Z + Calendar ignores the Calendar");
+
+str = "1970-01-01T00:00+01:00[u-ca=hebrew]";
+const result5 = instance.getPlainDateTimeFor(str);
+TemporalHelpers.assertPlainDateTime(result5, 1969, 12, "M12", 31, 23, 0, 0, 0, 0, 0, "date-time + offset + Calendar ignores the Calendar");
+
+str = "1970-01-01T00:00+01:00[Etc/Ignored][u-ca=hebrew]";
+const result7 = instance.getPlainDateTimeFor(str);
+TemporalHelpers.assertPlainDateTime(result7, 1969, 12, "M12", 31, 23, 0, 0, 0, 0, 0, "date-time + offset + IANA annotation + Calendar ignores the Calendar and IANA annotation");

--- a/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/instant-string.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/instant-string.js
@@ -21,6 +21,9 @@ const valids = [
   "1970-01-01T00:00+01:00",
   "1970-01-01T00:00Z[UTC]",
   "1970-01-01T00:00+01:00[UTC]",
+  "1970-01-01T00:00Z[u-ca=hebrew]",
+  "1970-01-01T00:00+01:00[u-ca=hebrew]",
+  "1970-01-01T00:00+01:00[Etc/Ignored][u-ca=hebrew]",
 ];
 for (const str of valids) {
   const result = instance.getPreviousTransition(str);


### PR DESCRIPTION
This adds tests for the normative change: https://github.com/tc39/proposal-temporal/pull/2345

These tests ensure that while parsing an Instant string, calendar annotation is ignored. 