### PR TITLE
Temporal: Fix test that depends on pre-1970 time zone data

### DIFF
--- a/test/staging/Temporal/TimeZone/old/subminute-offset.js
+++ b/test/staging/Temporal/TimeZone/old/subminute-offset.js
@@ -7,11 +7,8 @@ description: sub-minute offset
 features: [Temporal]
 ---*/
 
-var zone = new Temporal.TimeZone("Europe/Amsterdam");
-var inst = Temporal.Instant.from("1900-01-01T12:00Z");
-var dtm = Temporal.PlainDateTime.from("1900-01-01T12:00");
-assert.sameValue(zone.id, `${ zone }`)
-assert.sameValue(zone.getOffsetNanosecondsFor(inst), 1172000000000)
-assert.sameValue(`${ zone.getInstantFor(dtm) }`, "1900-01-01T11:40:28Z")
-assert.sameValue(`${ zone.getNextTransition(inst) }`, "1916-04-30T23:40:28Z")
-assert.sameValue(zone.getPreviousTransition(inst), null)
+var zone = new Temporal.TimeZone("+00:19:32");
+var inst = Temporal.Instant.from("2000-01-01T12:00Z");
+var dtm = Temporal.PlainDateTime.from("2000-01-01T12:00");
+assert.sameValue(zone.getOffsetNanosecondsFor(inst), 1172000000000);
+assert.sameValue(`${ zone.getInstantFor(dtm) }`, "2000-01-01T11:40:28Z");


### PR DESCRIPTION
Due to the TZDB's recent merging of time zones whose pre-1970 data was different but post-1970 have been the same, this test is going to start failing on implementations with up-to-date time zone data (because the Europe/Amsterdam time zone was absorbed into Europe/Brussels in the latest update.)

It's on our to-do list to remove all dependencies on IANA time zones from the Temporal tests in staging/,
(see https://github.com/tc39/test262/issues/3649#issuecomment-1232326175) but this one is more urgent.