### PR TITLE
test: AssignmentExpression where LeftHandSideExpression is CallExpresion

### DIFF
--- a/test/language/expressions/assignment/target-callexpression.js
+++ b/test/language/expressions/assignment/target-callexpression.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2012 Ecma International.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-assignment-operators-static-semantics-early-errors
+description: >
+    simple assignment throws SyntaxError if LeftHandSide is not a
+    CallExpression
+info: |
+    AssignmentExpression : LeftHandSideExpression = AssignmentExpression
+
+    It is an early Syntax Error if LeftHandSideExpression is neither an
+    ObjectLiteral nor an ArrayLiteral and AssignmentTargetType of
+    LeftHandSideExpression is invalid or strict.
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+f() = 42


### PR DESCRIPTION
closes #3650
a missing scenario from https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors