### PR TITLE
Temporal: Fix expectation for observable operations in Duration.p.round()

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
@@ -202,9 +202,6 @@ assert.compareArray(actual, expectedOpsForMonthToYearBalancing, "order of operat
 actual.splice(0, actual.length); // clear
 
 const expectedOpsForDayToMonthBalancing = expected.concat([
-  // UnbalanceDurationRelative
-  "get options.relativeTo.calendar.dateAdd",     // 9.b
-  "get options.relativeTo.calendar.dateUntil",   // 9.c
   // BalanceDurationRelative
   "get options.relativeTo.calendar.dateAdd",     // 11.a
   "call options.relativeTo.calendar.dateAdd",    // 11.b MoveRelativeDate
@@ -216,8 +213,6 @@ assert.compareArray(actual, expectedOpsForDayToMonthBalancing, "order of operati
 actual.splice(0, actual.length); // clear
 
 const expectedOpsForDayToWeekBalancing = expected.concat([
-  // UnbalanceDurationRelative
-  "get options.relativeTo.calendar.dateAdd",   // 10.b
   // BalanceDurationRelative
   "get options.relativeTo.calendar.dateAdd",   // 12.b
   "call options.relativeTo.calendar.dateAdd",  // 12.c MoveRelativeDate


### PR DESCRIPTION
I had missed that there's an early return step from [UnbalanceDurationRelative](https://tc39.es/proposal-temporal/#sec-temporal-unbalancedurationrelative) if years, months, weeks, and days are all 0.

Closes: #3684