### PR TITLE
Add tests for proposal-resizable-arraybuffer to staging

### DIFF
--- a/test/staging/ArrayBuffer/resizable/access-out-of-bounds-typed-array.js
+++ b/test/staging/ArrayBuffer/resizable/access-out-of-bounds-typed-array.js
@@ -1,0 +1,92 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from AccessOutOfBoundsTypedArray test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+for (let ctor of ctors) {
+  if (ctor.BYTES_PER_ELEMENT != 1) {
+    continue;
+  }
+  const rab = CreateResizableArrayBuffer(16, 40);
+  const array = new ctor(rab, 0, 4);
+  // Initial values
+  for (let i = 0; i < 4; ++i) {
+    assert.sameValue(array[i], 0);
+  }
+  // Within-bounds write
+  for (let i = 0; i < 4; ++i) {
+    array[i] = i;
+  }
+  // Within-bounds read
+  for (let i = 0; i < 4; ++i) {
+    assert.sameValue(array[i], i);
+  }
+  rab.resize(2);
+  // OOB read. If the RAB isn't large enough to fit the entire TypedArray,
+  // the length of the TypedArray is treated as 0.
+  for (let i = 0; i < 4; ++i) {
+    assert.sameValue(array[i], undefined);
+  }
+  // OOB write (has no effect)
+  for (let i = 0; i < 4; ++i) {
+    array[i] = 10;
+  }
+  rab.resize(4);
+  // Within-bounds read
+  for (let i = 0; i < 2; ++i) {
+    assert.sameValue(array[i], i);
+  }
+  // The shrunk-and-regrown part got zeroed.
+  for (let i = 2; i < 4; ++i) {
+    assert.sameValue(array[i], 0);
+  }
+  rab.resize(40);
+  // Within-bounds read
+  for (let i = 0; i < 2; ++i) {
+    assert.sameValue(array[i], i);
+  }
+  for (let i = 2; i < 4; ++i) {
+    assert.sameValue(array[i], 0);
+  }
+}

--- a/test/staging/ArrayBuffer/resizable/array-fill-parameter-conversion-resizes.js
+++ b/test/staging/ArrayBuffer/resizable/array-fill-parameter-conversion-resizes.js
@@ -1,0 +1,109 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ArrayFillParameterConversionResizes test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function ReadDataFromBuffer(ab, ctor) {
+  let result = [];
+  const ta = new ctor(ab, 0, ab.byteLength / ctor.BYTES_PER_ELEMENT);
+  for (let item of ta) {
+    result.push(Number(item));
+  }
+  return result;
+}
+
+function ArrayFillHelper(ta, n, start, end) {
+  if (ta instanceof BigInt64Array || ta instanceof BigUint64Array) {
+    Array.prototype.fill.call(ta, BigInt(n), start, end);
+  } else {
+    Array.prototype.fill.call(ta, n, start, end);
+  }
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 3;
+    }
+  };
+  ArrayFillHelper(fixedLength, evil, 1, 2);
+  assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+    0,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 1;
+    }
+  };
+  ArrayFillHelper(fixedLength, 3, evil, 2);
+  assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+    0,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  ArrayFillHelper(fixedLength, 3, 1, evil);
+  assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+    0,
+    0
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/array-sort-with-default-comparison.js
+++ b/test/staging/ArrayBuffer/resizable/array-sort-with-default-comparison.js
@@ -1,0 +1,235 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ArraySortWithDefaultComparison test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+// The default comparison function for Array.prototype.sort is the string sort.
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const ArraySortHelper = (ta, ...rest) => {
+  Array.prototype.sort.call(ta, ...rest);
+};
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  const taFull = new ctor(rab, 0);
+  function WriteUnsortedData() {
+    // Write some data into the array.
+    for (let i = 0; i < taFull.length; ++i) {
+      WriteToTypedArray(taFull, i, 10 - 2 * i);
+    }
+  }
+  // Orig. array: [10, 8, 6, 4]
+  //              [10, 8, 6, 4] << fixedLength
+  //                     [6, 4] << fixedLengthWithOffset
+  //              [10, 8, 6, 4, ...] << lengthTracking
+  //                     [6, 4, ...] << lengthTrackingWithOffset
+
+  WriteUnsortedData();
+  ArraySortHelper(fixedLength);
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    4,
+    6,
+    8
+  ]);
+  WriteUnsortedData();
+  ArraySortHelper(fixedLengthWithOffset);
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    4,
+    6
+  ]);
+  WriteUnsortedData();
+  ArraySortHelper(lengthTracking);
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    4,
+    6,
+    8
+  ]);
+  WriteUnsortedData();
+  ArraySortHelper(lengthTrackingWithOffset);
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    4,
+    6
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [10, 8, 6]
+  //              [10, 8, 6, ...] << lengthTracking
+  //                     [6, ...] << lengthTrackingWithOffset
+
+  WriteUnsortedData();
+  ArraySortHelper(fixedLength);  // OOB -> NOOP
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    6
+  ]);
+  ArraySortHelper(fixedLengthWithOffset);  // OOB -> NOOP
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    6
+  ]);
+  ArraySortHelper(lengthTracking);
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    6,
+    8
+  ]);
+  WriteUnsortedData();
+  ArraySortHelper(lengthTrackingWithOffset);
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    6
+  ]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  WriteUnsortedData();
+  ArraySortHelper(fixedLength);  // OOB -> NOOP
+  assert.compareArray(ToNumbers(taFull), [10]);
+  ArraySortHelper(fixedLengthWithOffset);  // OOB -> NOOP
+  assert.compareArray(ToNumbers(taFull), [10]);
+  ArraySortHelper(lengthTrackingWithOffset);   // OOB -> NOOP
+  assert.compareArray(ToNumbers(taFull), [10]);
+  ArraySortHelper(lengthTracking);
+  assert.compareArray(ToNumbers(taFull), [10]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  ArraySortHelper(fixedLength);  // OOB -> NOOP
+  assert.compareArray(ToNumbers(taFull), []);
+  ArraySortHelper(fixedLengthWithOffset);  // OOB -> NOOP
+  assert.compareArray(ToNumbers(taFull), []);
+  ArraySortHelper(lengthTrackingWithOffset);  // OOB -> NOOP
+  assert.compareArray(ToNumbers(taFull), []);
+  ArraySortHelper(lengthTracking);
+  assert.compareArray(ToNumbers(taFull), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [10, 8, 6, 4, 2, 0]
+  //              [10, 8, 6, 4] << fixedLength
+  //                     [6, 4] << fixedLengthWithOffset
+  //              [10, 8, 6, 4, 2, 0, ...] << lengthTracking
+  //                     [6, 4, 2, 0, ...] << lengthTrackingWithOffset
+
+  WriteUnsortedData();
+  ArraySortHelper(fixedLength);
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    4,
+    6,
+    8,
+    2,
+    0
+  ]);
+  WriteUnsortedData();
+  ArraySortHelper(fixedLengthWithOffset);
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    4,
+    6,
+    2,
+    0
+  ]);
+  WriteUnsortedData();
+  ArraySortHelper(lengthTracking);
+  assert.compareArray(ToNumbers(taFull), [
+    0,
+    10,
+    2,
+    4,
+    6,
+    8
+  ]);
+  WriteUnsortedData();
+  ArraySortHelper(lengthTrackingWithOffset);
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    0,
+    2,
+    4,
+    6
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/at-parameter-conversion-resizes.js
+++ b/test/staging/ArrayBuffer/resizable/at-parameter-conversion-resizes.js
@@ -1,0 +1,91 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from AtParameterConversionResizes test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function TypedArrayAtHelper(ta, index) {
+  const result = ta.at(index);
+  return Convert(result);
+}
+
+function ArrayAtHelper(ta, index) {
+  const result = Array.prototype.at.call(ta, index);
+  return Convert(result);
+}
+
+function AtParameterConversionResizes(atHelper) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2);
+        return 0;
+      }
+    };
+    assert.sameValue(atHelper(fixedLength, evil), undefined);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2);
+        return -1;
+      }
+    };
+    // The TypedArray is *not* out of bounds since it's length-tracking.
+    assert.sameValue(atHelper(lengthTracking, evil), undefined);
+  }
+}
+
+AtParameterConversionResizes(TypedArrayAtHelper);
+AtParameterConversionResizes(ArrayAtHelper);

--- a/test/staging/ArrayBuffer/resizable/at.js
+++ b/test/staging/ArrayBuffer/resizable/at.js
@@ -1,0 +1,135 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from At test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function TypedArrayAtHelper(ta, index) {
+  const result = ta.at(index);
+  return Convert(result);
+}
+
+function ArrayAtHelper(ta, index) {
+  const result = Array.prototype.at.call(ta, index);
+  return Convert(result);
+}
+
+function At(atHelper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    let ta_write = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(ta_write, i, i);
+    }
+    assert.sameValue(atHelper(fixedLength, -1), 3);
+    assert.sameValue(atHelper(lengthTracking, -1), 3);
+    assert.sameValue(atHelper(fixedLengthWithOffset, -1), 3);
+    assert.sameValue(atHelper(lengthTrackingWithOffset, -1), 3);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        atHelper(fixedLength, -1);
+      });
+      assert.throws(TypeError, () => {
+        atHelper(fixedLengthWithOffset, -1);
+      });
+    } else {
+      assert.sameValue(atHelper(fixedLength, -1), undefined);
+      assert.sameValue(atHelper(fixedLengthWithOffset, -1), undefined);
+    }
+    assert.sameValue(atHelper(lengthTracking, -1), 2);
+    assert.sameValue(atHelper(lengthTrackingWithOffset, -1), 2);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        atHelper(fixedLength, -1);
+      });
+      assert.throws(TypeError, () => {
+        atHelper(fixedLengthWithOffset, -1);
+      });
+      assert.throws(TypeError, () => {
+        atHelper(lengthTrackingWithOffset, -1);
+      });
+    } else {
+      assert.sameValue(atHelper(fixedLength, -1), undefined);
+      assert.sameValue(atHelper(fixedLengthWithOffset, -1), undefined);
+      assert.sameValue(atHelper(lengthTrackingWithOffset, -1), undefined);
+    }
+    assert.sameValue(atHelper(lengthTracking, -1), 0);
+
+    // Grow so that all TAs are back in-bounds. New memory is zeroed.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    assert.sameValue(atHelper(fixedLength, -1), 0);
+    assert.sameValue(atHelper(lengthTracking, -1), 0);
+    assert.sameValue(atHelper(fixedLengthWithOffset, -1), 0);
+    assert.sameValue(atHelper(lengthTrackingWithOffset, -1), 0);
+  }
+}
+
+At(TypedArrayAtHelper, true);
+At(ArrayAtHelper, false);

--- a/test/staging/ArrayBuffer/resizable/construct-from-typed-array.js
+++ b/test/staging/ArrayBuffer/resizable/construct-from-typed-array.js
@@ -1,0 +1,208 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ConstructFromTypedArray test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function IsBigIntTypedArray(ta) {
+  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+}
+
+function AllBigIntMatchedCtorCombinations(test) {
+  for (let targetCtor of ctors) {
+    for (let sourceCtor of ctors) {
+      if (IsBigIntTypedArray(new targetCtor()) != IsBigIntTypedArray(new sourceCtor())) {
+        continue;
+      }
+      test(targetCtor, sourceCtor);
+    }
+  }
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+AllBigIntMatchedCtorCombinations((targetCtor, sourceCtor) => {
+  const rab = CreateResizableArrayBuffer(4 * sourceCtor.BYTES_PER_ELEMENT, 8 * sourceCtor.BYTES_PER_ELEMENT);
+  const fixedLength = new sourceCtor(rab, 0, 4);
+  const fixedLengthWithOffset = new sourceCtor(rab, 2 * sourceCtor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new sourceCtor(rab, 0);
+  const lengthTrackingWithOffset = new sourceCtor(rab, 2 * sourceCtor.BYTES_PER_ELEMENT);
+
+  // Write some data into the array.
+  const taFull = new sourceCtor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taFull, i, i + 1);
+  }
+
+  // Orig. array: [1, 2, 3, 4]
+  //              [1, 2, 3, 4] << fixedLength
+  //                    [3, 4] << fixedLengthWithOffset
+  //              [1, 2, 3, 4, ...] << lengthTracking
+  //                    [3, 4, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(ToNumbers(new targetCtor(fixedLength)), [
+    1,
+    2,
+    3,
+    4
+  ]);
+  assert.compareArray(ToNumbers(new targetCtor(fixedLengthWithOffset)), [
+    3,
+    4
+  ]);
+  assert.compareArray(ToNumbers(new targetCtor(lengthTracking)), [
+    1,
+    2,
+    3,
+    4
+  ]);
+  assert.compareArray(ToNumbers(new targetCtor(lengthTrackingWithOffset)), [
+    3,
+    4
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * sourceCtor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [1, 2, 3]
+  //              [1, 2, 3, ...] << lengthTracking
+  //                    [3, ...] << lengthTrackingWithOffset
+
+  assert.throws(TypeError, () => {
+    new targetCtor(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    new targetCtor(fixedLengthWithOffset);
+  });
+  assert.compareArray(ToNumbers(new targetCtor(lengthTracking)), [
+    1,
+    2,
+    3
+  ]);
+  assert.compareArray(ToNumbers(new targetCtor(lengthTrackingWithOffset)), [3]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * sourceCtor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    new targetCtor(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    new targetCtor(fixedLengthWithOffset);
+  });
+  assert.compareArray(ToNumbers(new targetCtor(lengthTracking)), [1]);
+  assert.throws(TypeError, () => {
+    new targetCtor(lengthTrackingWithOffset);
+  });
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    new targetCtor(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    new targetCtor(fixedLengthWithOffset);
+  });
+  assert.compareArray(ToNumbers(new targetCtor(lengthTracking)), []);
+  assert.throws(TypeError, () => {
+    new targetCtor(lengthTrackingWithOffset);
+  });
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * sourceCtor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taFull, i, i + 1);
+  }
+
+  // Orig. array: [1, 2, 3, 4, 5, 6]
+  //              [1, 2, 3, 4] << fixedLength
+  //                    [3, 4] << fixedLengthWithOffset
+  //              [1, 2, 3, 4, 5, 6, ...] << lengthTracking
+  //                    [3, 4, 5, 6, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(ToNumbers(new targetCtor(fixedLength)), [
+    1,
+    2,
+    3,
+    4
+  ]);
+  assert.compareArray(ToNumbers(new targetCtor(fixedLengthWithOffset)), [
+    3,
+    4
+  ]);
+  assert.compareArray(ToNumbers(new targetCtor(lengthTracking)), [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6
+  ]);
+  assert.compareArray(ToNumbers(new targetCtor(lengthTrackingWithOffset)), [
+    3,
+    4,
+    5,
+    6
+  ]);
+});

--- a/test/staging/ArrayBuffer/resizable/construct-invalid.js
+++ b/test/staging/ArrayBuffer/resizable/construct-invalid.js
@@ -1,0 +1,70 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ConstructInvalid test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const rab = CreateResizableArrayBuffer(40, 80);
+for (let ctor of ctors) {
+  // Length too big.
+  assert.throws(RangeError, () => {
+    new ctor(rab, 0, 40 / ctor.BYTES_PER_ELEMENT + 1);
+  });
+  // Offset too close to the end.
+  assert.throws(RangeError, () => {
+    new ctor(rab, 40 - ctor.BYTES_PER_ELEMENT, 2);
+  });
+  // Offset beyond end.
+  assert.throws(RangeError, () => {
+    new ctor(rab, 40, 1);
+  });
+  if (ctor.BYTES_PER_ELEMENT > 1) {
+    // Offset not a multiple of the byte size.
+    assert.throws(RangeError, () => {
+      new ctor(rab, 1, 1);
+    });
+    assert.throws(RangeError, () => {
+      new ctor(rab, 1);
+    });
+  }
+}

