### PR TITLE
Fix toSpliced mutate-while-iterating test

### DIFF
--- a/test/built-ins/Array/prototype/toSpliced/mutate-while-iterating.js
+++ b/test/built-ins/Array/prototype/toSpliced/mutate-while-iterating.js
@@ -29,10 +29,14 @@ includes: [compareArray.js]
 ---*/
 
 var arr = [0, 1, 2, 3];
+var zerothElementStorage = arr[0];
 Object.defineProperty(arr, "0", {
   get() {
     arr[1] = 42;
-    return 0;
+    return zerothElementStorage;
+  },
+  set(v) {
+    zerothElementStorage = v;
   }
 });
 Object.defineProperty(arr, "2", {


### PR DESCRIPTION
The `arr[0] = 17` throws in strict mode. I'm not sure what that line is supposed to be testing. This can be either fixed per this PR or by adding a `flags: [noStrict]`.