### PR TITLE
CI: Update CircleCI Docker images.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ execution_steps: &execution_steps
 jobs:
   "Test262: verify tools; build & lint tests (Python 2)":
     docker:
-      - image: circleci/python:2.7
+      - image: cimg/python:2.7
     working_directory: ~/test262
     steps:
       - checkout
@@ -66,7 +66,7 @@ jobs:
       #     command: ./tools/scripts/deploy.sh
   "Test262: verify tools; build & lint tests (Python 3)":
     docker:
-      - image: circleci/python:3.7.4
+      - image: cimg/python:3.7.4
     working_directory: ~/test262
     steps:
       - checkout


### PR DESCRIPTION
CircleCI reports: "You’re using a [deprecated Docker convenience image.](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) Upgrade to a next-gen Docker convenience image."