--- a/test/staging/ArrayBuffer/resizable/copy-within-parameter-conversion-grows.js
+++ b/test/staging/ArrayBuffer/resizable/copy-within-parameter-conversion-grows.js
@@ -1,0 +1,114 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from CopyWithinParameterConversionGrows test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+  const evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      WriteToTypedArray(lengthTracking, 4, 4);
+      WriteToTypedArray(lengthTracking, 5, 5);
+      return 0;
+    }
+  };
+  // Orig. array: [0, 1, 2, 3]  [4, 5]
+  //               ^     ^       ^ new elements
+  //          target     start
+  lengthTracking.copyWithin(evil, 2);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    2,
+    3,
+    2,
+    3,
+    4,
+    5
+  ]);
+  rab.resize(4 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+
+  // Orig. array: [0, 1, 2, 3]  [4, 5]
+  //               ^     ^       ^ new elements
+  //           start     target
+  lengthTracking.copyWithin(2, evil);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    0,
+    1,
+    0,
+    1,
+    4,
+    5
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/copy-within-parameter-conversion-shrinks.js
+++ b/test/staging/ArrayBuffer/resizable/copy-within-parameter-conversion-shrinks.js
@@ -1,0 +1,139 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from CopyWithinParameterConversionShrinks test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  assert.throws(TypeError, () => {
+    fixedLength.copyWithin(evil, 0, 1);
+  });
+  rab.resize(4 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    fixedLength.copyWithin(0, evil, 3);
+  });
+  rab.resize(4 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    fixedLength.copyWithin(0, 1, evil);
+  });
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+  // [0, 1, 2, 3]
+  //        ^
+  //        target
+  // ^
+  // start
+  const evil = {
+    valueOf: () => {
+      rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  lengthTracking.copyWithin(evil, 0);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    0,
+    1,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i);
+  }
+  // [0, 1, 2, 3]
+  //        ^
+  //        start
+  // ^
+  // target
+  const evil = {
+    valueOf: () => {
+      rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  lengthTracking.copyWithin(0, evil);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    2,
+    1,
+    2
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/destructuring.js
+++ b/test/staging/ArrayBuffer/resizable/destructuring.js
@@ -1,0 +1,258 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from Destructuring test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+  // Write some data into the array.
+  let ta_write = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(ta_write, i, i);
+  }
+  {
+    let [a, b, c, d, e] = fixedLength;
+    assert.compareArray(ToNumbers([
+      a,
+      b,
+      c,
+      d
+    ]), [
+      0,
+      1,
+      2,
+      3
+    ]);
+    assert.sameValue(e, undefined);
+  }
+  {
+    let [a, b, c] = fixedLengthWithOffset;
+    assert.compareArray(ToNumbers([
+      a,
+      b
+    ]), [
+      2,
+      3
+    ]);
+    assert.sameValue(c, undefined);
+  }
+  {
+    let [a, b, c, d, e] = lengthTracking;
+    assert.compareArray(ToNumbers([
+      a,
+      b,
+      c,
+      d
+    ]), [
+      0,
+      1,
+      2,
+      3
+    ]);
+    assert.sameValue(e, undefined);
+  }
+  {
+    let [a, b, c] = lengthTrackingWithOffset;
+    assert.compareArray(ToNumbers([
+      a,
+      b
+    ]), [
+      2,
+      3
+    ]);
+    assert.sameValue(c, undefined);
+  }
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    let [a, b, c] = fixedLength;
+  });
+  assert.throws(TypeError, () => {
+    let [a, b, c] = fixedLengthWithOffset;
+  });
+  {
+    let [a, b, c, d] = lengthTracking;
+    assert.compareArray(ToNumbers([
+      a,
+      b,
+      c
+    ]), [
+      0,
+      1,
+      2
+    ]);
+    assert.sameValue(d, undefined);
+  }
+  {
+    let [a, b] = lengthTrackingWithOffset;
+    assert.compareArray(ToNumbers([a]), [2]);
+    assert.sameValue(b, undefined);
+  }
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    let [a, b, c] = fixedLength;
+  });
+  assert.throws(TypeError, () => {
+    let [a, b, c] = fixedLengthWithOffset;
+  });
+  assert.throws(TypeError, () => {
+    let [a, b, c] = lengthTrackingWithOffset;
+  });
+  {
+    let [a, b] = lengthTracking;
+    assert.compareArray(ToNumbers([a]), [0]);
+    assert.sameValue(b, undefined);
+  }
+
+  // Shrink to 0.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    let [a, b, c] = fixedLength;
+  });
+  assert.throws(TypeError, () => {
+    let [a, b, c] = fixedLengthWithOffset;
+  });
+  assert.throws(TypeError, () => {
+    let [a, b, c] = lengthTrackingWithOffset;
+  });
+  {
+    let [a] = lengthTracking;
+    assert.sameValue(a, undefined);
+  }
+
+  // Grow so that all TAs are back in-bounds. The new memory is zeroed.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  {
+    let [a, b, c, d, e] = fixedLength;
+    assert.compareArray(ToNumbers([
+      a,
+      b,
+      c,
+      d
+    ]), [
+      0,
+      0,
+      0,
+      0
+    ]);
+    assert.sameValue(e, undefined);
+  }
+  {
+    let [a, b, c] = fixedLengthWithOffset;
+    assert.compareArray(ToNumbers([
+      a,
+      b
+    ]), [
+      0,
+      0
+    ]);
+    assert.sameValue(c, undefined);
+  }
+  {
+    let [a, b, c, d, e, f, g] = lengthTracking;
+    assert.compareArray(ToNumbers([
+      a,
+      b,
+      c,
+      d,
+      e,
+      f
+    ]), [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+    assert.sameValue(g, undefined);
+  }
+  {
+    let [a, b, c, d, e] = lengthTrackingWithOffset;
+    assert.compareArray(ToNumbers([
+      a,
+      b,
+      c,
+      d
+    ]), [
+      0,
+      0,
+      0,
+      0
+    ]);
+    assert.sameValue(e, undefined);
+  }
+}

--- a/test/staging/ArrayBuffer/resizable/entries-keys-values-grow-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/entries-keys-values-grow-mid-iteration.js
@@ -1,0 +1,299 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from EntriesKeysValuesGrowMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayEntriesHelper(ta) {
+  return ta.entries();
+}
+
+function ArrayEntriesHelper(ta) {
+  return Array.prototype.entries.call(ta);
+}
+
+function TypedArrayKeysHelper(ta) {
+  return ta.keys();
+}
+
+function ArrayKeysHelper(ta) {
+  return Array.prototype.keys.call(ta);
+}
+
+function TypedArrayValuesHelper(ta) {
+  return ta.values();
+}
+
+function ArrayValuesHelper(ta) {
+  return Array.prototype.values.call(ta);
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values.flat(), expected.flat());
+  assert(resized);
+}
+
+function EntriesKeysValuesGrowMidIteration(entriesHelper, keysHelper, valuesHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+
+  // Iterating with entries() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(entriesHelper(fixedLength), [
+      [
+        0,
+        0
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        2,
+        4
+      ],
+      [
+        3,
+        6
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(entriesHelper(fixedLengthWithOffset), [
+      [
+        0,
+        4
+      ],
+      [
+        1,
+        6
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(entriesHelper(lengthTracking), [
+      [
+        0,
+        0
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        2,
+        4
+      ],
+      [
+        3,
+        6
+      ],
+      [
+        4,
+        0
+      ],
+      [
+        5,
+        0
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(entriesHelper(lengthTrackingWithOffset), [
+      [
+        0,
+        4
+      ],
+      [
+        1,
+        6
+      ],
+      [
+        2,
+        0
+      ],
+      [
+        3,
+        0
+      ]
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+
+  // Iterating with keys() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(keysHelper(fixedLength), [
+      0,
+      1,
+      2,
+      3
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(keysHelper(fixedLengthWithOffset), [
+      0,
+      1
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(keysHelper(lengthTracking), [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(keysHelper(lengthTrackingWithOffset), [
+      0,
+      1,
+      2,
+      3
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+
+  // Iterating with values() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(valuesHelper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    // The fixed length array is not affected by resizing.
+    TestIterationAndResize(valuesHelper(fixedLengthWithOffset), [
+      4,
+      6
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(valuesHelper(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      0,
+      0
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(valuesHelper(lengthTrackingWithOffset), [
+      4,
+      6,
+      0,
+      0
+    ], rab, 2, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+EntriesKeysValuesGrowMidIteration(TypedArrayEntriesHelper, TypedArrayKeysHelper, TypedArrayValuesHelper);
+EntriesKeysValuesGrowMidIteration(ArrayEntriesHelper, ArrayKeysHelper, ArrayValuesHelper);

--- a/test/staging/ArrayBuffer/resizable/entries-keys-values-shrink-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/entries-keys-values-shrink-mid-iteration.js
@@ -1,0 +1,244 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from EntriesKeysValuesShrinkMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayEntriesHelper(ta) {
+  return ta.entries();
+}
+
+function ArrayEntriesHelper(ta) {
+  return Array.prototype.entries.call(ta);
+}
+
+function TypedArrayKeysHelper(ta) {
+  return ta.keys();
+}
+
+function ArrayKeysHelper(ta) {
+  return Array.prototype.keys.call(ta);
+}
+
+function TypedArrayValuesHelper(ta) {
+  return ta.values();
+}
+
+function ArrayValuesHelper(ta) {
+  return Array.prototype.values.call(ta);
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values.flat(), expected.flat());
+  assert(resized);
+}
+
+function EntriesKeysValuesShrinkMidIteration(entriesHelper, keysHelper, valuesHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+
+  // Iterating with entries() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(entriesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(entriesHelper(fixedLengthWithOffset), null, rab, 1, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(entriesHelper(lengthTracking), [
+      [
+        0,
+        0
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        2,
+        4
+      ]
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(entriesHelper(lengthTrackingWithOffset), [
+      [
+        0,
+        4
+      ],
+      [
+        1,
+        6
+      ]
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+
+  // Iterating with keys() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(keysHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(keysHelper(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(keysHelper(lengthTracking), [
+      0,
+      1,
+      2
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    TestIterationAndResize(keysHelper(lengthTrackingWithOffset), [
+      0,
+      1
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+
+  // Iterating with values() (the 4 loops below).
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(valuesHelper(fixedLength), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    assert.throws(TypeError, () => {
+      TestIterationAndResize(valuesHelper(fixedLengthWithOffset), null, rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+    });
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    TestIterationAndResize(valuesHelper(lengthTracking), [
+      0,
+      2,
+      4
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // The fixed length array goes out of bounds when the RAB is resized.
+    TestIterationAndResize(valuesHelper(lengthTrackingWithOffset), [
+      4,
+      6
+    ], rab, 2, 3 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+EntriesKeysValuesShrinkMidIteration(TypedArrayEntriesHelper, TypedArrayKeysHelper, TypedArrayValuesHelper);
+EntriesKeysValuesShrinkMidIteration(ArrayEntriesHelper, ArrayKeysHelper, ArrayValuesHelper);

--- a/test/staging/ArrayBuffer/resizable/entries-keys-values.js
+++ b/test/staging/ArrayBuffer/resizable/entries-keys-values.js
@@ -1,0 +1,505 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from EntriesKeysValues test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayEntriesHelper(ta) {
+  return ta.entries();
+}
+
+function ArrayEntriesHelper(ta) {
+  return Array.prototype.entries.call(ta);
+}
+
+function ValuesFromTypedArrayEntries(ta) {
+  let result = [];
+  let expectedKey = 0;
+  for (let [key, value] of ta.entries()) {
+    assert.sameValue(key, expectedKey);
+    ++expectedKey;
+    result.push(Number(value));
+  }
+  return result;
+}
+
+function ValuesFromArrayEntries(ta) {
+  let result = [];
+  let expectedKey = 0;
+  for (let [key, value] of Array.prototype.entries.call(ta)) {
+    assert.sameValue(key, expectedKey);
+    ++expectedKey;
+    result.push(Number(value));
+  }
+  return result;
+}
+
+function TypedArrayKeysHelper(ta) {
+  return ta.keys();
+}
+
+function ArrayKeysHelper(ta) {
+  return Array.prototype.keys.call(ta);
+}
+
+function TypedArrayValuesHelper(ta) {
+  return ta.values();
+}
+
+function ArrayValuesHelper(ta) {
+  return Array.prototype.values.call(ta);
+}
+
+function ValuesFromTypedArrayValues(ta) {
+  let result = [];
+  for (let value of ta.values()) {
+    result.push(Number(value));
+  }
+  return result;
+}
+
+function ValuesFromArrayValues(ta) {
+  const result = [];
+  for (let value of Array.prototype.values.call(ta)) {
+    result.push(Number(value));
+  }
+  return result;
+}
+
+function EntriesKeysValues(entriesHelper, keysHelper, valuesHelper, valuesFromEntries, valuesFromValues, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(valuesFromEntries(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(valuesFromValues(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Array.from(keysHelper(fixedLength)), [
+      0,
+      1,
+      2,
+      3
+    ]);
+    assert.compareArray(valuesFromEntries(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(valuesFromValues(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Array.from(keysHelper(fixedLengthWithOffset)), [
+      0,
+      1
+    ]);
+    assert.compareArray(valuesFromEntries(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(valuesFromValues(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Array.from(keysHelper(lengthTracking)), [
+      0,
+      1,
+      2,
+      3
+    ]);
+    assert.compareArray(valuesFromEntries(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(valuesFromValues(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Array.from(keysHelper(lengthTrackingWithOffset)), [
+      0,
+      1
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    // TypedArray.prototype.{entries, keys, values} throw right away when
+    // called. Array.prototype.{entries, keys, values} don't throw, but when
+    // we try to iterate the returned ArrayIterator, that throws.
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        entriesHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        valuesHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        keysHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        entriesHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        valuesHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        keysHelper(fixedLengthWithOffset);
+      });
+    } else {
+      entriesHelper(fixedLength);
+      valuesHelper(fixedLength);
+      keysHelper(fixedLength);
+      entriesHelper(fixedLengthWithOffset);
+      valuesHelper(fixedLengthWithOffset);
+      keysHelper(fixedLengthWithOffset);
+    }
+    assert.throws(TypeError, () => {
+      Array.from(entriesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(valuesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(keysHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(entriesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(valuesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(keysHelper(fixedLengthWithOffset));
+    });
+    assert.compareArray(valuesFromEntries(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(valuesFromValues(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(Array.from(keysHelper(lengthTracking)), [
+      0,
+      1,
+      2
+    ]);
+    assert.compareArray(valuesFromEntries(lengthTrackingWithOffset), [4]);
+    assert.compareArray(valuesFromValues(lengthTrackingWithOffset), [4]);
+    assert.compareArray(Array.from(keysHelper(lengthTrackingWithOffset)), [0]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        entriesHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        valuesHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        keysHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        entriesHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        valuesHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        keysHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        entriesHelper(lengthTrackingWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        valuesHelper(lengthTrackingWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        keysHelper(lengthTrackingWithOffset);
+      });
+    } else {
+      entriesHelper(fixedLength);
+      valuesHelper(fixedLength);
+      keysHelper(fixedLength);
+      entriesHelper(fixedLengthWithOffset);
+      valuesHelper(fixedLengthWithOffset);
+      keysHelper(fixedLengthWithOffset);
+      entriesHelper(lengthTrackingWithOffset);
+      valuesHelper(lengthTrackingWithOffset);
+      keysHelper(lengthTrackingWithOffset);
+    }
+    assert.throws(TypeError, () => {
+      Array.from(entriesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(valuesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(keysHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(entriesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(valuesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(keysHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(entriesHelper(lengthTrackingWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(valuesHelper(lengthTrackingWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(keysHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(valuesFromEntries(lengthTracking), [0]);
+    assert.compareArray(valuesFromValues(lengthTracking), [0]);
+    assert.compareArray(Array.from(keysHelper(lengthTracking)), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        entriesHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        valuesHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        keysHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        entriesHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        valuesHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        keysHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        entriesHelper(lengthTrackingWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        valuesHelper(lengthTrackingWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        keysHelper(lengthTrackingWithOffset);
+      });
+    } else {
+      entriesHelper(fixedLength);
+      valuesHelper(fixedLength);
+      keysHelper(fixedLength);
+      entriesHelper(fixedLengthWithOffset);
+      valuesHelper(fixedLengthWithOffset);
+      keysHelper(fixedLengthWithOffset);
+      entriesHelper(lengthTrackingWithOffset);
+      valuesHelper(lengthTrackingWithOffset);
+      keysHelper(lengthTrackingWithOffset);
+    }
+    assert.throws(TypeError, () => {
+      Array.from(entriesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(valuesHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(keysHelper(fixedLength));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(entriesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(valuesHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(keysHelper(fixedLengthWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(entriesHelper(lengthTrackingWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(valuesHelper(lengthTrackingWithOffset));
+    });
+    assert.throws(TypeError, () => {
+      Array.from(keysHelper(lengthTrackingWithOffset));
+    });
+    assert.compareArray(valuesFromEntries(lengthTracking), []);
+    assert.compareArray(valuesFromValues(lengthTracking), []);
+    assert.compareArray(Array.from(keysHelper(lengthTracking)), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(valuesFromEntries(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(valuesFromValues(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Array.from(keysHelper(fixedLength)), [
+      0,
+      1,
+      2,
+      3
+    ]);
+    assert.compareArray(valuesFromEntries(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(valuesFromValues(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Array.from(keysHelper(fixedLengthWithOffset)), [
+      0,
+      1
+    ]);
+    assert.compareArray(valuesFromEntries(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(valuesFromValues(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(Array.from(keysHelper(lengthTracking)), [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ]);
+    assert.compareArray(valuesFromEntries(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(valuesFromValues(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(Array.from(keysHelper(lengthTrackingWithOffset)), [
+      0,
+      1,
+      2,
+      3
+    ]);
+  }
+}
+
+EntriesKeysValues(TypedArrayEntriesHelper, TypedArrayKeysHelper, TypedArrayValuesHelper, ValuesFromTypedArrayEntries, ValuesFromTypedArrayValues, true);
+EntriesKeysValues(ArrayEntriesHelper, ArrayKeysHelper, ArrayValuesHelper, ValuesFromArrayEntries, ValuesFromArrayValues, false);

--- a/test/staging/ArrayBuffer/resizable/enumerate-elements.js
+++ b/test/staging/ArrayBuffer/resizable/enumerate-elements.js
@@ -1,0 +1,55 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from EnumerateElements test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+let rab = CreateResizableArrayBuffer(100, 200);
+for (let ctor of ctors) {
+  const ta = new ctor(rab, 0, 3);
+  let keys = '';
+  for (const key in ta) {
+    keys += key;
+  }
+  assert.sameValue(keys, '012');
+}

--- a/test/staging/ArrayBuffer/resizable/every-grow-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/every-grow-mid-iteration.js
@@ -1,0 +1,149 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from EveryGrowMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArrayEveryHelper = (ta, ...rest) => {
+  return ta.every(...rest);
+};
+
+const ArrayEveryHelper = (ta, ...rest) => {
+  return Array.prototype.every.call(ta, ...rest);
+};
+
+function EveryGrowMidIteration(everyHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return true;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(everyHelper(fixedLength, CollectValuesAndResize));
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(everyHelper(fixedLengthWithOffset, CollectValuesAndResize));
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(everyHelper(lengthTracking, CollectValuesAndResize));
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(everyHelper(lengthTrackingWithOffset, CollectValuesAndResize));
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+EveryGrowMidIteration(TypedArrayEveryHelper);
+EveryGrowMidIteration(ArrayEveryHelper);

--- a/test/staging/ArrayBuffer/resizable/every-shrink-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/every-shrink-mid-iteration.js
@@ -1,0 +1,172 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from EveryShrinkMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArrayEveryHelper = (ta, ...rest) => {
+  return ta.every(...rest);
+};
+
+const ArrayEveryHelper = (ta, ...rest) => {
+  return Array.prototype.every.call(ta, ...rest);
+};
+
+function EveryShrinkMidIteration(everyHelper, hasUndefined) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return true;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(everyHelper(fixedLength, CollectValuesAndResize));
+    if (hasUndefined) {
+      assert.compareArray(values, [
+        0,
+        2,
+        undefined,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(values, [
+        0,
+        2
+      ]);
+    }
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(everyHelper(fixedLengthWithOffset, CollectValuesAndResize));
+    if (hasUndefined) {
+      assert.compareArray(values, [
+        4,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(values, [4]);
+    }
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(everyHelper(lengthTracking, CollectValuesAndResize));
+    if (hasUndefined) {
+      assert.compareArray(values, [
+        0,
+        2,
+        4,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(values, [
+        0,
+        2,
+        4
+      ]);
+    }
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(everyHelper(lengthTrackingWithOffset, CollectValuesAndResize));
+    if (hasUndefined) {
+      assert.compareArray(values, [
+        4,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(values, [4]);
+    }
+  }
+}
+
+EveryShrinkMidIteration(TypedArrayEveryHelper, true);
+EveryShrinkMidIteration(ArrayEveryHelper, false);

--- a/test/staging/ArrayBuffer/resizable/every-some.js
+++ b/test/staging/ArrayBuffer/resizable/every-some.js
@@ -1,0 +1,252 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from EverySome test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArrayEveryHelper = (ta, ...rest) => {
+  return ta.every(...rest);
+};
+
+const ArrayEveryHelper = (ta, ...rest) => {
+  return Array.prototype.every.call(ta, ...rest);
+};
+
+const TypedArraySomeHelper = (ta, ...rest) => {
+  return ta.some(...rest);
+};
+
+const ArraySomeHelper = (ta, ...rest) => {
+  return Array.prototype.some.call(ta, ...rest);
+};
+
+function EverySome(everyHelper, someHelper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function div3(n) {
+      return Number(n) % 3 == 0;
+    }
+    function even(n) {
+      return Number(n) % 2 == 0;
+    }
+    function over10(n) {
+      return Number(n) > 10;
+    }
+    assert(!everyHelper(fixedLength, div3));
+    assert(everyHelper(fixedLength, even));
+    assert(someHelper(fixedLength, div3));
+    assert(!someHelper(fixedLength, over10));
+    assert(!everyHelper(fixedLengthWithOffset, div3));
+    assert(everyHelper(fixedLengthWithOffset, even));
+    assert(someHelper(fixedLengthWithOffset, div3));
+    assert(!someHelper(fixedLengthWithOffset, over10));
+    assert(!everyHelper(lengthTracking, div3));
+    assert(everyHelper(lengthTracking, even));
+    assert(someHelper(lengthTracking, div3));
+    assert(!someHelper(lengthTracking, over10));
+    assert(!everyHelper(lengthTrackingWithOffset, div3));
+    assert(everyHelper(lengthTrackingWithOffset, even));
+    assert(someHelper(lengthTrackingWithOffset, div3));
+    assert(!someHelper(lengthTrackingWithOffset, over10));
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        everyHelper(fixedLength, div3);
+      });
+      assert.throws(TypeError, () => {
+        someHelper(fixedLength, div3);
+      });
+      assert.throws(TypeError, () => {
+        everyHelper(fixedLengthWithOffset, div3);
+      });
+      assert.throws(TypeError, () => {
+        someHelper(fixedLengthWithOffset, div3);
+      });
+    } else {
+      assert(everyHelper(fixedLength, div3));
+      assert(!someHelper(fixedLength, div3));
+      assert(everyHelper(fixedLengthWithOffset, div3));
+      assert(!someHelper(fixedLengthWithOffset, div3));
+    }
+    assert(!everyHelper(lengthTracking, div3));
+    assert(everyHelper(lengthTracking, even));
+    assert(someHelper(lengthTracking, div3));
+    assert(!someHelper(lengthTracking, over10));
+    assert(!everyHelper(lengthTrackingWithOffset, div3));
+    assert(everyHelper(lengthTrackingWithOffset, even));
+    assert(!someHelper(lengthTrackingWithOffset, div3));
+    assert(!someHelper(lengthTrackingWithOffset, over10));
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        everyHelper(fixedLength, div3);
+      });
+      assert.throws(TypeError, () => {
+        someHelper(fixedLength, div3);
+      });
+      assert.throws(TypeError, () => {
+        everyHelper(fixedLengthWithOffset, div3);
+      });
+      assert.throws(TypeError, () => {
+        someHelper(fixedLengthWithOffset, div3);
+      });
+      assert.throws(TypeError, () => {
+        everyHelper(lengthTrackingWithOffset, div3);
+      });
+      assert.throws(TypeError, () => {
+        someHelper(lengthTrackingWithOffset, div3);
+      });
+    } else {
+      assert(everyHelper(fixedLength, div3));
+      assert(!someHelper(fixedLength, div3));
+      assert(everyHelper(fixedLengthWithOffset, div3));
+      assert(!someHelper(fixedLengthWithOffset, div3));
+      assert(everyHelper(lengthTrackingWithOffset, div3));
+      assert(!someHelper(lengthTrackingWithOffset, div3));
+    }
+    assert(everyHelper(lengthTracking, div3));
+    assert(everyHelper(lengthTracking, even));
+    assert(someHelper(lengthTracking, div3));
+    assert(!someHelper(lengthTracking, over10));
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        everyHelper(fixedLength, div3);
+      });
+      assert.throws(TypeError, () => {
+        someHelper(fixedLength, div3);
+      });
+      assert.throws(TypeError, () => {
+        everyHelper(fixedLengthWithOffset, div3);
+      });
+      assert.throws(TypeError, () => {
+        someHelper(fixedLengthWithOffset, div3);
+      });
+      assert.throws(TypeError, () => {
+        everyHelper(lengthTrackingWithOffset, div3);
+      });
+      assert.throws(TypeError, () => {
+        someHelper(lengthTrackingWithOffset, div3);
+      });
+    } else {
+      assert(everyHelper(fixedLength, div3));
+      assert(!someHelper(fixedLength, div3));
+      assert(everyHelper(fixedLengthWithOffset, div3));
+      assert(!someHelper(fixedLengthWithOffset, div3));
+      assert(everyHelper(lengthTrackingWithOffset, div3));
+      assert(!someHelper(lengthTrackingWithOffset, div3));
+    }
+    assert(everyHelper(lengthTracking, div3));
+    assert(everyHelper(lengthTracking, even));
+    assert(!someHelper(lengthTracking, div3));
+    assert(!someHelper(lengthTracking, over10));
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert(!everyHelper(fixedLength, div3));
+    assert(everyHelper(fixedLength, even));
+    assert(someHelper(fixedLength, div3));
+    assert(!someHelper(fixedLength, over10));
+    assert(!everyHelper(fixedLengthWithOffset, div3));
+    assert(everyHelper(fixedLengthWithOffset, even));
+    assert(someHelper(fixedLengthWithOffset, div3));
+    assert(!someHelper(fixedLengthWithOffset, over10));
+    assert(!everyHelper(lengthTracking, div3));
+    assert(everyHelper(lengthTracking, even));
+    assert(someHelper(lengthTracking, div3));
+    assert(!someHelper(lengthTracking, over10));
+    assert(!everyHelper(lengthTrackingWithOffset, div3));
+    assert(everyHelper(lengthTrackingWithOffset, even));
+    assert(someHelper(lengthTrackingWithOffset, div3));
+    assert(!someHelper(lengthTrackingWithOffset, over10));
+  }
+}
+
+EverySome(TypedArrayEveryHelper, TypedArraySomeHelper, true);
+EverySome(ArrayEveryHelper, ArraySomeHelper, false);

--- a/test/staging/ArrayBuffer/resizable/fill-parameter-conversion-resizes.js
+++ b/test/staging/ArrayBuffer/resizable/fill-parameter-conversion-resizes.js
@@ -1,0 +1,93 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FillParameterConversionResizes test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function TypedArrayFillHelper(ta, n, start, end) {
+  if (ta instanceof BigInt64Array || ta instanceof BigUint64Array) {
+    ta.fill(BigInt(n), start, end);
+  } else {
+    ta.fill(n, start, end);
+  }
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 3;
+    }
+  };
+  assert.throws(TypeError, () => {
+    TypedArrayFillHelper(fixedLength, evil, 1, 2);
+  });
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 1;
+    }
+  };
+  assert.throws(TypeError, () => {
+    TypedArrayFillHelper(fixedLength, 3, evil, 2);
+  });
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 2;
+    }
+  };
+  assert.throws(TypeError, () => {
+    TypedArrayFillHelper(fixedLength, 3, 1, evil);
+  });
+}

--- a/test/staging/ArrayBuffer/resizable/filter-grow-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/filter-grow-mid-iteration.js
@@ -1,0 +1,164 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FilterGrowMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArrayFilterHelper = (ta, ...rest) => {
+  return ta.filter(...rest);
+};
+
+const ArrayFilterHelper = (ta, ...rest) => {
+  return Array.prototype.filter.call(ta, ...rest);
+};
+
+function FilterGrowMidIteration(filterHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(filterHelper(fixedLength, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(filterHelper(fixedLengthWithOffset, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(filterHelper(lengthTracking, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ToNumbers(filterHelper(lengthTrackingWithOffset, CollectValuesAndResize)), []);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+FilterGrowMidIteration(TypedArrayFilterHelper);
+FilterGrowMidIteration(ArrayFilterHelper);

--- a/test/staging/ArrayBuffer/resizable/filter-shrink-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/filter-shrink-mid-iteration.js
@@ -1,0 +1,151 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FilterShrinkMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+function CollectValuesAndResize(n) {
+  if (typeof n == 'bigint') {
+    values.push(Number(n));
+  } else {
+    values.push(n);
+  }
+  if (values.length == resizeAfter) {
+    rab.resize(resizeTo);
+  }
+  return false;
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(fixedLength.filter(CollectValuesAndResize)), []);
+  assert.compareArray(values, [
+    0,
+    2,
+    undefined,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(fixedLengthWithOffset.filter(CollectValuesAndResize)), []);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  values = [];
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(lengthTracking.filter(CollectValuesAndResize)), []);
+  assert.compareArray(values, [
+    0,
+    2,
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  values = [];
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset.filter(CollectValuesAndResize)), []);
+  assert.compareArray(values, [
+    4,
+    undefined
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/filter.js
+++ b/test/staging/ArrayBuffer/resizable/filter.js
@@ -1,0 +1,205 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from Filter test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArrayFilterHelper = (ta, ...rest) => {
+  return ta.filter(...rest);
+};
+
+const ArrayFilterHelper = (ta, ...rest) => {
+  return Array.prototype.filter.call(ta, ...rest);
+};
+
+function Filter(filterHelper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, ...] << lengthTracking
+    //                    [2, 3, ...] << lengthTrackingWithOffset
+
+    function isEven(n) {
+      return n != undefined && Number(n) % 2 == 0;
+    }
+    assert.compareArray(ToNumbers(filterHelper(fixedLength, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(filterHelper(fixedLengthWithOffset, isEven)), [2]);
+    assert.compareArray(ToNumbers(filterHelper(lengthTracking, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(filterHelper(lengthTrackingWithOffset, isEven)), [2]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 1, 2]
+    //              [0, 1, 2, ...] << lengthTracking
+    //                    [2, ...] << lengthTrackingWithOffset
+
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        filterHelper(fixedLength, isEven);
+      });
+      assert.throws(TypeError, () => {
+        filterHelper(fixedLengthWithOffset, isEven);
+      });
+    } else {
+      assert.compareArray(filterHelper(fixedLength, isEven), []);
+      assert.compareArray(filterHelper(fixedLengthWithOffset, isEven), []);
+    }
+    assert.compareArray(ToNumbers(filterHelper(lengthTracking, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(filterHelper(lengthTrackingWithOffset, isEven)), [2]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        filterHelper(fixedLength, isEven);
+      });
+      assert.throws(TypeError, () => {
+        filterHelper(fixedLengthWithOffset, isEven);
+      });
+      assert.throws(TypeError, () => {
+        filterHelper(lengthTrackingWithOffset, isEven);
+      });
+    } else {
+      assert.compareArray(filterHelper(fixedLength, isEven), []);
+      assert.compareArray(filterHelper(fixedLengthWithOffset, isEven), []);
+      assert.compareArray(filterHelper(lengthTrackingWithOffset, isEven), []);
+    }
+    assert.compareArray(ToNumbers(filterHelper(lengthTracking, isEven)), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        filterHelper(fixedLength, isEven);
+      });
+      assert.throws(TypeError, () => {
+        filterHelper(fixedLengthWithOffset, isEven);
+      });
+      assert.throws(TypeError, () => {
+        filterHelper(lengthTrackingWithOffset, isEven);
+      });
+    } else {
+      assert.compareArray(filterHelper(fixedLength, isEven), []);
+      assert.compareArray(filterHelper(fixedLengthWithOffset, isEven), []);
+      assert.compareArray(filterHelper(lengthTrackingWithOffset, isEven), []);
+    }
+    assert.compareArray(ToNumbers(filterHelper(lengthTracking, isEven)), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3, 4, 5]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(ToNumbers(filterHelper(fixedLength, isEven)), [
+      0,
+      2
+    ]);
+    assert.compareArray(ToNumbers(filterHelper(fixedLengthWithOffset, isEven)), [2]);
+    assert.compareArray(ToNumbers(filterHelper(lengthTracking, isEven)), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(ToNumbers(filterHelper(lengthTrackingWithOffset, isEven)), [
+      2,
+      4
+    ]);
+  }
+}
+
+Filter(TypedArrayFilterHelper, true);
+Filter(ArrayFilterHelper, false);

--- a/test/staging/ArrayBuffer/resizable/find-find-index-find-last-find-last-index.js
+++ b/test/staging/ArrayBuffer/resizable/find-find-index-find-last-find-last-index.js
@@ -1,0 +1,328 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FindFindIndexFindLastFindLastIndex test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindHelper(ta, p) {
+  return ta.find(p);
+}
+
+function ArrayFindHelper(ta, p) {
+  return Array.prototype.find.call(ta, p);
+}
+
+function TypedArrayFindIndexHelper(ta, p) {
+  return ta.findIndex(p);
+}
+
+function ArrayFindIndexHelper(ta, p) {
+  return Array.prototype.findIndex.call(ta, p);
+}
+
+function TypedArrayFindLastHelper(ta, p) {
+  return ta.findLast(p);
+}
+
+function ArrayFindLastHelper(ta, p) {
+  return Array.prototype.findLast.call(ta, p);
+}
+
+function TypedArrayFindLastIndexHelper(ta, p) {
+  return ta.findLastIndex(p);
+}
+
+function ArrayFindLastIndexHelper(ta, p) {
+  return Array.prototype.findLastIndex.call(ta, p);
+}
+
+function FindFindIndexFindLastFindLastIndex(findHelper, findIndexHelper, findLastHelper, findLastIndexHelper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function isTwoOrFour(n) {
+      return n == 2 || n == 4;
+    }
+    assert.sameValue(Number(findHelper(fixedLength, isTwoOrFour)), 2);
+    assert.sameValue(Number(findHelper(fixedLengthWithOffset, isTwoOrFour)), 4);
+    assert.sameValue(Number(findHelper(lengthTracking, isTwoOrFour)), 2);
+    assert.sameValue(Number(findHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
+    assert.sameValue(findIndexHelper(fixedLength, isTwoOrFour), 1);
+    assert.sameValue(findIndexHelper(fixedLengthWithOffset, isTwoOrFour), 0);
+    assert.sameValue(findIndexHelper(lengthTracking, isTwoOrFour), 1);
+    assert.sameValue(findIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
+    assert.sameValue(Number(findLastHelper(fixedLength, isTwoOrFour)), 4);
+    assert.sameValue(Number(findLastHelper(fixedLengthWithOffset, isTwoOrFour)), 4);
+    assert.sameValue(Number(findLastHelper(lengthTracking, isTwoOrFour)), 4);
+    assert.sameValue(Number(findLastHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
+    assert.sameValue(findLastIndexHelper(fixedLength, isTwoOrFour), 2);
+    assert.sameValue(findLastIndexHelper(fixedLengthWithOffset, isTwoOrFour), 0);
+    assert.sameValue(findLastIndexHelper(lengthTracking, isTwoOrFour), 2);
+    assert.sameValue(findLastIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        findHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findIndexHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastIndexHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findIndexHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastIndexHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+    } else {
+      assert.sameValue(findHelper(fixedLength, isTwoOrFour), undefined);
+      assert.sameValue(findIndexHelper(fixedLength, isTwoOrFour), -1);
+      assert.sameValue(findLastHelper(fixedLength, isTwoOrFour), undefined);
+      assert.sameValue(findLastIndexHelper(fixedLength, isTwoOrFour), -1);
+      assert.sameValue(findHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+      assert.sameValue(findIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+      assert.sameValue(findLastHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+      assert.sameValue(findLastIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+    }
+    assert.sameValue(Number(findHelper(lengthTracking, isTwoOrFour)), 2);
+    assert.sameValue(Number(findHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
+    assert.sameValue(findIndexHelper(lengthTracking, isTwoOrFour), 1);
+    assert.sameValue(findIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
+    assert.sameValue(Number(findLastHelper(lengthTracking, isTwoOrFour)), 4);
+    assert.sameValue(Number(findLastHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
+    assert.sameValue(findLastIndexHelper(lengthTracking, isTwoOrFour), 2);
+    assert.sameValue(findLastIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 0);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        findHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findIndexHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastIndexHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findIndexHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastIndexHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findHelper(lengthTrackingWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findIndexHelper(lengthTrackingWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastHelper(lengthTrackingWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastIndexHelper(lengthTrackingWithOffset, isTwoOrFour);
+      });
+    } else {
+      assert.sameValue(findHelper(fixedLength, isTwoOrFour), undefined);
+      assert.sameValue(findIndexHelper(fixedLength, isTwoOrFour), -1);
+      assert.sameValue(findLastHelper(fixedLength, isTwoOrFour), undefined);
+      assert.sameValue(findLastIndexHelper(fixedLength, isTwoOrFour), -1);
+      assert.sameValue(findHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+      assert.sameValue(findIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+      assert.sameValue(findLastHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+      assert.sameValue(findLastIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+      assert.sameValue(findHelper(lengthTrackingWithOffset, isTwoOrFour), undefined);
+      assert.sameValue(findIndexHelper(lengthTrackingWithOffset, isTwoOrFour), -1);
+      assert.sameValue(findLastHelper(lengthTrackingWithOffset, isTwoOrFour), undefined);
+      assert.sameValue(findLastIndexHelper(lengthTrackingWithOffset, isTwoOrFour), -1);
+    }
+    assert.sameValue(findHelper(lengthTracking, isTwoOrFour), undefined);
+    assert.sameValue(findIndexHelper(lengthTracking, isTwoOrFour), -1);
+    assert.sameValue(findLastHelper(lengthTracking, isTwoOrFour), undefined);
+    assert.sameValue(findLastIndexHelper(lengthTracking, isTwoOrFour), -1);
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        findHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findIndexHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastIndexHelper(fixedLength, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findIndexHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastIndexHelper(fixedLengthWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findHelper(lengthTrackingWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findIndexHelper(lengthTrackingWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastHelper(lengthTrackingWithOffset, isTwoOrFour);
+      });
+      assert.throws(TypeError, () => {
+        findLastIndexHelper(lengthTrackingWithOffset, isTwoOrFour);
+      });
+    } else {
+      assert.sameValue(findHelper(fixedLength, isTwoOrFour), undefined);
+      assert.sameValue(findIndexHelper(fixedLength, isTwoOrFour), -1);
+      assert.sameValue(findLastHelper(fixedLength, isTwoOrFour), undefined);
+      assert.sameValue(findLastIndexHelper(fixedLength, isTwoOrFour), -1);
+      assert.sameValue(findHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+      assert.sameValue(findIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+      assert.sameValue(findLastHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+      assert.sameValue(findLastIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+      assert.sameValue(findHelper(lengthTrackingWithOffset, isTwoOrFour), undefined);
+      assert.sameValue(findIndexHelper(lengthTrackingWithOffset, isTwoOrFour), -1);
+      assert.sameValue(findLastHelper(lengthTrackingWithOffset, isTwoOrFour), undefined);
+      assert.sameValue(findLastIndexHelper(lengthTrackingWithOffset, isTwoOrFour), -1);
+    }
+    assert.sameValue(findHelper(lengthTracking, isTwoOrFour), undefined);
+    assert.sameValue(findIndexHelper(lengthTracking, isTwoOrFour), -1);
+    assert.sameValue(findLastHelper(lengthTracking, isTwoOrFour), undefined);
+    assert.sameValue(findLastIndexHelper(lengthTracking, isTwoOrFour), -1);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 0);
+    }
+    WriteToTypedArray(taWrite, 4, 2);
+    WriteToTypedArray(taWrite, 5, 4);
+
+    // Orig. array: [0, 0, 0, 0, 2, 4]
+    //              [0, 0, 0, 0] << fixedLength
+    //                    [0, 0] << fixedLengthWithOffset
+    //              [0, 0, 0, 0, 2, 4, ...] << lengthTracking
+    //                    [0, 0, 2, 4, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(findHelper(fixedLength, isTwoOrFour), undefined);
+    assert.sameValue(findHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+    assert.sameValue(Number(findHelper(lengthTracking, isTwoOrFour)), 2);
+    assert.sameValue(Number(findHelper(lengthTrackingWithOffset, isTwoOrFour)), 2);
+    assert.sameValue(findIndexHelper(fixedLength, isTwoOrFour), -1);
+    assert.sameValue(findIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+    assert.sameValue(findIndexHelper(lengthTracking, isTwoOrFour), 4);
+    assert.sameValue(findIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 2);
+    assert.sameValue(findLastHelper(fixedLength, isTwoOrFour), undefined);
+    assert.sameValue(findLastHelper(fixedLengthWithOffset, isTwoOrFour), undefined);
+    assert.sameValue(Number(findLastHelper(lengthTracking, isTwoOrFour)), 4);
+    assert.sameValue(Number(findLastHelper(lengthTrackingWithOffset, isTwoOrFour)), 4);
+    assert.sameValue(findLastIndexHelper(fixedLength, isTwoOrFour), -1);
+    assert.sameValue(findLastIndexHelper(fixedLengthWithOffset, isTwoOrFour), -1);
+    assert.sameValue(findLastIndexHelper(lengthTracking, isTwoOrFour), 5);
+    assert.sameValue(findLastIndexHelper(lengthTrackingWithOffset, isTwoOrFour), 3);
+  }
+}
+
+FindFindIndexFindLastFindLastIndex(TypedArrayFindHelper, TypedArrayFindIndexHelper, TypedArrayFindLastHelper, TypedArrayFindLastIndexHelper, true);
+FindFindIndexFindLastFindLastIndex(ArrayFindHelper, ArrayFindIndexHelper, ArrayFindLastHelper, ArrayFindLastIndexHelper, false);

--- a/test/staging/ArrayBuffer/resizable/find-grow-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/find-grow-mid-iteration.js
@@ -1,0 +1,149 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FindGrowMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindHelper(ta, p) {
+  return ta.find(p);
+}
+
+function ArrayFindHelper(ta, p) {
+  return Array.prototype.find.call(ta, p);
+}
+
+function FindGrowMidIteration(findHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findHelper(fixedLength, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findHelper(lengthTracking, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+FindGrowMidIteration(TypedArrayFindHelper);
+FindGrowMidIteration(ArrayFindHelper);

--- a/test/staging/ArrayBuffer/resizable/find-index-grow-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/find-index-grow-mid-iteration.js
@@ -1,0 +1,149 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FindIndexGrowMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindIndexHelper(ta, p) {
+  return ta.findIndex(p);
+}
+
+function ArrayFindIndexHelper(ta, p) {
+  return Array.prototype.findIndex.call(ta, p);
+}
+
+function FindIndexGrowMidIteration(findIndexHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findIndexHelper(fixedLength, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findIndexHelper(lengthTracking, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+FindIndexGrowMidIteration(TypedArrayFindIndexHelper);
+FindIndexGrowMidIteration(ArrayFindIndexHelper);

--- a/test/staging/ArrayBuffer/resizable/find-index-shrink-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/find-index-shrink-mid-iteration.js
@@ -1,0 +1,149 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FindIndexShrinkMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindIndexHelper(ta, p) {
+  return ta.findIndex(p);
+}
+
+function ArrayFindIndexHelper(ta, p) {
+  return Array.prototype.findIndex.call(ta, p);
+}
+
+function FindIndexShrinkMidIteration(findIndexHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findIndexHelper(fixedLength, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      undefined,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findIndexHelper(lengthTracking, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+}
+
+FindIndexShrinkMidIteration(TypedArrayFindIndexHelper);
+FindIndexShrinkMidIteration(ArrayFindIndexHelper);

--- a/test/staging/ArrayBuffer/resizable/find-last-grow-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/find-last-grow-mid-iteration.js
@@ -1,0 +1,149 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FindLastGrowMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindLastHelper(ta, p) {
+  return ta.findLast(p);
+}
+
+function ArrayFindLastHelper(ta, p) {
+  return Array.prototype.findLast.call(ta, p);
+}
+
+function FindLastGrowMidIteration(findLastHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastHelper(fixedLength, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      6,
+      4
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastHelper(lengthTracking, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      6,
+      4
+    ]);
+  }
+}
+
+FindLastGrowMidIteration(TypedArrayFindLastHelper);
+FindLastGrowMidIteration(ArrayFindLastHelper);

--- a/test/staging/ArrayBuffer/resizable/find-last-index-grow-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/find-last-index-grow-mid-iteration.js
@@ -1,0 +1,149 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FindLastIndexGrowMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindLastIndexHelper(ta, p) {
+  return ta.findLastIndex(p);
+}
+
+function ArrayFindLastIndexHelper(ta, p) {
+  return Array.prototype.findLastIndex.call(ta, p);
+}
+
+function FindLastIndexGrowMidIteration(findLastIndexHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastIndexHelper(fixedLength, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      6,
+      4
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastIndexHelper(lengthTracking, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      6,
+      4
+    ]);
+  }
+}
+
+FindLastIndexGrowMidIteration(TypedArrayFindLastIndexHelper);
+FindLastIndexGrowMidIteration(ArrayFindLastIndexHelper);

--- a/test/staging/ArrayBuffer/resizable/find-last-index-shrink-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/find-last-index-shrink-mid-iteration.js
@@ -1,0 +1,163 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FindLastIndexShrinkMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindLastIndexHelper(ta, p) {
+  return ta.findLastIndex(p);
+}
+
+function ArrayFindLastIndexHelper(ta, p) {
+  return Array.prototype.findLastIndex.call(ta, p);
+}
+
+function FindLastIndexShrinkMidIteration(findLastIndexHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastIndexHelper(fixedLength, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      6,
+      4,
+      undefined,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastIndexHelper(fixedLengthWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      6,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastIndexHelper(lengthTracking, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 2 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastIndexHelper(lengthTracking, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      6,
+      undefined,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastIndexHelper(lengthTrackingWithOffset, CollectValuesAndResize), -1);
+    assert.compareArray(values, [
+      6,
+      4
+    ]);
+  }
+}
+
+FindLastIndexShrinkMidIteration(TypedArrayFindLastIndexHelper);
+FindLastIndexShrinkMidIteration(ArrayFindLastIndexHelper);

--- a/test/staging/ArrayBuffer/resizable/find-last-shrink-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/find-last-shrink-mid-iteration.js
@@ -1,0 +1,149 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FindLastShrinkMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindLastHelper(ta, p) {
+  return ta.findLast(p);
+}
+
+function ArrayFindLastHelper(ta, p) {
+  return Array.prototype.findLast.call(ta, p);
+}
+
+function FindLastShrinkMidIteration(findLastHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastHelper(fixedLength, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      6,
+      4,
+      undefined,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      6,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastHelper(lengthTracking, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findLastHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      6,
+      4
+    ]);
+  }
+}
+
+FindLastShrinkMidIteration(TypedArrayFindLastHelper);
+FindLastShrinkMidIteration(ArrayFindLastHelper);

--- a/test/staging/ArrayBuffer/resizable/find-shrink-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/find-shrink-mid-iteration.js
@@ -1,0 +1,149 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FindShrinkMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayFindHelper(ta, p) {
+  return ta.find(p);
+}
+
+function ArrayFindHelper(ta, p) {
+  return Array.prototype.find.call(ta, p);
+}
+
+function FindShrinkMidIteration(findHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findHelper(fixedLength, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      undefined,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findHelper(fixedLengthWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findHelper(lengthTracking, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      undefined
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert.sameValue(findHelper(lengthTrackingWithOffset, CollectValuesAndResize), undefined);
+    assert.compareArray(values, [
+      4,
+      undefined
+    ]);
+  }
+}
+
+FindShrinkMidIteration(TypedArrayFindHelper);
+FindShrinkMidIteration(ArrayFindHelper);

--- a/test/staging/ArrayBuffer/resizable/for-each-reduce-reduce-right-grow-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/for-each-reduce-reduce-right-grow-mid-iteration.js
@@ -1,0 +1,273 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ForEachReduceReduceRightGrowMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArrayForEachHelper = (ta, ...rest) => {
+  return ta.forEach(...rest);
+};
+
+const ArrayForEachHelper = (ta, ...rest) => {
+  return Array.prototype.forEach.call(ta, ...rest);
+};
+
+const TypedArrayReduceHelper = (ta, ...rest) => {
+  return ta.reduce(...rest);
+};
+
+const ArrayReduceHelper = (ta, ...rest) => {
+  return Array.prototype.reduce.call(ta, ...rest);
+};
+
+const TypedArrayReduceRightHelper = (ta, ...rest) => {
+  return ta.reduceRight(...rest);
+};
+
+const ArrayReduceRightHelper = (ta, ...rest) => {
+  return Array.prototype.reduceRight.call(ta, ...rest);
+};
+
+function ForEachReduceReduceRightGrowMidIteration(forEachHelper, reduceHelper, reduceRightHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return true;
+  }
+  function ForEachHelper(array) {
+    values = [];
+    forEachHelper(array, CollectValuesAndResize);
+    return values;
+  }
+  function ReduceHelper(array) {
+    values = [];
+    reduceHelper(array, (acc, n) => {
+      CollectValuesAndResize(n);
+    }, 'initial value');
+    return values;
+  }
+  function ReduceRightHelper(array) {
+    values = [];
+    reduceRightHelper(array, (acc, n) => {
+      CollectValuesAndResize(n);
+    }, 'initial value');
+    return values;
+  }
+
+  // Test for forEach.
+
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ForEachHelper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ForEachHelper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ForEachHelper(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ForEachHelper(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+  }
+
+  // Test for reduce.
+
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceHelper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceHelper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceHelper(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceHelper(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+  }
+
+  // Test for reduceRight.
+
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(fixedLength), [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(fixedLengthWithOffset), [
+      6,
+      4
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(lengthTracking), [
+      6,
+      4,
+      2,
+      0
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(ReduceRightHelper(lengthTrackingWithOffset), [
+      6,
+      4
+    ]);
+  }
+}
+
+ForEachReduceReduceRightGrowMidIteration(TypedArrayForEachHelper, TypedArrayReduceHelper, TypedArrayReduceRightHelper);
+ForEachReduceReduceRightGrowMidIteration(ArrayForEachHelper, ArrayReduceHelper, ArrayReduceRightHelper);

--- a/test/staging/ArrayBuffer/resizable/for-each-reduce-reduce-right-shrink-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/for-each-reduce-reduce-right-shrink-mid-iteration.js
@@ -1,0 +1,258 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ForEachReduceReduceRightShrinkMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let values;
+let rab;
+let resizeAfter;
+let resizeTo;
+function CollectValuesAndResize(n) {
+  if (typeof n == 'bigint') {
+    values.push(Number(n));
+  } else {
+    values.push(n);
+  }
+  if (values.length == resizeAfter) {
+    rab.resize(resizeTo);
+  }
+  return true;
+}
+function ForEachHelper(array) {
+  values = [];
+  array.forEach(CollectValuesAndResize);
+  return values;
+}
+function ReduceHelper(array) {
+  values = [];
+  array.reduce((acc, n) => {
+    CollectValuesAndResize(n);
+  }, 'initial value');
+  return values;
+}
+function ReduceRightHelper(array) {
+  values = [];
+  array.reduceRight((acc, n) => {
+    CollectValuesAndResize(n);
+  }, 'initial value');
+  return values;
+}
+
+// Test for forEach.
+
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ForEachHelper(fixedLength), [
+    0,
+    2,
+    undefined,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ForEachHelper(fixedLengthWithOffset), [
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ForEachHelper(lengthTracking), [
+    0,
+    2,
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ForEachHelper(lengthTrackingWithOffset), [
+    4,
+    undefined
+  ]);
+}
+
+// Tests for reduce.
+
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ReduceHelper(fixedLength), [
+    0,
+    2,
+    undefined,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ReduceHelper(fixedLengthWithOffset), [
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ReduceHelper(lengthTracking), [
+    0,
+    2,
+    4,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ReduceHelper(lengthTrackingWithOffset), [
+    4,
+    undefined
+  ]);
+}
+
+// Tests for reduceRight.
+
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ReduceRightHelper(fixedLength), [
+    6,
+    4,
+    undefined,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ReduceRightHelper(fixedLengthWithOffset), [
+    6,
+    undefined
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  // Unaffected by the shrinking, since we've already iterated past the point.
+  assert.compareArray(ReduceRightHelper(lengthTracking), [
+    6,
+    4,
+    2,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAfter = 1;
+  resizeTo = 2 * ctor.BYTES_PER_ELEMENT;
+  assert.compareArray(ReduceRightHelper(lengthTracking), [
+    6,
+    undefined,
+    2,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAfter = 1;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  // Unaffected by the shrinking, since we've already iterated past the point.
+  assert.compareArray(ReduceRightHelper(lengthTrackingWithOffset), [
+    6,
+    4
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/for-each-reduce-reduce-right.js
+++ b/test/staging/ArrayBuffer/resizable/for-each-reduce-reduce-right.js
@@ -1,0 +1,256 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ForEachReduceReduceRight test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArrayForEachHelper = (ta, ...rest) => {
+  return ta.forEach(...rest);
+};
+
+const ArrayForEachHelper = (ta, ...rest) => {
+  return Array.prototype.forEach.call(ta, ...rest);
+};
+
+const TypedArrayReduceHelper = (ta, ...rest) => {
+  return ta.reduce(...rest);
+};
+
+const ArrayReduceHelper = (ta, ...rest) => {
+  return Array.prototype.reduce.call(ta, ...rest);
+};
+
+const TypedArrayReduceRightHelper = (ta, ...rest) => {
+  return ta.reduceRight(...rest);
+};
+
+const ArrayReduceRightHelper = (ta, ...rest) => {
+  return Array.prototype.reduceRight.call(ta, ...rest);
+};
+
+function ForEachReduceReduceRight(forEachHelper, reduceHelper, reduceRightHelper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function Helper(array) {
+      const forEachValues = [];
+      const reduceValues = [];
+      const reduceRightValues = [];
+      forEachHelper(array, n => {
+        forEachValues.push(n);
+      });
+      reduceHelper(array, (acc, n) => {
+        reduceValues.push(n);
+      }, 'initial value');
+      reduceRightHelper(array, (acc, n) => {
+        reduceRightValues.push(n);
+      }, 'initial value');
+      assert.compareArray(forEachValues, reduceValues);
+      reduceRightValues.reverse();
+      assert.compareArray(reduceRightValues, reduceValues);
+      return ToNumbers(forEachValues);
+    }
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        Helper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        Helper(fixedLengthWithOffset);
+      });
+    } else {
+      assert.compareArray(Helper(fixedLength), []);
+      assert.compareArray(Helper(fixedLengthWithOffset), []);
+    }
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        Helper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        Helper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        Helper(lengthTrackingWithOffset);
+      });
+    } else {
+      assert.compareArray(Helper(fixedLength), []);
+      assert.compareArray(Helper(fixedLengthWithOffset), []);
+    }
+    assert.compareArray(Helper(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        Helper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        Helper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        Helper(lengthTrackingWithOffset);
+      });
+    } else {
+      assert.compareArray(Helper(fixedLength), []);
+      assert.compareArray(Helper(fixedLengthWithOffset), []);
+      assert.compareArray(Helper(lengthTrackingWithOffset), []);
+    }
+    assert.compareArray(Helper(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+  }
+}
+
+ForEachReduceReduceRight(TypedArrayForEachHelper, TypedArrayReduceHelper, TypedArrayReduceRightHelper, true);
+ForEachReduceReduceRight(ArrayForEachHelper, ArrayReduceHelper, ArrayReduceRightHelper, false);

--- a/test/staging/ArrayBuffer/resizable/function-apply.js
+++ b/test/staging/ArrayBuffer/resizable/function-apply.js
@@ -1,0 +1,156 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from FunctionApply test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  function func(...args) {
+    return [...args];
+  }
+  assert.compareArray(ToNumbers(func.apply(null, fixedLength)), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.compareArray(ToNumbers(func.apply(null, fixedLengthWithOffset)), [
+    2,
+    3
+  ]);
+  assert.compareArray(ToNumbers(func.apply(null, lengthTracking)), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.compareArray(ToNumbers(func.apply(null, lengthTrackingWithOffset)), [
+    2,
+    3
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+  assert.compareArray(ToNumbers(func.apply(null, fixedLength)), []);
+  assert.compareArray(ToNumbers(func.apply(null, fixedLengthWithOffset)), []);
+  assert.compareArray(ToNumbers(func.apply(null, lengthTracking)), [
+    0,
+    1,
+    2
+  ]);
+  assert.compareArray(ToNumbers(func.apply(null, lengthTrackingWithOffset)), [2]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.compareArray(ToNumbers(func.apply(null, fixedLength)), []);
+  assert.compareArray(ToNumbers(func.apply(null, fixedLengthWithOffset)), []);
+  assert.compareArray(ToNumbers(func.apply(null, lengthTracking)), [0]);
+  assert.compareArray(ToNumbers(func.apply(null, lengthTrackingWithOffset)), []);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.compareArray(ToNumbers(func.apply(null, fixedLength)), []);
+  assert.compareArray(ToNumbers(func.apply(null, fixedLengthWithOffset)), []);
+  assert.compareArray(ToNumbers(func.apply(null, lengthTracking)), []);
+  assert.compareArray(ToNumbers(func.apply(null, lengthTrackingWithOffset)), []);
+
+  // Grow so that all TAs are back in-bounds. New memory is zeroed.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  assert.compareArray(ToNumbers(func.apply(null, fixedLength)), [
+    0,
+    0,
+    0,
+    0
+  ]);
+  assert.compareArray(ToNumbers(func.apply(null, fixedLengthWithOffset)), [
+    0,
+    0
+  ]);
+  assert.compareArray(ToNumbers(func.apply(null, lengthTracking)), [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ]);
+  assert.compareArray(ToNumbers(func.apply(null, lengthTrackingWithOffset)), [
+    0,
+    0,
+    0,
+    0
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/includes-parameter-conversion-resizes.js
+++ b/test/staging/ArrayBuffer/resizable/includes-parameter-conversion-resizes.js
@@ -1,0 +1,143 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from IncludesParameterConversionResizes test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayIncludesHelper(array, n, fromIndex) {
+  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
+    return array.includes(BigInt(n), fromIndex);
+  }
+  return array.includes(n, fromIndex);
+}
+
+function ArrayIncludesHelper(array, n, fromIndex) {
+  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
+    return Array.prototype.includes.call(array, BigInt(n), fromIndex);
+  }
+  return Array.prototype.includes.call(array, n, fromIndex);
+}
+
+function IncludesParameterConversionResizes(helper) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(!helper(fixedLength, undefined));
+    // The TA is OOB so it includes only "undefined".
+    assert(helper(fixedLength, undefined, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(helper(fixedLength, 0));
+    // The TA is OOB so it includes only "undefined".
+    assert(!helper(fixedLength, 0, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(!helper(lengthTracking, undefined));
+    // "includes" iterates until the original length and sees "undefined"s.
+    assert(helper(lengthTracking, undefined, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, 1);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert(!helper(lengthTracking, 0));
+    // The TA grew but we only look at the data until the original length.
+    assert(!helper(lengthTracking, 0, evil));
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    WriteToTypedArray(lengthTracking, 0, 1);
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -4;
+      }
+    };
+    assert(helper(lengthTracking, 1, -4));
+    // The TA grew but the start index conversion is done based on the original
+    // length.
+    assert(helper(lengthTracking, 1, evil));
+  }
+}
+
+IncludesParameterConversionResizes(TypedArrayIncludesHelper);
+IncludesParameterConversionResizes(ArrayIncludesHelper);

--- a/test/staging/ArrayBuffer/resizable/includes-special-values.js
+++ b/test/staging/ArrayBuffer/resizable/includes-special-values.js
@@ -1,0 +1,35 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from IncludesSpecialValues test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyFloat32Array extends Float32Array {
+}
+
+const floatCtors = [
+  Float32Array,
+  Float64Array,
+  MyFloat32Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+for (let ctor of floatCtors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  lengthTracking[0] = -Infinity;
+  lengthTracking[1] = Infinity;
+  lengthTracking[2] = NaN;
+  assert(lengthTracking.includes(-Infinity));
+  assert(lengthTracking.includes(Infinity));
+  assert(lengthTracking.includes(NaN));
+}

--- a/test/staging/ArrayBuffer/resizable/includes.js
+++ b/test/staging/ArrayBuffer/resizable/includes.js
@@ -1,0 +1,208 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from Includes test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayIncludesHelper(array, n, fromIndex) {
+  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
+    return array.includes(BigInt(n), fromIndex);
+  }
+  return array.includes(n, fromIndex);
+}
+
+function ArrayIncludesHelper(array, n, fromIndex) {
+  if (typeof n == 'number' && (array instanceof BigInt64Array || array instanceof BigUint64Array)) {
+    return Array.prototype.includes.call(array, BigInt(n), fromIndex);
+  }
+  return Array.prototype.includes.call(array, n, fromIndex);
+}
+
+function Includes(helper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert(helper(fixedLength, 2));
+    assert(!helper(fixedLength, undefined));
+    assert(helper(fixedLength, 2, 1));
+    assert(!helper(fixedLength, 2, 2));
+    assert(helper(fixedLength, 2, -3));
+    assert(!helper(fixedLength, 2, -2));
+    assert(!helper(fixedLengthWithOffset, 2));
+    assert(helper(fixedLengthWithOffset, 4));
+    assert(!helper(fixedLengthWithOffset, undefined));
+    assert(helper(fixedLengthWithOffset, 4, 0));
+    assert(!helper(fixedLengthWithOffset, 4, 1));
+    assert(helper(fixedLengthWithOffset, 4, -2));
+    assert(!helper(fixedLengthWithOffset, 4, -1));
+    assert(helper(lengthTracking, 2));
+    assert(!helper(lengthTracking, undefined));
+    assert(helper(lengthTracking, 2, 1));
+    assert(!helper(lengthTracking, 2, 2));
+    assert(helper(lengthTracking, 2, -3));
+    assert(!helper(lengthTracking, 2, -2));
+    assert(!helper(lengthTrackingWithOffset, 2));
+    assert(helper(lengthTrackingWithOffset, 4));
+    assert(!helper(lengthTrackingWithOffset, undefined));
+    assert(helper(lengthTrackingWithOffset, 4, 0));
+    assert(!helper(lengthTrackingWithOffset, 4, 1));
+    assert(helper(lengthTrackingWithOffset, 4, -2));
+    assert(!helper(lengthTrackingWithOffset, 4, -1));
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        helper(fixedLength, 2);
+      });
+      assert.throws(TypeError, () => {
+        helper(fixedLengthWithOffset, 2);
+      });
+    } else {
+      assert(!helper(fixedLength, 2));
+      assert(!helper(fixedLengthWithOffset, 2));
+    }
+    assert(helper(lengthTracking, 2));
+    assert(!helper(lengthTracking, undefined));
+    assert(!helper(lengthTrackingWithOffset, 2));
+    assert(helper(lengthTrackingWithOffset, 4));
+    assert(!helper(lengthTrackingWithOffset, undefined));
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        helper(fixedLength, 2);
+      });
+      assert.throws(TypeError, () => {
+        helper(fixedLengthWithOffset, 2);
+      });
+      assert.throws(TypeError, () => {
+        helper(lengthTrackingWithOffset, 2);
+      });
+    } else {
+      assert(!helper(fixedLength, 2));
+      assert(!helper(fixedLengthWithOffset, 2));
+      assert(!helper(lengthTrackingWithOffset, 2));
+    }
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        helper(fixedLength, 2);
+      });
+      assert.throws(TypeError, () => {
+        helper(fixedLengthWithOffset, 2);
+      });
+      assert.throws(TypeError, () => {
+        helper(lengthTrackingWithOffset, 2);
+      });
+    } else {
+      assert(!helper(fixedLength, 2));
+      assert(!helper(fixedLengthWithOffset, 2));
+      assert(!helper(lengthTrackingWithOffset, 2));
+    }
+    assert(!helper(lengthTracking, 2));
+    assert(!helper(lengthTracking, undefined));
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert(helper(fixedLength, 2));
+    assert(!helper(fixedLength, undefined));
+    assert(!helper(fixedLength, 8));
+    assert(!helper(fixedLengthWithOffset, 2));
+    assert(helper(fixedLengthWithOffset, 4));
+    assert(!helper(fixedLengthWithOffset, undefined));
+    assert(!helper(fixedLengthWithOffset, 8));
+    assert(helper(lengthTracking, 2));
+    assert(!helper(lengthTracking, undefined));
+    assert(helper(lengthTracking, 8));
+    assert(!helper(lengthTrackingWithOffset, 2));
+    assert(helper(lengthTrackingWithOffset, 4));
+    assert(!helper(lengthTrackingWithOffset, undefined));
+    assert(helper(lengthTrackingWithOffset, 8));
+  }
+}
+
+Includes(TypedArrayIncludesHelper, true);
+Includes(ArrayIncludesHelper, false);

--- a/test/staging/ArrayBuffer/resizable/index-of-last-index-of-special-values.js
+++ b/test/staging/ArrayBuffer/resizable/index-of-last-index-of-special-values.js
@@ -1,0 +1,42 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from IndexOfLastIndexOfSpecialValues test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyFloat32Array extends Float32Array {
+}
+
+const floatCtors = [
+  Float32Array,
+  Float64Array,
+  MyFloat32Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+for (let ctor of floatCtors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  lengthTracking[0] = -Infinity;
+  lengthTracking[1] = -Infinity;
+  lengthTracking[2] = Infinity;
+  lengthTracking[3] = Infinity;
+  lengthTracking[4] = NaN;
+  lengthTracking[5] = NaN;
+  assert.sameValue(lengthTracking.indexOf(-Infinity), 0);
+  assert.sameValue(lengthTracking.lastIndexOf(-Infinity), 1);
+  assert.sameValue(lengthTracking.indexOf(Infinity), 2);
+  assert.sameValue(lengthTracking.lastIndexOf(Infinity), 3);
+  // NaN is never found.
+  assert.sameValue(lengthTracking.indexOf(NaN), -1);
+  assert.sameValue(lengthTracking.lastIndexOf(NaN), -1);
+}

--- a/test/staging/ArrayBuffer/resizable/index-of-last-index-of.js
+++ b/test/staging/ArrayBuffer/resizable/index-of-last-index-of.js
@@ -1,0 +1,325 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from IndexOfLastIndexOf test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.indexOf(BigInt(n));
+    }
+    return ta.indexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.indexOf(n);
+  }
+  return ta.indexOf(n, fromIndex);
+}
+
+function ArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.indexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.indexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.indexOf.call(ta, n);
+  }
+  return Array.prototype.indexOf.call(ta, n, fromIndex);
+}
+
+function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.lastIndexOf(BigInt(n));
+    }
+    return ta.lastIndexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.lastIndexOf(n);
+  }
+  return ta.lastIndexOf(n, fromIndex);
+}
+
+function ArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.lastIndexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.lastIndexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.lastIndexOf.call(ta, n);
+  }
+  return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
+}
+
+function IndexOfLastIndexOf(indexOfHelper, lastIndexOfHelper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+    }
+
+    // Orig. array: [0, 0, 1, 1]
+    //              [0, 0, 1, 1] << fixedLength
+    //                    [1, 1] << fixedLengthWithOffset
+    //              [0, 0, 1, 1, ...] << lengthTracking
+    //                    [1, 1, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(indexOfHelper(fixedLength, 0), 0);
+    assert.sameValue(indexOfHelper(fixedLength, 0, 1), 1);
+    assert.sameValue(indexOfHelper(fixedLength, 0, 2), -1);
+    assert.sameValue(indexOfHelper(fixedLength, 0, -2), -1);
+    assert.sameValue(indexOfHelper(fixedLength, 0, -3), 1);
+    assert.sameValue(indexOfHelper(fixedLength, 1, 1), 2);
+    assert.sameValue(indexOfHelper(fixedLength, 1, -3), 2);
+    assert.sameValue(indexOfHelper(fixedLength, 1, -2), 2);
+    assert.sameValue(indexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(lastIndexOfHelper(fixedLength, 0), 1);
+    assert.sameValue(lastIndexOfHelper(fixedLength, 0, 1), 1);
+    assert.sameValue(lastIndexOfHelper(fixedLength, 0, 2), 1);
+    assert.sameValue(lastIndexOfHelper(fixedLength, 0, -2), 1);
+    assert.sameValue(lastIndexOfHelper(fixedLength, 0, -3), 1);
+    assert.sameValue(lastIndexOfHelper(fixedLength, 1, 1), -1);
+    assert.sameValue(lastIndexOfHelper(fixedLength, 1, -2), 2);
+    assert.sameValue(lastIndexOfHelper(fixedLength, 1, -3), -1);
+    assert.sameValue(lastIndexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(indexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(indexOfHelper(fixedLengthWithOffset, 1), 0);
+    assert.sameValue(indexOfHelper(fixedLengthWithOffset, 1, -2), 0);
+    assert.sameValue(indexOfHelper(fixedLengthWithOffset, 1, -1), 1);
+    assert.sameValue(indexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, 1), 1);
+    assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, 1, -2), 0);
+    assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, 1, -1), 1);
+    assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(indexOfHelper(lengthTracking, 0), 0);
+    assert.sameValue(indexOfHelper(lengthTracking, 0, 2), -1);
+    assert.sameValue(indexOfHelper(lengthTracking, 1, -3), 2);
+    assert.sameValue(indexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 0), 1);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 0, 2), 1);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 0, -3), 1);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 1, 1), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 1, 2), 2);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 1, -3), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, 1, 1), 1);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, 1, -2), 0);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, undefined), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 1), 1);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 1, 1), 1);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 1, -2), 0);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 1, -1), 1);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 0, 1]
+    //              [0, 0, 1, ...] << lengthTracking
+    //                    [1, ...] << lengthTrackingWithOffset
+
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        indexOfHelper(fixedLength, 1);
+      });
+      assert.throws(TypeError, () => {
+        indexOfHelper(fixedLengthWithOffset, 1);
+      });
+      assert.throws(TypeError, () => {
+        lastIndexOfHelper(fixedLength, 1);
+      });
+      assert.throws(TypeError, () => {
+        lastIndexOfHelper(fixedLengthWithOffset, 1);
+      });
+    } else {
+      assert.sameValue(indexOfHelper(fixedLength, 1), -1);
+      assert.sameValue(indexOfHelper(fixedLengthWithOffset, 1), -1);
+      assert.sameValue(lastIndexOfHelper(fixedLength, 1), -1);
+      assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, 1), -1);
+    }
+    assert.sameValue(indexOfHelper(lengthTracking, 1), 2);
+    assert.sameValue(indexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 0), 1);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, undefined), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        indexOfHelper(fixedLength, 0);
+      });
+      assert.throws(TypeError, () => {
+        indexOfHelper(fixedLengthWithOffset, 0);
+      });
+      assert.throws(TypeError, () => {
+        indexOfHelper(lengthTrackingWithOffset, 0);
+      });
+      assert.throws(TypeError, () => {
+        lastIndexOfHelper(fixedLength, 0);
+      });
+      assert.throws(TypeError, () => {
+        lastIndexOfHelper(fixedLengthWithOffset, 0);
+      });
+      assert.throws(TypeError, () => {
+        lastIndexOfHelper(lengthTrackingWithOffset, 0);
+      });
+    } else {
+      assert.sameValue(indexOfHelper(fixedLength, 0), -1);
+      assert.sameValue(indexOfHelper(fixedLengthWithOffset, 0), -1);
+      assert.sameValue(indexOfHelper(lengthTrackingWithOffset, 0), -1);
+      assert.sameValue(lastIndexOfHelper(fixedLength, 0), -1);
+      assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, 0), -1);
+      assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    }
+    assert.sameValue(indexOfHelper(lengthTracking, 0), 0);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 0), 0);
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        indexOfHelper(fixedLength, 0);
+      });
+      assert.throws(TypeError, () => {
+        indexOfHelper(fixedLengthWithOffset, 0);
+      });
+      assert.throws(TypeError, () => {
+        indexOfHelper(lengthTrackingWithOffset, 0);
+      });
+      assert.throws(TypeError, () => {
+        lastIndexOfHelper(fixedLength, 0);
+      });
+      assert.throws(TypeError, () => {
+        lastIndexOfHelper(fixedLengthWithOffset, 0);
+      });
+      assert.throws(TypeError, () => {
+        lastIndexOfHelper(lengthTrackingWithOffset, 0);
+      });
+    } else {
+      assert.sameValue(indexOfHelper(fixedLength, 0), -1);
+      assert.sameValue(indexOfHelper(fixedLengthWithOffset, 0), -1);
+      assert.sameValue(indexOfHelper(lengthTrackingWithOffset, 0), -1);
+      assert.sameValue(lastIndexOfHelper(fixedLength, 0), -1);
+      assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, 0), -1);
+      assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    }
+    assert.sameValue(indexOfHelper(lengthTracking, 0), -1);
+    assert.sameValue(indexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 0), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, undefined), -1);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, Math.floor(i / 2));
+    }
+
+    // Orig. array: [0, 0, 1, 1, 2, 2]
+    //              [0, 0, 1, 1] << fixedLength
+    //                    [1, 1] << fixedLengthWithOffset
+    //              [0, 0, 1, 1, 2, 2, ...] << lengthTracking
+    //                    [1, 1, 2, 2, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(indexOfHelper(fixedLength, 1), 2);
+    assert.sameValue(indexOfHelper(fixedLength, 2), -1);
+    assert.sameValue(indexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(lastIndexOfHelper(fixedLength, 1), 3);
+    assert.sameValue(lastIndexOfHelper(fixedLength, 2), -1);
+    assert.sameValue(lastIndexOfHelper(fixedLength, undefined), -1);
+    assert.sameValue(indexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(indexOfHelper(fixedLengthWithOffset, 1), 0);
+    assert.sameValue(indexOfHelper(fixedLengthWithOffset, 2), -1);
+    assert.sameValue(indexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, 0), -1);
+    assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, 1), 1);
+    assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, 2), -1);
+    assert.sameValue(lastIndexOfHelper(fixedLengthWithOffset, undefined), -1);
+    assert.sameValue(indexOfHelper(lengthTracking, 1), 2);
+    assert.sameValue(indexOfHelper(lengthTracking, 2), 4);
+    assert.sameValue(indexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 1), 3);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 2), 5);
+    assert.sameValue(lastIndexOfHelper(lengthTracking, undefined), -1);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, 1), 0);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, 2), 2);
+    assert.sameValue(indexOfHelper(lengthTrackingWithOffset, undefined), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 0), -1);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 1), 1);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, 2), 3);
+    assert.sameValue(lastIndexOfHelper(lengthTrackingWithOffset, undefined), -1);
+  }
+}
+
+IndexOfLastIndexOf(TypedArrayIndexOfHelper, TypedArrayLastIndexOfHelper, true);
+IndexOfLastIndexOf(ArrayIndexOfHelper, ArrayLastIndexOfHelper, false);

--- a/test/staging/ArrayBuffer/resizable/index-of-parameter-conversion-grows.js
+++ b/test/staging/ArrayBuffer/resizable/index-of-parameter-conversion-grows.js
@@ -1,0 +1,119 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from IndexOfParameterConversionGrows test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.indexOf(BigInt(n));
+    }
+    return ta.indexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.indexOf(n);
+  }
+  return ta.indexOf(n, fromIndex);
+}
+
+function ArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.indexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.indexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.indexOf.call(ta, n);
+  }
+  return Array.prototype.indexOf.call(ta, n, fromIndex);
+}
+
+function IndexOfParameterConversionGrows(indexOfHelper) {
+  // Growing + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, 1);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(indexOfHelper(lengthTracking, 0), -1);
+    // The TA grew but we only look at the data until the original length.
+    assert.sameValue(indexOfHelper(lengthTracking, 0, evil), -1);
+  }
+
+  // Growing + length-tracking TA, index conversion.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    WriteToTypedArray(lengthTracking, 0, 1);
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -4;
+      }
+    };
+    assert.sameValue(indexOfHelper(lengthTracking, 1, -4), 0);
+    // The TA grew but the start index conversion is done based on the original
+    // length.
+    assert.sameValue(indexOfHelper(lengthTracking, 1, evil), 0);
+  }
+}
+
+IndexOfParameterConversionGrows(TypedArrayIndexOfHelper);
+IndexOfParameterConversionGrows(ArrayIndexOfHelper);

--- a/test/staging/ArrayBuffer/resizable/index-of-parameter-conversion-shrinks.js
+++ b/test/staging/ArrayBuffer/resizable/index-of-parameter-conversion-shrinks.js
@@ -1,0 +1,130 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from IndexOfParameterConversionShrinks test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.indexOf(BigInt(n));
+    }
+    return ta.indexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.indexOf(n);
+  }
+  return ta.indexOf(n, fromIndex);
+}
+
+function ArrayIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.indexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.indexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.indexOf.call(ta, n);
+  }
+  return Array.prototype.indexOf.call(ta, n, fromIndex);
+}
+
+function IndexOfParameterConversionShrinks(indexOfHelper, lastIndexOfHelper) {
+  // Shrinking + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(indexOfHelper(fixedLength, 0), 0);
+    // The TA is OOB so indexOf returns -1.
+    assert.sameValue(indexOfHelper(fixedLength, 0, evil), -1);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(indexOfHelper(fixedLength, 0), 0);
+    // The TA is OOB so indexOf returns -1, also for undefined).
+    assert.sameValue(indexOfHelper(fixedLength, undefined, evil), -1);
+  }
+
+  // Shrinking + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.sameValue(indexOfHelper(lengthTracking, 2), 2);
+    // 2 no longer found.
+    assert.sameValue(indexOfHelper(lengthTracking, 2, evil), -1);
+  }
+}
+
+IndexOfParameterConversionShrinks(TypedArrayIndexOfHelper);
+IndexOfParameterConversionShrinks(ArrayIndexOfHelper);

--- a/test/staging/ArrayBuffer/resizable/iterate-typed-array-and-grow-just-before-iteration-would-end.js
+++ b/test/staging/ArrayBuffer/resizable/iterate-typed-array-and-grow-just-before-iteration-would-end.js
@@ -1,0 +1,122 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from IterateTypedArrayAndGrowJustBeforeIterationWouldEnd test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function CreateRab(buffer_byte_length, ctor) {
+  const rab = CreateResizableArrayBuffer(buffer_byte_length, 2 * buffer_byte_length);
+  let ta_write = new ctor(rab);
+  for (let i = 0; i < buffer_byte_length / ctor.BYTES_PER_ELEMENT; ++i) {
+    WriteToTypedArray(ta_write, i, i % 128);
+  }
+  return rab;
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values, expected);
+  assert(resized);
+}
+
+const no_elements = 10;
+const offset = 2;
+
+// We need to recreate the RAB between all TA tests, since we grow it.
+for (let ctor of ctors) {
+  const buffer_byte_length = no_elements * ctor.BYTES_PER_ELEMENT;
+  const byte_offset = offset * ctor.BYTES_PER_ELEMENT;
+
+  // Create various different styles of TypedArrays with the RAB as the
+  // backing store and iterate them.
+
+  let rab = CreateRab(buffer_byte_length, ctor);
+  const length_tracking_ta = new ctor(rab);
+  {
+    let expected = [];
+    for (let i = 0; i < no_elements; ++i) {
+      expected.push(i % 128);
+    }
+    // After resizing, the new memory contains zeros.
+    for (let i = 0; i < no_elements; ++i) {
+      expected.push(0);
+    }
+    TestIterationAndResize(length_tracking_ta, expected, rab, no_elements, buffer_byte_length * 2);
+  }
+  rab = CreateRab(buffer_byte_length, ctor);
+  const length_tracking_ta_with_offset = new ctor(rab, byte_offset);
+  {
+    let expected = [];
+    for (let i = offset; i < no_elements; ++i) {
+      expected.push(i % 128);
+    }
+    for (let i = 0; i < no_elements; ++i) {
+      expected.push(0);
+    }
+    TestIterationAndResize(length_tracking_ta_with_offset, expected, rab, no_elements - offset, buffer_byte_length * 2);
+  }
+}

--- a/test/staging/ArrayBuffer/resizable/iterate-typed-array-and-grow-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/iterate-typed-array-and-grow-mid-iteration.js
@@ -1,0 +1,135 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from IterateTypedArrayAndGrowMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function CreateRab(buffer_byte_length, ctor) {
+  const rab = CreateResizableArrayBuffer(buffer_byte_length, 2 * buffer_byte_length);
+  let ta_write = new ctor(rab);
+  for (let i = 0; i < buffer_byte_length / ctor.BYTES_PER_ELEMENT; ++i) {
+    WriteToTypedArray(ta_write, i, i % 128);
+  }
+  return rab;
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values, expected);
+  assert(resized);
+}
+
+const no_elements = 10;
+const offset = 2;
+for (let ctor of ctors) {
+  const buffer_byte_length = no_elements * ctor.BYTES_PER_ELEMENT;
+  const byte_offset = offset * ctor.BYTES_PER_ELEMENT;
+
+  // Create various different styles of TypedArrays with the RAB as the
+  // backing store and iterate them.
+
+  // Fixed-length TAs aren't affected by resizing.
+  let rab = CreateRab(buffer_byte_length, ctor);
+  const ta = new ctor(rab, 0, 3);
+  TestIterationAndResize(ta, [
+    0,
+    1,
+    2
+  ], rab, 2, buffer_byte_length * 2);
+  rab = CreateRab(buffer_byte_length, ctor);
+  const ta_with_offset = new ctor(rab, byte_offset, 3);
+  TestIterationAndResize(ta_with_offset, [
+    2,
+    3,
+    4
+  ], rab, 2, buffer_byte_length * 2);
+  rab = CreateRab(buffer_byte_length, ctor);
+  const length_tracking_ta = new ctor(rab);
+  {
+    let expected = [];
+    for (let i = 0; i < no_elements; ++i) {
+      expected.push(i % 128);
+    }
+    for (let i = 0; i < no_elements; ++i) {
+      // After resizing, the new memory contains zeros.
+      expected.push(0);
+    }
+    TestIterationAndResize(length_tracking_ta, expected, rab, 2, buffer_byte_length * 2);
+  }
+  rab = CreateRab(buffer_byte_length, ctor);
+  const length_tracking_ta_with_offset = new ctor(rab, byte_offset);
+  {
+    let expected = [];
+    for (let i = offset; i < no_elements; ++i) {
+      expected.push(i % 128);
+    }
+    for (let i = 0; i < no_elements; ++i) {
+      expected.push(0);
+    }
+    TestIterationAndResize(length_tracking_ta_with_offset, expected, rab, 2, buffer_byte_length * 2);
+  }
+}

--- a/test/staging/ArrayBuffer/resizable/iterate-typed-array-and-shrink-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/iterate-typed-array-and-shrink-mid-iteration.js
@@ -1,0 +1,150 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from IterateTypedArrayAndShrinkMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function CreateRab(buffer_byte_length, ctor) {
+  const rab = CreateResizableArrayBuffer(buffer_byte_length, 2 * buffer_byte_length);
+  let ta_write = new ctor(rab);
+  for (let i = 0; i < buffer_byte_length / ctor.BYTES_PER_ELEMENT; ++i) {
+    WriteToTypedArray(ta_write, i, i % 128);
+  }
+  return rab;
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values, expected);
+  assert(resized);
+}
+
+const no_elements = 10;
+const offset = 2;
+for (let ctor of ctors) {
+  const buffer_byte_length = no_elements * ctor.BYTES_PER_ELEMENT;
+  const byte_offset = offset * ctor.BYTES_PER_ELEMENT;
+
+  // Create various different styles of TypedArrays with the RAB as the
+  // backing store and iterate them.
+
+  // Fixed-length TAs aren't affected by shrinking if they stay in-bounds.
+  // They appear detached after shrinking out of bounds.
+  let rab = CreateRab(buffer_byte_length, ctor);
+  const ta1 = new ctor(rab, 0, 3);
+  TestIterationAndResize(ta1, [
+    0,
+    1,
+    2
+  ], rab, 2, buffer_byte_length / 2);
+  rab = CreateRab(buffer_byte_length, ctor);
+  const ta2 = new ctor(rab, 0, 3);
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(ta2, null, rab, 2, 1);
+  });
+  rab = CreateRab(buffer_byte_length, ctor);
+  const ta_with_offset1 = new ctor(rab, byte_offset, 3);
+  TestIterationAndResize(ta_with_offset1, [
+    2,
+    3,
+    4
+  ], rab, 2, buffer_byte_length / 2);
+  rab = CreateRab(buffer_byte_length, ctor);
+  const ta_with_offset2 = new ctor(rab, byte_offset, 3);
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(ta_with_offset2, null, rab, 2, 0);
+  });
+
+  // Length-tracking TA with offset 0 doesn't throw, but its length gracefully
+  // reduces too.
+  rab = CreateRab(buffer_byte_length, ctor);
+  const length_tracking_ta = new ctor(rab);
+  TestIterationAndResize(length_tracking_ta, [
+    0,
+    1,
+    2,
+    3,
+    4
+  ], rab, 2, buffer_byte_length / 2);
+
+  // Length-tracking TA appears detached when the buffer is resized beyond the
+  // offset.
+  rab = CreateRab(buffer_byte_length, ctor);
+  const length_tracking_ta_with_offset = new ctor(rab, byte_offset);
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(length_tracking_ta_with_offset, null, rab, 2, byte_offset / 2);
+  });
+
+  // Length-tracking TA reduces its length gracefully when the buffer is
+  // resized to barely cover the offset.
+  rab = CreateRab(buffer_byte_length, ctor);
+  const length_tracking_ta_with_offset2 = new ctor(rab, byte_offset);
+  TestIterationAndResize(length_tracking_ta_with_offset2, [
+    2,
+    3
+  ], rab, 2, byte_offset);
+}

--- a/test/staging/ArrayBuffer/resizable/iterate-typed-array-and-shrink-to-zero-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/iterate-typed-array-and-shrink-to-zero-mid-iteration.js
@@ -1,0 +1,122 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from IterateTypedArrayAndShrinkToZeroMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function CreateRab(buffer_byte_length, ctor) {
+  const rab = CreateResizableArrayBuffer(buffer_byte_length, 2 * buffer_byte_length);
+  let ta_write = new ctor(rab);
+  for (let i = 0; i < buffer_byte_length / ctor.BYTES_PER_ELEMENT; ++i) {
+    WriteToTypedArray(ta_write, i, i % 128);
+  }
+  return rab;
+}
+
+function TestIterationAndResize(ta, expected, rab, resize_after, new_byte_length) {
+  let values = [];
+  let resized = false;
+  for (const value of ta) {
+    if (value instanceof Array) {
+      values.push([
+        value[0],
+        Number(value[1])
+      ]);
+    } else {
+      values.push(Number(value));
+    }
+    if (!resized && values.length == resize_after) {
+      rab.resize(new_byte_length);
+      resized = true;
+    }
+  }
+  assert.compareArray(values, expected);
+  assert(resized);
+}
+
+const no_elements = 10;
+const offset = 2;
+for (let ctor of ctors) {
+  const buffer_byte_length = no_elements * ctor.BYTES_PER_ELEMENT;
+  const byte_offset = offset * ctor.BYTES_PER_ELEMENT;
+
+  // Create various different styles of TypedArrays with the RAB as the
+  // backing store and iterate them.
+
+  // Fixed-length TAs appear detached after shrinking out of bounds.
+  let rab = CreateRab(buffer_byte_length, ctor);
+  const ta = new ctor(rab, 0, 3);
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(ta, null, rab, 2, 0);
+  });
+  rab = CreateRab(buffer_byte_length, ctor);
+  const ta_with_offset = new ctor(rab, byte_offset, 3);
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(ta_with_offset, null, rab, 2, 0);
+  });
+
+  // Length-tracking TA with offset 0 doesn't throw, but its length gracefully
+  // goes to zero too.
+  rab = CreateRab(buffer_byte_length, ctor);
+  const length_tracking_ta = new ctor(rab);
+  TestIterationAndResize(length_tracking_ta, [
+    0,
+    1
+  ], rab, 2, 0);
+
+  // Length-tracking TA which is resized beyond the offset appars detached.
+  rab = CreateRab(buffer_byte_length, ctor);
+  const length_tracking_ta_with_offset = new ctor(rab, byte_offset);
+  assert.throws(TypeError, () => {
+    TestIterationAndResize(length_tracking_ta_with_offset, null, rab, 2, 0);
+  });
+}

--- a/test/staging/ArrayBuffer/resizable/iterate-typed-array.js
+++ b/test/staging/ArrayBuffer/resizable/iterate-typed-array.js
@@ -1,0 +1,114 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from IterateTypedArray test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+includes: [compareArray.js]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const no_elements = 10;
+const offset = 2;
+function TestIteration(ta, expected) {
+  let values = [];
+  for (const value of ta) {
+    values.push(Number(value));
+  }
+  assert.compareArray(values, expected);
+}
+for (let ctor of ctors) {
+  const buffer_byte_length = no_elements * ctor.BYTES_PER_ELEMENT;
+  // We can use the same RAB for all the TAs below, since we won't modify it
+  // after writing the initial values.
+  const rab = CreateResizableArrayBuffer(buffer_byte_length, 2 * buffer_byte_length);
+  const byte_offset = offset * ctor.BYTES_PER_ELEMENT;
+
+  // Write some data into the array.
+  let ta_write = new ctor(rab);
+  for (let i = 0; i < no_elements; ++i) {
+    WriteToTypedArray(ta_write, i, i % 128);
+  }
+
+  // Create various different styles of TypedArrays with the RAB as the
+  // backing store and iterate them.
+  const ta = new ctor(rab, 0, 3);
+  TestIteration(ta, [
+    0,
+    1,
+    2
+  ]);
+  const empty_ta = new ctor(rab, 0, 0);
+  TestIteration(empty_ta, []);
+  const ta_with_offset = new ctor(rab, byte_offset, 3);
+  TestIteration(ta_with_offset, [
+    2,
+    3,
+    4
+  ]);
+  const empty_ta_with_offset = new ctor(rab, byte_offset, 0);
+  TestIteration(empty_ta_with_offset, []);
+  const length_tracking_ta = new ctor(rab);
+  {
+    let expected = [];
+    for (let i = 0; i < no_elements; ++i) {
+      expected.push(i % 128);
+    }
+    TestIteration(length_tracking_ta, expected);
+  }
+  const length_tracking_ta_with_offset = new ctor(rab, byte_offset);
+  {
+    let expected = [];
+    for (let i = offset; i < no_elements; ++i) {
+      expected.push(i % 128);
+    }
+    TestIteration(length_tracking_ta_with_offset, expected);
+  }
+  const empty_length_tracking_ta_with_offset = new ctor(rab, buffer_byte_length);
+  TestIteration(empty_length_tracking_ta_with_offset, []);
+}

--- a/test/staging/ArrayBuffer/resizable/join-parameter-conversion-grows.js
+++ b/test/staging/ArrayBuffer/resizable/join-parameter-conversion-grows.js
@@ -1,0 +1,85 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from JoinParameterConversionGrows test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const TypedArrayJoinHelper = (ta, ...rest) => {
+  return ta.join(...rest);
+};
+
+const ArrayJoinHelper = (ta, ...rest) => {
+  return Array.prototype.join.call(ta, ...rest);
+};
+
+function JoinParameterConversionGrows(joinHelper) {
+  // Growing + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      toString: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    assert.sameValue(joinHelper(fixedLength, evil), '0.0.0.0');
+  }
+
+  // Growing + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      toString: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    // We iterate 4 elements, since it was the starting length.
+    assert.sameValue(joinHelper(lengthTracking, evil), '0.0.0.0');
+  }
+}
+
+JoinParameterConversionGrows(TypedArrayJoinHelper);
+JoinParameterConversionGrows(ArrayJoinHelper);

--- a/test/staging/ArrayBuffer/resizable/join-parameter-conversion-shrinks.js
+++ b/test/staging/ArrayBuffer/resizable/join-parameter-conversion-shrinks.js
@@ -1,0 +1,89 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from JoinParameterConversionShrinks test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const TypedArrayJoinHelper = (ta, ...rest) => {
+  return ta.join(...rest);
+};
+
+const ArrayJoinHelper = (ta, ...rest) => {
+  return Array.prototype.join.call(ta, ...rest);
+};
+
+function JoinParameterConversionShrinks(joinHelper) {
+  // Shrinking + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      toString: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    // We iterate 4 elements, since it was the starting length, but the TA is
+    // OOB right after parameter conversion, so all elements are converted to
+    // the empty string.
+    assert.sameValue(joinHelper(fixedLength, evil), '...');
+  }
+
+  // Shrinking + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      toString: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return '.';
+      }
+    };
+    // We iterate 4 elements, since it was the starting length. Elements beyond
+    // the new length are converted to the empty string.
+    assert.sameValue(joinHelper(lengthTracking, evil), '0.0..');
+  }
+}
+
+JoinParameterConversionShrinks(TypedArrayJoinHelper);
+JoinParameterConversionShrinks(ArrayJoinHelper);

--- a/test/staging/ArrayBuffer/resizable/join-to-locale-string.js
+++ b/test/staging/ArrayBuffer/resizable/join-to-locale-string.js
@@ -1,0 +1,219 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from JoinToLocaleString test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArrayJoinHelper = (ta, ...rest) => {
+  return ta.join(...rest);
+};
+
+const ArrayJoinHelper = (ta, ...rest) => {
+  return Array.prototype.join.call(ta, ...rest);
+};
+
+const TypedArrayToLocaleStringHelper = (ta, ...rest) => {
+  return ta.toLocaleString(...rest);
+};
+
+const ArrayToLocaleStringHelper = (ta, ...rest) => {
+  return Array.prototype.toLocaleString.call(ta, ...rest);
+};
+
+function JoinToLocaleString(joinHelper, toLocaleStringHelper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    const taWrite = new ctor(rab);
+
+    // Write some data into the array.
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(joinHelper(fixedLength), '0,2,4,6');
+    assert.sameValue(toLocaleStringHelper(fixedLength), '0,2,4,6');
+    assert.sameValue(joinHelper(fixedLengthWithOffset), '4,6');
+    assert.sameValue(toLocaleStringHelper(fixedLengthWithOffset), '4,6');
+    assert.sameValue(joinHelper(lengthTracking), '0,2,4,6');
+    assert.sameValue(toLocaleStringHelper(lengthTracking), '0,2,4,6');
+    assert.sameValue(joinHelper(lengthTrackingWithOffset), '4,6');
+    assert.sameValue(toLocaleStringHelper(lengthTrackingWithOffset), '4,6');
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        joinHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        toLocaleStringHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        joinHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        toLocaleStringHelper(fixedLengthWithOffset);
+      });
+    } else {
+      assert.sameValue(joinHelper(fixedLength), '');
+      assert.sameValue(toLocaleStringHelper(fixedLength), '');
+      assert.sameValue(joinHelper(fixedLengthWithOffset), '');
+      assert.sameValue(toLocaleStringHelper(fixedLengthWithOffset), '');
+    }
+    assert.sameValue(joinHelper(lengthTracking), '0,2,4');
+    assert.sameValue(toLocaleStringHelper(lengthTracking), '0,2,4');
+    assert.sameValue(joinHelper(lengthTrackingWithOffset), '4');
+    assert.sameValue(toLocaleStringHelper(lengthTrackingWithOffset), '4');
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        joinHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        toLocaleStringHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        joinHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        toLocaleStringHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        joinHelper(lengthTrackingWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        toLocaleStringHelper(lengthTrackingWithOffset);
+      });
+    } else {
+      assert.sameValue(joinHelper(fixedLength), '');
+      assert.sameValue(toLocaleStringHelper(fixedLength), '');
+      assert.sameValue(joinHelper(fixedLengthWithOffset), '');
+      assert.sameValue(toLocaleStringHelper(fixedLengthWithOffset), '');
+      assert.sameValue(joinHelper(lengthTrackingWithOffset), '');
+      assert.sameValue(toLocaleStringHelper(lengthTrackingWithOffset), '');
+    }
+    assert.sameValue(joinHelper(lengthTracking), '0');
+    assert.sameValue(toLocaleStringHelper(lengthTracking), '0');
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        joinHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        toLocaleStringHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        joinHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        toLocaleStringHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        joinHelper(lengthTrackingWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        toLocaleStringHelper(lengthTrackingWithOffset);
+      });
+    } else {
+      assert.sameValue(joinHelper(fixedLength), '');
+      assert.sameValue(toLocaleStringHelper(fixedLength), '');
+      assert.sameValue(joinHelper(fixedLengthWithOffset), '');
+      assert.sameValue(toLocaleStringHelper(fixedLengthWithOffset), '');
+      assert.sameValue(joinHelper(lengthTrackingWithOffset), '');
+      assert.sameValue(toLocaleStringHelper(lengthTrackingWithOffset), '');
+    }
+    assert.sameValue(joinHelper(lengthTracking), '');
+    assert.sameValue(toLocaleStringHelper(lengthTracking), '');
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.sameValue(joinHelper(fixedLength), '0,2,4,6');
+    assert.sameValue(toLocaleStringHelper(fixedLength), '0,2,4,6');
+    assert.sameValue(joinHelper(fixedLengthWithOffset), '4,6');
+    assert.sameValue(toLocaleStringHelper(fixedLengthWithOffset), '4,6');
+    assert.sameValue(joinHelper(lengthTracking), '0,2,4,6,8,10');
+    assert.sameValue(toLocaleStringHelper(lengthTracking), '0,2,4,6,8,10');
+    assert.sameValue(joinHelper(lengthTrackingWithOffset), '4,6,8,10');
+    assert.sameValue(toLocaleStringHelper(lengthTrackingWithOffset), '4,6,8,10');
+  }
+}
+
+JoinToLocaleString(TypedArrayJoinHelper, TypedArrayToLocaleStringHelper, true);
+JoinToLocaleString(ArrayJoinHelper, ArrayToLocaleStringHelper, false);

