### PR TITLE
Temporal: Tests for normative changes around date-only strings

### DIFF
--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -1845,11 +1845,14 @@ var TemporalHelpers = {
     plainTimeStringsAmbiguous() {
       const ambiguousStrings = [
         "2021-12",  // ambiguity between YYYY-MM and HHMM-UU
+        "2021-12[-12:00]",  // ditto, TZ does not disambiguate
         "1214",     // ambiguity between MMDD and HHMM
         "0229",     //   ditto, including MMDD that doesn't occur every year
         "1130",     //   ditto, including DD that doesn't occur in every month
         "12-14",    // ambiguity between MM-DD and HH-UU
+        "12-14[-14:00]",  // ditto, TZ does not disambiguate
         "202112",   // ambiguity between YYYYMM and HHMMSS
+        "202112[UTC]",  // ditto, TZ does not disambiguate
       ];
       // Adding a calendar annotation to one of these strings must not cause
       // disambiguation in favour of time.
@@ -1879,8 +1882,6 @@ var TemporalHelpers = {
         "0631",             // 31 is not a day in June
         "0000",             // 0 is neither a month nor a day
         "00-00",            //   ditto
-        "2021-12[-12:00]",  // HHMM-UU is ambiguous with YYYY-MM, but TZ disambiguates
-        "202112[UTC]",      // HHMMSS is ambiguous with YYYYMM, but TZ disambiguates
       ];
     },
 

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-date-with-utc-offset.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.dateAdd(arg, new Temporal.Duration());
+
+  TemporalHelpers.assertPlainDate(
+    result,
+    2000, 5, "M05", 2,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.dateAdd(arg, new Temporal.Duration()),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-time-zone-annotation.js
@@ -9,14 +9,10 @@ includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-string-date-with-utc-offset.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  TemporalHelpers.assertDuration(
+    instance.dateUntil(arg, arg),
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)),
+    `"${arg}" UTC offset without time is not valid for PlainDate (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-string-time-zone-annotation.js
@@ -9,14 +9,10 @@ includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ['2000-05-02[Asia/Kolkata]', 'named, with no time'],
+  ['2000-05-02[!Europe/Vienna]', 'named, with ! and no time'],
+  ['2000-05-02[+00:00]', 'numeric, with no time'],
+  ['2000-05-02[!-02:30]', 'numeric, with ! and no time'],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.day
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.day(arg);
+
+  assert.sameValue(
+    result,
+    2,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.day(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofweek
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.dayOfWeek(arg);
+
+  assert.sameValue(
+    result,
+    2,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.dayOfWeek(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofyear
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.dayOfYear(arg);
+
+  assert.sameValue(
+    result,
+    123,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.dayOfYear(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinmonth
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.daysInMonth(arg);
+
+  assert.sameValue(
+    result,
+    31,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.daysInMonth(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinweek
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.daysInWeek(arg);
+
+  assert.sameValue(
+    result,
+    7,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.daysInWeek(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinyear
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.daysInYear(arg);
+
+  assert.sameValue(
+    result,
+    366,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.daysInYear(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.inleapyear
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.inLeapYear(arg);
+
+  assert.sameValue(
+    result,
+    true,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.inLeapYear(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.month
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.month(arg);
+
+  assert.sameValue(
+    result,
+    5,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.month(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthcode
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.monthCode(arg);
+
+  assert.sameValue(
+    result,
+    "M05",
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.monthCode(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthsinyear
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.monthsInYear(arg);
+
+  assert.sameValue(
+    result,
+    12,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.monthsInYear(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.weekofyear
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.weekOfYear(arg);
+
+  assert.sameValue(
+    result,
+    18,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.weekOfYear(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.year
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.year(arg);
+
+  assert.sameValue(
+    result,
+    2000,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.year(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/Instant/compare/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Instant/compare/argument-string-date-with-utc-offset.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.compare
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const validStrings = [
+  "1970-01-01T00Z",
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00Z[Europe/Vienna]",
+  "1970-01-01T00+00:00",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+  "1969-12-31T16-08:00[America/Vancouver]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.Instant.compare(arg, arg);
+
+  assert.sameValue(
+    result,
+    0,
+    `"${arg}" is a valid UTC offset with time for Instant`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+const epoch = new Temporal.Instant(0n);
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.Instant.compare(arg, epoch),
+    `"${arg}" UTC offset without time is not valid for Instant (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.Instant.compare(epoch, arg),
+    `"${arg}" UTC offset without time is not valid for Instant (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/Instant/from/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Instant/from/argument-string-date-with-utc-offset.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.from
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const validStrings = [
+  "1970-01-01T00Z",
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00Z[Europe/Vienna]",
+  "1970-01-01T00+00:00",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+  "1969-12-31T16-08:00[America/Vancouver]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.Instant.from(arg);
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    0n,
+    `"${arg}" is a valid UTC offset with time for Instant`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.Instant.from(arg),
+    `"${arg}" UTC offset without time is not valid for Instant`
+  );
+}

--- a/test/built-ins/Temporal/Instant/prototype/equals/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/argument-string-date-with-utc-offset.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.equals
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const validStrings = [
+  "1970-01-01T00Z",
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00Z[Europe/Vienna]",
+  "1970-01-01T00+00:00",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+  "1969-12-31T16-08:00[America/Vancouver]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
+    result,
+    true,
+    `"${arg}" is a valid UTC offset with time for Instant`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `"${arg}" UTC offset without time is not valid for Instant`
+  );
+}

--- a/test/built-ins/Temporal/Instant/prototype/since/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/argument-string-date-with-utc-offset.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const validStrings = [
+  "1970-01-01T00Z",
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00Z[Europe/Vienna]",
+  "1970-01-01T00+00:00",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+  "1969-12-31T16-08:00[America/Vancouver]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for Instant`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `"${arg}" UTC offset without time is not valid for Instant`
+  );
+}

