### PR TITLE
Temporal: Test new limits for getOffsetNanosecondsFor

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const duration = new Temporal.Duration(1);

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const date = new Temporal.PlainDate(2000, 5, 2);

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
   const other = new Temporal.Duration(2);

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
   const other = new Temporal.Duration(2);

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
   assert.throws(RangeError, () => duration.round({ smallestUnit: "seconds", relativeTo: { year: 2000, month: 5, day: 2, hour: 12, timeZone } }));

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
   const other = new Temporal.Duration(0, 3);

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
   const other = new Temporal.Duration(0, 3);

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
   assert.throws(RangeError, () => duration.total({ unit: "seconds", relativeTo: { year: 2000, month: 5, day: 2, hour: 12, timeZone } }));

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/Instant/prototype/toString/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const instant = new Temporal.Instant(1_000_000_000_987_654_321n);
   assert.throws(RangeError, () => instant.toString({ timeZone }));

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const date = new Temporal.PlainDate(2000, 5, 2);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const date = new Temporal.PlainDate(2000, 5, 2);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const date = new Temporal.PlainDate(2000, 5, 2);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/plaintime-argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/plaintime-argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const date = new Temporal.PlainDate(2000, 5, 2);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-non-integer.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-non-integer.js
@@ -12,5 +12,8 @@ includes: [temporalHelpers.js]
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const date = new Temporal.PlainDate(2000, 5, 2);
   const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(RangeError, () => date.toZonedDateTime({ plainTime, timeZone }));
 });

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -12,5 +12,8 @@ includes: [temporalHelpers.js]
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const date = new Temporal.PlainDate(2000, 5, 2);
   const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(RangeError, () => date.toZonedDateTime({ plainTime, timeZone }));
 });

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const date = new Temporal.PlainDate(2000, 5, 2);
   const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-wrong-type.js
@@ -21,5 +21,8 @@ includes: [temporalHelpers.js]
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const date = new Temporal.PlainDate(2000, 5, 2);
   const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(TypeError, () => date.toZonedDateTime({ plainTime, timeZone }));
 });

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const date = new Temporal.PlainDate(2000, 5, 2);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const plain = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
   const zoned = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const plain = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
   const zoned = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-non-integer.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-non-integer.js
@@ -11,5 +11,8 @@ includes: [temporalHelpers.js]
 [3600_000_000_000.5, NaN, -Infinity, Infinity].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(RangeError, () => datetime.toZonedDateTime(timeZone));
 });

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
   timeZone.getPossibleInstantsFor = function () {

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -11,5 +11,8 @@ includes: [temporalHelpers.js]
 [-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(RangeError, () => datetime.toZonedDateTime(timeZone));
 });

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-wrong-type.js
@@ -20,5 +20,8 @@ includes: [temporalHelpers.js]
 ].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(TypeError, () => datetime.toZonedDateTime(timeZone));
 });

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const plain = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
   const zoned = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const plain = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
   const zoned = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const plain = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
   const zoned = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-non-integer.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-non-integer.js
@@ -12,5 +12,8 @@ includes: [temporalHelpers.js]
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
   const plainDate = new Temporal.PlainDate(2000, 5, 2);
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(RangeError, () => time.toZonedDateTime({ plainDate, timeZone }));
 });

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -12,5 +12,8 @@ includes: [temporalHelpers.js]
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
   const plainDate = new Temporal.PlainDate(2000, 5, 2);
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(RangeError, () => time.toZonedDateTime({ plainDate, timeZone }));
 });

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
   const plainDate = new Temporal.PlainDate(2000, 5, 2);

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-getoffsetnanosecondsfor-wrong-type.js
@@ -21,5 +21,8 @@ includes: [temporalHelpers.js]
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
   const plainDate = new Temporal.PlainDate(2000, 5, 2);
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(TypeError, () => time.toZonedDateTime({ plainDate, timeZone }));
 });

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   const builtinTimeZone = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const instant = new Temporal.Instant(1_000_000_000_987_654_321n);
   assert.throws(RangeError, () => timeZone.getOffsetStringFor(instant));

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const instant = new Temporal.Instant(1_000_000_000_987_654_321n);
   assert.throws(RangeError, () => timeZone.getPlainDateTimeFor(instant));

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   const builtinTimeZone = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/add/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/add/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const duration = new Temporal.Duration(1);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/day/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/day/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.day);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/dayOfWeek/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/dayOfWeek/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.dayOfWeek);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/dayOfYear/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/dayOfYear/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.dayOfYear);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/daysInMonth/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/daysInMonth/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.daysInMonth);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/daysInWeek/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/daysInWeek/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.daysInWeek);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/daysInYear/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/daysInYear/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.daysInYear);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-getoffsetnanosecondsfor-non-integer.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-getoffsetnanosecondsfor-non-integer.js
@@ -11,5 +11,8 @@ includes: [temporalHelpers.js]
 [3600_000_000_000.5, NaN, -Infinity, Infinity].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(RangeError, () => datetime.equals({ year: 2000, month: 5, day: 2, hour: 12, timeZone }));
 });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
   timeZone.getPossibleInstantsFor = function () {

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -11,5 +11,8 @@ includes: [temporalHelpers.js]
 [-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(RangeError, () => datetime.equals({ year: 2000, month: 5, day: 2, hour: 12, timeZone }));
 });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-getoffsetnanosecondsfor-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-getoffsetnanosecondsfor-wrong-type.js