--- a/test/staging/ArrayBuffer/resizable/last-index-of-parameter-conversion-grows.js
+++ b/test/staging/ArrayBuffer/resizable/last-index-of-parameter-conversion-grows.js
@@ -1,0 +1,121 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from LastIndexOfParameterConversionGrows test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.lastIndexOf(BigInt(n));
+    }
+    return ta.lastIndexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.lastIndexOf(n);
+  }
+  return ta.lastIndexOf(n, fromIndex);
+}
+
+function ArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.lastIndexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.lastIndexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.lastIndexOf.call(ta, n);
+  }
+  return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
+}
+
+function LastIndexOfParameterConversionGrows(lastIndexOfHelper) {
+  // Growing + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, 1);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -1;
+      }
+    };
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 0), -1);
+    // Because lastIndexOf iterates from the given index downwards, it's not
+    // possible to test that "we only look at the data until the original
+    // length" without also testing that the index conversion happening with the
+    // original length.
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 0, evil), -1);
+  }
+
+  // Growing + length-tracking TA, index conversion.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return -4;
+      }
+    };
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 0, -4), 0);
+    // The TA grew but the start index conversion is done based on the original
+    // length.
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 0, evil), 0);
+  }
+}
+
+LastIndexOfParameterConversionGrows(TypedArrayLastIndexOfHelper);
+LastIndexOfParameterConversionGrows(ArrayLastIndexOfHelper);

