### PR TITLE
Temporal refactors

### DIFF
--- a/test/built-ins/Temporal/Calendar/from/calendar-object-operations.js
+++ b/test/built-ins/Temporal/Calendar/from/calendar-object-operations.js
@@ -16,24 +16,17 @@ const expected = [
   "call inner.toString",
 ];
 const actual = [];
-const calendar = new Proxy({}, {
-  has(t, p) {
-    actual.push(`has outer.${p}`);
-    return true;
-  },
-  get(t, p) {
-    actual.push(`get outer.${p}`);
-    return new Proxy(TemporalHelpers.toPrimitiveObserver(actual, "iso8601", "inner"), {
-      has(t, p) {
-        actual.push(`has inner.${p}`);
-        return true;
-      },
-      get(t, p) {
-        return t[p];
-      },
-    });
-  },
-});
+const calendar = TemporalHelpers.propertyBagObserver(actual, {
+  calendar: new Proxy(TemporalHelpers.toPrimitiveObserver(actual, "iso8601", "inner"), {
+    has(t, p) {
+      actual.push(`has inner.${p}`);
+      return true;
+    },
+    get(t, p) {
+      return t[p];
+    },
+  }),
+}, "outer");
 const result = Temporal.Calendar.from(calendar);
 assert.sameValue(result.id, "iso8601");
 assert.compareArray(actual, expected);

--- a/test/built-ins/Temporal/Calendar/prototype/dateFromFields/order-of-operations.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateFromFields/order-of-operations.js
@@ -29,40 +29,18 @@ const actual = [];
 
 const instance = new Temporal.Calendar("iso8601");
 
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
   day: 1.7,
-};
-const arg1 = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get fields.${key}`);
-    if (key === "calendar") return instance;
-    const result = target[key];
-    return TemporalHelpers.toPrimitiveObserver(actual, result, `fields.${key}`);
-  },
-  has(target, key) {
-    actual.push(`has fields.${key}`);
-    return key in target;
-  },
-});
+}, "fields");
 
-const options = {
+const options = TemporalHelpers.propertyBagObserver(actual, {
   overflow: "reject",
-};
-const arg2 = new Proxy(options, {
-  get(target, key) {
-    actual.push(`get options.${key}`);
-    return TemporalHelpers.toPrimitiveObserver(actual, target[key], `options.${key}`);
-  },
-  has(target, key) {
-    actual.push(`has options.${key}`);
-    return key in target;
-  },
-});
+}, "options");
 
-const result = instance.dateFromFields(arg1, arg2);
+const result = instance.dateFromFields(fields, options);
 TemporalHelpers.assertPlainDate(result, 1, 1, "M01", 1, "date result");
 assert.sameValue(result.calendar, instance, "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/order-of-operations.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/order-of-operations.js
@@ -29,40 +29,18 @@ const actual = [];
 
 const instance = new Temporal.Calendar("iso8601");
 
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
   day: 1.7,
-};
-const arg1 = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get fields.${key}`);
-    if (key === "calendar") return instance;
-    const result = target[key];
-    return TemporalHelpers.toPrimitiveObserver(actual, result, `fields.${key}`);
-  },
-  has(target, key) {
-    actual.push(`has fields.${key}`);
-    return key in target;
-  },
-});
+}, "fields");
 
-const options = {
+const options = TemporalHelpers.propertyBagObserver(actual, {
   overflow: "reject",
-};
-const arg2 = new Proxy(options, {
-  get(target, key) {
-    actual.push(`get options.${key}`);
-    return TemporalHelpers.toPrimitiveObserver(actual, target[key], `options.${key}`);
-  },
-  has(target, key) {
-    actual.push(`has options.${key}`);
-    return key in target;
-  },
-});
+}, "options");
 
