### PR TITLE
Temporal: Adjust order of operations in Calendar.___fromFields

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/dateFromFields/order-of-operations.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateFromFields/order-of-operations.js
@@ -9,9 +9,6 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get options.overflow",
-  "get options.overflow.toString",
-  "call options.overflow.toString",
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -24,6 +21,9 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 

--- a/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/order-of-operations.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/order-of-operations.js
@@ -9,9 +9,6 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get options.overflow",
-  "get options.overflow.toString",
-  "call options.overflow.toString",
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -24,6 +21,9 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 

--- a/test/built-ins/Temporal/Calendar/prototype/yearMonthFromFields/order-of-operations.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearMonthFromFields/order-of-operations.js
@@ -9,9 +9,6 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get options.overflow",
-  "get options.overflow.toString",
-  "call options.overflow.toString",
   "get fields.month",
   "get fields.month.valueOf",
   "call fields.month.valueOf",
@@ -21,6 +18,9 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 

--- a/test/intl402/Temporal/Calendar/prototype/dateFromFields/order-of-operations.js
+++ b/test/intl402/Temporal/Calendar/prototype/dateFromFields/order-of-operations.js
@@ -9,9 +9,6 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get options.overflow",
-  "get options.overflow.toString",
-  "call options.overflow.toString",
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -30,6 +27,9 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 

--- a/test/intl402/Temporal/Calendar/prototype/monthDayFromFields/order-of-operations.js
+++ b/test/intl402/Temporal/Calendar/prototype/monthDayFromFields/order-of-operations.js
@@ -9,9 +9,6 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get options.overflow",
-  "get options.overflow.toString",
-  "call options.overflow.toString",
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -30,6 +27,9 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 

--- a/test/intl402/Temporal/Calendar/prototype/yearMonthFromFields/order-of-operations.js
+++ b/test/intl402/Temporal/Calendar/prototype/yearMonthFromFields/order-of-operations.js
@@ -9,9 +9,6 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get options.overflow",
-  "get options.overflow.toString",
-  "call options.overflow.toString",
   "get fields.era",
   "get fields.era.toString",
   "call fields.era.toString",
@@ -27,6 +24,9 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 


### PR DESCRIPTION
This implements the normative change in
https://github.com/tc39/proposal-temporal/pull/2377 which reached consensus at the September 2022 TC39 meeting.

It changes the order in which observable operations are performed on the values passed to the ___fromFields methods of Calendar.