--- a/test/staging/ArrayBuffer/resizable/last-index-of-parameter-conversion-shrinks.js
+++ b/test/staging/ArrayBuffer/resizable/last-index-of-parameter-conversion-shrinks.js
@@ -1,0 +1,130 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from LastIndexOfParameterConversionShrinks test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function TypedArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return ta.lastIndexOf(BigInt(n));
+    }
+    return ta.lastIndexOf(BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return ta.lastIndexOf(n);
+  }
+  return ta.lastIndexOf(n, fromIndex);
+}
+
+function ArrayLastIndexOfHelper(ta, n, fromIndex) {
+  if (typeof n == 'number' && (ta instanceof BigInt64Array || ta instanceof BigUint64Array)) {
+    if (fromIndex == undefined) {
+      return Array.prototype.lastIndexOf.call(ta, BigInt(n));
+    }
+    return Array.prototype.lastIndexOf.call(ta, BigInt(n), fromIndex);
+  }
+  if (fromIndex == undefined) {
+    return Array.prototype.lastIndexOf.call(ta, n);
+  }
+  return Array.prototype.lastIndexOf.call(ta, n, fromIndex);
+}
+
+function LastIndexOfParameterConversionShrinks(lastIndexOfHelper) {
+  // Shrinking + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 2;
+      }
+    };
+    assert.sameValue(lastIndexOfHelper(fixedLength, 0), 3);
+    // The TA is OOB so lastIndexOf returns -1.
+    assert.sameValue(lastIndexOfHelper(fixedLength, 0, evil), -1);
+  }
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 2;
+      }
+    };
+    assert.sameValue(lastIndexOfHelper(fixedLength, 0), 3);
+    // The TA is OOB so lastIndexOf returns -1, also for undefined).
+    assert.sameValue(lastIndexOfHelper(fixedLength, undefined, evil), -1);
+  }
+
+  // Shrinking + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i);
+    }
+    let evil = {
+      valueOf: () => {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+        return 2;
+      }
+    };
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 2), 2);
+    // 2 no longer found.
+    assert.sameValue(lastIndexOfHelper(lengthTracking, 2, evil), -1);
+  }
+}
+
+LastIndexOfParameterConversionShrinks(TypedArrayLastIndexOfHelper);
+LastIndexOfParameterConversionShrinks(ArrayLastIndexOfHelper);