-const result = instance.monthDayFromFields(arg1, arg2);
+const result = instance.monthDayFromFields(fields, options);
 TemporalHelpers.assertPlainMonthDay(result, "M01", 1, "monthDay result");
 assert.sameValue(result.calendar, instance, "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/Calendar/prototype/yearMonthFromFields/order-of-operations.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearMonthFromFields/order-of-operations.js
@@ -26,39 +26,17 @@ const actual = [];
 
 const instance = new Temporal.Calendar("iso8601");
 
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
-};
-const arg1 = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get fields.${key}`);
-    if (key === "calendar") return instance;
-    const result = target[key];
-    return TemporalHelpers.toPrimitiveObserver(actual, result, `fields.${key}`);
-  },
-  has(target, key) {
-    actual.push(`has fields.${key}`);
-    return key in target;
-  },
-});
+}, "fields");
 
-const options = {
+const options = TemporalHelpers.propertyBagObserver(actual, {
   overflow: "reject",
-};
-const arg2 = new Proxy(options, {
-  get(target, key) {
-    actual.push(`get options.${key}`);
-    return TemporalHelpers.toPrimitiveObserver(actual, target[key], `options.${key}`);
-  },
-  has(target, key) {
-    actual.push(`has options.${key}`);
-    return key in target;
-  },
-});
+}, "options");
 
-const result = instance.yearMonthFromFields(arg1, arg2);
+const result = instance.yearMonthFromFields(fields, options);
 TemporalHelpers.assertPlainYearMonth(result, 1, 1, "M01", "yearMonth result");
 assert.sameValue(result.calendar, instance, "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/Duration/from/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/from/order-of-operations.js
@@ -9,39 +9,39 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -52,18 +52,7 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = Temporal.Duration.from(argument);
+}, "fields");
+const result = Temporal.Duration.from(fields);
 TemporalHelpers.assertDuration(result, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/Duration/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/order-of-operations.js
@@ -11,39 +11,39 @@ features: [Temporal]
 const instance = new Temporal.Duration(1, 2, 0, 4, 5, 6, 7, 987, 654, 321);
 const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -54,21 +54,7 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.add(argument, { relativeTo });
+}, "fields");
+const result = instance.add(fields, { relativeTo });
 TemporalHelpers.assertDuration(result, 2, 3, 0, 12, 6, 7, 8, 988, 655, 322);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/Duration/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/order-of-operations.js
@@ -11,39 +11,39 @@ features: [Temporal]
 const instance = new Temporal.Duration(1, 2, 1, 4, 5, 6, 7, 987, 654, 321);
 const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -54,21 +54,7 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.subtract(argument, { relativeTo });
+}, "fields");
+const result = instance.subtract(fields, { relativeTo });
 TemporalHelpers.assertDuration(result, 0, 1, 0, 3, 4, 5, 6, 986, 653, 320);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/Duration/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/with/order-of-operations.js
@@ -10,39 +10,39 @@ features: [Temporal]
 
 const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -53,21 +53,7 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.with(argument);
+}, "fields");
+const result = instance.with(fields);
 TemporalHelpers.assertDuration(result, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/Instant/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/Instant/prototype/add/order-of-operations.js
@@ -10,52 +10,38 @@ features: [Temporal]
 
 const instance = new Temporal.Instant(10n);
 const expected = [
-  "get days",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get years",
+  "get fields.days",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.years",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   hours: 1,
   minutes: 1,
   seconds: 1,
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.add(argument);
+}, "fields");
+const result = instance.add(fields);
 assert.sameValue(result.epochNanoseconds, 3661001001011n, "epochNanoseconds result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/Instant/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/Instant/prototype/subtract/order-of-operations.js
@@ -10,52 +10,38 @@ features: [Temporal]
 
 const instance = new Temporal.Instant(10n);
 const expected = [
-  "get days",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get years",
+  "get fields.days",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.years",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   hours: 1,
   minutes: 1,
   seconds: 1,
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.subtract(argument);
+}, "fields");
+const result = instance.subtract(fields);
 assert.sameValue(result.epochNanoseconds, -3661001000991n, "epochNanoseconds result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDate/from/argument-plaindate.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-plaindate.js
@@ -8,8 +8,7 @@ includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const calendar = new Temporal.Calendar("iso8601");
-const orig = new Temporal.PlainDate(2000, 5, 2, calendar);
+const orig = new Temporal.PlainDate(2000, 5, 2);
 const result = Temporal.PlainDate.from(orig);
 
 TemporalHelpers.assertPlainDate(
@@ -18,11 +17,7 @@ TemporalHelpers.assertPlainDate(
   "PlainDate is copied"
 );
 
-assert.sameValue(
-  result.calendar,
-  calendar,
-  "Calendar is copied"
-);
+assert.sameValue(result.calendar, orig.calendar, "Calendar is copied");
 
 assert.notSameValue(
   result,

--- a/test/built-ins/Temporal/PlainDate/from/calendar-fields-custom.js
+++ b/test/built-ins/Temporal/PlainDate/from/calendar-fields-custom.js
@@ -24,16 +24,7 @@ class CustomCalendar extends Temporal.Calendar {
 
 const calendar = new CustomCalendar();
 const actual = [];
-const item = new Proxy({ calendar }, {
-  has(target, property) {
-    actual.push(`has item.${property}`);
-    return property in target;
-  },
-  get(target, property) {
-    actual.push(`get item.${property}`);
-    return target[property];
-  },
-});
+const item = TemporalHelpers.propertyBagObserver(actual, { calendar }, "item");
 
 const plainDate = Temporal.PlainDate.from(item);
 TemporalHelpers.assertPlainDate(plainDate, 2020, 7, "M07", 4);

--- a/test/built-ins/Temporal/PlainDate/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/from/order-of-operations.js
@@ -9,40 +9,28 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get calendar",
-  "get day",
-  "get day.valueOf",
-  "call day.valueOf",
-  "get month",
-  "get month.valueOf",
-  "call month.valueOf",
-  "get monthCode",
-  "get monthCode.toString",
-  "call monthCode.toString",
-  "get year",
-  "get year.valueOf",
-  "call year.valueOf",
+  "get fields.calendar",
+  "get fields.day",
+  "get fields.day.valueOf",
+  "call fields.day.valueOf",
+  "get fields.month",
+  "get fields.month.valueOf",
+  "call fields.month.valueOf",
+  "get fields.monthCode",
+  "get fields.monthCode.toString",
+  "call fields.monthCode.toString",
+  "get fields.year",
+  "get fields.year.valueOf",
+  "call fields.year.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
   day: 1.7,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    if (key === "calendar") return Temporal.Calendar.from("iso8601");
-    const result = target[key];
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = Temporal.PlainDate.from(argument);
+}, "fields");
+const result = Temporal.PlainDate.from(fields);
 TemporalHelpers.assertPlainDate(result, 1, 1, "M01", 1);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDate/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/add/order-of-operations.js
@@ -10,39 +10,39 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -53,22 +53,8 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.add(argument);
+}, "fields");
+const result = instance.add(fields);
 TemporalHelpers.assertPlainDate(result, 2001, 6, "M06", 10);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDate/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/subtract/order-of-operations.js
@@ -10,39 +10,39 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -53,22 +53,8 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.subtract(argument);
+}, "fields");
+const result = instance.subtract(fields);
 TemporalHelpers.assertPlainDate(result, 1999, 3, "M03", 25);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDate/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/with/order-of-operations.js
@@ -10,43 +10,29 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDate(2000, 5, 2);
 const expected = [
-  "get calendar",
-  "get timeZone",
-  "get day",
-  "get day.valueOf",
-  "call day.valueOf",
-  "get month",
-  "get month.valueOf",
-  "call month.valueOf",
-  "get monthCode",
-  "get monthCode.toString",
-  "call monthCode.toString",
-  "get year",
-  "get year.valueOf",
-  "call year.valueOf",
+  "get fields.calendar",
+  "get fields.timeZone",
+  "get fields.day",
+  "get fields.day.valueOf",
+  "call fields.day.valueOf",
+  "get fields.month",
+  "get fields.month.valueOf",
+  "call fields.month.valueOf",
+  "get fields.monthCode",
+  "get fields.monthCode.toString",
+  "call fields.monthCode.toString",
+  "get fields.year",
+  "get fields.year.valueOf",
+  "call fields.year.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
   day: 1.7,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.with(argument);
+}, "fields");
+const result = instance.with(fields);
 TemporalHelpers.assertPlainDate(result, 1, 1, "M01", 1);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-plaindatetime.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-plaindatetime.js
@@ -17,6 +17,8 @@ TemporalHelpers.assertPlainDateTime(
   "PlainDateTime is copied"
 );
 
+assert.sameValue(result.calendar, orig.calendar, "Calendar is copied");
+
 assert.notSameValue(
   result,
   orig,

--- a/test/built-ins/Temporal/PlainDateTime/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/order-of-operations.js
@@ -9,40 +9,40 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get calendar",
-  "get day",
-  "get day.valueOf",
-  "call day.valueOf",
-  "get hour",
-  "get hour.valueOf",
-  "call hour.valueOf",
-  "get microsecond",
-  "get microsecond.valueOf",
-  "call microsecond.valueOf",
-  "get millisecond",
-  "get millisecond.valueOf",
-  "call millisecond.valueOf",
-  "get minute",
-  "get minute.valueOf",
-  "call minute.valueOf",
-  "get month",
-  "get month.valueOf",
-  "call month.valueOf",
-  "get monthCode",
-  "get monthCode.toString",
-  "call monthCode.toString",
-  "get nanosecond",
-  "get nanosecond.valueOf",
-  "call nanosecond.valueOf",
-  "get second",
-  "get second.valueOf",
-  "call second.valueOf",
-  "get year",
-  "get year.valueOf",
-  "call year.valueOf",
+  "get fields.calendar",
+  "get fields.day",
+  "get fields.day.valueOf",
+  "call fields.day.valueOf",
+  "get fields.hour",
+  "get fields.hour.valueOf",
+  "call fields.hour.valueOf",
+  "get fields.microsecond",
+  "get fields.microsecond.valueOf",
+  "call fields.microsecond.valueOf",
+  "get fields.millisecond",
+  "get fields.millisecond.valueOf",
+  "call fields.millisecond.valueOf",
+  "get fields.minute",
+  "get fields.minute.valueOf",
+  "call fields.minute.valueOf",
+  "get fields.month",
+  "get fields.month.valueOf",
+  "call fields.month.valueOf",
+  "get fields.monthCode",
+  "get fields.monthCode.toString",
+  "call fields.monthCode.toString",
+  "get fields.nanosecond",
+  "get fields.nanosecond.valueOf",
+  "call fields.nanosecond.valueOf",
+  "get fields.second",
+  "get fields.second.valueOf",
+  "call fields.second.valueOf",
+  "get fields.year",
+  "get fields.year.valueOf",
+  "call fields.year.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
@@ -53,20 +53,8 @@ const fields = {
   millisecond: 1.7,
   microsecond: 1.7,
   nanosecond: 1.7,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    if (key === "calendar") return Temporal.Calendar.from("iso8601");
-    const result = target[key];
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = Temporal.PlainDateTime.from(argument);
+}, "fields");
+const result = Temporal.PlainDateTime.from(fields);
 TemporalHelpers.assertPlainDateTime(result, 1, 1, "M01", 1, 1, 1, 1, 1, 1, 1);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/add/order-of-operations.js
@@ -10,39 +10,39 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -53,22 +53,8 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.add(argument);
+}, "fields");
+const result = instance.add(fields);
 TemporalHelpers.assertPlainDateTime(result, 2001, 6, "M06", 10, 13, 35, 57, 988, 655, 322);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/subtract/order-of-operations.js
@@ -10,39 +10,39 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -53,22 +53,8 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.subtract(argument);
+}, "fields");
+const result = instance.subtract(fields);
 TemporalHelpers.assertPlainDateTime(result, 1999, 3, "M03", 25, 11, 33, 55, 986, 653, 320);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/plain-custom-timezone.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/plain-custom-timezone.js
@@ -12,8 +12,8 @@ const actual = [];
 const expected = [
   "has timeZone.timeZone",
   "get options.disambiguation",
-  "get disambiguation.toString",
-  "call disambiguation.toString",
+  "get options.disambiguation.toString",
+  "call options.disambiguation.toString",
   "get timeZone.getPossibleInstantsFor",
   "call timeZone.getPossibleInstantsFor",
 ];
@@ -28,18 +28,7 @@ Object.defineProperty(Temporal.TimeZone, "from", {
 const dateTime = Temporal.PlainDateTime.from("1975-02-02T14:25:36.123456789");
 const instant = Temporal.Instant.fromEpochNanoseconds(-205156799012345679n);
 
-const options = new Proxy({
-  disambiguation: TemporalHelpers.toPrimitiveObserver(actual, "reject", "disambiguation"),
-}, {
-  has(target, property) {
-    actual.push(`has options.${property}`);
-    return property in target;
-  },
-  get(target, property) {
-    actual.push(`get options.${property}`);
-    return target[property];
-  },
-});
+const options = TemporalHelpers.propertyBagObserver(actual, { disambiguation: "reject" }, "options");
 
 const timeZone = new Proxy({
   getPossibleInstantsFor(dateTimeArg) {

--- a/test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js
@@ -10,47 +10,41 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 const expected = [
-  "get calendar",
-  "get timeZone",
-  "get day",
-  "get day.valueOf",
-  "call day.valueOf",
-  "get hour",
-  "get hour.valueOf",
-  "call hour.valueOf",
-  "get microsecond",
-  "get microsecond.valueOf",
-  "call microsecond.valueOf",
-  "get millisecond",
-  "get millisecond.valueOf",
-  "call millisecond.valueOf",
-  "get minute",
-  "get minute.valueOf",
-  "call minute.valueOf",
-  "get month",
-  "get month.valueOf",
-  "call month.valueOf",
-  "get monthCode",
-  "get monthCode.toString",
-  "call monthCode.toString",
-  "get nanosecond",
-  "get nanosecond.valueOf",
-  "call nanosecond.valueOf",
-  "get second",
-  "get second.valueOf",
-  "call second.valueOf",
-  "get year",
-  "get year.valueOf",
-  "call year.valueOf",
-  "get options.overflow",
-  "get options.overflow.toString",
-  "call options.overflow.toString",
-  "get options.overflow",
-  "get options.overflow.toString",
-  "call options.overflow.toString",
+  "get fields.calendar",
+  "get fields.timeZone",
+  "get fields.day",
+  "get fields.day.valueOf",
+  "call fields.day.valueOf",
+  "get fields.hour",
+  "get fields.hour.valueOf",
+  "call fields.hour.valueOf",
+  "get fields.microsecond",
+  "get fields.microsecond.valueOf",
+  "call fields.microsecond.valueOf",
+  "get fields.millisecond",
+  "get fields.millisecond.valueOf",
+  "call fields.millisecond.valueOf",
+  "get fields.minute",
+  "get fields.minute.valueOf",
+  "call fields.minute.valueOf",
+  "get fields.month",
+  "get fields.month.valueOf",
+  "call fields.month.valueOf",
+  "get fields.monthCode",
+  "get fields.monthCode.toString",
+  "call fields.monthCode.toString",
+  "get fields.nanosecond",
+  "get fields.nanosecond.valueOf",
+  "call fields.nanosecond.valueOf",
+  "get fields.second",
+  "get fields.second.valueOf",
+  "call fields.second.valueOf",
+  "get fields.year",
+  "get fields.year.valueOf",
+  "call fields.year.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
@@ -61,28 +55,8 @@ const fields = {
   millisecond: 1.7,
   microsecond: 1.7,
   nanosecond: 1.7,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const options = {
-  get overflow() {
-    actual.push("get options.overflow");
-    return TemporalHelpers.toPrimitiveObserver(actual, "constrain", "options.overflow");
-  }
-};
-const result = instance.with(argument, options);
+}, "fields");
+const result = instance.with(fields);
 TemporalHelpers.assertPlainDateTime(result, 1, 1, "M01", 1, 1, 1, 1, 1, 1, 1);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-plainmonthday.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-plainmonthday.js
@@ -18,6 +18,8 @@ TemporalHelpers.assertPlainMonthDay(
   /* isoYear = */ 2000
 );
 
+assert.sameValue(result.calendar, orig.calendar, "Calendar is copied");
+
 assert.notSameValue(
   result,
   orig,

--- a/test/built-ins/Temporal/PlainMonthDay/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/order-of-operations.js
@@ -9,40 +9,28 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get calendar",
-  "get day",
-  "get day.valueOf",
-  "call day.valueOf",
-  "get month",
-  "get month.valueOf",
-  "call month.valueOf",
-  "get monthCode",
-  "get monthCode.toString",
-  "call monthCode.toString",
-  "get year",
-  "get year.valueOf",
-  "call year.valueOf",
+  "get fields.calendar",
+  "get fields.day",
+  "get fields.day.valueOf",
+  "call fields.day.valueOf",
+  "get fields.month",
+  "get fields.month.valueOf",
+  "call fields.month.valueOf",
+  "get fields.monthCode",
+  "get fields.monthCode.toString",
+  "call fields.monthCode.toString",
+  "get fields.year",
+  "get fields.year.valueOf",
+  "call fields.year.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
   day: 1.7,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    if (key === "calendar") return Temporal.Calendar.from("iso8601");
-    const result = target[key];
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = Temporal.PlainMonthDay.from(argument);
+}, "fields");
+const result = Temporal.PlainMonthDay.from(fields);
 TemporalHelpers.assertPlainMonthDay(result, "M01", 1);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/with/order-of-operations.js
@@ -10,42 +10,28 @@ features: [Temporal]
 
 const instance = new Temporal.PlainMonthDay(5, 2);
 const expected = [
-  "get calendar",
-  "get timeZone",
-  "get day",
-  "get day.valueOf",
-  "call day.valueOf",
-  "get month",
-  "get month.valueOf",
-  "call month.valueOf",
-  "get monthCode",
-  "get monthCode.toString",
-  "call monthCode.toString",
-  "get year",
-  "get year.valueOf",
-  "call year.valueOf",
+  "get fields.calendar",
+  "get fields.timeZone",
+  "get fields.day",
+  "get fields.day.valueOf",
+  "call fields.day.valueOf",
+  "get fields.month",
+  "get fields.month.valueOf",
+  "call fields.month.valueOf",
+  "get fields.monthCode",
+  "get fields.monthCode.toString",
+  "call fields.monthCode.toString",
+  "get fields.year",
+  "get fields.year.valueOf",
+  "call fields.year.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
   day: 1.7,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.with(argument);
+}, "fields");
+const result = instance.with(fields);
 TemporalHelpers.assertPlainMonthDay(result, "M01", 1);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainTime/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainTime/from/order-of-operations.js
@@ -9,48 +9,36 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get calendar",
-  "get hour",
-  "get hour.valueOf",
-  "call hour.valueOf",
-  "get microsecond",
-  "get microsecond.valueOf",
-  "call microsecond.valueOf",
-  "get millisecond",
-  "get millisecond.valueOf",
-  "call millisecond.valueOf",
-  "get minute",
-  "get minute.valueOf",
-  "call minute.valueOf",
-  "get nanosecond",
-  "get nanosecond.valueOf",
-  "call nanosecond.valueOf",
-  "get second",
-  "get second.valueOf",
-  "call second.valueOf",
+  "get fields.calendar",
+  "get fields.hour",
+  "get fields.hour.valueOf",
+  "call fields.hour.valueOf",
+  "get fields.microsecond",
+  "get fields.microsecond.valueOf",
+  "call fields.microsecond.valueOf",
+  "get fields.millisecond",
+  "get fields.millisecond.valueOf",
+  "call fields.millisecond.valueOf",
+  "get fields.minute",
+  "get fields.minute.valueOf",
+  "call fields.minute.valueOf",
+  "get fields.nanosecond",
+  "get fields.nanosecond.valueOf",
+  "call fields.nanosecond.valueOf",
+  "get fields.second",
+  "get fields.second.valueOf",
+  "call fields.second.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   hour: 1.7,
   minute: 1.7,
   second: 1.7,
   millisecond: 1.7,
   microsecond: 1.7,
   nanosecond: 1.7,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    if (key === "calendar") return Temporal.Calendar.from("iso8601");
-    const result = target[key];
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = Temporal.PlainTime.from(argument);
+}, "fields");
+const result = Temporal.PlainTime.from(fields);
 TemporalHelpers.assertPlainTime(result, 1, 1, 1, 1, 1, 1);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainTime/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/add/order-of-operations.js
@@ -10,39 +10,39 @@ features: [Temporal]
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -53,22 +53,8 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.add(argument);
+}, "fields");
+const result = instance.add(fields);
 TemporalHelpers.assertPlainTime(result, 13, 35, 57, 988, 655, 322);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainTime/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/subtract/order-of-operations.js
@@ -10,39 +10,39 @@ features: [Temporal]
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -53,22 +53,8 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.subtract(argument);
+}, "fields");
+const result = instance.subtract(fields);
 TemporalHelpers.assertPlainTime(result, 11, 33, 55, 986, 653, 320);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainTime/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/with/order-of-operations.js
@@ -10,51 +10,37 @@ features: [Temporal]
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 const expected = [
-  "get calendar",
-  "get timeZone",
-  "get hour",
-  "get hour.valueOf",
-  "call hour.valueOf",
-  "get microsecond",
-  "get microsecond.valueOf",
-  "call microsecond.valueOf",
-  "get millisecond",
-  "get millisecond.valueOf",
-  "call millisecond.valueOf",
-  "get minute",
-  "get minute.valueOf",
-  "call minute.valueOf",
-  "get nanosecond",
-  "get nanosecond.valueOf",
-  "call nanosecond.valueOf",
-  "get second",
-  "get second.valueOf",
-  "call second.valueOf",
+  "get fields.calendar",
+  "get fields.timeZone",
+  "get fields.hour",
+  "get fields.hour.valueOf",
+  "call fields.hour.valueOf",
+  "get fields.microsecond",
+  "get fields.microsecond.valueOf",
+  "call fields.microsecond.valueOf",
+  "get fields.millisecond",
+  "get fields.millisecond.valueOf",
+  "call fields.millisecond.valueOf",
+  "get fields.minute",
+  "get fields.minute.valueOf",
+  "call fields.minute.valueOf",
+  "get fields.nanosecond",
+  "get fields.nanosecond.valueOf",
+  "call fields.nanosecond.valueOf",
+  "get fields.second",
+  "get fields.second.valueOf",
+  "call fields.second.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   hour: 1.7,
   minute: 1.7,
   second: 1.7,
   millisecond: 1.7,
   microsecond: 1.7,
   nanosecond: 1.7,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.with(argument);
+}, "fields");
+const result = instance.with(fields);
 TemporalHelpers.assertPlainTime(result, 1, 1, 1, 1, 1, 1);
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-plainyearmonth.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-plainyearmonth.js
@@ -18,6 +18,8 @@ TemporalHelpers.assertPlainYearMonth(
   /* era = */ undefined, /* eraYear = */ undefined, /* isoDay = */ 7
 );
 
+assert.sameValue(result.calendar, orig.calendar, "Calendar is copied");
+
 assert.notSameValue(
   result,
   orig,

--- a/test/built-ins/Temporal/PlainYearMonth/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/order-of-operations.js
@@ -9,36 +9,24 @@ features: [Temporal]
 ---*/
 
 const expected = [
-  "get calendar",
-  "get month",
-  "get month.valueOf",
-  "call month.valueOf",
-  "get monthCode",
-  "get monthCode.toString",
-  "call monthCode.toString",
-  "get year",
-  "get year.valueOf",
-  "call year.valueOf",
+  "get fields.calendar",
+  "get fields.month",
+  "get fields.month.valueOf",
+  "call fields.month.valueOf",
+  "get fields.monthCode",
+  "get fields.monthCode.toString",
+  "call fields.monthCode.toString",
+  "get fields.year",
+  "get fields.year.valueOf",
+  "call fields.year.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    if (key === "calendar") return Temporal.Calendar.from("iso8601");
-    const result = target[key];
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = Temporal.PlainYearMonth.from(argument);
+}, "fields");
+const result = Temporal.PlainYearMonth.from(fields);
 TemporalHelpers.assertPlainYearMonth(result, 1, 1, "M01");
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/calendar-arguments-extra-options.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/calendar-arguments-extra-options.js
@@ -14,23 +14,11 @@ features: [Temporal]
 
 const actual = [];
 const expected = [
-  "get extra",
-  "get overflow",
+  "ownKeys options",
+  "get options.extra",
+  "get options.overflow",
 ];
-const options = new Proxy({ extra: 5 }, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
+const options = TemporalHelpers.propertyBagObserver(actual, { extra: 5 }, "options");
 
 class CustomCalendar extends Temporal.Calendar {
   constructor() {

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/calendar-arguments.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/calendar-arguments.js
@@ -14,27 +14,15 @@ features: [Temporal]
 
 const actual = [];
 const expected = [
-  "get overflow",
-  "get overflow",
-  "get overflow.toString",
-  "call overflow.toString",
-  "get overflow.toString",
-  "call overflow.toString",
+  "ownKeys options",
+  "get options.overflow",
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
-const options = new Proxy({ overflow: "constrain" }, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
 
 class CustomCalendar extends Temporal.Calendar {
   constructor() {

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/order-of-operations.js
@@ -10,39 +10,39 @@ features: [Temporal]
 
 const instance = new Temporal.PlainYearMonth(2000, 5);
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -53,22 +53,8 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.add(argument);
+}, "fields");
+const result = instance.add(fields);
 TemporalHelpers.assertPlainYearMonth(result, 2001, 6, "M06");
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/calendar-arguments-extra-options.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/calendar-arguments-extra-options.js
@@ -14,23 +14,11 @@ features: [Temporal]
 
 const actual = [];
 const expected = [
-  "get extra",
-  "get overflow",
+  "ownKeys options",
+  "get options.extra",
+  "get options.overflow",
 ];
-const options = new Proxy({ extra: 5 }, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
+const options = TemporalHelpers.propertyBagObserver(actual, { extra: 5 }, "options");
 
 class CustomCalendar extends Temporal.Calendar {
   constructor() {

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/calendar-arguments.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/calendar-arguments.js
@@ -14,27 +14,15 @@ features: [Temporal]
 
 const actual = [];
 const expected = [
-  "get overflow",
-  "get overflow",
-  "get overflow.toString",
-  "call overflow.toString",
-  "get overflow.toString",
-  "call overflow.toString",
+  "ownKeys options",
+  "get options.overflow",
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
-const options = new Proxy({ overflow: "constrain" }, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
 
 class CustomCalendar extends Temporal.Calendar {
   constructor() {

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/order-of-operations.js
@@ -10,39 +10,39 @@ features: [Temporal]
 
 const instance = new Temporal.PlainYearMonth(2000, 5);
 const expected = [
-  "get days",
-  "get days.valueOf",
-  "call days.valueOf",
-  "get hours",
-  "get hours.valueOf",
-  "call hours.valueOf",
-  "get microseconds",
-  "get microseconds.valueOf",
-  "call microseconds.valueOf",
-  "get milliseconds",
-  "get milliseconds.valueOf",
-  "call milliseconds.valueOf",
-  "get minutes",
-  "get minutes.valueOf",
-  "call minutes.valueOf",
-  "get months",
-  "get months.valueOf",
-  "call months.valueOf",
-  "get nanoseconds",
-  "get nanoseconds.valueOf",
-  "call nanoseconds.valueOf",
-  "get seconds",
-  "get seconds.valueOf",
-  "call seconds.valueOf",
-  "get weeks",
-  "get weeks.valueOf",
-  "call weeks.valueOf",
-  "get years",
-  "get years.valueOf",
-  "call years.valueOf",
+  "get fields.days",
+  "get fields.days.valueOf",
+  "call fields.days.valueOf",
+  "get fields.hours",
+  "get fields.hours.valueOf",
+  "call fields.hours.valueOf",
+  "get fields.microseconds",
+  "get fields.microseconds.valueOf",
+  "call fields.microseconds.valueOf",
+  "get fields.milliseconds",
+  "get fields.milliseconds.valueOf",
+  "call fields.milliseconds.valueOf",
+  "get fields.minutes",
+  "get fields.minutes.valueOf",
+  "call fields.minutes.valueOf",
+  "get fields.months",
+  "get fields.months.valueOf",
+  "call fields.months.valueOf",
+  "get fields.nanoseconds",
+  "get fields.nanoseconds.valueOf",
+  "call fields.nanoseconds.valueOf",
+  "get fields.seconds",
+  "get fields.seconds.valueOf",
+  "call fields.seconds.valueOf",
+  "get fields.weeks",
+  "get fields.weeks.valueOf",
+  "call fields.weeks.valueOf",
+  "get fields.years",
+  "get fields.years.valueOf",
+  "call fields.years.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
   weeks: 1,
@@ -53,22 +53,8 @@ const fields = {
   milliseconds: 1,
   microseconds: 1,
   nanoseconds: 1,
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.subtract(argument);
+}, "fields");
+const result = instance.subtract(fields);
 TemporalHelpers.assertPlainYearMonth(result, 1999, 4, "M04");
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/with/order-of-operations.js
@@ -10,39 +10,25 @@ features: [Temporal]
 
 const instance = new Temporal.PlainYearMonth(2000, 5);
 const expected = [
-  "get calendar",
-  "get timeZone",
-  "get month",
-  "get month.valueOf",
-  "call month.valueOf",
-  "get monthCode",
-  "get monthCode.toString",
-  "call monthCode.toString",
-  "get year",
-  "get year.valueOf",
-  "call year.valueOf",
+  "get fields.calendar",
+  "get fields.timeZone",
+  "get fields.month",
+  "get fields.month.valueOf",
+  "call fields.month.valueOf",
+  "get fields.monthCode",
+  "get fields.monthCode.toString",
+  "call fields.monthCode.toString",
+  "get fields.year",
+  "get fields.year.valueOf",
+  "call fields.year.valueOf",
 ];
 const actual = [];
-const fields = {
+const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
-};
-const argument = new Proxy(fields, {
-  get(target, key) {
-    actual.push(`get ${key}`);
-    const result = target[key];
-    if (result === undefined) {
-      return undefined;
-    }
-    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
-  },
-  has(target, key) {
-    actual.push(`has ${key}`);
-    return key in target;
-  },
-});
-const result = instance.with(argument);
+}, "fields");
+const result = instance.with(fields);
 TemporalHelpers.assertPlainYearMonth(result, 1, 1, "M01");
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");


### PR DESCRIPTION
These are in preparation for writing some more tests for recent normative changes to the Temporal proposal.

- A helper for testing the order of observable Get, Has, and EnumerateOwnKeys operations on property bags (and a refactor of existing tests to use it)
- An improvement in how property names are formatted in lists of observable operations, to avoid bugs when such operations are unexpectedly performed on Symbols
- Added consistency in the tests for the from() methods of Temporal types with calendars — we now consistently test that from() copies the calendar from the original object