--- a/test/built-ins/Temporal/Instant/prototype/until/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/argument-string-date-with-utc-offset.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.Instant(0n);
+
+const validStrings = [
+  "1970-01-01T00Z",
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00Z[Europe/Vienna]",
+  "1970-01-01T00+00:00",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+  "1969-12-31T16-08:00[America/Vancouver]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for Instant`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `"${arg}" UTC offset without time is not valid for Instant`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/compare/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-string-date-with-utc-offset.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.compare
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.PlainDate.compare(arg, arg);
+
+  assert.sameValue(
+    result,
+    0,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)),
+    `"${arg}" UTC offset without time is not valid for PlainDate (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/compare/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ['2000-05-02[Asia/Kolkata]', 'named, with no time'],
+  ['2000-05-02[!Europe/Vienna]', 'named, with ! and no time'],
+  ['2000-05-02[+00:00]', 'numeric, with no time'],
+  ['2000-05-02[!-02:30]', 'numeric, with ! and no time'],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/PlainDate/from/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-string-date-with-utc-offset.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.PlainDate.from(arg);
+
+  TemporalHelpers.assertPlainDate(
+    result,
+    2000, 5, "M05", 2,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.from(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/from/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-string-time-zone-annotation.js
@@ -9,14 +9,10 @@ includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.equals
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
+    result,
+    true,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-string-date-with-utc-offset.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-string-time-zone-annotation.js
@@ -9,14 +9,10 @@ includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-date-with-utc-offset.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplaindatetime
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const validStrings = [
+  "12:34:56.987654321+00:00",
+  "12:34:56.987654321+00:00[UTC]",
+  "12:34:56.987654321+00:00[!UTC]",
+  "12:34:56.987654321-02:30[America/St_Johns]",
+  "1976-11-18T12:34:56.987654321+00:00",
+  "1976-11-18T12:34:56.987654321+00:00[UTC]",
+  "1976-11-18T12:34:56.987654321+00:00[!UTC]",
+  "1976-11-18T12:34:56.987654321-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.toPlainDateTime(arg);
+
+  TemporalHelpers.assertPlainDateTime(
+    result,
+    2000, 5, "M05", 2, 12, 34, 56, 987, 654, 321,
+    `"${arg}" is a valid UTC offset with time for PlainTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.toPlainDateTime(arg),
+    `"${arg}" UTC offset without time is not valid for PlainTime`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-date-with-utc-offset.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const validStrings = [
+  "12:34:56.987654321+00:00",
+  "12:34:56.987654321+00:00[UTC]",
+  "12:34:56.987654321+00:00[!UTC]",
+  "12:34:56.987654321-02:30[America/St_Johns]",
+  "1976-11-18T12:34:56.987654321+00:00",
+  "1976-11-18T12:34:56.987654321+00:00[UTC]",
+  "1976-11-18T12:34:56.987654321+00:00[!UTC]",
+  "1976-11-18T12:34:56.987654321-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" });
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    957_270_896_987_654_321n,
+    `"${arg}" is a valid UTC offset with time for PlainTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" }),
+    `"${arg}" UTC offset without time is not valid for PlainTime`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-string-date-with-utc-offset.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-string-time-zone-annotation.js
@@ -9,14 +9,10 @@ includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-string-date-with-utc-offset.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const validStrings = [
+  "1976-11-18T15:23+00:00",
+  "1976-11-18T15:23+00:00[UTC]",
+  "1976-11-18T15:23+00:00[!UTC]",
+  "1976-11-18T15:23-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.PlainDateTime.compare(arg, arg);
+
+  assert.sameValue(
+    result,
+    0,
+    `"${arg}" is a valid UTC offset with time for PlainDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)),
+    `"${arg}" UTC offset without time is not valid for PlainDateTime (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg),
+    `"${arg}" UTC offset without time is not valid for PlainDateTime (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-string-date-with-utc-offset.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const validStrings = [
+  "1976-11-18T15:23+00:00",
+  "1976-11-18T15:23+00:00[UTC]",
+  "1976-11-18T15:23+00:00[!UTC]",
+  "1976-11-18T15:23-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.PlainDateTime.from(arg);
+
+  TemporalHelpers.assertPlainDateTime(
+    result,
+    1976, 11, "M11", 18, 15, 23, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for PlainDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.from(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDateTime`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
+
+const validStrings = [
+  "1976-11-18T15:23+00:00",
+  "1976-11-18T15:23+00:00[UTC]",
+  "1976-11-18T15:23+00:00[!UTC]",
+  "1976-11-18T15:23-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
+    result,
+    true,
+    `"${arg}" is a valid UTC offset with time for PlainDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDateTime`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-string-date-with-utc-offset.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
+
+const validStrings = [
+  "1976-11-18T15:23+00:00",
+  "1976-11-18T15:23+00:00[UTC]",
+  "1976-11-18T15:23+00:00[!UTC]",
+  "1976-11-18T15:23-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for PlainDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDateTime`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-string-date-with-utc-offset.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
+
+const validStrings = [
+  "1976-11-18T15:23+00:00",
+  "1976-11-18T15:23+00:00[UTC]",
+  "1976-11-18T15:23+00:00[!UTC]",
+  "1976-11-18T15:23-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for PlainDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDateTime`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-date-with-utc-offset.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaindate
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.withPlainDate(arg);
+
+  TemporalHelpers.assertPlainDateTime(
+    result,
+    2000, 5, "M05", 2, 15, 23, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.withPlainDate(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-time-zone-annotation.js
@@ -9,14 +9,10 @@ includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-date-with-utc-offset.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaintime
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);
+
+const validStrings = [
+  "12:34:56.987654321+00:00",
+  "12:34:56.987654321+00:00[UTC]",
+  "12:34:56.987654321+00:00[!UTC]",
+  "12:34:56.987654321-02:30[America/St_Johns]",
+  "1976-11-18T12:34:56.987654321+00:00",
+  "1976-11-18T12:34:56.987654321+00:00[UTC]",
+  "1976-11-18T12:34:56.987654321+00:00[!UTC]",
+  "1976-11-18T12:34:56.987654321-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.withPlainTime(arg);
+
+  TemporalHelpers.assertPlainDateTime(
+    result,
+    1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321,
+    `"${arg}" is a valid UTC offset with time for PlainTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.withPlainTime(arg),
+    `"${arg}" UTC offset without time is not valid for PlainTime`
+  );
+}

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-string-date-with-utc-offset.js
@@ -1,0 +1,60 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const validStrings = [
+  "05-02[Asia/Katmandu]",
+  "05-02[!Asia/Katmandu]",
+  "05-02[u-ca=iso8601]",
+  "05-02[Asia/Tokyo][u-ca=iso8601]",
+  "--05-02[Asia/Katmandu]",
+  "--05-02[!Asia/Katmandu]",
+  "--05-02[u-ca=iso8601]",
+  "--05-02[Asia/Tokyo][u-ca=iso8601]",
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.PlainMonthDay.from(arg);
+
+  TemporalHelpers.assertPlainMonthDay(
+    result,
+    "M05", 2,
+    `"${arg}" is a valid UTC offset with time for PlainMonthDay`
+  );
+}
+
+const invalidStrings = [
+  "09-15Z",
+  "09-15Z[UTC]",
+  "09-15+01:00",
+  "09-15+01:00[Europe/Vienna]",
+  "--09-15Z",
+  "--09-15Z[UTC]",
+  "--09-15+01:00",
+  "--09-15+01:00[Europe/Vienna]",
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+  "09-15[u-ca=chinese]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainMonthDay.from(arg),
+    `"${arg}" UTC offset without time is not valid for PlainMonthDay`
+  );
+}

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-date-with-utc-offset.js
@@ -1,0 +1,61 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainMonthDay(5, 2);
+
+const validStrings = [
+  "05-02[Asia/Katmandu]",
+  "05-02[!Asia/Katmandu]",
+  "05-02[u-ca=iso8601]",
+  "05-02[Asia/Tokyo][u-ca=iso8601]",
+  "--05-02[Asia/Katmandu]",
+  "--05-02[!Asia/Katmandu]",
+  "--05-02[u-ca=iso8601]",
+  "--05-02[Asia/Tokyo][u-ca=iso8601]",
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
+    result,
+    true,
+    `"${arg}" is a valid UTC offset with time for PlainMonthDay`
+  );
+}
+
+const invalidStrings = [
+  "09-15Z",
+  "09-15Z[UTC]",
+  "09-15+01:00",
+  "09-15+01:00[Europe/Vienna]",
+  "--09-15Z",
+  "--09-15Z[UTC]",
+  "--09-15+01:00",
+  "--09-15+01:00[Europe/Vienna]",
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+  "09-15[u-ca=chinese]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `"${arg}" UTC offset without time is not valid for PlainMonthDay`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/compare/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainTime/compare/argument-string-date-with-utc-offset.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.compare
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const validStrings = [
+  "12:34:56.987654321+00:00",
+  "12:34:56.987654321+00:00[UTC]",
+  "12:34:56.987654321+00:00[!UTC]",
+  "12:34:56.987654321-02:30[America/St_Johns]",
+  "1976-11-18T12:34:56.987654321+00:00",
+  "1976-11-18T12:34:56.987654321+00:00[UTC]",
+  "1976-11-18T12:34:56.987654321+00:00[!UTC]",
+  "1976-11-18T12:34:56.987654321-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.PlainTime.compare(arg, arg);
+
+  assert.sameValue(
+    result,
+    0,
+    `"${arg}" is a valid UTC offset with time for PlainTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainTime.compare(arg, new Temporal.PlainTime(12, 34, 56, 987, 654, 321)),
+    `"${arg}" UTC offset without time is not valid for PlainTime (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainTime.compare(new Temporal.PlainTime(12, 34, 56, 987, 654, 321), arg),
+    `"${arg}" UTC offset without time is not valid for PlainTime (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/from/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-string-date-with-utc-offset.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.from
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const validStrings = [
+  "12:34:56.987654321+00:00",
+  "12:34:56.987654321+00:00[UTC]",
+  "12:34:56.987654321+00:00[!UTC]",
+  "12:34:56.987654321-02:30[America/St_Johns]",
+  "1976-11-18T12:34:56.987654321+00:00",
+  "1976-11-18T12:34:56.987654321+00:00[UTC]",
+  "1976-11-18T12:34:56.987654321+00:00[!UTC]",
+  "1976-11-18T12:34:56.987654321-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.PlainTime.from(arg);
+
+  TemporalHelpers.assertPlainTime(
+    result,
+    12, 34, 56, 987, 654, 321,
+    `"${arg}" is a valid UTC offset with time for PlainTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainTime.from(arg),
+    `"${arg}" UTC offset without time is not valid for PlainTime`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-date-with-utc-offset.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.equals
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const validStrings = [
+  "12:34:56.987654321+00:00",
+  "12:34:56.987654321+00:00[UTC]",
+  "12:34:56.987654321+00:00[!UTC]",
+  "12:34:56.987654321-02:30[America/St_Johns]",
+  "1976-11-18T12:34:56.987654321+00:00",
+  "1976-11-18T12:34:56.987654321+00:00[UTC]",
+  "1976-11-18T12:34:56.987654321+00:00[!UTC]",
+  "1976-11-18T12:34:56.987654321-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
+    result,
+    true,
+    `"${arg}" is a valid UTC offset with time for PlainTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `"${arg}" UTC offset without time is not valid for PlainTime`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-date-with-utc-offset.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const validStrings = [
+  "12:34:56.987654321+00:00",
+  "12:34:56.987654321+00:00[UTC]",
+  "12:34:56.987654321+00:00[!UTC]",
+  "12:34:56.987654321-02:30[America/St_Johns]",
+  "1976-11-18T12:34:56.987654321+00:00",
+  "1976-11-18T12:34:56.987654321+00:00[UTC]",
+  "1976-11-18T12:34:56.987654321+00:00[!UTC]",
+  "1976-11-18T12:34:56.987654321-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for PlainTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `"${arg}" UTC offset without time is not valid for PlainTime`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-string-date-with-utc-offset.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.toplaindatetime
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.toPlainDateTime(arg);
+
+  TemporalHelpers.assertPlainDateTime(
+    result,
+    2000, 5, "M05", 2, 12, 34, 56, 987, 654, 321,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.toPlainDateTime(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-string-time-zone-annotation.js
@@ -9,14 +9,10 @@ includes: [temporalHelpers.js]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" });
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    957_270_896_987_654_321n,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-date-with-utc-offset.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const validStrings = [
+  "12:34:56.987654321+00:00",
+  "12:34:56.987654321+00:00[UTC]",
+  "12:34:56.987654321+00:00[!UTC]",
+  "12:34:56.987654321-02:30[America/St_Johns]",
+  "1976-11-18T12:34:56.987654321+00:00",
+  "1976-11-18T12:34:56.987654321+00:00[UTC]",
+  "1976-11-18T12:34:56.987654321+00:00[!UTC]",
+  "1976-11-18T12:34:56.987654321-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for PlainTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `"${arg}" UTC offset without time is not valid for PlainTime`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-string-date-with-utc-offset.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const validStrings = [
+  "2019-12[Africa/Abidjan]",
+  "2019-12[!Africa/Abidjan]",
+  "2019-12[u-ca=iso8601]",
+  "2019-12[Africa/Abidjan][u-ca=iso8601]",
+  "2019-12-15T00+00:00",
+  "2019-12-15T00+00:00[UTC]",
+  "2019-12-15T00+00:00[!UTC]",
+  "2019-12-15T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.PlainYearMonth.compare(arg, arg);
+
+  assert.sameValue(
+    result,
+    0,
+    `"${arg}" is a valid UTC offset with time for PlainYearMonth`
+  );
+}
+
+const invalidStrings = [
+  "2022-09[u-ca=hebrew]",
+  "2022-09Z",
+  "2022-09+01:00",
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)),
+    `"${arg}" UTC offset without time is not valid for PlainYearMonth (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg),
+    `"${arg}" UTC offset without time is not valid for PlainYearMonth (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-string-date-with-utc-offset.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const validStrings = [
+  "2019-12[Africa/Abidjan]",
+  "2019-12[!Africa/Abidjan]",
+  "2019-12[u-ca=iso8601]",
+  "2019-12[Africa/Abidjan][u-ca=iso8601]",
+  "2019-12-15T00+00:00",
+  "2019-12-15T00+00:00[UTC]",
+  "2019-12-15T00+00:00[!UTC]",
+  "2019-12-15T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.PlainYearMonth.from(arg);
+
+  TemporalHelpers.assertPlainYearMonth(
+    result,
+    2019, 12, "M12",
+    `"${arg}" is a valid UTC offset with time for PlainYearMonth`
+  );
+}
+
+const invalidStrings = [
+  "2022-09[u-ca=hebrew]",
+  "2022-09Z",
+  "2022-09+01:00",
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.from(arg),
+    `"${arg}" UTC offset without time is not valid for PlainYearMonth`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-date-with-utc-offset.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.equals
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2019, 12);
+
+const validStrings = [
+  "2019-12[Africa/Abidjan]",
+  "2019-12[!Africa/Abidjan]",
+  "2019-12[u-ca=iso8601]",
+  "2019-12[Africa/Abidjan][u-ca=iso8601]",
+  "2019-12-15T00+00:00",
+  "2019-12-15T00+00:00[UTC]",
+  "2019-12-15T00+00:00[!UTC]",
+  "2019-12-15T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
+    result,
+    true,
+    `"${arg}" is a valid UTC offset with time for PlainYearMonth`
+  );
+}
+
+const invalidStrings = [
+  "2022-09[u-ca=hebrew]",
+  "2022-09Z",
+  "2022-09+01:00",
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `"${arg}" UTC offset without time is not valid for PlainYearMonth`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-date-with-utc-offset.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2019, 12);
+
+const validStrings = [
+  "2019-12[Africa/Abidjan]",
+  "2019-12[!Africa/Abidjan]",
+  "2019-12[u-ca=iso8601]",
+  "2019-12[Africa/Abidjan][u-ca=iso8601]",
+  "2019-12-15T00+00:00",
+  "2019-12-15T00+00:00[UTC]",
+  "2019-12-15T00+00:00[!UTC]",
+  "2019-12-15T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for PlainYearMonth`
+  );
+}
+
+const invalidStrings = [
+  "2022-09[u-ca=hebrew]",
+  "2022-09Z",
+  "2022-09+01:00",
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `"${arg}" UTC offset without time is not valid for PlainYearMonth`
+  );
+}

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-date-with-utc-offset.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2019, 12);
+
+const validStrings = [
+  "2019-12[Africa/Abidjan]",
+  "2019-12[!Africa/Abidjan]",
+  "2019-12[u-ca=iso8601]",
+  "2019-12[Africa/Abidjan][u-ca=iso8601]",
+  "2019-12-15T00+00:00",
+  "2019-12-15T00+00:00[UTC]",
+  "2019-12-15T00+00:00[!UTC]",
+  "2019-12-15T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for PlainYearMonth`
+  );
+}
+
+const invalidStrings = [
+  "2022-09[u-ca=hebrew]",
+  "2022-09Z",
+  "2022-09+01:00",
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `"${arg}" UTC offset without time is not valid for PlainYearMonth`
+  );
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const validStrings = [
+  "1976-11-18T15:23+00:00",
+  "1976-11-18T15:23+00:00[UTC]",
+  "1976-11-18T15:23+00:00[!UTC]",
+  "1976-11-18T15:23-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.getInstantFor(arg);
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    217_178_580_000_000_000n,
+    `"${arg}" is a valid UTC offset with time for PlainDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.getInstantFor(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDateTime`
+  );
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/argument-string-date-with-utc-offset.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getnexttransition
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const validStrings = [
+  "1970-01-01T00Z",
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00Z[Europe/Vienna]",
+  "1970-01-01T00+00:00",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+  "1969-12-31T16-08:00[America/Vancouver]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.getNextTransition(arg);
+
+  assert.sameValue(
+    result,
+    null,
+    `"${arg}" is a valid UTC offset with time for Instant`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.getNextTransition(arg),
+    `"${arg}" UTC offset without time is not valid for Instant`
+  );
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/argument-string-date-with-utc-offset.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getoffsetnanosecondsfor
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const validStrings = [
+  "1970-01-01T00Z",
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00Z[Europe/Vienna]",
+  "1970-01-01T00+00:00",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+  "1969-12-31T16-08:00[America/Vancouver]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.getOffsetNanosecondsFor(arg);
+
+  assert.sameValue(
+    result,
+    0,
+    `"${arg}" is a valid UTC offset with time for Instant`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.getOffsetNanosecondsFor(arg),
+    `"${arg}" UTC offset without time is not valid for Instant`
+  );
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-string-date-with-utc-offset.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getoffsetstringfor
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const validStrings = [
+  "1970-01-01T00Z",
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00Z[Europe/Vienna]",
+  "1970-01-01T00+00:00",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+  "1969-12-31T16-08:00[America/Vancouver]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.getOffsetStringFor(arg);
+
+  assert.sameValue(
+    result,
+    "+00:00",
+    `"${arg}" is a valid UTC offset with time for Instant`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.getOffsetStringFor(arg),
+    `"${arg}" UTC offset without time is not valid for Instant`
+  );
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-string-date-with-utc-offset.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const validStrings = [
+  "1970-01-01T00Z",
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00Z[Europe/Vienna]",
+  "1970-01-01T00+00:00",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+  "1969-12-31T16-08:00[America/Vancouver]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.getPlainDateTimeFor(arg);
+
+  TemporalHelpers.assertPlainDateTime(
+    result,
+    1970, 1, "M01", 1, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for Instant`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.getPlainDateTimeFor(arg),
+    `"${arg}" UTC offset without time is not valid for Instant`
+  );
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-string-date-with-utc-offset.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [compareArray.js]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const validStrings = [
+  "1976-11-18T15:23+00:00",
+  "1976-11-18T15:23+00:00[UTC]",
+  "1976-11-18T15:23+00:00[!UTC]",
+  "1976-11-18T15:23-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.getPossibleInstantsFor(arg);
+
+  assert.compareArray(
+    result.map(i => i.epochNanoseconds),
+    [217_178_580_000_000_000n],
+    `"${arg}" is a valid UTC offset with time for PlainDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.getPossibleInstantsFor(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDateTime`
+  );
+}

--- a/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/argument-string-date-with-utc-offset.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getprevioustransition
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.TimeZone("UTC");
+
+const validStrings = [
+  "1970-01-01T00Z",
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00Z[Europe/Vienna]",
+  "1970-01-01T00+00:00",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+  "1969-12-31T16-08:00[America/Vancouver]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.getPreviousTransition(arg);
+
+  assert.sameValue(
+    result,
+    null,
+    `"${arg}" is a valid UTC offset with time for Instant`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.getPreviousTransition(arg),
+    `"${arg}" UTC offset without time is not valid for Instant`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-string-date-with-utc-offset.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const validStrings = [
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.ZonedDateTime.compare(arg, arg);
+
+  assert.sameValue(
+    result,
+    0,
+    `"${arg}" is a valid UTC offset with time for ZonedDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+const datetime = new Temporal.ZonedDateTime(0n, "UTC");
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.compare(arg, datetime),
+    `"${arg}" UTC offset without time is not valid for ZonedDateTime (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.compare(datetime, arg),
+    `"${arg}" UTC offset without time is not valid for ZonedDateTime (second argument)`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-string-date-with-utc-offset.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const validStrings = [
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+];
+
+for (const arg of validStrings) {
+  const result = Temporal.ZonedDateTime.from(arg);
+
+  assert.sameValue(
+    result.timeZone.toString(),
+    "UTC",
+    `"${arg}" is a valid UTC offset with time for ZonedDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.from(arg),
+    `"${arg}" UTC offset without time is not valid for ZonedDateTime`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-string-date-with-utc-offset.js
@@ -1,0 +1,43 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const validStrings = [
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.equals(arg);
+
+  assert.sameValue(
+    result,
+    true,
+    `"${arg}" is a valid UTC offset with time for ZonedDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `"${arg}" UTC offset without time is not valid for ZonedDateTime`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-string-date-with-utc-offset.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const validStrings = [
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.since(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for ZonedDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `"${arg}" UTC offset without time is not valid for ZonedDateTime`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-string-date-with-utc-offset.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const validStrings = [
+  "1970-01-01T00Z[UTC]",
+  "1970-01-01T00Z[!UTC]",
+  "1970-01-01T00+00:00[UTC]",
+  "1970-01-01T00+00:00[!UTC]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.until(arg);
+
+  TemporalHelpers.assertDuration(
+    result,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    `"${arg}" is a valid UTC offset with time for ZonedDateTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `"${arg}" UTC offset without time is not valid for ZonedDateTime`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-string-date-with-utc-offset.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.withPlainDate(arg);
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    957_225_600_000_000_000n,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.withPlainDate(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-date-with-utc-offset.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaintime
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+
+const validStrings = [
+  "12:34:56.987654321+00:00",
+  "12:34:56.987654321+00:00[UTC]",
+  "12:34:56.987654321+00:00[!UTC]",
+  "12:34:56.987654321-02:30[America/St_Johns]",
+  "1976-11-18T12:34:56.987654321+00:00",
+  "1976-11-18T12:34:56.987654321+00:00[UTC]",
+  "1976-11-18T12:34:56.987654321+00:00[!UTC]",
+  "1976-11-18T12:34:56.987654321-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.withPlainTime(arg);
+
+  assert.sameValue(
+    result.epochNanoseconds,
+    45_296_987_654_321n,
+    `"${arg}" is a valid UTC offset with time for PlainTime`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.withPlainTime(arg),
+    `"${arg}" UTC offset without time is not valid for PlainTime`
+  );
+}

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-string-date-with-utc-offset.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.era
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.era(arg);
+
+  assert.sameValue(
+    result,
+    undefined,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.era(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-string-time-zone-annotation.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-string-date-with-utc-offset.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.erayear
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.eraYear(arg);
+
+  assert.sameValue(
+    result,
+    undefined,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.eraYear(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-string-time-zone-annotation.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],

--- a/test/staging/Temporal/Regex/old/instant.js
+++ b/test/staging/Temporal/Regex/old/instant.js
@@ -28,14 +28,6 @@ function generateTest(dateTimeString, zoneString, components) {
   test(`${ dateTimeString }:30.123456789${ zoneString }`, components);
 }
 // valid strings
-test("2020-01-01Z", [
-  2020,
-  1,
-  1,
-  0,
-  0,
-  0
-]);
 [
   "+01:00",
   "+01",


### PR DESCRIPTION
As per the discussion in
https://github.com/tc39/proposal-temporal/issues/2379#issuecomment-1248557100 and the PR https://github.com/tc39/proposal-temporal/pull/2428, which is to be presented for consensus to TC39 in the upcoming plenary meeting, UTC offsets and the Z designator should be disallowed after any date-only strings (YYYY-MM-DD, YYYY-MM, and MM-DD). They should only be allowed to follow a time component. Z remains disallowed in any string being parsed into a Plain type.

Annotations become allowed after any ISO string, even YYYY-MM and MM-DD where they were previously disallowed.