--- a/test/staging/ArrayBuffer/resizable/length-tracking-1.js
+++ b/test/staging/ArrayBuffer/resizable/length-tracking-1.js
@@ -1,0 +1,92 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from LengthTracking1 test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const rab = CreateResizableArrayBuffer(16, 40);
+let tas = [];
+for (let ctor of ctors) {
+  tas.push(new ctor(rab));
+}
+for (let ta of tas) {
+  assert.sameValue(ta.length, 16 / ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteLength, 16);
+}
+rab.resize(40);
+for (let ta of tas) {
+  assert.sameValue(ta.length, 40 / ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteLength, 40);
+}
+// Resize to a number which is not a multiple of all byte_lengths.
+rab.resize(19);
+for (let ta of tas) {
+  const expected_length = Math.floor(19 / ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.length, expected_length);
+  assert.sameValue(ta.byteLength, expected_length * ta.BYTES_PER_ELEMENT);
+}
+rab.resize(1);
+for (let ta of tas) {
+  if (ta.BYTES_PER_ELEMENT == 1) {
+    assert.sameValue(ta.length, 1);
+    assert.sameValue(ta.byteLength, 1);
+  } else {
+    assert.sameValue(ta.length, 0);
+    assert.sameValue(ta.byteLength, 0);
+  }
+}
+rab.resize(0);
+for (let ta of tas) {
+  assert.sameValue(ta.length, 0);
+  assert.sameValue(ta.byteLength, 0);
+}
+rab.resize(8);
+for (let ta of tas) {
+  assert.sameValue(ta.length, 8 / ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteLength, 8);
+}
+rab.resize(40);
+for (let ta of tas) {
+  assert.sameValue(ta.length, 40 / ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteLength, 40);
+}

--- a/test/staging/ArrayBuffer/resizable/length-tracking-2.js
+++ b/test/staging/ArrayBuffer/resizable/length-tracking-2.js
@@ -1,0 +1,112 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from LengthTracking2 test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+// length-tracking-1 but with offsets.
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const rab = CreateResizableArrayBuffer(16, 40);
+const offset = 8;
+let tas = [];
+for (let ctor of ctors) {
+  tas.push(new ctor(rab, offset));
+}
+for (let ta of tas) {
+  assert.sameValue(ta.length, (16 - offset) / ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteLength, 16 - offset);
+  assert.sameValue(ta.byteOffset, offset);
+}
+rab.resize(40);
+for (let ta of tas) {
+  assert.sameValue(ta.length, (40 - offset) / ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteLength, 40 - offset);
+  assert.sameValue(ta.byteOffset, offset);
+}
+// Resize to a number which is not a multiple of all byte_lengths.
+rab.resize(20);
+for (let ta of tas) {
+  const expected_length = Math.floor((20 - offset) / ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.length, expected_length);
+  assert.sameValue(ta.byteLength, expected_length * ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteOffset, offset);
+}
+// Resize so that all TypedArrays go out of bounds (because of the offset).
+rab.resize(7);
+for (let ta of tas) {
+  assert.sameValue(ta.length, 0);
+  assert.sameValue(ta.byteLength, 0);
+  assert.sameValue(ta.byteOffset, 0);
+}
+rab.resize(0);
+for (let ta of tas) {
+  assert.sameValue(ta.length, 0);
+  assert.sameValue(ta.byteLength, 0);
+  assert.sameValue(ta.byteOffset, 0);
+}
+rab.resize(8);
+for (let ta of tas) {
+  assert.sameValue(ta.length, 0);
+  assert.sameValue(ta.byteLength, 0);
+  assert.sameValue(ta.byteOffset, offset);
+}
+// Resize so that the TypedArrays which have element size > 1 go out of bounds
+// (because less than 1 full element would fit).
+rab.resize(offset + 1);
+for (let ta of tas) {
+  if (ta.BYTES_PER_ELEMENT == 1) {
+    assert.sameValue(ta.length, 1);
+    assert.sameValue(ta.byteLength, 1);
+    assert.sameValue(ta.byteOffset, offset);
+  } else {
+    assert.sameValue(ta.length, 0);
+    assert.sameValue(ta.byteLength, 0);
+    assert.sameValue(ta.byteOffset, offset);
+  }
+}
+rab.resize(40);
+for (let ta of tas) {
+  assert.sameValue(ta.length, (40 - offset) / ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteLength, 40 - offset);
+  assert.sameValue(ta.byteOffset, offset);
+}

--- a/test/staging/ArrayBuffer/resizable/map-grow-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/map-grow-mid-iteration.js
@@ -1,0 +1,146 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from MapGrowMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArrayMapHelper = (ta, ...rest) => {
+  return ta.map(...rest);
+};
+
+const ArrayMapHelper = (ta, ...rest) => {
+  return Array.prototype.map.call(ta, ...rest);
+};
+
+function MapGrowMidIteration(mapHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return n;
+  }
+  function Helper(array) {
+    values = [];
+    mapHelper(array, CollectValuesAndResize);
+    return values;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+  }
+}
+
+MapGrowMidIteration(TypedArrayMapHelper);
+MapGrowMidIteration(ArrayMapHelper);

--- a/test/staging/ArrayBuffer/resizable/map-shrink-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/map-shrink-mid-iteration.js
@@ -1,0 +1,178 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from MapShrinkMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function IsBigIntTypedArray(ta) {
+  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArrayMapHelper = (ta, ...rest) => {
+  return ta.map(...rest);
+};
+
+const ArrayMapHelper = (ta, ...rest) => {
+  return Array.prototype.map.call(ta, ...rest);
+};
+
+function MapShrinkMidIteration(mapHelper, hasUndefined) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n, ix, ta) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    // We still need to return a valid BigInt / non-BigInt, even if
+    // n is `undefined`.
+    if (IsBigIntTypedArray(ta)) {
+      return 0n;
+    }
+    return 0;
+  }
+  function Helper(array) {
+    values = [];
+    mapHelper(array, CollectValuesAndResize);
+    return values;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    if (hasUndefined) {
+      assert.compareArray(Helper(fixedLength), [
+        0,
+        2,
+        undefined,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(Helper(fixedLength), [
+        0,
+        2
+      ]);
+    }
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    if (hasUndefined) {
+      assert.compareArray(Helper(fixedLengthWithOffset), [
+        4,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(Helper(fixedLengthWithOffset), [4]);
+    }
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    if (hasUndefined) {
+      assert.compareArray(Helper(lengthTracking), [
+        0,
+        2,
+        4,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(Helper(lengthTracking), [
+        0,
+        2,
+        4
+      ]);
+    }
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    if (hasUndefined) {
+      assert.compareArray(Helper(lengthTrackingWithOffset), [
+        4,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
+    }
+  }
+}
+
+MapShrinkMidIteration(TypedArrayMapHelper, true);
+MapShrinkMidIteration(ArrayMapHelper, false);

--- a/test/staging/ArrayBuffer/resizable/map-species-create-grows.js
+++ b/test/staging/ArrayBuffer/resizable/map-species-create-grows.js
@@ -1,0 +1,131 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from MapSpeciesCreateGrows test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function IsBigIntTypedArray(ta) {
+  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+let values;
+let rab;
+function CollectValues(n, ix, ta) {
+  if (typeof n == 'bigint') {
+    values.push(Number(n));
+  } else {
+    values.push(n);
+  }
+  // We still need to return a valid BigInt / non-BigInt, even if
+  // n is `undefined`.
+  if (IsBigIntTypedArray(ta)) {
+    return 0n;
+  }
+  return 0;
+}
+function Helper(array) {
+  values = [];
+  array.map(CollectValues);
+  return values;
+}
+for (let ctor of ctors) {
+  rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends ctor {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      }
+    }
+  }
+  ;
+  const fixedLength = new MyArray(rab, 0, 4);
+  resizeWhenConstructorCalled = true;
+  assert.compareArray(Helper(fixedLength), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.sameValue(rab.byteLength, 6 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends ctor {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      }
+    }
+  }
+  ;
+  const lengthTracking = new MyArray(rab);
+  resizeWhenConstructorCalled = true;
+  assert.compareArray(Helper(lengthTracking), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.sameValue(rab.byteLength, 6 * ctor.BYTES_PER_ELEMENT);
+}

--- a/test/staging/ArrayBuffer/resizable/map-species-create-shrinks.js
+++ b/test/staging/ArrayBuffer/resizable/map-species-create-shrinks.js
@@ -1,0 +1,127 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from MapSpeciesCreateShrinks test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function IsBigIntTypedArray(ta) {
+  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+let values;
+let rab;
+function CollectValues(n, ix, ta) {
+  if (typeof n == 'bigint') {
+    values.push(Number(n));
+  } else {
+    values.push(n);
+  }
+  if (IsBigIntTypedArray(ta)) {
+    // We still need to return a valid BigInt / non-BigInt, even if
+    // n is `undefined`.
+    return 0n;
+  }
+  return 0;
+}
+function Helper(array) {
+  values = [];
+  array.map(CollectValues);
+  return values;
+}
+for (let ctor of ctors) {
+  rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends ctor {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      }
+    }
+  }
+  ;
+  const fixedLength = new MyArray(rab, 0, 4);
+  resizeWhenConstructorCalled = true;
+  assert.compareArray(Helper(fixedLength), [
+    undefined,
+    undefined,
+    undefined,
+    undefined
+  ]);
+  assert.sameValue(rab.byteLength, 2 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends ctor {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      }
+    }
+  }
+  ;
+  const lengthTracking = new MyArray(rab);
+  resizeWhenConstructorCalled = true;
+  assert.compareArray(Helper(lengthTracking), [
+    0,
+    1,
+    undefined,
+    undefined
+  ]);
+  assert.sameValue(rab.byteLength, 2 * ctor.BYTES_PER_ELEMENT);
+}

--- a/test/staging/ArrayBuffer/resizable/object-define-property-define-properties.js
+++ b/test/staging/ArrayBuffer/resizable/object-define-property-define-properties.js
@@ -1,0 +1,275 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ObjectDefinePropertyDefineProperties test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+function ObjectDefinePropertyHelper(ta, index, value) {
+  if (ta instanceof BigInt64Array || ta instanceof BigUint64Array) {
+    Object.defineProperty(ta, index, { value: BigInt(value) });
+  } else {
+    Object.defineProperty(ta, index, { value: value });
+  }
+}
+
+function ObjectDefinePropertiesHelper(ta, index, value) {
+  const values = {};
+  if (ta instanceof BigInt64Array || ta instanceof BigUint64Array) {
+    values[index] = { value: BigInt(value) };
+  } else {
+    values[index] = { value: value };
+  }
+  Object.defineProperties(ta, values);
+}
+
+for (let helper of [
+    ObjectDefinePropertyHelper,
+    ObjectDefinePropertiesHelper
+  ]) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    const taFull = new ctor(rab, 0);
+
+    // Orig. array: [0, 0, 0, 0]
+    //              [0, 0, 0, 0] << fixedLength
+    //                    [0, 0] << fixedLengthWithOffset
+    //              [0, 0, 0, 0, ...] << lengthTracking
+    //                    [0, 0, ...] << lengthTrackingWithOffset
+
+    helper(fixedLength, 0, 1);
+    assert.compareArray(ToNumbers(taFull), [
+      1,
+      0,
+      0,
+      0
+    ]);
+    helper(fixedLengthWithOffset, 0, 2);
+    assert.compareArray(ToNumbers(taFull), [
+      1,
+      0,
+      2,
+      0
+    ]);
+    helper(lengthTracking, 1, 3);
+    assert.compareArray(ToNumbers(taFull), [
+      1,
+      3,
+      2,
+      0
+    ]);
+    helper(lengthTrackingWithOffset, 1, 4);
+    assert.compareArray(ToNumbers(taFull), [
+      1,
+      3,
+      2,
+      4
+    ]);
+    assert.throws(TypeError, () => {
+      helper(fixedLength, 4, 8);
+    });
+    assert.throws(TypeError, () => {
+      helper(fixedLengthWithOffset, 2, 8);
+    });
+    assert.throws(TypeError, () => {
+      helper(lengthTracking, 4, 8);
+    });
+    assert.throws(TypeError, () => {
+      helper(lengthTrackingWithOffset, 2, 8);
+    });
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [1, 3, 2]
+    //              [1, 3, 2, ...] << lengthTracking
+    //                    [2, ...] << lengthTrackingWithOffset
+
+    assert.throws(TypeError, () => {
+      helper(fixedLength, 0, 8);
+    });
+    assert.throws(TypeError, () => {
+      helper(fixedLengthWithOffset, 0, 8);
+    });
+    assert.compareArray(ToNumbers(taFull), [
+      1,
+      3,
+      2
+    ]);
+    helper(lengthTracking, 0, 5);
+    assert.compareArray(ToNumbers(taFull), [
+      5,
+      3,
+      2
+    ]);
+    helper(lengthTrackingWithOffset, 0, 6);
+    assert.compareArray(ToNumbers(taFull), [
+      5,
+      3,
+      6
+    ]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    assert.throws(TypeError, () => {
+      helper(fixedLength, 0, 8);
+    });
+    assert.throws(TypeError, () => {
+      helper(fixedLengthWithOffset, 0, 8);
+    });
+    assert.throws(TypeError, () => {
+      helper(lengthTrackingWithOffset, 0, 8);
+    });
+    assert.compareArray(ToNumbers(taFull), [5]);
+    helper(lengthTracking, 0, 7);
+    assert.compareArray(ToNumbers(taFull), [7]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    assert.throws(TypeError, () => {
+      helper(fixedLength, 0, 8);
+    });
+    assert.throws(TypeError, () => {
+      helper(fixedLengthWithOffset, 0, 8);
+    });
+    assert.throws(TypeError, () => {
+      helper(lengthTracking, 0, 8);
+    });
+    assert.throws(TypeError, () => {
+      helper(lengthTrackingWithOffset, 0, 8);
+    });
+    assert.compareArray(ToNumbers(taFull), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    helper(fixedLength, 0, 9);
+    assert.compareArray(ToNumbers(taFull), [
+      9,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+    helper(fixedLengthWithOffset, 0, 10);
+    assert.compareArray(ToNumbers(taFull), [
+      9,
+      0,
+      10,
+      0,
+      0,
+      0
+    ]);
+    helper(lengthTracking, 1, 11);
+    assert.compareArray(ToNumbers(taFull), [
+      9,
+      11,
+      10,
+      0,
+      0,
+      0
+    ]);
+    helper(lengthTrackingWithOffset, 2, 12);
+    assert.compareArray(ToNumbers(taFull), [
+      9,
+      11,
+      10,
+      0,
+      12,
+      0
+    ]);
+
+    // Trying to define properties out of the fixed-length bounds throws.
+    assert.throws(TypeError, () => {
+      helper(fixedLength, 5, 13);
+    });
+    assert.throws(TypeError, () => {
+      helper(fixedLengthWithOffset, 3, 13);
+    });
+    assert.compareArray(ToNumbers(taFull), [
+      9,
+      11,
+      10,
+      0,
+      12,
+      0
+    ]);
+    helper(lengthTracking, 4, 14);
+    assert.compareArray(ToNumbers(taFull), [
+      9,
+      11,
+      10,
+      0,
+      14,
+      0
+    ]);
+    helper(lengthTrackingWithOffset, 3, 15);
+    assert.compareArray(ToNumbers(taFull), [
+      9,
+      11,
+      10,
+      0,
+      14,
+      15
+    ]);
+  }
+}

--- a/test/staging/ArrayBuffer/resizable/object-define-property-parameter-conversion-grows.js
+++ b/test/staging/ArrayBuffer/resizable/object-define-property-parameter-conversion-grows.js
@@ -1,0 +1,113 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ObjectDefinePropertyParameterConversionGrows test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+function ObjectDefinePropertyHelper(ta, index, value) {
+  if (ta instanceof BigInt64Array || ta instanceof BigUint64Array) {
+    Object.defineProperty(ta, index, { value: BigInt(value) });
+  } else {
+    Object.defineProperty(ta, index, { value: value });
+  }
+}
+
+const helper = ObjectDefinePropertyHelper;
+
+// Fixed length.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  // Make fixedLength go OOB.
+  rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+  const evil = {
+    toString: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  helper(fixedLength, evil, 8);
+  assert.compareArray(ToNumbers(fixedLength), [
+    8,
+    0,
+    0,
+    0
+  ]);
+}
+
+// Length tracking.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab, 0);
+  const evil = {
+    toString: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return 4;  // Index valid after resize.
+    }
+  };
+  helper(lengthTracking, evil, 8);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    0,
+    0,
+    0,
+    0,
+    8,
+    0
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/object-define-property-parameter-conversion-shrinks.js
+++ b/test/staging/ArrayBuffer/resizable/object-define-property-parameter-conversion-shrinks.js
@@ -1,0 +1,85 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ObjectDefinePropertyParameterConversionShrinks test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function ObjectDefinePropertyHelper(ta, index, value) {
+  if (ta instanceof BigInt64Array || ta instanceof BigUint64Array) {
+    Object.defineProperty(ta, index, { value: BigInt(value) });
+  } else {
+    Object.defineProperty(ta, index, { value: value });
+  }
+}
+
+const helper = ObjectDefinePropertyHelper;
+
+// Fixed length.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    toString: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.throws(TypeError, () => {
+    helper(fixedLength, evil, 8);
+  });
+}
+
+// Length tracking.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab, 0);
+  const evil = {
+    toString: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 3;  // Index too large after resize.
+    }
+  };
+  assert.throws(TypeError, () => {
+    helper(lengthTracking, evil, 8);
+  });
+}

--- a/test/staging/ArrayBuffer/resizable/object-freeze.js
+++ b/test/staging/ArrayBuffer/resizable/object-freeze.js
@@ -1,0 +1,87 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ObjectFreeze test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+// Freezing non-OOB non-zero-length TAs throws.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    Object.freeze(fixedLength);
+  });
+  assert.throws(TypeError, () => {
+    Object.freeze(fixedLengthWithOffset);
+  });
+  assert.throws(TypeError, () => {
+    Object.freeze(lengthTracking);
+  });
+  assert.throws(TypeError, () => {
+    Object.freeze(lengthTrackingWithOffset);
+  });
+}
+// Freezing zero-length TAs doesn't throw.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 0);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 4 * ctor.BYTES_PER_ELEMENT);
+  Object.freeze(fixedLength);
+  Object.freeze(fixedLengthWithOffset);
+  Object.freeze(lengthTrackingWithOffset);
+}
+// If the buffer has been resized to make length-tracking TAs zero-length,
+// freezing them also doesn't throw.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+  Object.freeze(lengthTrackingWithOffset);
+  rab.resize(0 * ctor.BYTES_PER_ELEMENT);
+  Object.freeze(lengthTracking);
+}

--- a/test/staging/ArrayBuffer/resizable/oobbehaves-like-detached.js
+++ b/test/staging/ArrayBuffer/resizable/oobbehaves-like-detached.js
@@ -1,0 +1,31 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from OOBBehavesLikeDetached test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function ReadElement2(ta) {
+  return ta[2];
+}
+function HasElement2(ta) {
+  return 2 in ta;
+}
+const rab = CreateResizableArrayBuffer(16, 40);
+const i8a = new Int8Array(rab, 0, 4);
+i8a.__proto__ = { 2: 'wrong value' };
+i8a[2] = 10;
+assert.sameValue(ReadElement2(i8a), 10);
+assert(HasElement2(i8a));
+rab.resize(0);
+assert.sameValue(ReadElement2(i8a), undefined);
+assert(!HasElement2(i8a));