@@ -20,5 +20,8 @@ includes: [temporalHelpers.js]
 ].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
   assert.throws(TypeError, () => datetime.equals({ year: 2000, month: 5, day: 2, hour: 12, timeZone }));
 });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/getISOFields/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/getISOFields/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.getISOFields());

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/hour/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/hour/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.hour);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/hoursInDay/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/hoursInDay/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.hoursInDay);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/inLeapYear/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/inLeapYear/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.inLeapYear);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/microsecond/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/microsecond/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.microsecond);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/millisecond/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/millisecond/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.millisecond);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/minute/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/minute/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.minute);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/month/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/month/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.month);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/monthCode/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/monthCode/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.monthCode);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/monthsInYear/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/monthsInYear/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.monthsInYear);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/nanosecond/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/nanosecond/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.nanosecond);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/offset/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/offset/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.offset);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/offsetNanoseconds/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/offsetNanoseconds/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.offsetNanoseconds);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.round({ smallestUnit: "second" }));

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/second/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/second/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.second);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-getoffsetnanosecondsfor-non-integer.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-getoffsetnanosecondsfor-non-integer.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: RangeError thrown if time zone reports an offset that is not an integer number of nanoseconds
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[3600_000_000_000.5, NaN, -Infinity, Infinity].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+  const properties = { year: 2004, month: 11, day: 9, hour: 11, minute: 33, second: 20, timeZone };
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
+  assert.throws(RangeError, () => datetime.since(properties, { largestUnit: "days" }));
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
   const properties = { year: 2004, month: 11, day: 9, hour: 11, minute: 33, second: 20, timeZone };

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: RangeError thrown if time zone reports an offset that is out of range
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+  const properties = { year: 2004, month: 11, day: 9, hour: 11, minute: 33, second: 20, timeZone };
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
+  assert.throws(RangeError, () => datetime.since(properties, { largestUnit: "days" }));
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-getoffsetnanosecondsfor-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-getoffsetnanosecondsfor-wrong-type.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: TypeError thrown if time zone reports an offset that is not a Number
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[
+  undefined,
+  null,
+  true,
+  "+01:00",
+  Symbol(),
+  3600_000_000_000n,
+  {},
+  { valueOf() { return 3600_000_000_000; } },
+].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+  const properties = { year: 2004, month: 11, day: 9, hour: 11, minute: 33, second: 20, timeZone };
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
+  assert.throws(TypeError, () => datetime.since(properties, { largestUnit: "days" }));
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   const other = new Temporal.ZonedDateTime(1_100_000_000_123_456_789n, timeZone);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/startOfDay/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/startOfDay/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.startOfDay());

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const duration = new Temporal.Duration(1);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toJSON/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toJSON/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.toJSON());

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainDate/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainDate/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.toPlainDate());

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainDateTime/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.toPlainDateTime());

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainMonthDay/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainMonthDay/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.toPlainMonthDay());

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainTime/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainTime/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.toPlainTime());

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainYearMonth/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainYearMonth/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.toPlainYearMonth());

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.toString());

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-getoffsetnanosecondsfor-non-integer.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-getoffsetnanosecondsfor-non-integer.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: RangeError thrown if time zone reports an offset that is not an integer number of nanoseconds
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[3600_000_000_000.5, NaN, -Infinity, Infinity].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+  const properties = { year: 2004, month: 11, day: 9, hour: 11, minute: 33, second: 20, timeZone };
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
+  assert.throws(RangeError, () => datetime.until(properties, { largestUnit: "days" }));
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: RangeError thrown if time zone reports an offset that is out of range
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+  const properties = { year: 2004, month: 11, day: 9, hour: 11, minute: 33, second: 20, timeZone };
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
+  assert.throws(RangeError, () => datetime.until(properties, { largestUnit: "days" }));
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
   const properties = { year: 2004, month: 11, day: 9, hour: 11, minute: 33, second: 20, timeZone };

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-getoffsetnanosecondsfor-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-getoffsetnanosecondsfor-wrong-type.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: TypeError thrown if time zone reports an offset that is not a Number
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[
+  undefined,
+  null,
+  true,
+  "+01:00",
+  Symbol(),
+  3600_000_000_000n,
+  {},
+  { valueOf() { return 3600_000_000_000; } },
+].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+  const properties = { year: 2004, month: 11, day: 9, hour: 11, minute: 33, second: 20, timeZone };
+  timeZone.getPossibleInstantsFor = function () {
+    return [];
+  };
+  assert.throws(TypeError, () => datetime.until(properties, { largestUnit: "days" }));
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   const other = new Temporal.ZonedDateTime(1_100_000_000_123_456_789n, timeZone);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/weekOfYear/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/weekOfYear/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.weekOfYear);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/with/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/with/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.with({ day: 27 }));

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
   const other = new Temporal.ZonedDateTime(1_100_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   const date = new Temporal.PlainDate(2000, 5, 2);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
   const other = new Temporal.ZonedDateTime(1_100_000_000_987_654_321n, timeZone);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/year/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/year/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.year);

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.era
+description: RangeError thrown if time zone reports an offset that is not an integer number of nanoseconds
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[3600_000_000_000.5, NaN, -Infinity, Infinity].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const calendar = new Temporal.Calendar("iso8601");
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
+  assert.throws(RangeError, () => calendar.era(datetime));
+});

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.era
+description: RangeError thrown if time zone reports an offset that is out of range
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const calendar = new Temporal.Calendar("iso8601");
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
+  assert.throws(RangeError, () => calendar.era(datetime));
+});

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.era
+description: TypeError thrown if time zone reports an offset that is not a Number
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[
+  undefined,
+  null,
+  true,
+  "+01:00",
+  Symbol(),
+  3600_000_000_000n,
+  {},
+  { valueOf() { return 3600_000_000_000; } },
+].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const calendar = new Temporal.Calendar("iso8601");
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
+  assert.throws(TypeError, () => calendar.era(datetime));
+});

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.erayear
+description: RangeError thrown if time zone reports an offset that is not an integer number of nanoseconds
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[3600_000_000_000.5, NaN, -Infinity, Infinity].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const calendar = new Temporal.Calendar("iso8601");
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
+  assert.throws(RangeError, () => calendar.eraYear(datetime));
+});

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const calendar = new Temporal.Calendar("iso8601");
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.erayear
+description: RangeError thrown if time zone reports an offset that is out of range
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const calendar = new Temporal.Calendar("iso8601");
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
+  assert.throws(RangeError, () => calendar.eraYear(datetime));
+});

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.erayear
+description: TypeError thrown if time zone reports an offset that is not a Number
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[
+  undefined,
+  null,
+  true,
+  "+01:00",
+  Symbol(),
+  3600_000_000_000n,
+  {},
+  { valueOf() { return 3600_000_000_000; } },
+].forEach((wrongOffset) => {
+  const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
+  const calendar = new Temporal.Calendar("iso8601");
+  const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
+  assert.throws(TypeError, () => calendar.eraYear(datetime));
+});

--- a/test/intl402/Temporal/ZonedDateTime/prototype/era/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/era/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.era);

--- a/test/intl402/Temporal/ZonedDateTime/prototype/eraYear/timezone-getoffsetnanosecondsfor-out-of-range.js
+++ b/test/intl402/Temporal/ZonedDateTime/prototype/eraYear/timezone-getoffsetnanosecondsfor-out-of-range.js
@@ -8,7 +8,7 @@ features: [Temporal]
 includes: [temporalHelpers.js]
 ---*/
 
-[-86400_000_000_001, 86400_000_000_001].forEach((wrongOffset) => {
+[-86400_000_000_000, 86400_000_000_000].forEach((wrongOffset) => {
   const timeZone = TemporalHelpers.specificOffsetTimeZone(wrongOffset);
   const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, timeZone);
   assert.throws(RangeError, () => datetime.eraYear);


### PR DESCRIPTION
This implements the normative change from https://github.com/tc39/proposal-temporal/pull/2260 which achieved consensus in the July 2022 TC39 meeting. The PR is mostly subtracting 1 from a number of nanoseconds :stuck_out_tongue: but there are two other commits that bring some similar tests more in line with each other.