### PR TITLE
Temporal: Test use of CopyDataProperties 

### DIFF
--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -1612,6 +1612,10 @@ var TemporalHelpers = {
         calls.push(`ownKeys ${objectName}`);
         return Reflect.ownKeys(target);
       },
+      getOwnPropertyDescriptor(target, key) {
+        calls.push(`getOwnPropertyDescriptor ${formatPropertyName(key, objectName)}`);
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
       get(target, key, receiver) {
         calls.push(`get ${formatPropertyName(key, objectName)}`);
         const result = Reflect.get(target, key, receiver);

--- a/test/built-ins/Temporal/Calendar/prototype/mergeFields/non-string-properties.js
+++ b/test/built-ins/Temporal/Calendar/prototype/mergeFields/non-string-properties.js
@@ -4,7 +4,7 @@
 
 /*---
 esid: sec-temporal.calendar.prototype.mergefields
-description: Only string keys from the arguments are merged
+description: Both string and symbol keys from the arguments are merged
 info: |
   1. Let calendar be the this value.
   2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
@@ -50,6 +50,6 @@ const foo = Symbol("foo");
 const bar = Symbol("bar");
 assertEntriesEqual(
   cal.mergeFields({ [foo]: 1 }, { [bar]: 2 }),
-  [],
-  "symbol keys are not merged"
+  [[foo, 1], [bar, 2]],
+  "symbol keys are also merged"
 );

--- a/test/built-ins/Temporal/Calendar/prototype/mergeFields/non-string-properties.js
+++ b/test/built-ins/Temporal/Calendar/prototype/mergeFields/non-string-properties.js
@@ -13,22 +13,43 @@ info: |
   5. Set additionalFields to ? ToObject(additionalFields).
   6. Return ? DefaultMergeFields(fields, additionalFields).
 features: [Temporal]
-includes: [deepEqual.js]
 ---*/
+
+function assertEntriesEqual(actual, expectedEntries, message) {
+  const names = Object.getOwnPropertyNames(actual);
+  const symbols = Object.getOwnPropertySymbols(actual);
+  const actualKeys = names.concat(symbols);
+  assert.sameValue(
+    actualKeys.length,
+    expectedEntries.length,
+    `${message}: expected object to have ${expectedEntries.length} properties, not ${actualKeys.length}:`
+  );
+  for (var index = 0; index < actualKeys.length; index++) {
+    const actualKey = actualKeys[index];
+    const expectedKey = expectedEntries[index][0];
+    const expectedValue = expectedEntries[index][1];
+    assert.sameValue(actualKey, expectedKey, `${message}: key ${index}:`);
+    assert.sameValue(actual[actualKey], expectedValue, `${message}: value ${index}:`);
+  }
+}
 
 const cal = new Temporal.Calendar("iso8601");
 
-assert.deepEqual(
+assertEntriesEqual(
   cal.mergeFields({ 1: 2 }, { 3: 4 }),
-  { "1": 2, "3": 4 },
+  [["1", 2], ["3", 4]],
   "number keys are actually string keys and are merged as such"
 );
-assert.deepEqual(
+assertEntriesEqual(
   cal.mergeFields({ 1n: 2 }, { 2n: 4 }),
-  { "1": 2, "2": 4 },
+  [["1", 2], ["2", 4]],
   "bigint keys are actually string keys and are merged as such"
 );
 
 const foo = Symbol("foo");
 const bar = Symbol("bar");
-assert.deepEqual(cal.mergeFields({ [foo]: 1 }, { [bar]: 2 }), {}, "symbol keys are not merged");
+assertEntriesEqual(
+  cal.mergeFields({ [foo]: 1 }, { [bar]: 2 }),
+  [],
+  "symbol keys are not merged"
+);

--- a/test/built-ins/Temporal/Calendar/prototype/mergeFields/order-of-operations.js
+++ b/test/built-ins/Temporal/Calendar/prototype/mergeFields/order-of-operations.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.mergefields
+description: Properties on objects passed to mergeFields() are accessed in the correct order
+features: [Temporal]
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+const expected = [
+  "ownKeys fields",
+  "getOwnPropertyDescriptor fields.year",
+  "get fields.year",
+  "getOwnPropertyDescriptor fields.month",
+  "get fields.month",
+  "getOwnPropertyDescriptor fields.day",
+  "get fields.day",
+  "getOwnPropertyDescriptor fields.extra",
+  "get fields.extra",
+  "ownKeys additionalFields",
+  "getOwnPropertyDescriptor additionalFields.3",
+  "get additionalFields.3",
+  "getOwnPropertyDescriptor additionalFields.monthCode",
+  "get additionalFields.monthCode",
+  "getOwnPropertyDescriptor additionalFields[Symbol('extra')]",
+  "get additionalFields[Symbol('extra')]",
+];
+const actual = [];
+
+const fields = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2022,
+  month: 10,
+  day: 17,
+  extra: "extra property",
+}, "fields");
+const additionalFields = TemporalHelpers.propertyBagObserver(actual, {
+  [Symbol("extra")]: "extra symbol property",
+  monthCode: "M10",
+  3: "extra array index property",
+}, "additionalFields");
+
+const instance = new Temporal.Calendar("iso8601");
+instance.mergeFields(fields, additionalFields);
+assert.compareArray(actual, expected, "order of observable operations");

--- a/test/built-ins/Temporal/PlainDate/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/order-of-operations.js
@@ -48,12 +48,17 @@ const expected = [
   "get options.roundingIncrement",
   "get options.roundingIncrement.valueOf",
   "call options.roundingIncrement.valueOf",
-  // MergeLargestUnitOption
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.roundingIncrement",
   "get options.roundingIncrement",
+  "getOwnPropertyDescriptor options.roundingMode",
   "get options.roundingMode",
+  "getOwnPropertyDescriptor options.largestUnit",
   "get options.largestUnit",
+  "getOwnPropertyDescriptor options.smallestUnit",
   "get options.smallestUnit",
+  "getOwnPropertyDescriptor options.additional",
   "get options.additional",
   // CalendarDateUntil
   "get this.calendar.dateUntil",

--- a/test/built-ins/Temporal/PlainDate/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/order-of-operations.js
@@ -48,12 +48,17 @@ const expected = [
   "get options.roundingIncrement",
   "get options.roundingIncrement.valueOf",
   "call options.roundingIncrement.valueOf",
-  // MergeLargestUnitOption
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.roundingIncrement",
   "get options.roundingIncrement",
+  "getOwnPropertyDescriptor options.roundingMode",
   "get options.roundingMode",
+  "getOwnPropertyDescriptor options.largestUnit",
   "get options.largestUnit",
+  "getOwnPropertyDescriptor options.smallestUnit",
   "get options.smallestUnit",
+  "getOwnPropertyDescriptor options.additional",
   "get options.additional",
   // CalendarDateUntil
   "get this.calendar.dateUntil",

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/order-of-operations.js
@@ -66,12 +66,17 @@ const expected = [
   "get options.roundingIncrement",
   "get options.roundingIncrement.valueOf",
   "call options.roundingIncrement.valueOf",
-  // MergeLargestUnitOption
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.roundingIncrement",
   "get options.roundingIncrement",
+  "getOwnPropertyDescriptor options.roundingMode",
   "get options.roundingMode",
+  "getOwnPropertyDescriptor options.largestUnit",
   "get options.largestUnit",
+  "getOwnPropertyDescriptor options.smallestUnit",
   "get options.smallestUnit",
+  "getOwnPropertyDescriptor options.additional",
   "get options.additional",
   // CalendarDateUntil
   "get this.calendar.dateUntil",

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/order-of-operations.js
@@ -66,12 +66,17 @@ const expected = [
   "get options.roundingIncrement",
   "get options.roundingIncrement.valueOf",
   "call options.roundingIncrement.valueOf",
-  // MergeLargestUnitOption
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.roundingIncrement",
   "get options.roundingIncrement",
+  "getOwnPropertyDescriptor options.roundingMode",
   "get options.roundingMode",
+  "getOwnPropertyDescriptor options.largestUnit",
   "get options.largestUnit",
+  "getOwnPropertyDescriptor options.smallestUnit",
   "get options.smallestUnit",
+  "getOwnPropertyDescriptor options.additional",
   "get options.additional",
   // CalendarDateUntil
   "get this.calendar.dateUntil",

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/calendar-arguments-extra-options.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/calendar-arguments-extra-options.js
@@ -14,9 +14,14 @@ features: [Temporal]
 
 const actual = [];
 const expected = [
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.extra",
   "get options.extra",
+  // Temporal.Calendar.prototype.dateAdd
   "get options.overflow",
+  // overwriting property in custom calendar dateAdd
+  "getOwnPropertyDescriptor options.overflow",
 ];
 const options = TemporalHelpers.propertyBagObserver(actual, { extra: 5 }, "options");
 

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/calendar-arguments.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/calendar-arguments.js
@@ -14,11 +14,17 @@ features: [Temporal]
 
 const actual = [];
 const expected = [
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.overflow",
   "get options.overflow",
+  // Temporal.Calendar.prototype.dateAdd
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
+  // overwriting property in custom calendar dateAdd
+  "getOwnPropertyDescriptor options.overflow",
+  // Temporal.Calendar.prototype.yearMonthFromFields (toPrimitiveObserver copied but not options object)
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/order-of-operations.js
@@ -60,12 +60,17 @@ const expected = [
   "call this.calendar.year",
   "get this.calendar.dateFromFields",
   "call this.calendar.dateFromFields",
-  // MergeLargestUnitOption
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.roundingIncrement",
   "get options.roundingIncrement",
+  "getOwnPropertyDescriptor options.roundingMode",
   "get options.roundingMode",
+  "getOwnPropertyDescriptor options.largestUnit",
   "get options.largestUnit",
+  "getOwnPropertyDescriptor options.smallestUnit",
   "get options.smallestUnit",
+  "getOwnPropertyDescriptor options.additional",
   "get options.additional",
   // CalendarDateUntil
   "get this.calendar.dateUntil",

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/calendar-arguments-extra-options.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/calendar-arguments-extra-options.js
@@ -14,9 +14,14 @@ features: [Temporal]
 
 const actual = [];
 const expected = [
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.extra",
   "get options.extra",
+  // Temporal.Calendar.prototype.dateAdd
   "get options.overflow",
+  // overwriting property in custom calendar dateAdd
+  "getOwnPropertyDescriptor options.overflow",
 ];
 const options = TemporalHelpers.propertyBagObserver(actual, { extra: 5 }, "options");
 

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/calendar-arguments.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/calendar-arguments.js
@@ -14,11 +14,17 @@ features: [Temporal]
 
 const actual = [];
 const expected = [
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.overflow",
   "get options.overflow",
+  // Temporal.Calendar.prototype.dateAdd
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
+  // overwriting property in custom calendar dateAdd
+  "getOwnPropertyDescriptor options.overflow",
+  // Temporal.Calendar.prototype.yearMonthFromFields (toPrimitiveObserver copied but not options object)
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/order-of-operations.js
@@ -60,12 +60,17 @@ const expected = [
   "call this.calendar.year",
   "get this.calendar.dateFromFields",
   "call this.calendar.dateFromFields",
-  // MergeLargestUnitOption
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.roundingIncrement",
   "get options.roundingIncrement",
+  "getOwnPropertyDescriptor options.roundingMode",
   "get options.roundingMode",
+  "getOwnPropertyDescriptor options.largestUnit",
   "get options.largestUnit",
+  "getOwnPropertyDescriptor options.smallestUnit",
   "get options.smallestUnit",
+  "getOwnPropertyDescriptor options.additional",
   "get options.additional",
   // CalendarDateUntil
   "get this.calendar.dateUntil",

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
@@ -122,12 +122,17 @@ const expectedOpsForCalendarDifference = [
   "get other.timeZone[Symbol.toPrimitive]",
   "get other.timeZone.toString",
   "call other.timeZone.toString",
-  // MergeLargestUnitOption
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.roundingIncrement",
   "get options.roundingIncrement",
+  "getOwnPropertyDescriptor options.roundingMode",
   "get options.roundingMode",
+  "getOwnPropertyDescriptor options.largestUnit",
   "get options.largestUnit",
+  "getOwnPropertyDescriptor options.smallestUnit",
   "get options.smallestUnit",
+  "getOwnPropertyDescriptor options.additional",
   "get options.additional",
   // DifferenceZonedDateTime
   "get this.timeZone.getOffsetNanosecondsFor",

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
@@ -122,12 +122,17 @@ const expectedOpsForCalendarDifference = [
   "get other.timeZone[Symbol.toPrimitive]",
   "get other.timeZone.toString",
   "call other.timeZone.toString",
-  // MergeLargestUnitOption
+  // CopyDataProperties
   "ownKeys options",
+  "getOwnPropertyDescriptor options.roundingIncrement",
   "get options.roundingIncrement",
+  "getOwnPropertyDescriptor options.roundingMode",
   "get options.roundingMode",
+  "getOwnPropertyDescriptor options.largestUnit",
   "get options.largestUnit",
+  "getOwnPropertyDescriptor options.smallestUnit",
   "get options.smallestUnit",
+  "getOwnPropertyDescriptor options.additional",
   "get options.additional",
   // DifferenceZonedDateTime
   "get this.timeZone.getOffsetNanosecondsFor",


### PR DESCRIPTION
This consists of tests for the normative change https://github.com/tc39/proposal-temporal/pull/2245 which achieved consensus at the July 2022 TC39 meeting.

Also contains a bug fix for an existing test (it ought to have been invalidated by this normative change, but spuriously passed.)