--- a/test/staging/ArrayBuffer/resizable/out-of-bounds-typed-array-and-has.js
+++ b/test/staging/ArrayBuffer/resizable/out-of-bounds-typed-array-and-has.js
@@ -1,0 +1,73 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from OutOfBoundsTypedArrayAndHas test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+for (let ctor of ctors) {
+  if (ctor.BYTES_PER_ELEMENT != 1) {
+    continue;
+  }
+  const rab = CreateResizableArrayBuffer(16, 40);
+  const array = new ctor(rab, 0, 4);
+  // Within-bounds read
+  for (let i = 0; i < 4; ++i) {
+    assert(i in array);
+  }
+  rab.resize(2);
+  // OOB read. If the RAB isn't large enough to fit the entire TypedArray,
+  // the length of the TypedArray is treated as 0.
+  for (let i = 0; i < 4; ++i) {
+    assert(!(i in array));
+  }
+  rab.resize(4);
+  // Within-bounds read
+  for (let i = 0; i < 4; ++i) {
+    assert(i in array);
+  }
+  rab.resize(40);
+  // Within-bounds read
+  for (let i = 0; i < 4; ++i) {
+    assert(i in array);
+  }
+}

--- a/test/staging/ArrayBuffer/resizable/reverse.js
+++ b/test/staging/ArrayBuffer/resizable/reverse.js
@@ -1,0 +1,269 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from Reverse test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArrayReverseHelper = ta => {
+  ta.reverse();
+};
+
+const ArrayReverseHelper = ta => {
+  Array.prototype.reverse.call(ta);
+};
+
+function Reverse(reverseHelper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    const wholeArrayView = new ctor(rab);
+    function WriteData() {
+      // Write some data into the array.
+      for (let i = 0; i < wholeArrayView.length; ++i) {
+        WriteToTypedArray(wholeArrayView, i, 2 * i);
+      }
+    }
+    WriteData();
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    reverseHelper(fixedLength);
+    assert.compareArray(ToNumbers(wholeArrayView), [
+      6,
+      4,
+      2,
+      0
+    ]);
+    reverseHelper(fixedLengthWithOffset);
+    assert.compareArray(ToNumbers(wholeArrayView), [
+      6,
+      4,
+      0,
+      2
+    ]);
+    reverseHelper(lengthTracking);
+    assert.compareArray(ToNumbers(wholeArrayView), [
+      2,
+      0,
+      4,
+      6
+    ]);
+    reverseHelper(lengthTrackingWithOffset);
+    assert.compareArray(ToNumbers(wholeArrayView), [
+      2,
+      0,
+      6,
+      4
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+    WriteData();
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        reverseHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        reverseHelper(fixedLengthWithOffset);
+      });
+    } else {
+      reverseHelper(fixedLength);
+      assert.compareArray(ToNumbers(wholeArrayView), [
+        0,
+        2,
+        4
+      ]);
+      reverseHelper(fixedLengthWithOffset);
+      assert.compareArray(ToNumbers(wholeArrayView), [
+        0,
+        2,
+        4
+      ]);
+    }
+    reverseHelper(lengthTracking);
+    assert.compareArray(ToNumbers(wholeArrayView), [
+      4,
+      2,
+      0
+    ]);
+    reverseHelper(lengthTrackingWithOffset);
+    assert.compareArray(ToNumbers(wholeArrayView), [
+      4,
+      2,
+      0
+    ]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    WriteData();
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        reverseHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        reverseHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        reverseHelper(lengthTrackingWithOffset);
+      });
+    } else {
+      reverseHelper(fixedLength);
+      assert.compareArray(ToNumbers(wholeArrayView), [0]);
+      reverseHelper(fixedLengthWithOffset);
+      assert.compareArray(ToNumbers(wholeArrayView), [0]);
+      reverseHelper(lengthTrackingWithOffset);
+      assert.compareArray(ToNumbers(wholeArrayView), [0]);
+    }
+    reverseHelper(lengthTracking);
+    assert.compareArray(ToNumbers(wholeArrayView), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        reverseHelper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        reverseHelper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        reverseHelper(lengthTrackingWithOffset);
+      });
+    } else {
+      reverseHelper(fixedLength);
+      assert.compareArray(ToNumbers(wholeArrayView), []);
+      reverseHelper(fixedLengthWithOffset);
+      assert.compareArray(ToNumbers(wholeArrayView), []);
+      reverseHelper(lengthTrackingWithOffset);
+      assert.compareArray(ToNumbers(wholeArrayView), []);
+    }
+    reverseHelper(lengthTracking);
+    assert.compareArray(ToNumbers(wholeArrayView), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    WriteData();
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    reverseHelper(fixedLength);
+    assert.compareArray(ToNumbers(wholeArrayView), [
+      6,
+      4,
+      2,
+      0,
+      8,
+      10
+    ]);
+    reverseHelper(fixedLengthWithOffset);
+    assert.compareArray(ToNumbers(wholeArrayView), [
+      6,
+      4,
+      0,
+      2,
+      8,
+      10
+    ]);
+    reverseHelper(lengthTracking);
+    assert.compareArray(ToNumbers(wholeArrayView), [
+      10,
+      8,
+      2,
+      0,
+      4,
+      6
+    ]);
+    reverseHelper(lengthTrackingWithOffset);
+    assert.compareArray(ToNumbers(wholeArrayView), [
+      10,
+      8,
+      6,
+      4,
+      0,
+      2
+    ]);
+  }
+}
+
+Reverse(TypedArrayReverseHelper, true);
+Reverse(ArrayReverseHelper, false);

--- a/test/staging/ArrayBuffer/resizable/set-grow-target-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/set-grow-target-mid-iteration.js
@@ -1,0 +1,188 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SetGrowTargetMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let rab;
+// Resizing will happen when we're calling Get for the `resizeAt`:th data
+// element, but we haven't yet written it to the target.
+let resizeAt;
+let resizeTo;
+function CreateSourceProxy(length) {
+  let requestedIndices = [];
+  return new Proxy({}, {
+    get(target, prop, receiver) {
+      if (prop == 'length') {
+        return length;
+      }
+      requestedIndices.push(prop);
+      if (requestedIndices.length == resizeAt) {
+        rab.resize(resizeTo);
+      }
+      return true; // Can be converted to both BigInt and Number.
+    }
+  });
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAt = 2;
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.set(CreateSourceProxy(4));
+  assert.compareArray(ToNumbers(fixedLength), [
+    1,
+    1,
+    1,
+    1
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    1,
+    1,
+    1,
+    1,
+    0,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAt = 1;
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+    1,
+    1
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    1,
+    1,
+    0,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAt = 2;
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(lengthTracking), [
+    1,
+    1,
+    4,
+    6,
+    0,
+    0
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    1,
+    1,
+    4,
+    6,
+    0,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAt = 1;
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+    1,
+    1,
+    0,
+    0
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    1,
+    1,
+    0,
+    0
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/set-shrink-target-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/set-shrink-target-mid-iteration.js
@@ -1,0 +1,168 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SetShrinkTargetMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let rab;
+// Resizing will happen when we're calling Get for the `resizeAt`:th data
+// element, but we haven't yet written it to the target.
+let resizeAt;
+let resizeTo;
+function CreateSourceProxy(length) {
+  let requestedIndices = [];
+  return new Proxy({}, {
+    get(target, prop, receiver) {
+      if (prop == 'length') {
+        return length;
+      }
+      requestedIndices.push(prop);
+      if (requestedIndices.length == resizeAt) {
+        rab.resize(resizeTo);
+      }
+      return true; // Can be converted to both BigInt and Number.
+    }
+  });
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeAt = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.set(CreateSourceProxy(4));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    1,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeAt = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    1
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeAt = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(lengthTracking), [
+    1,
+    1,
+    4
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    1,
+    1,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAt = 2;
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [1]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    1
+  ]);
+}
+
+// Length-tracking TA goes OOB because of the offset.
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeAt = 1;
+  resizeTo = 1 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(2));
+  assert.compareArray(ToNumbers(new ctor(rab)), [0]);
+}

--- a/test/staging/ArrayBuffer/resizable/set-source-length-getter-grows-target.js
+++ b/test/staging/ArrayBuffer/resizable/set-source-length-getter-grows-target.js
@@ -1,0 +1,133 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SetSourceLengthGetterGrowsTarget test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let rab;
+let resizeTo;
+function CreateSourceProxy(length) {
+  return new Proxy({}, {
+    get(target, prop, receiver) {
+      if (prop == 'length') {
+        rab.resize(resizeTo);
+        return length;
+      }
+      return true; // Can be converted to both BigInt and Number.
+    }
+  });
+}
+
+// Test that we still throw for lengthTracking TAs if the source length is
+// too large, even though we resized in the length getter (we check against
+// the original length).
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  assert.throws(RangeError, () => {
+    lengthTracking.set(CreateSourceProxy(6));
+  });
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4,
+    6,
+    0,
+    0
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+  assert.throws(RangeError, () => {
+    lengthTrackingWithOffset.set(CreateSourceProxy(4));
+  });
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4,
+    6,
+    0,
+    0
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/set-source-length-getter-shrinks-target.js
+++ b/test/staging/ArrayBuffer/resizable/set-source-length-getter-shrinks-target.js
@@ -1,0 +1,215 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SetSourceLengthGetterShrinksTarget test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//                    [4, 6] << fixedLengthWithOffset
+//              [0, 2, 4, 6, ...] << lengthTracking
+//                    [4, 6, ...] << lengthTrackingWithOffset
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+let rab;
+let resizeTo;
+function CreateSourceProxy(length) {
+  return new Proxy({}, {
+    get(target, prop, receiver) {
+      if (prop == 'length') {
+        rab.resize(resizeTo);
+        return length;
+      }
+      return true; // Can be converted to both BigInt and Number.
+    }
+  });
+}
+
+// Tests where the length getter returns a non-zero value -> these are nop if
+// the TA went OOB.
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.set(CreateSourceProxy(1));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.set(CreateSourceProxy(1));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.set(CreateSourceProxy(1));
+  assert.compareArray(ToNumbers(lengthTracking), [
+    1,
+    2,
+    4
+  ]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    1,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(1));
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset), [1]);
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    1
+  ]);
+}
+
+// Length-tracking TA goes OOB because of the offset.
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeTo = 1 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(1));
+  assert.compareArray(ToNumbers(new ctor(rab)), [0]);
+}
+
+// Tests where the length getter returns a zero -> these don't throw even if
+// the TA went OOB.
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLength.set(CreateSourceProxy(0));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  fixedLengthWithOffset.set(CreateSourceProxy(0));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTracking.set(CreateSourceProxy(0));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(0));
+  assert.compareArray(ToNumbers(new ctor(rab)), [
+    0,
+    2,
+    4
+  ]);
+}
+
+// Length-tracking TA goes OOB because of the offset.
+for (let ctor of ctors) {
+  rab = CreateRabForTest(ctor);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  resizeTo = 1 * ctor.BYTES_PER_ELEMENT;
+  lengthTrackingWithOffset.set(CreateSourceProxy(0));
+  assert.compareArray(ToNumbers(new ctor(rab)), [0]);
+}

--- a/test/staging/ArrayBuffer/resizable/set-with-resizable-source.js
+++ b/test/staging/ArrayBuffer/resizable/set-with-resizable-source.js
@@ -1,0 +1,288 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SetWithResizableSource test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function IsBigIntTypedArray(ta) {
+  return ta instanceof BigInt64Array || ta instanceof BigUint64Array;
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+function SetHelper(target, source, offset) {
+  if (target instanceof BigInt64Array || target instanceof BigUint64Array) {
+    const bigIntSource = [];
+    for (const s of source) {
+      bigIntSource.push(BigInt(s));
+    }
+    source = bigIntSource;
+  }
+  if (offset == undefined) {
+    return target.set(source);
+  }
+  return target.set(source, offset);
+}
+
+for (let targetIsResizable of [
+    false,
+    true
+  ]) {
+  for (let targetCtor of ctors) {
+    for (let sourceCtor of ctors) {
+      const rab = CreateResizableArrayBuffer(4 * sourceCtor.BYTES_PER_ELEMENT, 8 * sourceCtor.BYTES_PER_ELEMENT);
+      const fixedLength = new sourceCtor(rab, 0, 4);
+      const fixedLengthWithOffset = new sourceCtor(rab, 2 * sourceCtor.BYTES_PER_ELEMENT, 2);
+      const lengthTracking = new sourceCtor(rab, 0);
+      const lengthTrackingWithOffset = new sourceCtor(rab, 2 * sourceCtor.BYTES_PER_ELEMENT);
+
+      // Write some data into the array.
+      const taFull = new sourceCtor(rab);
+      for (let i = 0; i < 4; ++i) {
+        WriteToTypedArray(taFull, i, i + 1);
+      }
+
+      // Orig. array: [1, 2, 3, 4]
+      //              [1, 2, 3, 4] << fixedLength
+      //                    [3, 4] << fixedLengthWithOffset
+      //              [1, 2, 3, 4, ...] << lengthTracking
+      //                    [3, 4, ...] << lengthTrackingWithOffset
+
+      const targetAb = targetIsResizable ? new ArrayBuffer(6 * targetCtor.BYTES_PER_ELEMENT) : new ArrayBuffer(6 * targetCtor.BYTES_PER_ELEMENT, { maxByteLength: 8 * targetCtor.BYTES_PER_ELEMENT });
+      const target = new targetCtor(targetAb);
+      if (IsBigIntTypedArray(target) != IsBigIntTypedArray(taFull)) {
+        // Can't mix BigInt and non-BigInt types.
+        continue;
+      }
+      SetHelper(target, fixedLength);
+      assert.compareArray(ToNumbers(target), [
+        1,
+        2,
+        3,
+        4,
+        0,
+        0
+      ]);
+      SetHelper(target, fixedLengthWithOffset);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        4,
+        3,
+        4,
+        0,
+        0
+      ]);
+      SetHelper(target, lengthTracking, 1);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        1,
+        2,
+        3,
+        4,
+        0
+      ]);
+      SetHelper(target, lengthTrackingWithOffset, 1);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        3,
+        4,
+        3,
+        4,
+        0
+      ]);
+
+      // Shrink so that fixed length TAs go out of bounds.
+      rab.resize(3 * sourceCtor.BYTES_PER_ELEMENT);
+
+      // Orig. array: [1, 2, 3]
+      //              [1, 2, 3, ...] << lengthTracking
+      //                    [3, ...] << lengthTrackingWithOffset
+
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLengthWithOffset);
+      });
+      assert.compareArray(ToNumbers(target), [
+        3,
+        3,
+        4,
+        3,
+        4,
+        0
+      ]);
+      SetHelper(target, lengthTracking);
+      assert.compareArray(ToNumbers(target), [
+        1,
+        2,
+        3,
+        3,
+        4,
+        0
+      ]);
+      SetHelper(target, lengthTrackingWithOffset);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        2,
+        3,
+        3,
+        4,
+        0
+      ]);
+
+      // Shrink so that the TAs with offset go out of bounds.
+      rab.resize(1 * sourceCtor.BYTES_PER_ELEMENT);
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        SetHelper(target, lengthTrackingWithOffset);
+      });
+      SetHelper(target, lengthTracking, 3);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        2,
+        3,
+        1,
+        4,
+        0
+      ]);
+
+      // Shrink to zero.
+      rab.resize(0);
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        SetHelper(target, fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        SetHelper(target, lengthTrackingWithOffset);
+      });
+      SetHelper(target, lengthTracking, 4);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        2,
+        3,
+        1,
+        4,
+        0
+      ]);
+
+      // Grow so that all TAs are back in-bounds.
+      rab.resize(6 * sourceCtor.BYTES_PER_ELEMENT);
+      for (let i = 0; i < 6; ++i) {
+        WriteToTypedArray(taFull, i, i + 1);
+      }
+
+      // Orig. array: [1, 2, 3, 4, 5, 6]
+      //              [1, 2, 3, 4] << fixedLength
+      //                    [3, 4] << fixedLengthWithOffset
+      //              [1, 2, 3, 4, 5, 6, ...] << lengthTracking
+      //                    [3, 4, 5, 6, ...] << lengthTrackingWithOffset
+
+      SetHelper(target, fixedLength);
+      assert.compareArray(ToNumbers(target), [
+        1,
+        2,
+        3,
+        4,
+        4,
+        0
+      ]);
+      SetHelper(target, fixedLengthWithOffset);
+      assert.compareArray(ToNumbers(target), [
+        3,
+        4,
+        3,
+        4,
+        4,
+        0
+      ]);
+      SetHelper(target, lengthTracking, 0);
+      assert.compareArray(ToNumbers(target), [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]);
+      SetHelper(target, lengthTrackingWithOffset, 1);
+      assert.compareArray(ToNumbers(target), [
+        1,
+        3,
+        4,
+        5,
+        6,
+        6
+      ]);
+    }
+  }
+}

--- a/test/staging/ArrayBuffer/resizable/set-with-resizable-target.js
+++ b/test/staging/ArrayBuffer/resizable/set-with-resizable-target.js
@@ -1,0 +1,576 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SetWithResizableTarget test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+function SetHelper(target, source, offset) {
+  if (target instanceof BigInt64Array || target instanceof BigUint64Array) {
+    const bigIntSource = [];
+    for (const s of source) {
+      bigIntSource.push(BigInt(s));
+    }
+    source = bigIntSource;
+  }
+  if (offset == undefined) {
+    return target.set(source);
+  }
+  return target.set(source, offset);
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  const taFull = new ctor(rab);
+
+  // Orig. array: [0, 0, 0, 0]
+  //              [0, 0, 0, 0] << fixedLength
+  //                    [0, 0] << fixedLengthWithOffset
+  //              [0, 0, 0, 0, ...] << lengthTracking
+  //                    [0, 0, ...] << lengthTrackingWithOffset
+
+  // For making sure we're not calling the source length or element getters
+  // if the target is OOB.
+  const throwingProxy = new Proxy({}, {
+    get(target, prop, receiver) {
+      throw new Error('Called getter for ' + prop);
+    }
+  });
+  SetHelper(fixedLength, [
+    1,
+    2
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    2,
+    0,
+    0
+  ]);
+  SetHelper(fixedLength, [
+    3,
+    4
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    3,
+    4,
+    0
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLength, [
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLength, [
+      0,
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    3,
+    4,
+    0
+  ]);
+  SetHelper(fixedLengthWithOffset, [
+    5,
+    6
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    3,
+    5,
+    6
+  ]);
+  SetHelper(fixedLengthWithOffset, [7], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    3,
+    5,
+    7
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLengthWithOffset, [
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLengthWithOffset, [
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    1,
+    3,
+    5,
+    7
+  ]);
+  SetHelper(lengthTracking, [
+    8,
+    9
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    9,
+    5,
+    7
+  ]);
+  SetHelper(lengthTracking, [
+    10,
+    11
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    11,
+    7
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    11,
+    7
+  ]);
+  SetHelper(lengthTrackingWithOffset, [
+    12,
+    13
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    12,
+    13
+  ]);
+  SetHelper(lengthTrackingWithOffset, [14], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    12,
+    14
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    12,
+    14
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [8, 10, 12]
+  //              [8, 10, 12, ...] << lengthTracking
+  //                     [12, ...] << lengthTrackingWithOffset
+
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLength, throwingProxy);
+  });
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLengthWithOffset, throwingProxy);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    8,
+    10,
+    12
+  ]);
+  SetHelper(lengthTracking, [
+    15,
+    16
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    15,
+    16,
+    12
+  ]);
+  SetHelper(lengthTracking, [
+    17,
+    18
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    15,
+    17,
+    18
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    15,
+    17,
+    18
+  ]);
+  SetHelper(lengthTrackingWithOffset, [19]);
+  assert.compareArray(ToNumbers(taFull), [
+    15,
+    17,
+    19
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [0], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    15,
+    17,
+    19
+  ]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLength, throwingProxy);
+  });
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLengthWithOffset, throwingProxy);
+  });
+  assert.throws(TypeError, () => {
+    SetHelper(lengthTrackingWithOffset, throwingProxy);
+  });
+  assert.compareArray(ToNumbers(taFull), [15]);
+  SetHelper(lengthTracking, [20]);
+  assert.compareArray(ToNumbers(taFull), [20]);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLength, throwingProxy);
+  });
+  assert.throws(TypeError, () => {
+    SetHelper(fixedLengthWithOffset, throwingProxy);
+  });
+  assert.throws(TypeError, () => {
+    SetHelper(lengthTrackingWithOffset, throwingProxy);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [0]);
+  });
+  assert.compareArray(ToNumbers(taFull), []);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 0, 0, 0, 0, 0]
+  //              [0, 0, 0, 0] << fixedLength
+  //                    [0, 0] << fixedLengthWithOffset
+  //              [0, 0, 0, 0, 0, 0, ...] << lengthTracking
+  //                    [0, 0, 0, 0, ...] << lengthTrackingWithOffset
+  SetHelper(fixedLength, [
+    21,
+    22
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    22,
+    0,
+    0,
+    0,
+    0
+  ]);
+  SetHelper(fixedLength, [
+    23,
+    24
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    23,
+    24,
+    0,
+    0,
+    0
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLength, [
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLength, [
+      0,
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    23,
+    24,
+    0,
+    0,
+    0
+  ]);
+  SetHelper(fixedLengthWithOffset, [
+    25,
+    26
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    23,
+    25,
+    26,
+    0,
+    0
+  ]);
+  SetHelper(fixedLengthWithOffset, [27], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    23,
+    25,
+    27,
+    0,
+    0
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLengthWithOffset, [
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(fixedLengthWithOffset, [
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    21,
+    23,
+    25,
+    27,
+    0,
+    0
+  ]);
+  SetHelper(lengthTracking, [
+    28,
+    29,
+    30,
+    31,
+    32,
+    33
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    29,
+    30,
+    31,
+    32,
+    33
+  ]);
+  SetHelper(lengthTracking, [
+    34,
+    35,
+    36,
+    37,
+    38
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    34,
+    35,
+    36,
+    37,
+    38
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTracking, [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    34,
+    35,
+    36,
+    37,
+    38
+  ]);
+  SetHelper(lengthTrackingWithOffset, [
+    39,
+    40,
+    41,
+    42
+  ]);
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    34,
+    39,
+    40,
+    41,
+    42
+  ]);
+  SetHelper(lengthTrackingWithOffset, [
+    43,
+    44,
+    45
+  ], 1);
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    34,
+    39,
+    43,
+    44,
+    45
+  ]);
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [
+      0,
+      0,
+      0,
+      0,
+      0
+    ]);
+  });
+  assert.throws(RangeError, () => {
+    SetHelper(lengthTrackingWithOffset, [
+      0,
+      0,
+      0,
+      0
+    ], 1);
+  });
+  assert.compareArray(ToNumbers(taFull), [
+    28,
+    34,
+    39,
+    43,
+    44,
+    45
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/slice-parameter-conversion-grows.js
+++ b/test/staging/ArrayBuffer/resizable/slice-parameter-conversion-grows.js
@@ -1,0 +1,103 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SliceParameterConversionGrows test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArraySliceHelper = (ta, ...rest) => {
+  return ta.slice(...rest);
+};
+
+const ArraySliceHelper = (ta, ...rest) => {
+  return Array.prototype.slice.call(ta, ...rest);
+};
+
+function SliceParameterConversionGrows(sliceHelper) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(lengthTracking, i, i + 1);
+    }
+    const evil = {
+      valueOf: () => {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+        return 0;
+      }
+    };
+    assert.compareArray(ToNumbers(sliceHelper(lengthTracking, evil)), [
+      1,
+      2,
+      3,
+      4
+    ]);
+    assert.sameValue(rab.byteLength, 6 * ctor.BYTES_PER_ELEMENT);
+  }
+}
+
+SliceParameterConversionGrows(TypedArraySliceHelper);
+SliceParameterConversionGrows(ArraySliceHelper);

--- a/test/staging/ArrayBuffer/resizable/slice-parameter-conversion-shrinks.js
+++ b/test/staging/ArrayBuffer/resizable/slice-parameter-conversion-shrinks.js
@@ -1,0 +1,104 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SliceParameterConversionShrinks test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.throws(TypeError, () => {
+    fixedLength.slice(evil);
+  });
+  assert.sameValue(rab.byteLength, 2 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const lengthTracking = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(lengthTracking, i, i + 1);
+  }
+  const evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.compareArray(ToNumbers(lengthTracking.slice(evil)), [
+    1,
+    2,
+    0,
+    0
+  ]);
+  assert.sameValue(rab.byteLength, 2 * ctor.BYTES_PER_ELEMENT);
+}

--- a/test/staging/ArrayBuffer/resizable/slice-species-create-resizes.js
+++ b/test/staging/ArrayBuffer/resizable/slice-species-create-resizes.js
@@ -1,0 +1,187 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SliceSpeciesCreateResizes test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+// The corresponding test for Array.prototype.slice is not possible, since it
+// doesn't call the species constructor if the "original array" is not an Array.
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends ctor {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      }
+    }
+  }
+  ;
+  const fixedLength = new MyArray(rab, 0, 4);
+  resizeWhenConstructorCalled = true;
+  assert.throws(TypeError, () => {
+    fixedLength.slice();
+  });
+  assert.sameValue(rab.byteLength, 2 * ctor.BYTES_PER_ELEMENT);
+}
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 1);
+  }
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends ctor {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      }
+    }
+  }
+  ;
+  const lengthTracking = new MyArray(rab);
+  resizeWhenConstructorCalled = true;
+  const a = lengthTracking.slice();
+  assert.sameValue(rab.byteLength, 2 * ctor.BYTES_PER_ELEMENT);
+  // The length of the resulting TypedArray is determined before
+  // TypedArraySpeciesCreate is called, and it doesn't change.
+  assert.sameValue(a.length, 4);
+  assert.compareArray(ToNumbers(a), [
+    1,
+    1,
+    0,
+    0
+  ]);
+}
+
+// Test that the (start, end) parameters are computed based on the original
+// length.
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 1);
+  }
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends ctor {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      }
+    }
+  }
+  ;
+  const lengthTracking = new MyArray(rab);
+  resizeWhenConstructorCalled = true;
+  const a = lengthTracking.slice(-3, -1);
+  assert.sameValue(rab.byteLength, 2 * ctor.BYTES_PER_ELEMENT);
+  // The length of the resulting TypedArray is determined before
+  // TypedArraySpeciesCreate is called, and it doesn't change.
+  assert.sameValue(a.length, 2);
+  assert.compareArray(ToNumbers(a), [
+    1,
+    0
+  ]);
+}
+
+// Test where the buffer gets resized "between elements".
+{
+  const rab = CreateResizableArrayBuffer(8, 16);
+  const taWrite = new Uint8Array(rab);
+  for (let i = 0; i < 8; ++i) {
+    WriteToTypedArray(taWrite, i, 255);
+  }
+  let resizeWhenConstructorCalled = false;
+  class MyArray extends Uint16Array {
+    constructor(...params) {
+      super(...params);
+      if (resizeWhenConstructorCalled) {
+        rab.resize(5);
+      }
+    }
+  }
+  ;
+  const lengthTracking = new MyArray(rab);
+  assert.compareArray(ToNumbers(lengthTracking), [
+    65535,
+    65535,
+    65535,
+    65535
+  ]);
+  resizeWhenConstructorCalled = true;
+  const a = lengthTracking.slice();
+  assert.sameValue(rab.byteLength, 5);
+  assert.sameValue(a.length, 4);
+  assert.sameValue(a[0], 65535);
+  assert.sameValue(a[1], 65535);
+  assert.sameValue(a[2], 0);
+  assert.sameValue(a[3], 0);
+}

