### PR TITLE
Update Tests NumberFormat V3 spec changes

### DIFF
--- a/test/intl402/NumberFormat/test-option-useGrouping-extended.js
+++ b/test/intl402/NumberFormat/test-option-useGrouping-extended.js
@@ -1,5 +1,6 @@
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Copyright 2022 Apple Inc. All rights reserved.
+// Copyright 2022 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -37,4 +38,3 @@ assert.sameValue(render({notation: 'compact', useGrouping: 'min2'}), 'min2', 'co
 assert.sameValue(render({useGrouping: 'undefined'}), 'auto', 'use fallback value');
 assert.sameValue(render({useGrouping: 'false'}), 'auto', 'use fallback value');
 assert.sameValue(render({useGrouping: 'true'}), 'auto', 'use fallback value');
-assert.sameValue(render({useGrouping: 'min3'}), 'auto', 'use fallback value');

--- a/test/intl402/NumberFormat/test-option-useGrouping.js
+++ b/test/intl402/NumberFormat/test-option-useGrouping.js
@@ -1,5 +1,6 @@
 // Copyright 2012 Mozilla Corporation. All rights reserved.
 // Copyright 2022 Apple Inc. All rights reserved.
+// Copyright 2022 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -7,7 +8,7 @@ es5id: 11.1.1_34
 description: Tests that the option useGrouping is processed correctly.
 info: |
   The "Intl.NumberFormat v3" proposal contradicts the behavior required by the
-  latest revision of ECMA402. 
+  latest revision of ECMA402.
 author: Norbert Lindenberg
 features: [Intl.NumberFormat-v3]
 ---*/
@@ -23,11 +24,17 @@ for (let string of ["min2", "auto", "always"]) {
 assert.sameValue(resolveUseGrouping(true), "always");
 assert.sameValue(resolveUseGrouping(false), false);
 assert.sameValue(resolveUseGrouping(undefined), "auto");
+assert.sameValue(resolveUseGrouping("true"), "auto");
+assert.sameValue(resolveUseGrouping("false"), "auto");
 
 for (let falsy of [0, null, ""]) {
   assert.sameValue(resolveUseGrouping(falsy), false);
 }
 
-for (let truthy of [42, "MIN2", {}]) {
-  assert.sameValue(resolveUseGrouping(truthy), "auto");
+for (let invalidOptions of [42, "MIN2", {} , "True",  "TRUE" , "FALSE" , "False"]) {
+  assert.throws(RangeError, function () {
+    return new Intl.NumberFormat(undefined, { useGrouping: invalidOptions });
+  }, "Throws RangeError when useGrouping value is not supported");
 }
+
+


### PR DESCRIPTION
Update test to be aligned with spec changes on https://github.com/tc39/proposal-intl-numberformat-v3/pull/107

cc @sffc 