### PR TITLE
Temporal: Add tests for avoiding observable iteration in CalendarFields

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: >
+  When calendar.fields is undefined, dateAdd() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.dateAdd(arg, new Temporal.Duration());
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: >
+  When calendar.fields is undefined, dateUntil() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.dateUntil(arg, arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.day
+description: >
+  When calendar.fields is undefined, day() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.day(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofweek
+description: >
+  When calendar.fields is undefined, dayOfWeek() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.dayOfWeek(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofyear
+description: >
+  When calendar.fields is undefined, dayOfYear() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.dayOfYear(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinmonth
+description: >
+  When calendar.fields is undefined, daysInMonth() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.daysInMonth(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinweek
+description: >
+  When calendar.fields is undefined, daysInWeek() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.daysInWeek(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinyear
+description: >
+  When calendar.fields is undefined, daysInYear() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.daysInYear(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.inleapyear
+description: >
+  When calendar.fields is undefined, inLeapYear() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.inLeapYear(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.month
+description: >
+  When calendar.fields is undefined, month() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.month(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthcode
+description: >
+  When calendar.fields is undefined, monthCode() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.monthCode(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthsinyear
+description: >
+  When calendar.fields is undefined, monthsInYear() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.monthsInYear(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.weekofyear
+description: >
+  When calendar.fields is undefined, weekOfYear() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.weekOfYear(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.year
+description: >
+  When calendar.fields is undefined, year() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.year(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: >
+  When calendar.fields is undefined, add() doesn't perform an
+  observable array iteration to convert the property bag to relativeTo
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const relativeTo = { year: 1981, month: 12, day: 15, calendar };
+
+instance.add(new Temporal.Duration(0, 0, 0, 0, -24), { relativeTo });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+  When calendar.fields is undefined, round() doesn't perform an
+  observable array iteration to convert the property bag to relativeTo
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const relativeTo = { year: 1981, month: 12, day: 15, calendar };
+
+instance.round({ largestUnit: "years", relativeTo });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: >
+  When calendar.fields is undefined, subtract() doesn't perform an
+  observable array iteration to convert the property bag to relativeTo
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Duration(1, 0, 0, 1);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const relativeTo = { year: 1981, month: 12, day: 15, calendar };
+
+instance.subtract(new Temporal.Duration(0, 0, 0, 0, 24), { relativeTo });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+  When calendar.fields is undefined, total() doesn't perform an
+  observable array iteration to convert the property bag to relativeTo
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Duration(1, 0, 0, 0, 24);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const relativeTo = { year: 1981, month: 12, day: 15, calendar };
+
+instance.total({ unit: "days", relativeTo });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDate/compare/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.compare
+description: >
+  When calendar.fields is undefined, compare() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+Temporal.PlainDate.compare(arg, arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDate/from/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.from
+description: >
+  When calendar.fields is undefined, from() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+Temporal.PlainDate.from(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.equals
+description: >
+  When calendar.fields is undefined, equals() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.equals(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: >
+  When calendar.fields is undefined, since() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.since(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplainmonthday
+description: >
+  When calendar.fields is undefined, toPlainMonthDay() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDate(1981, 12, 15, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.toPlainMonthDay();
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplainyearmonth
+description: >
+  When calendar.fields is undefined, toPlainYearMonth() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDate(1981, 12, 15, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.toPlainYearMonth();
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: >
+  When calendar.fields is undefined, until() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.until(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDate/prototype/with/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/with/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.with
+description: >
+  When calendar.fields is undefined, with() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDate(1981, 12, 15, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.with({ year: 2022 });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.compare
+description: >
+  When calendar.fields is undefined, compare() doesn't perform an
+  observable array iteration to convert the property bag to PlainDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+Temporal.PlainDateTime.compare(arg, arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.from
+description: >
+  When calendar.fields is undefined, from() doesn't perform an
+  observable array iteration to convert the property bag to PlainDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+Temporal.PlainDateTime.from(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: >
+  When calendar.fields is undefined, equals() doesn't perform an
+  observable array iteration to convert the property bag to PlainDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.equals(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: >
+  When calendar.fields is undefined, since() doesn't perform an
+  observable array iteration to convert the property bag to PlainDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.since(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toPlainMonthDay/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toPlainMonthDay/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.toplainmonthday
+description: >
+  When calendar.fields is undefined, toPlainMonthDay() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDateTime(1981, 12, 15, 14, 15, 45, 987, 654, 321, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.toPlainMonthDay();
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toPlainYearMonth/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toPlainYearMonth/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.toplainyearmonth
+description: >
+  When calendar.fields is undefined, toPlainYearMonth() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDateTime(1981, 12, 15, 14, 15, 45, 987, 654, 321, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.toPlainYearMonth();
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: >
+  When calendar.fields is undefined, until() doesn't perform an
+  observable array iteration to convert the property bag to PlainDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.until(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/with/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/with/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.with
+description: >
+  When calendar.fields is undefined, with() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDateTime(1981, 12, 15, 14, 15, 45, 987, 654, 321, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.with({ year: 2022 });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaindate
+description: >
+  When calendar.fields is undefined, withPlainDate() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.withPlainDate(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.from
+description: >
+  When calendar.fields is undefined, from() doesn't perform an
+  observable array iteration to convert the property bag to PlainMonthDay
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { monthCode: "M12", day: 15, calendar };
+
+Temporal.PlainMonthDay.from(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: >
+  When calendar.fields is undefined, equals() doesn't perform an
+  observable array iteration to convert the property bag to PlainMonthDay
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainMonthDay(5, 2);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { monthCode: "M12", day: 15, calendar };
+
+instance.equals(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/toPlainDate/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.toplaindate
+description: >
+  When calendar.fields is undefined, toPlainDate() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainMonthDay(12, 15, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.toPlainDate({ year: 2022 });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/with/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/with/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.with
+description: >
+  When calendar.fields is undefined, with() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainMonthDay(12, 15, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.with({ day: 1 });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.toplaindatetime
+description: >
+  When calendar.fields is undefined, toPlainDateTime() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.toPlainDateTime(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-calendar-fields-undefined.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: >
+  When calendar.fields is undefined, toZonedDateTime() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const timeZone = new class extends Temporal.TimeZone {
+  getPossibleInstantsFor(dt) {
+    const instants = super.getPossibleInstantsFor.call(this, dt);
+    // Return an iterable object that doesn't call Array iterator
+    return {
+      *[Symbol.iterator]() {
+        for (let index = 0; index < instants.length; index++) {
+          yield instants[index];
+        }
+      }
+    }
+  }
+}("UTC");
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.toZonedDateTime({ plainDate: arg, timeZone });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.compare
+description: >
+  When calendar.fields is undefined, compare() doesn't perform an
+  observable array iteration to convert the property bag to PlainYearMonth
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, calendar };
+
+Temporal.PlainYearMonth.compare(arg, arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.from
+description: >
+  When calendar.fields is undefined, from() doesn't perform an
+  observable array iteration to convert the property bag to PlainYearMonth
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, calendar };
+
+Temporal.PlainYearMonth.from(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  When calendar.fields is undefined, add() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainYearMonth(1981, 12, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.add({ years: 1 });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.equals
+description: >
+  When calendar.fields is undefined, equals() doesn't perform an
+  observable array iteration to convert the property bag to PlainYearMonth
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainYearMonth(2000, 5);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, calendar };
+
+instance.equals(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  When calendar.fields is undefined, since() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainYearMonth(1981, 12, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.since(new Temporal.PlainYearMonth(1979, 4, calendar));
+// Check that no iteration is performed when converting a property bag either
+instance.since({ year: 1979, month: 4, calendar });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  When calendar.fields is undefined, subtract() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainYearMonth(1981, 12, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.subtract({ years: 1 });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/toPlainDate/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.toplaindate
+description: >
+  When calendar.fields is undefined, toPlainDate() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainYearMonth(1981, 12, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.toPlainDate({ day: 1 });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  When calendar.fields is undefined, until() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainYearMonth(1981, 12, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.until(new Temporal.PlainYearMonth(2022, 10, calendar));
+// Check that no iteration is performed when converting a property bag either
+instance.since({ year: 2022, month: 10, calendar });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/with/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/with/calendar-fields-undefined.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.with
+description: >
+  When calendar.fields is undefined, with() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.PlainYearMonth(1981, 12, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.with({ year: 2022 });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-calendar-fields-undefined.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: >
+  When calendar.fields is undefined, getInstantFor() doesn't perform an
+  observable array iteration to convert the property bag to PlainDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new class extends Temporal.TimeZone {
+  getPossibleInstantsFor(dt) {
+    const instants = super.getPossibleInstantsFor.call(this, dt);
+    // Return an iterable object that doesn't call Array iterator
+    return {
+      *[Symbol.iterator]() {
+        for (let index = 0; index < instants.length; index++) {
+          yield instants[index];
+        }
+      }
+    }
+  }
+}("UTC");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.getInstantFor(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
+description: >
+  When calendar.fields is undefined, getPossibleInstantsFor() doesn't perform an
+  observable array iteration to convert the property bag to PlainDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.TimeZone("UTC");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.getPossibleInstantsFor(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-calendar-fields-undefined.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.compare
+description: >
+  When calendar.fields is undefined, compare() doesn't perform an
+  observable array iteration to convert the property bag to ZonedDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const timeZone = new class extends Temporal.TimeZone {
+  getPossibleInstantsFor(dt) {
+    const instants = super.getPossibleInstantsFor.call(this, dt);
+    // Return an iterable object that doesn't call Array iterator
+    return {
+      *[Symbol.iterator]() {
+        for (let index = 0; index < instants.length; index++) {
+          yield instants[index];
+        }
+      }
+    }
+  }
+}("UTC");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, timeZone, calendar };
+
+Temporal.ZonedDateTime.compare(arg, arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-calendar-fields-undefined.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.from
+description: >
+  When calendar.fields is undefined, from() doesn't perform an
+  observable array iteration to convert the property bag to ZonedDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const timeZone = new class extends Temporal.TimeZone {
+  getPossibleInstantsFor(dt) {
+    const instants = super.getPossibleInstantsFor.call(this, dt);
+    // Return an iterable object that doesn't call Array iterator
+    return {
+      *[Symbol.iterator]() {
+        for (let index = 0; index < instants.length; index++) {
+          yield instants[index];
+        }
+      }
+    }
+  }
+}("UTC");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, timeZone, calendar };
+
+Temporal.ZonedDateTime.from(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-calendar-fields-undefined.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: >
+  When calendar.fields is undefined, equals() doesn't perform an
+  observable array iteration to convert the property bag to ZonedDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const timeZone = new class extends Temporal.TimeZone {
+  getPossibleInstantsFor(dt) {
+    const instants = super.getPossibleInstantsFor.call(this, dt);
+    // Return an iterable object that doesn't call Array iterator
+    return {
+      *[Symbol.iterator]() {
+        for (let index = 0; index < instants.length; index++) {
+          yield instants[index];
+        }
+      }
+    }
+  }
+}("UTC");
+
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, timeZone, calendar };
+
+instance.equals(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-calendar-fields-undefined.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  When calendar.fields is undefined, since() doesn't perform an
+  observable array iteration to convert the property bag to ZonedDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const timeZone = new class extends Temporal.TimeZone {
+  getPossibleInstantsFor(dt) {
+    const instants = super.getPossibleInstantsFor.call(this, dt);
+    // Return an iterable object that doesn't call Array iterator
+    return {
+      *[Symbol.iterator]() {
+        for (let index = 0; index < instants.length; index++) {
+          yield instants[index];
+        }
+      }
+    }
+  }
+}("UTC");
+
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, timeZone, calendar };
+
+instance.since(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainMonthDay/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainMonthDay/calendar-fields-undefined.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.toplainmonthday
+description: >
+  When calendar.fields is undefined, toPlainMonthDay() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const timeZone = new class extends Temporal.TimeZone {
+  getPossibleInstantsFor(dt) {
+    const instants = super.getPossibleInstantsFor.call(this, dt);
+    // Return an iterable object that doesn't call Array iterator
+    return {
+      *[Symbol.iterator]() {
+        for (let index = 0; index < instants.length; index++) {
+          yield instants[index];
+        }
+      }
+    }
+  }
+}("UTC");
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, timeZone, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.toPlainMonthDay();
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainYearMonth/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toPlainYearMonth/calendar-fields-undefined.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.toplainyearmonth
+description: >
+  When calendar.fields is undefined, toPlainYearMonth() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const timeZone = new class extends Temporal.TimeZone {
+  getPossibleInstantsFor(dt) {
+    const instants = super.getPossibleInstantsFor.call(this, dt);
+    // Return an iterable object that doesn't call Array iterator
+    return {
+      *[Symbol.iterator]() {
+        for (let index = 0; index < instants.length; index++) {
+          yield instants[index];
+        }
+      }
+    }
+  }
+}("UTC");
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, timeZone, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.toPlainYearMonth();
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-calendar-fields-undefined.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  When calendar.fields is undefined, until() doesn't perform an
+  observable array iteration to convert the property bag to ZonedDateTime
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const timeZone = new class extends Temporal.TimeZone {
+  getPossibleInstantsFor(dt) {
+    const instants = super.getPossibleInstantsFor.call(this, dt);
+    // Return an iterable object that doesn't call Array iterator
+    return {
+      *[Symbol.iterator]() {
+        for (let index = 0; index < instants.length; index++) {
+          yield instants[index];
+        }
+      }
+    }
+  }
+}("UTC");
+
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, timeZone, calendar };
+
+instance.until(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/with/calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/with/calendar-fields-undefined.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.with
+description: >
+  When calendar.fields is undefined, with() doesn't perform an
+  observable array iteration
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const timeZone = new class extends Temporal.TimeZone {
+  getPossibleInstantsFor(dt) {
+    const instants = super.getPossibleInstantsFor.call(this, dt);
+    // Return an iterable object that doesn't call Array iterator
+    return {
+      *[Symbol.iterator]() {
+        for (let index = 0; index < instants.length; index++) {
+          yield instants[index];
+        }
+      }
+    }
+  }
+}("UTC");
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, timeZone, calendar);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+instance.with({ year: 2022 });
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-calendar-fields-undefined.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-calendar-fields-undefined.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: >
+  When calendar.fields is undefined, withPlainDate() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const timeZone = new class extends Temporal.TimeZone {
+  getPossibleInstantsFor(dt) {
+    const instants = super.getPossibleInstantsFor.call(this, dt);
+    // Return an iterable object that doesn't call Array iterator
+    return {
+      *[Symbol.iterator]() {
+        for (let index = 0; index < instants.length; index++) {
+          yield instants[index];
+        }
+      }
+    }
+  }
+}("UTC");
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, timeZone);
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.withPlainDate(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-calendar-fields-undefined.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.era
+description: >
+  When calendar.fields is undefined, era() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.era(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-calendar-fields-undefined.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-calendar-fields-undefined.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.erayear
+description: >
+  When calendar.fields is undefined, eraYear() doesn't perform an
+  observable array iteration to convert the property bag to PlainDate
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+calendar.fields = undefined;
+
+const instance = new Temporal.Calendar("iso8601");
+
+// Detect observable array iteration:
+const oldIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function () {
+  throw new Test262Error(`array shouldn't be iterated: ${new Error().stack}`);
+};
+
+const arg = { year: 1981, month: 12, day: 15, calendar };
+
+instance.eraYear(arg);
+
+Array.prototype[Symbol.iterator] = oldIterator;


### PR DESCRIPTION
See https://github.com/tc39/proposal-temporal/pull/2316 which eliminated an observable call to `Array.prototype[Symbol.iterator]()` in the case where a calendar's `fields` property was undefined.

The best way I've thought of to test this is to monkeypatch the `Array.prototype[Symbol.iterator]()` method to make it throw. In some cases, where we are actually expected to iterate the return value from a Temporal.TimeZone's getPossibleInstantsFor() method, we have to provide a custom method for that as well, that returns a non-Array iterable so we don't call the patched `Array.prototype[Symbol.iterator]()`.

This normative change reached consensus at the July 2022 TC39 plenary meeting.

There are a lot of tests here but they're mostly the same. I'd recommend reviewing just a representative sample, maybe a few of the calendar-fields-undefined.js files, a few of each type of property bag in the argument-calendar-fields-undefined.js files, and pay special attention to the compare() methods and PlainYearMonth.prototype.since() and until(), since those test more than one opportunity where an array
could be iterated.