--- a/test/staging/ArrayBuffer/resizable/slice.js
+++ b/test/staging/ArrayBuffer/resizable/slice.js
@@ -1,0 +1,202 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from Slice test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, i);
+  }
+  const fixedLengthSlice = fixedLength.slice();
+  assert.compareArray(ToNumbers(fixedLengthSlice), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert(!fixedLengthSlice.buffer.resizable);
+  const fixedLengthWithOffsetSlice = fixedLengthWithOffset.slice();
+  assert.compareArray(ToNumbers(fixedLengthWithOffsetSlice), [
+    2,
+    3
+  ]);
+  assert(!fixedLengthWithOffsetSlice.buffer.resizable);
+  const lengthTrackingSlice = lengthTracking.slice();
+  assert.compareArray(ToNumbers(lengthTrackingSlice), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert(!lengthTrackingSlice.buffer.resizable);
+  const lengthTrackingWithOffsetSlice = lengthTrackingWithOffset.slice();
+  assert.compareArray(ToNumbers(lengthTrackingWithOffsetSlice), [
+    2,
+    3
+  ]);
+  assert(!lengthTrackingWithOffsetSlice.buffer.resizable);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    fixedLength.slice();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.slice();
+  });
+  assert.compareArray(ToNumbers(lengthTracking.slice()), [
+    0,
+    1,
+    2
+  ]);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset.slice()), [2]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.throws(TypeError, () => {
+    fixedLength.slice();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.slice();
+  });
+  assert.compareArray(ToNumbers(lengthTracking.slice()), [0]);
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.slice();
+  });
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.throws(TypeError, () => {
+    fixedLength.slice();
+  });
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.slice();
+  });
+  assert.compareArray(ToNumbers(lengthTracking.slice()), []);
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.slice();
+  });
+
+  // Verify that the previously created slices aren't affected by the
+  // shrinking.
+  assert.compareArray(ToNumbers(fixedLengthSlice), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.compareArray(ToNumbers(fixedLengthWithOffsetSlice), [
+    2,
+    3
+  ]);
+  assert.compareArray(ToNumbers(lengthTrackingSlice), [
+    0,
+    1,
+    2,
+    3
+  ]);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffsetSlice), [
+    2,
+    3
+  ]);
+
+  // Grow so that all TAs are back in-bounds. New memory is zeroed.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  assert.compareArray(ToNumbers(fixedLength.slice()), [
+    0,
+    0,
+    0,
+    0
+  ]);
+  assert.compareArray(ToNumbers(fixedLengthWithOffset.slice()), [
+    0,
+    0
+  ]);
+  assert.compareArray(ToNumbers(lengthTracking.slice()), [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ]);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset.slice()), [
+    0,
+    0,
+    0,
+    0
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/some-grow-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/some-grow-mid-iteration.js
@@ -1,0 +1,150 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SomeGrowMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArraySomeHelper = (ta, ...rest) => {
+  return ta.some(...rest);
+};
+
+const ArraySomeHelper = (ta, ...rest) => {
+  return Array.prototype.some.call(ta, ...rest);
+};
+
+function SomeGrowMidIteration(someHelper) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values = [];
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(!someHelper(fixedLength, CollectValuesAndResize));
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(!someHelper(fixedLengthWithOffset, CollectValuesAndResize));
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(!someHelper(lengthTracking, CollectValuesAndResize));
+    assert.compareArray(values, [
+      0,
+      2,
+      4,
+      6
+    ]);
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    rab = rab;
+    resizeAfter = 1;
+    resizeTo = 5 * ctor.BYTES_PER_ELEMENT;
+    assert(!someHelper(lengthTrackingWithOffset, CollectValuesAndResize));
+    assert.compareArray(values, [
+      4,
+      6
+    ]);
+  }
+}
+
+SomeGrowMidIteration(TypedArraySomeHelper);
+SomeGrowMidIteration(ArraySomeHelper);

--- a/test/staging/ArrayBuffer/resizable/some-shrink-mid-iteration.js
+++ b/test/staging/ArrayBuffer/resizable/some-shrink-mid-iteration.js
@@ -1,0 +1,172 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SomeShrinkMidIteration test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+const TypedArraySomeHelper = (ta, ...rest) => {
+  return ta.some(...rest);
+};
+
+const ArraySomeHelper = (ta, ...rest) => {
+  return Array.prototype.some.call(ta, ...rest);
+};
+
+function SomeShrinkMidIteration(someHelper, hasUndefined) {
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+  function CreateRabForTest(ctor) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+    return rab;
+  }
+  let values;
+  let rab;
+  let resizeAfter;
+  let resizeTo;
+  function CollectValuesAndResize(n) {
+    if (typeof n == 'bigint') {
+      values.push(Number(n));
+    } else {
+      values.push(n);
+    }
+    if (values.length == resizeAfter) {
+      rab.resize(resizeTo);
+    }
+    return false;
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLength = new ctor(rab, 0, 4);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(!someHelper(fixedLength, CollectValuesAndResize));
+    if (hasUndefined) {
+      assert.compareArray(values, [
+        0,
+        2,
+        undefined,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(values, [
+        0,
+        2
+      ]);
+    }
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(!someHelper(fixedLengthWithOffset, CollectValuesAndResize));
+    if (hasUndefined) {
+      assert.compareArray(values, [
+        4,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(values, [4]);
+    }
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTracking = new ctor(rab, 0);
+    values = [];
+    resizeAfter = 2;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(!someHelper(lengthTracking, CollectValuesAndResize));
+    if (hasUndefined) {
+      assert.compareArray(values, [
+        0,
+        2,
+        4,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(values, [
+        0,
+        2,
+        4
+      ]);
+    }
+  }
+  for (let ctor of ctors) {
+    rab = CreateRabForTest(ctor);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    values = [];
+    resizeAfter = 1;
+    resizeTo = 3 * ctor.BYTES_PER_ELEMENT;
+    assert(!someHelper(lengthTrackingWithOffset, CollectValuesAndResize));
+    if (hasUndefined) {
+      assert.compareArray(values, [
+        4,
+        undefined
+      ]);
+    } else {
+      assert.compareArray(values, [4]);
+    }
+  }
+}
+
+SomeShrinkMidIteration(TypedArraySomeHelper, true);
+SomeShrinkMidIteration(ArraySomeHelper, false);

--- a/test/staging/ArrayBuffer/resizable/sort-callback-grows.js
+++ b/test/staging/ArrayBuffer/resizable/sort-callback-grows.js
@@ -1,0 +1,139 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SortCallbackGrows test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArraySortHelper = (ta, ...rest) => {
+  ta.sort(...rest);
+};
+
+const ArraySortHelper = (ta, ...rest) => {
+  Array.prototype.sort.call(ta, ...rest);
+};
+
+function SortCallbackGrows(sortHelper) {
+  function WriteUnsortedData(taFull) {
+    for (let i = 0; i < taFull.length; ++i) {
+      WriteToTypedArray(taFull, i, 10 - i);
+    }
+  }
+  let rab;
+  let resizeTo;
+  function CustomComparison(a, b) {
+    rab.resize(resizeTo);
+    if (a < b) {
+      return -1;
+    }
+    if (a > b) {
+      return 1;
+    }
+    return 0;
+  }
+
+  // Fixed length TA.
+  for (let ctor of ctors) {
+    rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+    const fixedLength = new ctor(rab, 0, 4);
+    const taFull = new ctor(rab, 0);
+    WriteUnsortedData(taFull);
+    sortHelper(fixedLength, CustomComparison);
+    // Growing doesn't affect the sorting.
+    assert.compareArray(ToNumbers(taFull), [
+      7,
+      8,
+      9,
+      10,
+      0,
+      0
+    ]);
+  }
+
+  // Length-tracking TA.
+  for (let ctor of ctors) {
+    rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    resizeTo = 6 * ctor.BYTES_PER_ELEMENT;
+    const lengthTracking = new ctor(rab, 0);
+    const taFull = new ctor(rab, 0);
+    WriteUnsortedData(taFull);
+    sortHelper(lengthTracking, CustomComparison);
+    // Growing doesn't affect the sorting. Only the elements that were part of
+    // the original TA are sorted.
+    assert.compareArray(ToNumbers(taFull), [
+      7,
+      8,
+      9,
+      10,
+      0,
+      0
+    ]);
+  }
+}
+
+SortCallbackGrows(TypedArraySortHelper);
+SortCallbackGrows(ArraySortHelper);

--- a/test/staging/ArrayBuffer/resizable/sort-callback-shrinks.js
+++ b/test/staging/ArrayBuffer/resizable/sort-callback-shrinks.js
@@ -1,0 +1,141 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SortCallbackShrinks test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArraySortHelper = (ta, ...rest) => {
+  ta.sort(...rest);
+};
+
+const ArraySortHelper = (ta, ...rest) => {
+  Array.prototype.sort.call(ta, ...rest);
+};
+
+function SortCallbackShrinks(sortHelper) {
+  function WriteUnsortedData(taFull) {
+    for (let i = 0; i < taFull.length; ++i) {
+      WriteToTypedArray(taFull, i, 10 - i);
+    }
+  }
+  let rab;
+  let resizeTo;
+  function CustomComparison(a, b) {
+    rab.resize(resizeTo);
+    if (a < b) {
+      return -1;
+    }
+    if (a > b) {
+      return 1;
+    }
+    return 0;
+  }
+
+  // Fixed length TA.
+  for (let ctor of ctors) {
+    rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    resizeTo = 2 * ctor.BYTES_PER_ELEMENT;
+    const fixedLength = new ctor(rab, 0, 4);
+    const taFull = new ctor(rab, 0);
+    WriteUnsortedData(taFull);
+    sortHelper(fixedLength, CustomComparison);
+    // The data is unchanged.
+    assert.compareArray(ToNumbers(taFull), [
+      10,
+      9
+    ]);
+  }
+
+  // Length-tracking TA.
+  for (let ctor of ctors) {
+    rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    resizeTo = 2 * ctor.BYTES_PER_ELEMENT;
+    const lengthTracking = new ctor(rab, 0);
+    const taFull = new ctor(rab, 0);
+    WriteUnsortedData(taFull);
+    sortHelper(lengthTracking, CustomComparison);
+    // The sort result is implementation defined, but it contains 2 elements out
+    // of the 4 original ones.
+    const newData = ToNumbers(taFull);
+    assert.sameValue(newData.length, 2);
+    assert([
+      10,
+      9,
+      8,
+      7
+    ].includes(newData[0]));
+    assert([
+      10,
+      9,
+      8,
+      7
+    ].includes(newData[1]));
+  }
+}
+
+SortCallbackShrinks(TypedArraySortHelper);
+SortCallbackShrinks(ArraySortHelper);

--- a/test/staging/ArrayBuffer/resizable/sort-with-custom-comparison.js
+++ b/test/staging/ArrayBuffer/resizable/sort-with-custom-comparison.js
@@ -1,0 +1,305 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SortWithCustomComparison test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArraySortHelper = (ta, ...rest) => {
+  ta.sort(...rest);
+};
+
+const ArraySortHelper = (ta, ...rest) => {
+  Array.prototype.sort.call(ta, ...rest);
+};
+
+function SortWithCustomComparison(sortHelper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    const taFull = new ctor(rab, 0);
+    function WriteUnsortedData() {
+      // Write some data into the array.
+      for (let i = 0; i < taFull.length; ++i) {
+        WriteToTypedArray(taFull, i, 10 - i);
+      }
+    }
+    function CustomComparison(a, b) {
+      // Sort all odd numbers before even numbers.
+      a = Number(a);
+      b = Number(b);
+      if (a % 2 == 1 && b % 2 == 0) {
+        return -1;
+      }
+      if (a % 2 == 0 && b % 2 == 1) {
+        return 1;
+      }
+      if (a < b) {
+        return -1;
+      }
+      if (a > b) {
+        return 1;
+      }
+      return 0;
+    }
+    // Orig. array: [10, 9, 8, 7]
+    //              [10, 9, 8, 7] << fixedLength
+    //                     [8, 7] << fixedLengthWithOffset
+    //              [10, 9, 8, 7, ...] << lengthTracking
+    //                     [8, 7, ...] << lengthTrackingWithOffset
+
+    WriteUnsortedData();
+    sortHelper(fixedLength, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), [
+      7,
+      9,
+      8,
+      10
+    ]);
+    WriteUnsortedData();
+    sortHelper(fixedLengthWithOffset, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), [
+      10,
+      9,
+      7,
+      8
+    ]);
+    WriteUnsortedData();
+    sortHelper(lengthTracking, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), [
+      7,
+      9,
+      8,
+      10
+    ]);
+    WriteUnsortedData();
+    sortHelper(lengthTrackingWithOffset, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), [
+      10,
+      9,
+      7,
+      8
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [10, 9, 8]
+    //              [10, 9, 8, ...] << lengthTracking
+    //                     [8, ...] << lengthTrackingWithOffset
+
+    WriteUnsortedData();
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        sortHelper(fixedLength, CustomComparison);
+      });
+      assert.compareArray(ToNumbers(taFull), [
+        10,
+        9,
+        8
+      ]);
+      assert.throws(TypeError, () => {
+        sortHelper(fixedLengthWithOffset, CustomComparison);
+      });
+      assert.compareArray(ToNumbers(taFull), [
+        10,
+        9,
+        8
+      ]);
+    } else {
+      sortHelper(fixedLength, CustomComparison);
+      assert.compareArray(ToNumbers(taFull), [
+        10,
+        9,
+        8
+      ]);
+      sortHelper(fixedLengthWithOffset, CustomComparison);
+      assert.compareArray(ToNumbers(taFull), [
+        10,
+        9,
+        8
+      ]);
+    }
+    WriteUnsortedData();
+    sortHelper(lengthTracking, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), [
+      9,
+      8,
+      10
+    ]);
+    WriteUnsortedData();
+    sortHelper(lengthTrackingWithOffset, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), [
+      10,
+      9,
+      8
+    ]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    WriteUnsortedData();
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        sortHelper(fixedLength, CustomComparison);
+      });
+      assert.compareArray(ToNumbers(taFull), [10]);
+      assert.throws(TypeError, () => {
+        sortHelper(fixedLengthWithOffset, CustomComparison);
+      });
+      assert.compareArray(ToNumbers(taFull), [10]);
+      assert.throws(TypeError, () => {
+        sortHelper(lengthTrackingWithOffset, CustomComparison);
+      });
+      assert.compareArray(ToNumbers(taFull), [10]);
+    } else {
+      sortHelper(fixedLength, CustomComparison);
+      assert.compareArray(ToNumbers(taFull), [10]);
+      sortHelper(fixedLengthWithOffset, CustomComparison);
+      assert.compareArray(ToNumbers(taFull), [10]);
+      sortHelper(lengthTrackingWithOffset, CustomComparison);
+      assert.compareArray(ToNumbers(taFull), [10]);
+    }
+    WriteUnsortedData();
+    sortHelper(lengthTracking, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), [10]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        sortHelper(fixedLength, CustomComparison);
+      });
+      assert.throws(TypeError, () => {
+        sortHelper(fixedLengthWithOffset, CustomComparison);
+      });
+      assert.throws(TypeError, () => {
+        sortHelper(lengthTrackingWithOffset, CustomComparison);
+      });
+    } else {
+      sortHelper(fixedLength, CustomComparison);
+      sortHelper(fixedLengthWithOffset, CustomComparison);
+      sortHelper(lengthTrackingWithOffset, CustomComparison);
+    }
+    sortHelper(lengthTracking, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [10, 9, 8, 7, 6, 5]
+    //              [10, 9, 8, 7] << fixedLength
+    //                     [8, 7] << fixedLengthWithOffset
+    //              [10, 9, 8, 7, 6, 5, ...] << lengthTracking
+    //                     [8, 7, 6, 5, ...] << lengthTrackingWithOffset
+
+    WriteUnsortedData();
+    sortHelper(fixedLength, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), [
+      7,
+      9,
+      8,
+      10,
+      6,
+      5
+    ]);
+    WriteUnsortedData();
+    sortHelper(fixedLengthWithOffset, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), [
+      10,
+      9,
+      7,
+      8,
+      6,
+      5
+    ]);
+    WriteUnsortedData();
+    sortHelper(lengthTracking, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), [
+      5,
+      7,
+      9,
+      6,
+      8,
+      10
+    ]);
+    WriteUnsortedData();
+    sortHelper(lengthTrackingWithOffset, CustomComparison);
+    assert.compareArray(ToNumbers(taFull), [
+      10,
+      9,
+      5,
+      7,
+      6,
+      8
+    ]);
+  }
+}
+
+SortWithCustomComparison(TypedArraySortHelper, true);
+SortWithCustomComparison(ArraySortHelper, false);

--- a/test/staging/ArrayBuffer/resizable/sort-with-default-comparison.js
+++ b/test/staging/ArrayBuffer/resizable/sort-with-default-comparison.js
@@ -1,0 +1,241 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SortWithDefaultComparison test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+// This test cannot be reused between TypedArray.protoype.sort and
+// Array.prototype.sort, since the default sorting functions differ.
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  const taFull = new ctor(rab, 0);
+  function WriteUnsortedData() {
+    // Write some data into the array.
+    for (let i = 0; i < taFull.length; ++i) {
+      WriteToTypedArray(taFull, i, 10 - 2 * i);
+    }
+  }
+  // Orig. array: [10, 8, 6, 4]
+  //              [10, 8, 6, 4] << fixedLength
+  //                     [6, 4] << fixedLengthWithOffset
+  //              [10, 8, 6, 4, ...] << lengthTracking
+  //                     [6, 4, ...] << lengthTrackingWithOffset
+
+  WriteUnsortedData();
+  fixedLength.sort();
+  assert.compareArray(ToNumbers(taFull), [
+    4,
+    6,
+    8,
+    10
+  ]);
+  WriteUnsortedData();
+  fixedLengthWithOffset.sort();
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    4,
+    6
+  ]);
+  WriteUnsortedData();
+  lengthTracking.sort();
+  assert.compareArray(ToNumbers(taFull), [
+    4,
+    6,
+    8,
+    10
+  ]);
+  WriteUnsortedData();
+  lengthTrackingWithOffset.sort();
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    4,
+    6
+  ]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [10, 8, 6]
+  //              [10, 8, 6, ...] << lengthTracking
+  //                     [6, ...] << lengthTrackingWithOffset
+
+  WriteUnsortedData();
+  assert.throws(TypeError, () => {
+    fixedLength.sort();
+  });
+  WriteUnsortedData();
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.sort();
+  });
+  WriteUnsortedData();
+  lengthTracking.sort();
+  assert.compareArray(ToNumbers(taFull), [
+    6,
+    8,
+    10
+  ]);
+  WriteUnsortedData();
+  lengthTrackingWithOffset.sort();
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    6
+  ]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  WriteUnsortedData();
+  assert.throws(TypeError, () => {
+    fixedLength.sort();
+  });
+  WriteUnsortedData();
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.sort();
+  });
+  WriteUnsortedData();
+  lengthTracking.sort();
+  assert.compareArray(ToNumbers(taFull), [10]);
+  WriteUnsortedData();
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.sort();
+  });
+
+  // Shrink to zero.
+  rab.resize(0);
+  WriteUnsortedData();
+  assert.throws(TypeError, () => {
+    fixedLength.sort();
+  });
+  WriteUnsortedData();
+  assert.throws(TypeError, () => {
+    fixedLengthWithOffset.sort();
+  });
+  WriteUnsortedData();
+  lengthTracking.sort();
+  assert.compareArray(ToNumbers(taFull), []);
+  WriteUnsortedData();
+  assert.throws(TypeError, () => {
+    lengthTrackingWithOffset.sort();
+  });
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [10, 8, 6, 4, 2, 0]
+  //              [10, 8, 6, 4] << fixedLength
+  //                     [6, 4] << fixedLengthWithOffset
+  //              [10, 8, 6, 4, 2, 0, ...] << lengthTracking
+  //                     [6, 4, 2, 0, ...] << lengthTrackingWithOffset
+
+  WriteUnsortedData();
+  fixedLength.sort();
+  assert.compareArray(ToNumbers(taFull), [
+    4,
+    6,
+    8,
+    10,
+    2,
+    0
+  ]);
+  WriteUnsortedData();
+  fixedLengthWithOffset.sort();
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    4,
+    6,
+    2,
+    0
+  ]);
+  WriteUnsortedData();
+  lengthTracking.sort();
+  assert.compareArray(ToNumbers(taFull), [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10
+  ]);
+  WriteUnsortedData();
+  lengthTrackingWithOffset.sort();
+  assert.compareArray(ToNumbers(taFull), [
+    10,
+    8,
+    0,
+    2,
+    4,
+    6
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/subarray-parameter-conversion-grows.js
+++ b/test/staging/ArrayBuffer/resizable/subarray-parameter-conversion-grows.js
@@ -1,0 +1,136 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SubarrayParameterConversionGrows test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//              [0, 2, 4, 6, ...] << lengthTracking
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+
+// Growing a fixed length TA back in bounds.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  // Make `fixedLength` OOB.
+  rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+  const evil = {
+    valueOf: () => {
+      rab.resize(4 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  // The length computation is done before parameter conversion. At that
+  // point, the length is 0, since the TA is OOB.
+  assert.compareArray(ToNumbers(fixedLength.subarray(evil, 0, 1)), []);
+}
+
+// Growing + fixed-length TA. Growing won't affect anything.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.compareArray(ToNumbers(fixedLength.subarray(evil)), [
+    0,
+    2,
+    4,
+    6
+  ]);
+}
+
+// Growing + length-tracking TA. The length computation is done with the
+// original length.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab, 0);
+  const evil = {
+    valueOf: () => {
+      rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.compareArray(ToNumbers(lengthTracking.subarray(evil)), [
+    0,
+    2,
+    4,
+    6
+  ]);
+}

--- a/test/staging/ArrayBuffer/resizable/subarray-parameter-conversion-shrinks.js
+++ b/test/staging/ArrayBuffer/resizable/subarray-parameter-conversion-shrinks.js
@@ -1,0 +1,219 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from SubarrayParameterConversionShrinks test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+// Orig. array: [0, 2, 4, 6]
+//              [0, 2, 4, 6] << fixedLength
+//              [0, 2, 4, 6, ...] << lengthTracking
+function CreateRabForTest(ctor) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+  return rab;
+}
+
+// Fixed-length TA + first parameter conversion shrinks. The old length is
+// used in the length computation, and the subarray construction fails.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.throws(RangeError, () => {
+    fixedLength.subarray(evil);
+  });
+}
+
+// Like the previous test, but now we construct a smaller subarray and it
+// succeeds.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.compareArray(ToNumbers(fixedLength.subarray(evil, 1)), [0]);
+}
+
+// Fixed-length TA + second parameter conversion shrinks. The old length is
+// used in the length computation, and the subarray construction fails.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 3;
+    }
+  };
+  assert.throws(RangeError, () => {
+    fixedLength.subarray(0, evil);
+  });
+}
+
+// Like the previous test, but now we construct a smaller subarray and it
+// succeeds.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 1;
+    }
+  };
+  assert.compareArray(ToNumbers(fixedLength.subarray(0, evil)), [0]);
+}
+
+// Shrinking + fixed-length TA, subarray construction succeeds even though the
+// TA goes OOB.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const fixedLength = new ctor(rab, 0, 4);
+  const evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.compareArray(ToNumbers(fixedLength.subarray(evil, 1)), [0]);
+}
+
+// Length-tracking TA + first parameter conversion shrinks. The old length is
+// used in the length computation, and the subarray construction fails.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.throws(RangeError, () => {
+    lengthTracking.subarray(evil);
+  });
+}
+
+// Like the previous test, but now we construct a smaller subarray and it
+// succeeds.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.compareArray(ToNumbers(lengthTracking.subarray(evil, 1)), [0]);
+}
+
+// Length-tracking TA + first parameter conversion shrinks. The second
+// parameter is negative -> the relative index is not recomputed, and the
+// subarray construction fails.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 0;
+    }
+  };
+  assert.throws(RangeError, () => {
+    lengthTracking.subarray(evil, -1);
+  });
+}
+
+// Length-tracking TA + second parameter conversion shrinks. The second
+// parameter is too large -> the subarray construction fails.
+for (let ctor of ctors) {
+  const rab = CreateRabForTest(ctor);
+  const lengthTracking = new ctor(rab);
+  let evil = {
+    valueOf: () => {
+      rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      return 3;
+    }
+  };
+  assert.throws(RangeError, () => {
+    lengthTracking.subarray(0, evil);
+  });
+}

--- a/test/staging/ArrayBuffer/resizable/subarray.js
+++ b/test/staging/ArrayBuffer/resizable/subarray.js
@@ -1,0 +1,230 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from Subarray test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+for (let ctor of ctors) {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const fixedLength = new ctor(rab, 0, 4);
+  const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+  const lengthTracking = new ctor(rab, 0);
+  const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+  // Write some data into the array.
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, ...] << lengthTracking
+  //                    [4, 6, ...] << lengthTrackingWithOffset
+
+  const fixedLengthSubFull = fixedLength.subarray(0);
+  assert.compareArray(ToNumbers(fixedLengthSubFull), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  const fixedLengthWithOffsetSubFull = fixedLengthWithOffset.subarray(0);
+  assert.compareArray(ToNumbers(fixedLengthWithOffsetSubFull), [
+    4,
+    6
+  ]);
+  const lengthTrackingSubFull = lengthTracking.subarray(0);
+  assert.compareArray(ToNumbers(lengthTrackingSubFull), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  const lengthTrackingWithOffsetSubFull = lengthTrackingWithOffset.subarray(0);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffsetSubFull), [
+    4,
+    6
+  ]);
+
+  // Relative offsets
+  assert.compareArray(ToNumbers(fixedLength.subarray(-2)), [
+    4,
+    6
+  ]);
+  assert.compareArray(ToNumbers(fixedLengthWithOffset.subarray(-1)), [6]);
+  assert.compareArray(ToNumbers(lengthTracking.subarray(-2)), [
+    4,
+    6
+  ]);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset.subarray(-1)), [6]);
+
+  // Shrink so that fixed length TAs go out of bounds.
+  rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+  // Orig. array: [0, 2, 4]
+  //              [0, 2, 4, ...] << lengthTracking
+  //                    [4, ...] << lengthTrackingWithOffset
+
+  // We can create subarrays of OOB arrays (which have length 0), as long as
+  // the new arrays are not OOB.
+  assert.compareArray(ToNumbers(fixedLength.subarray(0)), []);
+  assert.compareArray(ToNumbers(fixedLengthWithOffset.subarray(0)), []);
+  assert.compareArray(ToNumbers(lengthTracking.subarray(0)), [
+    0,
+    2,
+    4
+  ]);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset.subarray(0)), [4]);
+
+  // Also the previously created subarrays are OOB.
+  assert.sameValue(fixedLengthSubFull.length, 0);
+  assert.sameValue(fixedLengthWithOffsetSubFull.length, 0);
+
+  // Relative offsets
+  assert.compareArray(ToNumbers(lengthTracking.subarray(-2)), [
+    2,
+    4
+  ]);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset.subarray(-1)), [4]);
+
+  // Shrink so that the TAs with offset go out of bounds.
+  rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+  assert.compareArray(ToNumbers(fixedLength.subarray(0)), []);
+  assert.compareArray(ToNumbers(lengthTracking.subarray(0)), [0]);
+
+  // Even the 0-length subarray of fixedLengthWithOffset would be OOB ->
+  // this throws.
+  assert.throws(RangeError, () => {
+    fixedLengthWithOffset.subarray(0);
+  });
+
+  // Also the previously created subarrays are OOB.
+  assert.sameValue(fixedLengthSubFull.length, 0);
+  assert.sameValue(fixedLengthWithOffsetSubFull.length, 0);
+  assert.sameValue(lengthTrackingWithOffsetSubFull.length, 0);
+
+  // Shrink to zero.
+  rab.resize(0);
+  assert.compareArray(ToNumbers(fixedLength.subarray(0)), []);
+  assert.compareArray(ToNumbers(lengthTracking.subarray(0)), []);
+  assert.throws(RangeError, () => {
+    fixedLengthWithOffset.subarray(0);
+  });
+  assert.throws(RangeError, () => {
+    lengthTrackingWithOffset.subarray(0);
+  });
+
+  // Also the previously created subarrays are OOB.
+  assert.sameValue(fixedLengthSubFull.length, 0);
+  assert.sameValue(fixedLengthWithOffsetSubFull.length, 0);
+  assert.sameValue(lengthTrackingWithOffsetSubFull.length, 0);
+
+  // Grow so that all TAs are back in-bounds.
+  rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+  for (let i = 0; i < 6; ++i) {
+    WriteToTypedArray(taWrite, i, 2 * i);
+  }
+
+  // Orig. array: [0, 2, 4, 6, 8, 10]
+  //              [0, 2, 4, 6] << fixedLength
+  //                    [4, 6] << fixedLengthWithOffset
+  //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+  //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+  assert.compareArray(ToNumbers(fixedLength.subarray(0)), [
+    0,
+    2,
+    4,
+    6
+  ]);
+  assert.compareArray(ToNumbers(fixedLengthWithOffset.subarray(0)), [
+    4,
+    6
+  ]);
+  assert.compareArray(ToNumbers(lengthTracking.subarray(0)), [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10
+  ]);
+  assert.compareArray(ToNumbers(lengthTrackingWithOffset.subarray(0)), [
+    4,
+    6,
+    8,
+    10
+  ]);
+
+  // Also the previously created subarrays are no longer OOB.
+  assert.sameValue(fixedLengthSubFull.length, 4);
+  assert.sameValue(fixedLengthWithOffsetSubFull.length, 2);
+  // Subarrays of length-tracking TAs are also length-tracking.
+  assert.sameValue(lengthTrackingSubFull.length, 6);
+  assert.sameValue(lengthTrackingWithOffsetSubFull.length, 4);
+}

