### PR TITLE
More tests for duplicate named capturing groups

### DIFF
--- a/test/annexB/built-ins/RegExp/prototype/compile/duplicate-named-capturing-groups-syntax.js
+++ b/test/annexB/built-ins/RegExp/prototype/compile/duplicate-named-capturing-groups-syntax.js
@@ -1,0 +1,20 @@
+// Copyright 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-regexp.prototype.compile
+description: Runtime parsing of syntax for duplicate named capturing groups
+features: [regexp-duplicate-named-groups]
+---*/
+
+let r = /[ab]/;
+
+assert.throws(
+  SyntaxError,
+  () => r.compile("(?<x>a)(?<x>b)"),
+  "Duplicate named capturing groups in the same alternative do not parse"
+);
+
+let source = "(?<x>a)|(?<x>b)";
+r.compile(source);
+assert.sameValue(r.source, source, "Duplicate named capturing groups in separate alternatives parse correctly");

--- a/test/built-ins/RegExp/duplicate-named-capturing-groups-syntax.js
+++ b/test/built-ins/RegExp/duplicate-named-capturing-groups-syntax.js
@@ -1,0 +1,18 @@
+// Copyright 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-regexp-pattern-flags
+description: Runtime parsing of syntax for duplicate named capturing groups
+features: [regexp-duplicate-named-groups]
+---*/
+
+assert.throws(
+  SyntaxError,
+  () => new RegExp("(?<x>a)(?<x>b)"),
+  "Duplicate named capturing groups in the same alternative do not parse"
+);
+
+let source = "(?<x>a)|(?<x>b)";
+let parsed = new RegExp(source);
+assert.sameValue(parsed.source, source, "Duplicate named capturing groups in separate alternatives parse correctly");

--- a/test/built-ins/RegExp/named-groups/duplicate-names.js
+++ b/test/built-ins/RegExp/named-groups/duplicate-names.js
@@ -8,15 +8,15 @@ features: [regexp-duplicate-named-groups]
 includes: [compareArray.js]
 ---*/
 
-assert.compareArray(["b", "b"], "bab".match(/(?<x>a)|(?<x>b)/));
-assert.compareArray(["b", "b"], "bab".match(/(?<x>b)|(?<x>a)/));
+assert.compareArray(["b", undefined, "b"], "bab".match(/(?<x>a)|(?<x>b)/));
+assert.compareArray(["b", "b", undefined], "bab".match(/(?<x>b)|(?<x>a)/));
 
-assert.compareArray(["aa", "aa", undefined], "aa".match(/(?:(?<x>a)|(?<x>b))\k<x>/));
-assert.compareArray(["bb", undefined, "bb"], "bb".match(/(?:(?<x>a)|(?<x>b))\k<x>/));
+assert.compareArray(["aa", "a", undefined], "aa".match(/(?:(?<x>a)|(?<x>b))\k<x>/));
+assert.compareArray(["bb", undefined, "b"], "bb".match(/(?:(?<x>a)|(?<x>b))\k<x>/));
 
 let matchResult = "aabb".match(/(?:(?:(?<x>a)|(?<x>b))\k<x>){2}/);
-assert.compareArray(["aabb", undefined, "bb"], matchResult);
-assert.sameValue(matchResult.groups.x, "bb");
+assert.compareArray(["aabb", undefined, "b"], matchResult);
+assert.sameValue(matchResult.groups.x, "b");
 
 let notMatched = "abab".match(/(?:(?:(?<x>a)|(?<x>b))\k<x>){2}/);
 assert.sameValue(notMatched, null);

--- a/test/built-ins/RegExp/prototype/exec/duplicate-named-groups-properties.js
+++ b/test/built-ins/RegExp/prototype/exec/duplicate-named-groups-properties.js
@@ -1,0 +1,36 @@
+// Copyright 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Properties on groups object with duplicate named capture groups
+esid: prod-GroupSpecifier
+features: [regexp-duplicate-named-groups]
+includes: [compareArray.js]
+---*/
+
+const matcher = /(?:(?<x>a)|(?<y>a)(?<x>b))(?:(?<z>c)|(?<z>d))/;
+
+const threeMatchResult = matcher.exec("abc");
+assert.sameValue(threeMatchResult.groups.x, "b", "group x matches b");
+assert.sameValue(threeMatchResult.groups.y, "a", "group y matches a");
+assert.sameValue(threeMatchResult.groups.z, "c", "group z matches c");
+assert.compareArray(
+  Object.keys(threeMatchResult.groups),
+  ["x", "y", "z"],
+  "Properties of groups are ordered in RegExp source order despite y matching before x in this alternative"
+);
+
+const twoMatchResult = matcher.exec("ad");
+assert.sameValue(twoMatchResult.groups.x, "a", "group x matches a");
+assert.sameValue(twoMatchResult.groups.y, undefined, "group y does not match");
+assert.sameValue(twoMatchResult.groups.z, "d", "group z matches d");
+assert.compareArray(
+  Object.keys(twoMatchResult.groups),
+  ["x", "y", "z"],
+  "y is still present on groups object, in the right order, despite not matching"
+);
+
+const iteratedMatcher = /(?:(?:(?<x>a)|(?<x>b)|c)\k<x>){2}/;
+
+const matchedInPrevIterationResult = iteratedMatcher.exec("aac");
+assert.sameValue(matchedInPrevIterationResult.groups.x, undefined, "group x does not match in the last iteration");

--- a/test/built-ins/RegExp/prototype/exec/duplicate-named-indices-groups-properties.js
+++ b/test/built-ins/RegExp/prototype/exec/duplicate-named-indices-groups-properties.js
@@ -1,0 +1,36 @@
+// Copyright 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Properties on indices.groups object with duplicate named capture groups
+esid: prod-GroupSpecifier
+features: [regexp-duplicate-named-groups, regexp-match-indices]
+includes: [compareArray.js]
+---*/
+
+const matcher = /(?:(?<x>a)|(?<y>a)(?<x>b))(?:(?<z>c)|(?<z>d))/d;
+
+const threeMatchResult = matcher.exec("abc");
+assert.compareArray(threeMatchResult.indices.groups.x, [1, 2], "group x matches b");
+assert.compareArray(threeMatchResult.indices.groups.y, [0, 1], "group y matches a");
+assert.compareArray(threeMatchResult.indices.groups.z, [2, 3], "group z matches c");
+assert.compareArray(
+  Object.keys(threeMatchResult.indices.groups),
+  ["x", "y", "z"],
+  "Properties of groups are ordered in RegExp source order despite y matching before x in this alternative"
+);
+
+const twoMatchResult = matcher.exec("ad");
+assert.compareArray(twoMatchResult.indices.groups.x, [0, 1], "group x matches a");
+assert.sameValue(twoMatchResult.indices.groups.y, undefined, "group y does not match");
+assert.compareArray(twoMatchResult.indices.groups.z, [1, 2], "group z matches d");
+assert.compareArray(
+  Object.keys(twoMatchResult.indices.groups),
+  ["x", "y", "z"],
+  "y is still present on groups object, in the right order, despite not matching"
+);
+
+const iteratedMatcher = /(?:(?:(?<x>a)|(?<x>b)|c)\k<x>){2}/d;
+
+const matchedInPrevIterationResult = iteratedMatcher.exec("aac");
+assert.sameValue(matchedInPrevIterationResult.indices.groups.x, undefined, "group x does not match in the last iteration");

--- a/test/built-ins/String/prototype/match/duplicate-named-groups-properties.js
+++ b/test/built-ins/String/prototype/match/duplicate-named-groups-properties.js
@@ -1,0 +1,36 @@
+// Copyright 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Properties on groups object with duplicate named capture groups
+esid: prod-GroupSpecifier
+features: [regexp-duplicate-named-groups]
+includes: [compareArray.js]
+---*/
+
+const matcher = /(?:(?<x>a)|(?<y>a)(?<x>b))(?:(?<z>c)|(?<z>d))/;
+
+const threeMatchResult = "abc".match(matcher);
+assert.sameValue(threeMatchResult.groups.x, "b", "group x matches b");
+assert.sameValue(threeMatchResult.groups.y, "a", "group y matches a");
+assert.sameValue(threeMatchResult.groups.z, "c", "group z matches c");
+assert.compareArray(
+  Object.keys(threeMatchResult.groups),
+  ["x", "y", "z"],
+  "Properties of groups are ordered in RegExp source order despite y matching before x in this alternative"
+);
+
+const twoMatchResult = "ad".match(matcher);
+assert.sameValue(twoMatchResult.groups.x, "a", "group x matches a");
+assert.sameValue(twoMatchResult.groups.y, undefined, "group y does not match");
+assert.sameValue(twoMatchResult.groups.z, "d", "group z matches d");
+assert.compareArray(
+  Object.keys(twoMatchResult.groups),
+  ["x", "y", "z"],
+  "y is still present on groups object, in the right order, despite not matching"
+);
+
+const iteratedMatcher = /(?:(?:(?<x>a)|(?<x>b)|c)\k<x>){2}/;
+
+const matchedInPrevIterationResult = "aac".match(iteratedMatcher);
+assert.sameValue(matchedInPrevIterationResult.groups.x, undefined, "group x does not match in the last iteration");

--- a/test/built-ins/String/prototype/match/duplicate-named-indices-groups-properties.js
+++ b/test/built-ins/String/prototype/match/duplicate-named-indices-groups-properties.js
@@ -1,0 +1,36 @@
+// Copyright 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: Properties on indices.groups object with duplicate named capture groups
+esid: prod-GroupSpecifier
+features: [regexp-duplicate-named-groups, regexp-match-indices]
+includes: [compareArray.js]
+---*/
+
+const matcher = /(?:(?<x>a)|(?<y>a)(?<x>b))(?:(?<z>c)|(?<z>d))/d;
+
+const threeMatchResult = "abc".match(matcher);
+assert.compareArray(threeMatchResult.indices.groups.x, [1, 2], "group x matches b");
+assert.compareArray(threeMatchResult.indices.groups.y, [0, 1], "group y matches a");
+assert.compareArray(threeMatchResult.indices.groups.z, [2, 3], "group z matches c");
+assert.compareArray(
+  Object.keys(threeMatchResult.indices.groups),
+  ["x", "y", "z"],
+  "Properties of groups are ordered in RegExp source order despite y matching before x in this alternative"
+);
+
+const twoMatchResult = "ad".match(matcher);
+assert.compareArray(twoMatchResult.indices.groups.x, [0, 1], "group x matches a");
+assert.sameValue(twoMatchResult.indices.groups.y, undefined, "group y does not match");
+assert.compareArray(twoMatchResult.indices.groups.z, [1, 2], "group z matches d");
+assert.compareArray(
+  Object.keys(twoMatchResult.indices.groups),
+  ["x", "y", "z"],
+  "y is still present on groups object, in the right order, despite not matching"
+);
+
+const iteratedMatcher = /(?:(?:(?<x>a)|(?<x>b)|c)\k<x>){2}/d;
+
+const matchedInPrevIterationResult = "aac".match(iteratedMatcher);
+assert.sameValue(matchedInPrevIterationResult.indices.groups.x, undefined, "group x does not match in the last iteration");


### PR DESCRIPTION
See #3704. This covers the first and third tables in that issue: syntax tests, and tests covering the functionality of the `.groups` and `.indices.groups` objects.