--- a/test/staging/ArrayBuffer/resizable/test-copy-within.js
+++ b/test/staging/ArrayBuffer/resizable/test-copy-within.js
@@ -1,0 +1,268 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from TestCopyWithin test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArrayCopyWithinHelper = (ta, ...rest) => {
+  ta.copyWithin(...rest);
+};
+
+const ArrayCopyWithinHelper = (ta, ...rest) => {
+  Array.prototype.copyWithin.call(ta, ...rest);
+};
+
+function TestCopyWithin(helper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, ...] << lengthTracking
+    //                    [2, 3, ...] << lengthTrackingWithOffset
+
+    helper(fixedLength, 0, 2);
+    assert.compareArray(ToNumbers(fixedLength), [
+      2,
+      3,
+      2,
+      3
+    ]);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+    helper(fixedLengthWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+      3,
+      3
+    ]);
+    for (let i = 0; i < 4; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+    helper(lengthTracking, 0, 2);
+    assert.compareArray(ToNumbers(lengthTracking), [
+      2,
+      3,
+      2,
+      3
+    ]);
+    helper(lengthTrackingWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+      3,
+      3
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 3; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2]
+    //              [0, 1, 2, ...] << lengthTracking
+    //                    [2, ...] << lengthTrackingWithOffset
+
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        helper(fixedLength, 0, 1);
+      });
+      assert.throws(TypeError, () => {
+        helper(fixedLengthWithOffset, 0, 1);
+      });
+    } else {
+      helper(fixedLength, 0, 1);
+      helper(fixedLengthWithOffset, 0, 1);
+      // We'll check below that these were no-op.
+    }
+    assert.compareArray(ToNumbers(lengthTracking), [
+      0,
+      1,
+      2
+    ]);
+    helper(lengthTracking, 0, 1);
+    assert.compareArray(ToNumbers(lengthTracking), [
+      1,
+      2,
+      2
+    ]);
+    helper(lengthTrackingWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [2]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    WriteToTypedArray(taWrite, 0, 0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        helper(fixedLength, 0, 1, 1);
+      });
+      assert.throws(TypeError, () => {
+        helper(fixedLengthWithOffset, 0, 1, 1);
+      });
+      assert.throws(TypeError, () => {
+        helper(lengthTrackingWithOffset, 0, 1, 1);
+      });
+    } else {
+      helper(fixedLength, 0, 1, 1);
+      helper(fixedLengthWithOffset, 0, 1, 1);
+      helper(lengthTrackingWithOffset, 0, 1, 1);
+    }
+    assert.compareArray(ToNumbers(lengthTracking), [0]);
+    helper(lengthTracking, 0, 0, 1);
+    assert.compareArray(ToNumbers(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        helper(fixedLength, 0, 1, 1);
+      });
+      assert.throws(TypeError, () => {
+        helper(fixedLengthWithOffset, 0, 1, 1);
+      });
+      assert.throws(TypeError, () => {
+        helper(lengthTrackingWithOffset, 0, 1, 1);
+      });
+    } else {
+      helper(fixedLength, 0, 1, 1);
+      helper(fixedLengthWithOffset, 0, 1, 1);
+      helper(lengthTrackingWithOffset, 0, 1, 1);
+    }
+    assert.compareArray(ToNumbers(lengthTracking), []);
+    helper(lengthTracking, 0, 0, 1);
+    assert.compareArray(ToNumbers(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    // Orig. array: [0, 1, 2, 3, 4, 5]
+    //              [0, 1, 2, 3] << fixedLength
+    //                    [2, 3] << fixedLengthWithOffset
+    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+
+    helper(fixedLength, 0, 2);
+    assert.compareArray(ToNumbers(fixedLength), [
+      2,
+      3,
+      2,
+      3
+    ]);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+    helper(fixedLengthWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(fixedLengthWithOffset), [
+      3,
+      3
+    ]);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    //              [0, 1, 2, 3, 4, 5, ...] << lengthTracking
+    //        target ^     ^ start
+    helper(lengthTracking, 0, 2);
+    assert.compareArray(ToNumbers(lengthTracking), [
+      2,
+      3,
+      4,
+      5,
+      4,
+      5
+    ]);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, i);
+    }
+
+    //                    [2, 3, 4, 5, ...] << lengthTrackingWithOffset
+    //              target ^  ^ start
+    helper(lengthTrackingWithOffset, 0, 1);
+    assert.compareArray(ToNumbers(lengthTrackingWithOffset), [
+      3,
+      4,
+      5,
+      5
+    ]);
+  }
+}
+
+TestCopyWithin(TypedArrayCopyWithinHelper, true);
+TestCopyWithin(ArrayCopyWithinHelper, false);

--- a/test/staging/ArrayBuffer/resizable/test-fill.js
+++ b/test/staging/ArrayBuffer/resizable/test-fill.js
@@ -1,0 +1,239 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from TestFill test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function ReadDataFromBuffer(ab, ctor) {
+  let result = [];
+  const ta = new ctor(ab, 0, ab.byteLength / ctor.BYTES_PER_ELEMENT);
+  for (let item of ta) {
+    result.push(Number(item));
+  }
+  return result;
+}
+
+function TypedArrayFillHelper(ta, n, start, end) {
+  if (ta instanceof BigInt64Array || ta instanceof BigUint64Array) {
+    ta.fill(BigInt(n), start, end);
+  } else {
+    ta.fill(n, start, end);
+  }
+}
+
+function ArrayFillHelper(ta, n, start, end) {
+  if (ta instanceof BigInt64Array || ta instanceof BigUint64Array) {
+    Array.prototype.fill.call(ta, BigInt(n), start, end);
+  } else {
+    Array.prototype.fill.call(ta, n, start, end);
+  }
+}
+
+function TestFill(helper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      0,
+      0,
+      0,
+      0
+    ]);
+    helper(fixedLength, 1);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      1,
+      1,
+      1,
+      1
+    ]);
+    helper(fixedLengthWithOffset, 2);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      1,
+      1,
+      2,
+      2
+    ]);
+    helper(lengthTracking, 3);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      3,
+      3,
+      3,
+      3
+    ]);
+    helper(lengthTrackingWithOffset, 4);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      3,
+      3,
+      4,
+      4
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => helper(fixedLength, 5));
+      assert.throws(TypeError, () => helper(fixedLengthWithOffset, 6));
+    } else {
+      helper(fixedLength, 5);
+      helper(fixedLengthWithOffset, 6);
+      // We'll check below that these were no-op.
+    }
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      3,
+      3,
+      4
+    ]);
+    helper(lengthTracking, 7);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      7,
+      7,
+      7
+    ]);
+    helper(lengthTrackingWithOffset, 8);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      7,
+      7,
+      8
+    ]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => helper(fixedLength, 9));
+      assert.throws(TypeError, () => helper(fixedLengthWithOffset, 10));
+      assert.throws(TypeError, () => helper(lengthTrackingWithOffset, 11));
+    } else {
+      // We'll check below that these were no-op.
+      helper(fixedLength, 9);
+      helper(fixedLengthWithOffset, 10);
+      helper(lengthTrackingWithOffset, 11);
+    }
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [7]);
+    helper(lengthTracking, 12);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [12]);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    helper(fixedLength, 13);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      13,
+      13,
+      13,
+      13,
+      0,
+      0
+    ]);
+    helper(fixedLengthWithOffset, 14);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      13,
+      13,
+      14,
+      14,
+      0,
+      0
+    ]);
+    helper(lengthTracking, 15);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      15,
+      15,
+      15,
+      15,
+      15,
+      15
+    ]);
+    helper(lengthTrackingWithOffset, 16);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      15,
+      15,
+      16,
+      16,
+      16,
+      16
+    ]);
+
+    // Filling with non-undefined start & end.
+    helper(fixedLength, 17, 1, 3);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      15,
+      17,
+      17,
+      16,
+      16,
+      16
+    ]);
+    helper(fixedLengthWithOffset, 18, 1, 2);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      15,
+      17,
+      17,
+      18,
+      16,
+      16
+    ]);
+    helper(lengthTracking, 19, 1, 3);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      15,
+      19,
+      19,
+      18,
+      16,
+      16
+    ]);
+    helper(lengthTrackingWithOffset, 20, 1, 2);
+    assert.compareArray(ReadDataFromBuffer(rab, ctor), [
+      15,
+      19,
+      19,
+      20,
+      16,
+      16
+    ]);
+  }
+}
+
+TestFill(TypedArrayFillHelper, true);
+TestFill(ArrayFillHelper, false);

--- a/test/staging/ArrayBuffer/resizable/test-map.js
+++ b/test/staging/ArrayBuffer/resizable/test-map.js
@@ -1,0 +1,243 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from TestMap test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+function WriteToTypedArray(array, index, value) {
+  if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+    array[index] = BigInt(value);
+  } else {
+    array[index] = value;
+  }
+}
+
+function Convert(item) {
+  if (typeof item == 'bigint') {
+    return Number(item);
+  }
+  return item;
+}
+
+function ToNumbers(array) {
+  let result = [];
+  for (let item of array) {
+    result.push(Convert(item));
+  }
+  return result;
+}
+
+const TypedArrayMapHelper = (ta, ...rest) => {
+  return ta.map(...rest);
+};
+
+const ArrayMapHelper = (ta, ...rest) => {
+  return Array.prototype.map.call(ta, ...rest);
+};
+
+function TestMap(mapHelper, oobThrows) {
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    const fixedLengthWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 2);
+    const lengthTracking = new ctor(rab, 0);
+    const lengthTrackingWithOffset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT);
+
+    // Write some data into the array.
+    const taWrite = new ctor(rab);
+    for (let i = 0; i < taWrite.length; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, ...] << lengthTracking
+    //                    [4, 6, ...] << lengthTrackingWithOffset
+
+    function Helper(array) {
+      const values = [];
+      function GatherValues(n, ix) {
+        assert.sameValue(ix, values.length);
+        values.push(n);
+        if (typeof n == 'bigint') {
+          return n + 1n;
+        }
+        return n + 1;
+      }
+      const newValues = mapHelper(array, GatherValues);
+      for (let i = 0; i < values.length; ++i) {
+        if (typeof values[i] == 'bigint') {
+          assert.sameValue(values[i] + 1n, newValues[i]);
+        } else {
+          assert.sameValue(values[i] + 1, newValues[i]);
+        }
+      }
+      return ToNumbers(values);
+    }
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6
+    ]);
+
+    // Shrink so that fixed length TAs go out of bounds.
+    rab.resize(3 * ctor.BYTES_PER_ELEMENT);
+
+    // Orig. array: [0, 2, 4]
+    //              [0, 2, 4, ...] << lengthTracking
+    //                    [4, ...] << lengthTrackingWithOffset
+
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        Helper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        Helper(fixedLengthWithOffset);
+      });
+    } else {
+      assert.compareArray(Helper(fixedLength), []);
+      assert.compareArray(Helper(fixedLengthWithOffset), []);
+    }
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [4]);
+
+    // Shrink so that the TAs with offset go out of bounds.
+    rab.resize(1 * ctor.BYTES_PER_ELEMENT);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        Helper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        Helper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        Helper(lengthTrackingWithOffset);
+      });
+    } else {
+      assert.compareArray(Helper(fixedLength), []);
+      assert.compareArray(Helper(fixedLengthWithOffset), []);
+      assert.compareArray(Helper(lengthTrackingWithOffset), []);
+    }
+    assert.compareArray(Helper(lengthTracking), [0]);
+
+    // Shrink to zero.
+    rab.resize(0);
+    if (oobThrows) {
+      assert.throws(TypeError, () => {
+        Helper(fixedLength);
+      });
+      assert.throws(TypeError, () => {
+        Helper(fixedLengthWithOffset);
+      });
+      assert.throws(TypeError, () => {
+        Helper(lengthTrackingWithOffset);
+      });
+    } else {
+      assert.compareArray(Helper(fixedLength), []);
+      assert.compareArray(Helper(fixedLengthWithOffset), []);
+      assert.compareArray(Helper(lengthTrackingWithOffset), []);
+    }
+    assert.compareArray(Helper(lengthTracking), []);
+
+    // Grow so that all TAs are back in-bounds.
+    rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+    for (let i = 0; i < 6; ++i) {
+      WriteToTypedArray(taWrite, i, 2 * i);
+    }
+
+    // Orig. array: [0, 2, 4, 6, 8, 10]
+    //              [0, 2, 4, 6] << fixedLength
+    //                    [4, 6] << fixedLengthWithOffset
+    //              [0, 2, 4, 6, 8, 10, ...] << lengthTracking
+    //                    [4, 6, 8, 10, ...] << lengthTrackingWithOffset
+
+    assert.compareArray(Helper(fixedLength), [
+      0,
+      2,
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(fixedLengthWithOffset), [
+      4,
+      6
+    ]);
+    assert.compareArray(Helper(lengthTracking), [
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
+    assert.compareArray(Helper(lengthTrackingWithOffset), [
+      4,
+      6,
+      8,
+      10
+    ]);
+  }
+}
+
+TestMap(TypedArrayMapHelper, true);
+TestMap(ArrayMapHelper, false);

--- a/test/staging/ArrayBuffer/resizable/to-locale-string-number-prototype-to-locale-string-grows.js
+++ b/test/staging/ArrayBuffer/resizable/to-locale-string-number-prototype-to-locale-string-grows.js
@@ -1,0 +1,112 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ToLocaleStringNumberPrototypeToLocaleStringGrows test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const TypedArrayToLocaleStringHelper = (ta, ...rest) => {
+  return ta.toLocaleString(...rest);
+};
+
+const ArrayToLocaleStringHelper = (ta, ...rest) => {
+  return Array.prototype.toLocaleString.call(ta, ...rest);
+};
+
+function ToLocaleStringNumberPrototypeToLocaleStringGrows(toLocaleStringHelper) {
+  const oldNumberPrototypeToLocaleString = Number.prototype.toLocaleString;
+  const oldBigIntPrototypeToLocaleString = BigInt.prototype.toLocaleString;
+
+  // Growing + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let resizeAfter = 2;
+    Number.prototype.toLocaleString = function () {
+      --resizeAfter;
+      if (resizeAfter == 0) {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      }
+      return oldNumberPrototypeToLocaleString.call(this);
+    };
+    BigInt.prototype.toLocaleString = function () {
+      --resizeAfter;
+      if (resizeAfter == 0) {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      }
+      return oldBigIntPrototypeToLocaleString.call(this);
+    };
+
+    // We iterate 4 elements since it was the starting length. Resizing doesn't
+    // affect the TA.
+    assert.sameValue(toLocaleStringHelper(fixedLength), '0,0,0,0');
+  }
+
+  // Growing + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let resizeAfter = 2;
+    Number.prototype.toLocaleString = function () {
+      --resizeAfter;
+      if (resizeAfter == 0) {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      }
+      return oldNumberPrototypeToLocaleString.call(this);
+    };
+    BigInt.prototype.toLocaleString = function () {
+      --resizeAfter;
+      if (resizeAfter == 0) {
+        rab.resize(6 * ctor.BYTES_PER_ELEMENT);
+      }
+      return oldBigIntPrototypeToLocaleString.call(this);
+    };
+
+    // We iterate 4 elements since it was the starting length.
+    assert.sameValue(toLocaleStringHelper(lengthTracking), '0,0,0,0');
+  }
+  Number.prototype.toLocaleString = oldNumberPrototypeToLocaleString;
+  BigInt.prototype.toLocaleString = oldBigIntPrototypeToLocaleString;
+}
+
+ToLocaleStringNumberPrototypeToLocaleStringGrows(TypedArrayToLocaleStringHelper);
+ToLocaleStringNumberPrototypeToLocaleStringGrows(ArrayToLocaleStringHelper);

--- a/test/staging/ArrayBuffer/resizable/to-locale-string-number-prototype-to-locale-string-shrinks.js
+++ b/test/staging/ArrayBuffer/resizable/to-locale-string-number-prototype-to-locale-string-shrinks.js
@@ -1,0 +1,113 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from ToLocaleStringNumberPrototypeToLocaleStringShrinks test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const TypedArrayToLocaleStringHelper = (ta, ...rest) => {
+  return ta.toLocaleString(...rest);
+};
+
+const ArrayToLocaleStringHelper = (ta, ...rest) => {
+  return Array.prototype.toLocaleString.call(ta, ...rest);
+};
+
+function ToLocaleStringNumberPrototypeToLocaleStringShrinks(toLocaleStringHelper) {
+  const oldNumberPrototypeToLocaleString = Number.prototype.toLocaleString;
+  const oldBigIntPrototypeToLocaleString = BigInt.prototype.toLocaleString;
+
+  // Shrinking + fixed-length TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const fixedLength = new ctor(rab, 0, 4);
+    let resizeAfter = 2;
+    Number.prototype.toLocaleString = function () {
+      --resizeAfter;
+      if (resizeAfter == 0) {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      }
+      return oldNumberPrototypeToLocaleString.call(this);
+    };
+    BigInt.prototype.toLocaleString = function () {
+      --resizeAfter;
+      if (resizeAfter == 0) {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      }
+      return oldBigIntPrototypeToLocaleString.call(this);
+    };
+
+    // We iterate 4 elements, since it was the starting length. The TA goes
+    // OOB after 2 elements.
+    assert.sameValue(toLocaleStringHelper(fixedLength), '0,0,,');
+  }
+
+  // Shrinking + length-tracking TA.
+  for (let ctor of ctors) {
+    const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+    const lengthTracking = new ctor(rab);
+    let resizeAfter = 2;
+    Number.prototype.toLocaleString = function () {
+      --resizeAfter;
+      if (resizeAfter == 0) {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      }
+      return oldNumberPrototypeToLocaleString.call(this);
+    };
+    BigInt.prototype.toLocaleString = function () {
+      --resizeAfter;
+      if (resizeAfter == 0) {
+        rab.resize(2 * ctor.BYTES_PER_ELEMENT);
+      }
+      return oldBigIntPrototypeToLocaleString.call(this);
+    };
+
+    // We iterate 4 elements, since it was the starting length. Elements beyond
+    // the new length are converted to the empty string.
+    assert.sameValue(toLocaleStringHelper(lengthTracking), '0,0,,');
+  }
+  Number.prototype.toLocaleString = oldNumberPrototypeToLocaleString;
+  BigInt.prototype.toLocaleString = oldBigIntPrototypeToLocaleString;
+}
+
+ToLocaleStringNumberPrototypeToLocaleStringShrinks(TypedArrayToLocaleStringHelper);
+ToLocaleStringNumberPrototypeToLocaleStringShrinks(ArrayToLocaleStringHelper);

--- a/test/staging/ArrayBuffer/resizable/typed-array-length-and-byte-length.js
+++ b/test/staging/ArrayBuffer/resizable/typed-array-length-and-byte-length.js
@@ -1,0 +1,79 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from TypedArrayLengthAndByteLength test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+includes: [compareArray.js]
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const rab = CreateResizableArrayBuffer(40, 80);
+for (let ctor of ctors) {
+  const ta = new ctor(rab, 0, 3);
+  assert.compareArray(ta.buffer, rab);
+  assert.sameValue(ta.length, 3);
+  assert.sameValue(ta.byteLength, 3 * ctor.BYTES_PER_ELEMENT);
+  const empty_ta = new ctor(rab, 0, 0);
+  assert.compareArray(empty_ta.buffer, rab);
+  assert.sameValue(empty_ta.length, 0);
+  assert.sameValue(empty_ta.byteLength, 0);
+  const ta_with_offset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 3);
+  assert.compareArray(ta_with_offset.buffer, rab);
+  assert.sameValue(ta_with_offset.length, 3);
+  assert.sameValue(ta_with_offset.byteLength, 3 * ctor.BYTES_PER_ELEMENT);
+  const empty_ta_with_offset = new ctor(rab, 2 * ctor.BYTES_PER_ELEMENT, 0);
+  assert.compareArray(empty_ta_with_offset.buffer, rab);
+  assert.sameValue(empty_ta_with_offset.length, 0);
+  assert.sameValue(empty_ta_with_offset.byteLength, 0);
+  const length_tracking_ta = new ctor(rab);
+  assert.compareArray(length_tracking_ta.buffer, rab);
+  assert.sameValue(length_tracking_ta.length, 40 / ctor.BYTES_PER_ELEMENT);
+  assert.sameValue(length_tracking_ta.byteLength, 40);
+  const offset = 8;
+  const length_tracking_ta_with_offset = new ctor(rab, offset);
+  assert.compareArray(length_tracking_ta_with_offset.buffer, rab);
+  assert.sameValue(length_tracking_ta_with_offset.length, (40 - offset) / ctor.BYTES_PER_ELEMENT);
+  assert.sameValue(length_tracking_ta_with_offset.byteLength, 40 - offset);
+  const empty_length_tracking_ta_with_offset = new ctor(rab, 40);
+  assert.compareArray(empty_length_tracking_ta_with_offset.buffer, rab);
+  assert.sameValue(empty_length_tracking_ta_with_offset.length, 0);
+  assert.sameValue(empty_length_tracking_ta_with_offset.byteLength, 0);
+}

--- a/test/staging/ArrayBuffer/resizable/typed-array-length-when-resized-out-of-bounds-1.js
+++ b/test/staging/ArrayBuffer/resizable/typed-array-length-when-resized-out-of-bounds-1.js
@@ -1,0 +1,77 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from TypedArrayLengthWhenResizedOutOfBounds1 test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const rab = CreateResizableArrayBuffer(16, 40);
+
+// Create TAs which cover the bytes 0-7.
+let tas_and_lengths = [];
+for (let ctor of ctors) {
+  const length = 8 / ctor.BYTES_PER_ELEMENT;
+  tas_and_lengths.push([
+    new ctor(rab, 0, length),
+    length
+  ]);
+}
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+}
+rab.resize(2);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, 0);
+  assert.sameValue(ta.byteLength, 0);
+}
+// Resize the rab so that it just barely covers the needed 8 bytes.
+rab.resize(8);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+}
+rab.resize(40);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+}

--- a/test/staging/ArrayBuffer/resizable/typed-array-length-when-resized-out-of-bounds-2.js
+++ b/test/staging/ArrayBuffer/resizable/typed-array-length-when-resized-out-of-bounds-2.js
@@ -1,0 +1,83 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from TypedArrayLengthWhenResizedOutOfBounds2 test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+// typed-array-length-when-resized-out-of-bounds-1 but with offsets.
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const rab = CreateResizableArrayBuffer(20, 40);
+
+// Create TAs which cover the bytes 8-15.
+let tas_and_lengths = [];
+for (let ctor of ctors) {
+  const length = 8 / ctor.BYTES_PER_ELEMENT;
+  tas_and_lengths.push([
+    new ctor(rab, 8, length),
+    length
+  ]);
+}
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteOffset, 8);
+}
+rab.resize(10);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, 0);
+  assert.sameValue(ta.byteLength, 0);
+  assert.sameValue(ta.byteOffset, 0);
+}
+// Resize the rab so that it just barely covers the needed 8 bytes.
+rab.resize(16);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteOffset, 8);
+}
+rab.resize(40);
+for (let [ta, length] of tas_and_lengths) {
+  assert.sameValue(ta.length, length);
+  assert.sameValue(ta.byteLength, length * ta.BYTES_PER_ELEMENT);
+  assert.sameValue(ta.byteOffset, 8);
+}

--- a/test/staging/ArrayBuffer/resizable/typed-array-prototype.js
+++ b/test/staging/ArrayBuffer/resizable/typed-array-prototype.js
@@ -1,0 +1,53 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  Automatically ported from TypedArrayPrototype test
+  in V8's mjsunit test typedarray-resizablearraybuffer.js
+features: [resizable-arraybuffer]
+flags: [onlyStrict]
+---*/
+
+class MyUint8Array extends Uint8Array {
+}
+
+class MyFloat32Array extends Float32Array {
+}
+
+class MyBigInt64Array extends BigInt64Array {
+}
+
+const builtinCtors = [
+  Uint8Array,
+  Int8Array,
+  Uint16Array,
+  Int16Array,
+  Uint32Array,
+  Int32Array,
+  Float32Array,
+  Float64Array,
+  Uint8ClampedArray,
+  BigUint64Array,
+  BigInt64Array
+];
+
+const ctors = [
+  ...builtinCtors,
+  MyUint8Array,
+  MyFloat32Array,
+  MyBigInt64Array
+];
+
+function CreateResizableArrayBuffer(byteLength, maxByteLength) {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+
+const rab = CreateResizableArrayBuffer(40, 80);
+const ab = new ArrayBuffer(80);
+for (let ctor of ctors) {
+  const ta_rab = new ctor(rab, 0, 3);
+  const ta_ab = new ctor(ab, 0, 3);
+  assert.sameValue(ta_ab.__proto__, ta_rab.__proto__);
+}


### PR DESCRIPTION
These are tests for the Resizable ArrayBuffer proposal:
https://tc39.es/proposal-resizablearraybuffer/

These tests were automatically converted from V8's tests for the proposal:
https://source.chromium.org/chromium/chromium/src/+/main:v8/test/mjsunit/typedarray-resizablearraybuffer.js
and subsequently edited by hand to fix things that couldn't be converted automatically.