### PR TITLE
Temporal: Improve tests for observable order of operations

### DIFF
--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -1449,7 +1449,7 @@ var TemporalHelpers = {
       }
     };
     // Automatically generate the other methods that don't need any custom code
-    ["toString", "dateUntil", "era", "eraYear", "year", "month", "monthCode", "day", "fields", "mergeFields"].forEach((methodName) => {
+    ["toString", "dateUntil", "era", "eraYear", "year", "month", "monthCode", "day", "daysInMonth", "fields", "mergeFields"].forEach((methodName) => {
       trackingMethods[methodName] = function (...args) {
         actual.push(`call ${formatPropertyName(methodName, objectName)}`);
         if (methodName in methodOverrides) {

--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -252,7 +252,7 @@ var TemporalHelpers = {
     Object.entries(expectedLargestUnitCalls).forEach(([largestUnit, expected], index) => {
       func(calendar, largestUnit, index);
       assert.compareArray(actual, expected, `largestUnit passed to calendar.dateUntil() for largestUnit ${largestUnit}`);
-      actual.splice(0, actual.length); // empty it for the next check
+      actual.splice(0); // empty it for the next check
     });
   },
 

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/order-of-operations.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/order-of-operations.js
@@ -1,0 +1,98 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: Properties on an object passed to dateAdd() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  // ToTemporalDate → GetTemporalCalendarWithISODefault
+  "get date.calendar",
+  "has date.calendar.calendar",
+  // ToTemporalDate → CalendarFields
+  "get date.calendar.fields",
+  "call date.calendar.fields",
+  // ToTemporalDate → PrepareTemporalFields
+  "get date.day",
+  "get date.day.valueOf",
+  "call date.day.valueOf",
+  "get date.month",
+  "get date.month.valueOf",
+  "call date.month.valueOf",
+  "get date.monthCode",
+  "get date.monthCode.toString",
+  "call date.monthCode.toString",
+  "get date.year",
+  "get date.year.valueOf",
+  "call date.year.valueOf",
+  // ToTemporalDate → CalendarDateFromFields
+  "get date.calendar.dateFromFields",
+  "call date.calendar.dateFromFields",
+  // ToTemporalDuration
+  "get duration.days",
+  "get duration.days.valueOf",
+  "call duration.days.valueOf",
+  "get duration.hours",
+  "get duration.hours.valueOf",
+  "call duration.hours.valueOf",
+  "get duration.microseconds",
+  "get duration.microseconds.valueOf",
+  "call duration.microseconds.valueOf",
+  "get duration.milliseconds",
+  "get duration.milliseconds.valueOf",
+  "call duration.milliseconds.valueOf",
+  "get duration.minutes",
+  "get duration.minutes.valueOf",
+  "call duration.minutes.valueOf",
+  "get duration.months",
+  "get duration.months.valueOf",
+  "call duration.months.valueOf",
+  "get duration.nanoseconds",
+  "get duration.nanoseconds.valueOf",
+  "call duration.nanoseconds.valueOf",
+  "get duration.seconds",
+  "get duration.seconds.valueOf",
+  "call duration.seconds.valueOf",
+  "get duration.weeks",
+  "get duration.weeks.valueOf",
+  "call duration.weeks.valueOf",
+  "get duration.years",
+  "get duration.years.valueOf",
+  "call duration.years.valueOf",
+  // ToTemporalOverflow
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+];
+const actual = [];
+
+const instance = new Temporal.Calendar("iso8601");
+
+const date = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2000,
+  month: 5,
+  monthCode: "M05",
+  day: 2,
+  calendar: TemporalHelpers.calendarObserver(actual, "date.calendar"),
+}, "date");
+
+const duration = TemporalHelpers.propertyBagObserver(actual, {
+  years: 1,
+  months: 2,
+  weeks: 3,
+  days: 4,
+  hours: 5,
+  minutes: 6,
+  seconds: 7,
+  milliseconds: 8,
+  microseconds: 9,
+  nanoseconds: 10,
+}, "duration");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+instance.dateAdd(date, duration, options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/order-of-operations.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/order-of-operations.js
@@ -1,0 +1,84 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: Properties on an object passed to dateUntil() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  // ToTemporalDate 1 → GetTemporalCalendarWithISODefault
+  "get one.calendar",
+  "has one.calendar.calendar",
+  // ToTemporalDate 1 → CalendarFields
+  "get one.calendar.fields",
+  "call one.calendar.fields",
+  // ToTemporalDate 1 → PrepareTemporalFields
+  "get one.day",
+  "get one.day.valueOf",
+  "call one.day.valueOf",
+  "get one.month",
+  "get one.month.valueOf",
+  "call one.month.valueOf",
+  "get one.monthCode",
+  "get one.monthCode.toString",
+  "call one.monthCode.toString",
+  "get one.year",
+  "get one.year.valueOf",
+  "call one.year.valueOf",
+  // ToTemporalDate 1 → CalendarDateFromFields
+  "get one.calendar.dateFromFields",
+  "call one.calendar.dateFromFields",
+  // ToTemporalDate 2 → GetTemporalCalendarWithISODefault
+  "get two.calendar",
+  "has two.calendar.calendar",
+  // ToTemporalDate 2 → CalendarFields
+  "get two.calendar.fields",
+  "call two.calendar.fields",
+  // ToTemporalDate 2 → PrepareTemporalFields
+  "get two.day",
+  "get two.day.valueOf",
+  "call two.day.valueOf",
+  "get two.month",
+  "get two.month.valueOf",
+  "call two.month.valueOf",
+  "get two.monthCode",
+  "get two.monthCode.toString",
+  "call two.monthCode.toString",
+  "get two.year",
+  "get two.year.valueOf",
+  "call two.year.valueOf",
+  // ToTemporalDate 2 → CalendarDateFromFields
+  "get two.calendar.dateFromFields",
+  "call two.calendar.dateFromFields",
+  // GetTemporalUnit
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+];
+const actual = [];
+
+const instance = new Temporal.Calendar("iso8601");
+
+const one = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2000,
+  month: 5,
+  monthCode: "M05",
+  day: 2,
+  calendar: TemporalHelpers.calendarObserver(actual, "one.calendar"),
+}, "one");
+
+const two = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2001,
+  month: 10,
+  monthCode: "M10",
+  day: 4,
+  calendar: TemporalHelpers.calendarObserver(actual, "two.calendar"),
+}, "two");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { largestUnit: "day" }, "options");
+
+instance.dateUntil(one, two, options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/Duration/compare/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/compare/order-of-operations.js
@@ -247,7 +247,7 @@ Temporal.Duration.compare(
   createOptionsObserver(zonedRelativeTo)
 );
 assert.compareArray(actual, expectedOpsForZonedRelativeTo, "order of operations with ZonedDateTime relativeTo and no calendar units");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through UnbalanceDurationRelative that balances higher units down
 // to days:

--- a/test/built-ins/Temporal/Duration/compare/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/compare/order-of-operations.js
@@ -73,6 +73,86 @@ const expected = [
   "call two.years.valueOf",
   // ToRelativeTemporalObject
   "get options.relativeTo",
+];
+const actual = [];
+
+// basic order of observable operations with no relativeTo
+Temporal.Duration.compare(
+  createDurationPropertyBagObserver("one", 0, 0, 0, 7),
+  createDurationPropertyBagObserver("two", 0, 0, 0, 6),
+  createOptionsObserver(undefined)
+);
+assert.compareArray(actual, expected, "order of operations");
+actual.splice(0); // clear
+
+const expectedOpsForPlainRelativeTo = expected.concat([
+  // ToRelativeTemporalObject
+  "get options.relativeTo.calendar",
+  "has options.relativeTo.calendar.calendar",
+  "get options.relativeTo.calendar.fields",
+  "call options.relativeTo.calendar.fields",
+  "get options.relativeTo.day",
+  "get options.relativeTo.day.valueOf",
+  "call options.relativeTo.day.valueOf",
+  "get options.relativeTo.hour",
+  "get options.relativeTo.microsecond",
+  "get options.relativeTo.millisecond",
+  "get options.relativeTo.minute",
+  "get options.relativeTo.month",
+  "get options.relativeTo.month.valueOf",
+  "call options.relativeTo.month.valueOf",
+  "get options.relativeTo.monthCode",
+  "get options.relativeTo.monthCode.toString",
+  "call options.relativeTo.monthCode.toString",
+  "get options.relativeTo.nanosecond",
+  "get options.relativeTo.second",
+  "get options.relativeTo.year",
+  "get options.relativeTo.year.valueOf",
+  "call options.relativeTo.year.valueOf",
+  "get options.relativeTo.calendar.dateFromFields",
+  "call options.relativeTo.calendar.dateFromFields",
+  "get options.relativeTo.offset",
+  "get options.relativeTo.timeZone",
+]);
+
+const plainRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2001,
+  month: 5,
+  monthCode: "M05",
+  day: 2,
+  calendar: TemporalHelpers.calendarObserver(actual, "options.relativeTo.calendar"),
+}, "options.relativeTo");
+
+function createOptionsObserver(relativeTo = undefined) {
+  return TemporalHelpers.propertyBagObserver(actual, { relativeTo }, "options");
+}
+
+function createDurationPropertyBagObserver(name, y = 0, mon = 0, w = 0, d = 0, h = 0, min = 0, s = 0, ms = 0, µs = 0, ns = 0) {
+  return TemporalHelpers.propertyBagObserver(actual, {
+    years: y,
+    months: mon,
+    weeks: w,
+    days: d,
+    hours: h,
+    minutes: min,
+    seconds: s,
+    milliseconds: ms,
+    microseconds: µs,
+    nanoseconds: ns,
+  }, name);
+}
+
+// order of observable operations with plain relativeTo and without calendar units
+Temporal.Duration.compare(
+  createDurationPropertyBagObserver("one", 0, 0, 0, 7),
+  createDurationPropertyBagObserver("two", 0, 0, 0, 6),
+  createOptionsObserver(plainRelativeTo)
+);
+assert.compareArray(actual, expectedOpsForPlainRelativeTo, "order of operations with PlainDate relativeTo and no calendar units");
+actual.splice(0); // clear
+
+const expectedOpsForZonedRelativeTo = expected.concat([
+  // ToRelativeTemporalObject
   "get options.relativeTo.calendar",
   "has options.relativeTo.calendar.calendar",
   "get options.relativeTo.calendar.fields",
@@ -142,10 +222,9 @@ const expected = [
   "call options.relativeTo.timeZone.getPossibleInstantsFor",
   "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-];
-const actual = [];
+]);
 
-const relativeTo = TemporalHelpers.propertyBagObserver(actual, {
+const zonedRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
   year: 2001,
   month: 5,
   monthCode: "M05",
@@ -161,37 +240,18 @@ const relativeTo = TemporalHelpers.propertyBagObserver(actual, {
   timeZone: TemporalHelpers.timeZoneObserver(actual, "options.relativeTo.timeZone"),
 }, "options.relativeTo");
 
-function createOptionsObserver(relativeTo = undefined) {
-  return TemporalHelpers.propertyBagObserver(actual, { relativeTo }, "options");
-}
-
-function createDurationPropertyBagObserver(name, y = 0, mon = 0, w = 0, d = 0, h = 0, min = 0, s = 0, ms = 0, µs = 0, ns = 0) {
-  return TemporalHelpers.propertyBagObserver(actual, {
-    years: y,
-    months: mon,
-    weeks: w,
-    days: d,
-    hours: h,
-    minutes: min,
-    seconds: s,
-    milliseconds: ms,
-    microseconds: µs,
-    nanoseconds: ns,
-  }, name);
-}
-
-// basic order of observable operations, without
+// order of observable operations with zoned relativeTo and without calendar units
 Temporal.Duration.compare(
   createDurationPropertyBagObserver("one", 0, 0, 0, 7),
   createDurationPropertyBagObserver("two", 0, 0, 0, 6),
-  createOptionsObserver(relativeTo)
+  createOptionsObserver(zonedRelativeTo)
 );
-assert.compareArray(actual, expected, "order of operations");
+assert.compareArray(actual, expectedOpsForZonedRelativeTo, "order of operations with ZonedDateTime relativeTo and no calendar units");
 actual.splice(0, actual.length); // clear
 
 // code path through UnbalanceDurationRelative that balances higher units down
 // to days:
-const expectedOpsForDayBalancing = expected.concat([
+const expectedOpsForDayBalancing = expectedOpsForZonedRelativeTo.concat([
   // UnbalanceDurationRelative
   "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 7.a ToTemporalDate
   "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
@@ -210,7 +270,6 @@ const expectedOpsForDayBalancing = expected.concat([
 Temporal.Duration.compare(
   createDurationPropertyBagObserver("one", 1, 1, 1),
   createDurationPropertyBagObserver("two", 1, 1, 1, 1),
-  createOptionsObserver(relativeTo)
+  createOptionsObserver(zonedRelativeTo)
 );
-assert.compareArray(actual.slice(expected.length), expectedOpsForDayBalancing.slice(expected.length), "order of operations with calendar units");
-actual.splice(0, actual.length);  // clear
+assert.compareArray(actual, expectedOpsForDayBalancing, "order of operations with calendar units");

--- a/test/built-ins/Temporal/Duration/compare/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/compare/order-of-operations.js
@@ -112,8 +112,12 @@ const expected = [
   "get options.relativeTo.offset",
   "get options.relativeTo.timeZone",
   "has options.relativeTo.timeZone.timeZone",
+  "get options.relativeTo.offset.toString",
+  "call options.relativeTo.offset.toString",
   "get options.relativeTo.timeZone.getPossibleInstantsFor",
   "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   // CalculateOffsetShift on first argument
   "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
@@ -152,6 +156,7 @@ const relativeTo = TemporalHelpers.propertyBagObserver(actual, {
   millisecond: 987,
   microsecond: 654,
   nanosecond: 321,
+  offset: "+00:00",
   calendar: TemporalHelpers.calendarObserver(actual, "options.relativeTo.calendar"),
   timeZone: TemporalHelpers.timeZoneObserver(actual, "options.relativeTo.timeZone"),
 }, "options.relativeTo");

--- a/test/built-ins/Temporal/Duration/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/order-of-operations.js
@@ -8,9 +8,8 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.Duration(1, 2, 0, 4, 5, 6, 7, 987, 654, 321);
-const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
 const expected = [
+  // ToTemporalDurationRecord
   "get fields.days",
   "get fields.days.valueOf",
   "call fields.days.valueOf",
@@ -41,8 +40,75 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // ToRelativeTemporalObject
+  "get options.relativeTo",
 ];
 const actual = [];
+
+const simpleFields = TemporalHelpers.propertyBagObserver(actual, {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 1,
+  hours: 1,
+  minutes: 1,
+  seconds: 1,
+  milliseconds: 1,
+  microseconds: 1,
+  nanoseconds: 1,
+}, "fields");
+
+function createOptionsObserver(relativeTo = undefined) {
+  return TemporalHelpers.propertyBagObserver(actual, { relativeTo }, "options");
+}
+
+// basic order of observable operations, without any calendar units:
+const simpleInstance = new Temporal.Duration(0, 0, 0, 1, 1, 1, 1, 1, 1, 1);
+simpleInstance.add(simpleFields, createOptionsObserver());
+assert.compareArray(actual, expected, "order of operations");
+actual.splice(0); // clear
+
+const expectedOpsForPlainRelativeTo = expected.concat([
+  // ToRelativeTemporalObject
+  "get options.relativeTo.calendar",
+  "has options.relativeTo.calendar.calendar",
+  "get options.relativeTo.calendar.fields",
+  "call options.relativeTo.calendar.fields",
+  // PrepareTemporalFields
+  "get options.relativeTo.day",
+  "get options.relativeTo.day.valueOf",
+  "call options.relativeTo.day.valueOf",
+  "get options.relativeTo.hour",
+  "get options.relativeTo.microsecond",
+  "get options.relativeTo.millisecond",
+  "get options.relativeTo.minute",
+  "get options.relativeTo.month",
+  "get options.relativeTo.month.valueOf",
+  "call options.relativeTo.month.valueOf",
+  "get options.relativeTo.monthCode",
+  "get options.relativeTo.monthCode.toString",
+  "call options.relativeTo.monthCode.toString",
+  "get options.relativeTo.nanosecond",
+  "get options.relativeTo.second",
+  "get options.relativeTo.year",
+  "get options.relativeTo.year.valueOf",
+  "call options.relativeTo.year.valueOf",
+  // InterpretTemporalDateTimeFields
+  "get options.relativeTo.calendar.dateFromFields",
+  "call options.relativeTo.calendar.dateFromFields",
+  // ToRelativeTemporalObject again
+  "get options.relativeTo.offset",
+  "get options.relativeTo.timeZone",
+  // AddDuration
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.calendar.dateUntil",
+  "call options.relativeTo.calendar.dateUntil",
+]);
+
+const instance = new Temporal.Duration(1, 2, 0, 4, 5, 6, 7, 987, 654, 321);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
@@ -55,6 +121,138 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microseconds: 1,
   nanoseconds: 1,
 }, "fields");
-const result = instance.add(fields, { relativeTo });
-TemporalHelpers.assertDuration(result, 2, 3, 0, 12, 6, 7, 8, 988, 655, 322);
-assert.compareArray(actual, expected, "order of operations");
+
+const plainRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2000,
+  month: 1,
+  monthCode: "M01",
+  day: 1,
+  calendar: TemporalHelpers.calendarObserver(actual, "options.relativeTo.calendar"),
+}, "options.relativeTo");
+
+instance.add(fields, createOptionsObserver(plainRelativeTo));
+assert.compareArray(actual, expectedOpsForPlainRelativeTo, "order of operations with PlainDate relativeTo");
+actual.splice(0); // clear
+
+const expectedOpsForZonedRelativeTo = expected.concat([
+  // ToRelativeTemporalObject
+  "get options.relativeTo.calendar",
+  "has options.relativeTo.calendar.calendar",
+  "get options.relativeTo.calendar.fields",
+  "call options.relativeTo.calendar.fields",
+  // PrepareTemporalFields
+  "get options.relativeTo.day",
+  "get options.relativeTo.day.valueOf",
+  "call options.relativeTo.day.valueOf",
+  "get options.relativeTo.hour",
+  "get options.relativeTo.hour.valueOf",
+  "call options.relativeTo.hour.valueOf",
+  "get options.relativeTo.microsecond",
+  "get options.relativeTo.microsecond.valueOf",
+  "call options.relativeTo.microsecond.valueOf",
+  "get options.relativeTo.millisecond",
+  "get options.relativeTo.millisecond.valueOf",
+  "call options.relativeTo.millisecond.valueOf",
+  "get options.relativeTo.minute",
+  "get options.relativeTo.minute.valueOf",
+  "call options.relativeTo.minute.valueOf",
+  "get options.relativeTo.month",
+  "get options.relativeTo.month.valueOf",
+  "call options.relativeTo.month.valueOf",
+  "get options.relativeTo.monthCode",
+  "get options.relativeTo.monthCode.toString",
+  "call options.relativeTo.monthCode.toString",
+  "get options.relativeTo.nanosecond",
+  "get options.relativeTo.nanosecond.valueOf",
+  "call options.relativeTo.nanosecond.valueOf",
+  "get options.relativeTo.second",
+  "get options.relativeTo.second.valueOf",
+  "call options.relativeTo.second.valueOf",
+  "get options.relativeTo.year",
+  "get options.relativeTo.year.valueOf",
+  "call options.relativeTo.year.valueOf",
+  // InterpretTemporalDateTimeFields
+  "get options.relativeTo.calendar.dateFromFields",
+  "call options.relativeTo.calendar.dateFromFields",
+  // ToRelativeTemporalObject again
+  "get options.relativeTo.offset",
+  "get options.relativeTo.timeZone",
+  "has options.relativeTo.timeZone.timeZone",
+  "get options.relativeTo.offset.toString",
+  "call options.relativeTo.offset.toString",
+  // InterpretISODateTimeOffset
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  // AddDuration → AddZonedDateTime 1
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // AddDuration → AddZonedDateTime 2
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // AddDuration → DifferenceZonedDateTime
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  // AddDuration → DifferenceZonedDateTime → DifferenceISODateTime
+  "get options.relativeTo.calendar.dateUntil",
+  "call options.relativeTo.calendar.dateUntil",
+  // AddDuration → DifferenceZonedDateTime → AddZonedDateTime
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // AddDuration → DifferenceZonedDateTime → NanosecondsToDays
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  // AddDuration → DifferenceZonedDateTime → NanosecondsToDays → DifferenceISODateTime
+  "get options.relativeTo.calendar.dateUntil",
+  "call options.relativeTo.calendar.dateUntil",
+  // AddDuration → DifferenceZonedDateTime → NanosecondsToDays → AddZonedDateTime 1
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // AddDuration → DifferenceZonedDateTime → NanosecondsToDays → AddZonedDateTime 2
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+]);
+
+const zonedRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2000,
+  month: 1,
+  monthCode: "M01",
+  day: 1,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  offset: "+00:00",
+  calendar: TemporalHelpers.calendarObserver(actual, "options.relativeTo.calendar"),
+  timeZone: TemporalHelpers.timeZoneObserver(actual, "options.relativeTo.timeZone"),
+}, "options.relativeTo");
+
+instance.add(fields, createOptionsObserver(zonedRelativeTo));
+assert.compareArray(actual, expectedOpsForZonedRelativeTo, "order of operations with ZonedDateTime relativeTo");

--- a/test/built-ins/Temporal/Duration/prototype/round/dateuntil-field.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/dateuntil-field.js
@@ -32,7 +32,7 @@ assert.compareArray(actual, expected1, "operations");
 // There is a second path, through BalanceDurationRelative, that calls
 // dateUntil() in a loop for each year in the duration plus one extra time
 
-actual.splice(0, actual.length); // reset calls for next test
+actual.splice(0); // reset calls for next test
 const expected2 = [
   "call dateUntil",
   "call dateUntil",

--- a/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
@@ -84,7 +84,7 @@ const plainRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
 // basic order of observable operations, without rounding:
 instance.round(createOptionsObserver({ relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForPlainRelativeTo, "order of operations for PlainDate relativeTo");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expectedOpsForPlainRelativeTo.concat([
@@ -99,7 +99,7 @@ const expectedOpsForYearRounding = expectedOpsForPlainRelativeTo.concat([
 ]);
 instance.round(createOptionsObserver({ smallestUnit: "years", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through Duration.prototype.round that rounds to the nearest month:
 const expectedOpsForMonthRounding = expectedOpsForPlainRelativeTo.concat([
@@ -121,7 +121,7 @@ const expectedOpsForMonthRounding = expectedOpsForPlainRelativeTo.concat([
 const instance2 = new Temporal.Duration(1, 0, 0, 62);
 instance2.round(createOptionsObserver({ largestUnit: "months", smallestUnit: "months", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with largestUnit = smallestUnit = months");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through Duration.prototype.round that rounds to the nearest week:
 const expectedOpsForWeekRounding = expectedOpsForPlainRelativeTo.concat([
@@ -140,7 +140,7 @@ const expectedOpsForWeekRounding = expectedOpsForPlainRelativeTo.concat([
 const instance3 = new Temporal.Duration(1, 1, 0, 15);
 instance3.round(createOptionsObserver({ largestUnit: "weeks", smallestUnit: "weeks", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with largestUnit = smallestUnit = weeks");
-actual.splice(0, actual.length);  // clear
+actual.splice(0);  // clear
 
 // code path through UnbalanceDurationRelative that rounds to the nearest day:
 const expectedOpsForDayRounding = expectedOpsForPlainRelativeTo.concat([
@@ -152,7 +152,7 @@ const expectedOpsForDayRounding = expectedOpsForPlainRelativeTo.concat([
 const instance4 = new Temporal.Duration(1, 1, 1)
 instance4.round(createOptionsObserver({ largestUnit: "days", smallestUnit: "days", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForDayRounding, "order of operations with largestUnit = smallestUnit = days");
-actual.splice(0, actual.length);  // clear
+actual.splice(0);  // clear
 
 // code path through BalanceDurationRelative balancing from days up to years:
 const expectedOpsForDayToYearBalancing = expectedOpsForPlainRelativeTo.concat([
@@ -168,7 +168,7 @@ const expectedOpsForDayToYearBalancing = expectedOpsForPlainRelativeTo.concat([
 const instance5 = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 396 * 24);
 instance5.round(createOptionsObserver({ largestUnit: "years", smallestUnit: "days", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForDayToYearBalancing, "order of operations with largestUnit = years, smallestUnit = days");
-actual.splice(0, actual.length);  // clear
+actual.splice(0);  // clear
 
 // code path through Duration.prototype.round balancing from months up to years:
 const expectedOpsForMonthToYearBalancing = expectedOpsForPlainRelativeTo.concat([
@@ -190,7 +190,7 @@ const expectedOpsForMonthToYearBalancing = expectedOpsForPlainRelativeTo.concat(
 const instance6 = new Temporal.Duration(0, 12);
 instance6.round(createOptionsObserver({ largestUnit: "years", smallestUnit: "months", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForMonthToYearBalancing, "order of operations with largestUnit = years, smallestUnit = months");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 const expectedOpsForDayToMonthBalancing = expectedOpsForPlainRelativeTo.concat([
   // BalanceDurationRelative
@@ -201,7 +201,7 @@ const expectedOpsForDayToMonthBalancing = expectedOpsForPlainRelativeTo.concat([
 const instance7 = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 32 * 24);
 instance7.round(createOptionsObserver({ largestUnit: "months", smallestUnit: "days", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForDayToMonthBalancing, "order of operations with largestUnit = months, smallestUnit = days");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 const expectedOpsForDayToWeekBalancing = expectedOpsForPlainRelativeTo.concat([
   // BalanceDurationRelative
@@ -212,7 +212,7 @@ const expectedOpsForDayToWeekBalancing = expectedOpsForPlainRelativeTo.concat([
 const instance8 = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 8 * 24);
 instance8.round(createOptionsObserver({ largestUnit: "weeks", smallestUnit: "days", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForDayToWeekBalancing, "order of operations with largestUnit = weeks, smallestUnit = days");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 const expectedOpsForZonedRelativeTo = expected.concat([
   // ToRelativeTemporalObject

--- a/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
@@ -23,6 +23,199 @@ const expected = [
   "call options.roundingIncrement.valueOf",
   // ToRelativeTemporalObject
   "get options.relativeTo",
+];
+const actual = [];
+
+function createOptionsObserver({ smallestUnit = "nanoseconds", largestUnit = "auto", roundingMode = "halfExpand", roundingIncrement = 1, relativeTo = undefined } = {}) {
+  return TemporalHelpers.propertyBagObserver(actual, {
+    smallestUnit,
+    largestUnit,
+    roundingMode,
+    roundingIncrement,
+    relativeTo,
+  }, "options");
+}
+
+const instance = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 2400);
+
+// basic order of operations, without relativeTo:
+instance.round(createOptionsObserver({ smallestUnit: "microseconds" }));
+assert.compareArray(actual, expected, "order of operations");
+actual.splice(0); // clear
+
+const expectedOpsForPlainRelativeTo = expected.concat([
+  // ToRelativeTemporalObject
+  "get options.relativeTo.calendar",
+  "has options.relativeTo.calendar.calendar",
+  "get options.relativeTo.calendar.fields",
+  "call options.relativeTo.calendar.fields",
+  "get options.relativeTo.day",
+  "get options.relativeTo.day.valueOf",
+  "call options.relativeTo.day.valueOf",
+  "get options.relativeTo.hour",
+  "get options.relativeTo.microsecond",
+  "get options.relativeTo.millisecond",
+  "get options.relativeTo.minute",
+  "get options.relativeTo.month",
+  "get options.relativeTo.month.valueOf",
+  "call options.relativeTo.month.valueOf",
+  "get options.relativeTo.monthCode",
+  "get options.relativeTo.monthCode.toString",
+  "call options.relativeTo.monthCode.toString",
+  "get options.relativeTo.nanosecond",
+  "get options.relativeTo.second",
+  "get options.relativeTo.year",
+  "get options.relativeTo.year.valueOf",
+  "call options.relativeTo.year.valueOf",
+  "get options.relativeTo.calendar.dateFromFields",
+  "call options.relativeTo.calendar.dateFromFields",
+  "get options.relativeTo.offset",
+  "get options.relativeTo.timeZone",
+]);
+
+const plainRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2001,
+  month: 5,
+  monthCode: "M05",
+  day: 2,
+  calendar: TemporalHelpers.calendarObserver(actual, "options.relativeTo.calendar"),
+}, "options.relativeTo");
+
+// basic order of observable operations, without rounding:
+instance.round(createOptionsObserver({ relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForPlainRelativeTo, "order of operations for PlainDate relativeTo");
+actual.splice(0, actual.length); // clear
+
+// code path through RoundDuration that rounds to the nearest year:
+const expectedOpsForYearRounding = expectedOpsForPlainRelativeTo.concat([
+  "get options.relativeTo.calendar.dateAdd",     // 9.b
+  "call options.relativeTo.calendar.dateAdd",    // 9.c
+  "call options.relativeTo.calendar.dateAdd",    // 9.e
+  "call options.relativeTo.calendar.dateAdd",    // 9.j
+  "get options.relativeTo.calendar.dateUntil",   // 9.m
+  "call options.relativeTo.calendar.dateUntil",  // 9.m
+  "call options.relativeTo.calendar.dateAdd",    // 9.r
+  "call options.relativeTo.calendar.dateAdd",    // 9.w MoveRelativeDate
+]);
+instance.round(createOptionsObserver({ smallestUnit: "years", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
+actual.splice(0, actual.length); // clear
+
+// code path through Duration.prototype.round that rounds to the nearest month:
+const expectedOpsForMonthRounding = expectedOpsForPlainRelativeTo.concat([
+  // UnbalanceDurationRelative
+  "get options.relativeTo.calendar.dateAdd",     // 9.b
+  "get options.relativeTo.calendar.dateUntil",   // 9.c
+  "call options.relativeTo.calendar.dateAdd",    // 9.d.i
+  "call options.relativeTo.calendar.dateUntil",  // 9.d.iv
+  // RoundDuration
+  "get options.relativeTo.calendar.dateAdd",     // 10.b
+  "call options.relativeTo.calendar.dateAdd",    // 10.c
+  "call options.relativeTo.calendar.dateAdd",    // 10.e
+  "call options.relativeTo.calendar.dateAdd",    // 10.k MoveRelativeDate
+], Array(2).fill("call options.relativeTo.calendar.dateAdd"), [ // 2× 10.n.iii MoveRelativeDate
+  // BalanceDurationRelative
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+]);
+const instance2 = new Temporal.Duration(1, 0, 0, 62);
+instance2.round(createOptionsObserver({ largestUnit: "months", smallestUnit: "months", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with largestUnit = smallestUnit = months");
+actual.splice(0, actual.length); // clear
+
+// code path through Duration.prototype.round that rounds to the nearest week:
+const expectedOpsForWeekRounding = expectedOpsForPlainRelativeTo.concat([
+  // UnbalanceDurationRelative
+  "get options.relativeTo.calendar.dateAdd",   // 10.b
+  "call options.relativeTo.calendar.dateAdd",  // 10.c.i MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",  // 10.d.i MoveRelativeDate
+  // RoundDuration
+  "get options.relativeTo.calendar.dateAdd",   // 11.c
+  "call options.relativeTo.calendar.dateAdd",  // 11.d MoveRelativeDate
+], Array(58).fill("call options.relativeTo.calendar.dateAdd"), [  // 58× 11.g.iii MoveRelativeDate (52 + 4 + 2)
+  // BalanceDurationRelative
+  "get options.relativeTo.calendar.dateAdd",   // 12.b
+  "call options.relativeTo.calendar.dateAdd",  // 12.c
+]);
+const instance3 = new Temporal.Duration(1, 1, 0, 15);
+instance3.round(createOptionsObserver({ largestUnit: "weeks", smallestUnit: "weeks", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with largestUnit = smallestUnit = weeks");
+actual.splice(0, actual.length);  // clear
+
+// code path through UnbalanceDurationRelative that rounds to the nearest day:
+const expectedOpsForDayRounding = expectedOpsForPlainRelativeTo.concat([
+  "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
+  "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
+]);
+const instance4 = new Temporal.Duration(1, 1, 1)
+instance4.round(createOptionsObserver({ largestUnit: "days", smallestUnit: "days", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForDayRounding, "order of operations with largestUnit = smallestUnit = days");
+actual.splice(0, actual.length);  // clear
+
+// code path through BalanceDurationRelative balancing from days up to years:
+const expectedOpsForDayToYearBalancing = expectedOpsForPlainRelativeTo.concat([
+  "get options.relativeTo.calendar.dateAdd",     // 10.a
+  "call options.relativeTo.calendar.dateAdd",    // 10.b MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",    // 10.e.iv MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",    // 10.f MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",    // 10.i.iv MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",    // 10.j
+  "get options.relativeTo.calendar.dateUntil",   // 10.k
+  "call options.relativeTo.calendar.dateUntil",  // 10.n
+]);
+const instance5 = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 396 * 24);
+instance5.round(createOptionsObserver({ largestUnit: "years", smallestUnit: "days", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForDayToYearBalancing, "order of operations with largestUnit = years, smallestUnit = days");
+actual.splice(0, actual.length);  // clear
+
+// code path through Duration.prototype.round balancing from months up to years:
+const expectedOpsForMonthToYearBalancing = expectedOpsForPlainRelativeTo.concat([
+  // RoundDuration
+  "get options.relativeTo.calendar.dateAdd",     // 10.b
+  "call options.relativeTo.calendar.dateAdd",    // 10.c
+  "call options.relativeTo.calendar.dateAdd",    // 10.e
+  "call options.relativeTo.calendar.dateAdd",    // 10.k MoveRelativeDate
+  // BalanceDurationRelative
+  "get options.relativeTo.calendar.dateAdd",     // 10.a
+  "call options.relativeTo.calendar.dateAdd",    // 10.b MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",    // 10.f MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",    // 10.j
+  "get options.relativeTo.calendar.dateUntil",   // 10.k
+  "call options.relativeTo.calendar.dateUntil",  // 10.n
+  "call options.relativeTo.calendar.dateAdd",    // 10.p.iv
+  "call options.relativeTo.calendar.dateUntil",  // 10.p.vii
+]);
+const instance6 = new Temporal.Duration(0, 12);
+instance6.round(createOptionsObserver({ largestUnit: "years", smallestUnit: "months", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForMonthToYearBalancing, "order of operations with largestUnit = years, smallestUnit = months");
+actual.splice(0, actual.length); // clear
+
+const expectedOpsForDayToMonthBalancing = expectedOpsForPlainRelativeTo.concat([
+  // BalanceDurationRelative
+  "get options.relativeTo.calendar.dateAdd",     // 11.a
+  "call options.relativeTo.calendar.dateAdd",    // 11.b MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",    // 11.e.iv MoveRelativeDate
+]);
+const instance7 = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 32 * 24);
+instance7.round(createOptionsObserver({ largestUnit: "months", smallestUnit: "days", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForDayToMonthBalancing, "order of operations with largestUnit = months, smallestUnit = days");
+actual.splice(0, actual.length); // clear
+
+const expectedOpsForDayToWeekBalancing = expectedOpsForPlainRelativeTo.concat([
+  // BalanceDurationRelative
+  "get options.relativeTo.calendar.dateAdd",   // 12.b
+  "call options.relativeTo.calendar.dateAdd",  // 12.c MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",  // 12.f.iv MoveRelativeDate
+]);
+const instance8 = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 8 * 24);
+instance8.round(createOptionsObserver({ largestUnit: "weeks", smallestUnit: "days", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForDayToWeekBalancing, "order of operations with largestUnit = weeks, smallestUnit = days");
+actual.splice(0, actual.length); // clear
+
+const expectedOpsForZonedRelativeTo = expected.concat([
+  // ToRelativeTemporalObject
   "get options.relativeTo.calendar",
   "has options.relativeTo.calendar.calendar",
   "get options.relativeTo.calendar.fields",
@@ -61,10 +254,20 @@ const expected = [
   "call options.relativeTo.calendar.dateFromFields",
   "get options.relativeTo.offset",
   "get options.relativeTo.timeZone",
-];
-const actual = [];
+  "has options.relativeTo.timeZone.timeZone",
+  "get options.relativeTo.offset.toString",
+  "call options.relativeTo.offset.toString",
+  // InterpretISODateTimeOffset
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  // RoundDuration → ToTemporalDate
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+]);
 
-const relativeTo = TemporalHelpers.propertyBagObserver(actual, {
+const zonedRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
   year: 2001,
   month: 5,
   monthCode: "M05",
@@ -75,150 +278,11 @@ const relativeTo = TemporalHelpers.propertyBagObserver(actual, {
   millisecond: 987,
   microsecond: 654,
   nanosecond: 321,
+  offset: "+00:00",
   calendar: TemporalHelpers.calendarObserver(actual, "options.relativeTo.calendar"),
+  timeZone: TemporalHelpers.timeZoneObserver(actual, "options.relativeTo.timeZone"),
 }, "options.relativeTo");
 
-function createOptionsObserver({ smallestUnit = "nanoseconds", largestUnit = "auto", roundingMode = "halfExpand", roundingIncrement = 1, relativeTo = undefined } = {}) {
-  return TemporalHelpers.propertyBagObserver(actual, {
-    smallestUnit,
-    largestUnit,
-    roundingMode,
-    roundingIncrement,
-    relativeTo,
-  }, "options");
-}
-
-const instance = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 2400);
-
-// basic order of observable operations, without rounding:
-instance.round(createOptionsObserver({ relativeTo }));
-assert.compareArray(actual, expected, "order of operations");
-actual.splice(0, actual.length); // clear
-
-// code path through RoundDuration that rounds to the nearest year:
-const expectedOpsForYearRounding = expected.concat([
-  "get options.relativeTo.calendar.dateAdd",     // 9.b
-  "call options.relativeTo.calendar.dateAdd",    // 9.c
-  "call options.relativeTo.calendar.dateAdd",    // 9.e
-  "call options.relativeTo.calendar.dateAdd",    // 9.j
-  "get options.relativeTo.calendar.dateUntil",   // 9.m
-  "call options.relativeTo.calendar.dateUntil",  // 9.m
-  "call options.relativeTo.calendar.dateAdd",    // 9.r
-  "call options.relativeTo.calendar.dateAdd",    // 9.w MoveRelativeDate
-]);
-instance.round(createOptionsObserver({ smallestUnit: "years", relativeTo }));
-assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
-actual.splice(0, actual.length); // clear
-
-// code path through Duration.prototype.round that rounds to the nearest month:
-const expectedOpsForMonthRounding = expected.concat([
-  // UnbalanceDurationRelative
-  "get options.relativeTo.calendar.dateAdd",     // 9.b
-  "get options.relativeTo.calendar.dateUntil",   // 9.c
-  "call options.relativeTo.calendar.dateAdd",    // 9.d.i
-  "call options.relativeTo.calendar.dateUntil",  // 9.d.iv
-  // RoundDuration
-  "get options.relativeTo.calendar.dateAdd",     // 10.b
-  "call options.relativeTo.calendar.dateAdd",    // 10.c
-  "call options.relativeTo.calendar.dateAdd",    // 10.e
-  "call options.relativeTo.calendar.dateAdd",    // 10.k MoveRelativeDate
-], Array(2).fill("call options.relativeTo.calendar.dateAdd"), [ // 2× 10.n.iii MoveRelativeDate
-  // BalanceDurationRelative
-  "get options.relativeTo.calendar.dateAdd",
-  "call options.relativeTo.calendar.dateAdd",
-]);
-const instance2 = new Temporal.Duration(1, 0, 0, 62);
-instance2.round(createOptionsObserver({ largestUnit: "months", smallestUnit: "months", relativeTo }));
-assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with largestUnit = smallestUnit = months");
-actual.splice(0, actual.length); // clear
-
-// code path through Duration.prototype.round that rounds to the nearest week:
-const expectedOpsForWeekRounding = expected.concat([
-  // UnbalanceDurationRelative
-  "get options.relativeTo.calendar.dateAdd",   // 10.b
-  "call options.relativeTo.calendar.dateAdd",  // 10.c.i MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",  // 10.d.i MoveRelativeDate
-  // RoundDuration
-  "get options.relativeTo.calendar.dateAdd",   // 11.c
-  "call options.relativeTo.calendar.dateAdd",  // 11.d MoveRelativeDate
-], Array(58).fill("call options.relativeTo.calendar.dateAdd"), [  // 58× 11.g.iii MoveRelativeDate (52 + 4 + 2)
-  // BalanceDurationRelative
-  "get options.relativeTo.calendar.dateAdd",   // 12.b
-  "call options.relativeTo.calendar.dateAdd",  // 12.c
-]);
-const instance3 = new Temporal.Duration(1, 1, 0, 15);
-instance3.round(createOptionsObserver({ largestUnit: "weeks", smallestUnit: "weeks", relativeTo }));
-assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with largestUnit = smallestUnit = weeks");
-actual.splice(0, actual.length);  // clear
-
-// code path through UnbalanceDurationRelative that rounds to the nearest day:
-const expectedOpsForDayRounding = expected.concat([
-  "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
-]);
-const instance4 = new Temporal.Duration(1, 1, 1)
-instance4.round(createOptionsObserver({ largestUnit: "days", smallestUnit: "days", relativeTo }));
-assert.compareArray(actual, expectedOpsForDayRounding, "order of operations with largestUnit = smallestUnit = days");
-actual.splice(0, actual.length);  // clear
-
-// code path through BalanceDurationRelative balancing from days up to years:
-const expectedOpsForDayToYearBalancing = expected.concat([
-  "get options.relativeTo.calendar.dateAdd",     // 10.a
-  "call options.relativeTo.calendar.dateAdd",    // 10.b MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",    // 10.e.iv MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",    // 10.f MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",    // 10.i.iv MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",    // 10.j
-  "get options.relativeTo.calendar.dateUntil",   // 10.k
-  "call options.relativeTo.calendar.dateUntil",  // 10.n
-]);
-const instance5 = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 396 * 24);
-instance5.round(createOptionsObserver({ largestUnit: "years", smallestUnit: "days", relativeTo }));
-assert.compareArray(actual, expectedOpsForDayToYearBalancing, "order of operations with largestUnit = years, smallestUnit = days");
-actual.splice(0, actual.length);  // clear
-
-// code path through Duration.prototype.round balancing from months up to years:
-const expectedOpsForMonthToYearBalancing = expected.concat([
-  // RoundDuration
-  "get options.relativeTo.calendar.dateAdd",     // 10.b
-  "call options.relativeTo.calendar.dateAdd",    // 10.c
-  "call options.relativeTo.calendar.dateAdd",    // 10.e
-  "call options.relativeTo.calendar.dateAdd",    // 10.k MoveRelativeDate
-  // BalanceDurationRelative
-  "get options.relativeTo.calendar.dateAdd",     // 10.a
-  "call options.relativeTo.calendar.dateAdd",    // 10.b MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",    // 10.f MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",    // 10.j
-  "get options.relativeTo.calendar.dateUntil",   // 10.k
-  "call options.relativeTo.calendar.dateUntil",  // 10.n
-  "call options.relativeTo.calendar.dateAdd",    // 10.p.iv
-  "call options.relativeTo.calendar.dateUntil",  // 10.p.vii
-]);
-const instance6 = new Temporal.Duration(0, 12);
-instance6.round(createOptionsObserver({ largestUnit: "years", smallestUnit: "months", relativeTo }));
-assert.compareArray(actual, expectedOpsForMonthToYearBalancing, "order of operations with largestUnit = years, smallestUnit = months");
-actual.splice(0, actual.length); // clear
-
-const expectedOpsForDayToMonthBalancing = expected.concat([
-  // BalanceDurationRelative
-  "get options.relativeTo.calendar.dateAdd",     // 11.a
-  "call options.relativeTo.calendar.dateAdd",    // 11.b MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",    // 11.e.iv MoveRelativeDate
-]);
-const instance7 = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 32 * 24);
-instance7.round(createOptionsObserver({ largestUnit: "months", smallestUnit: "days", relativeTo }));
-assert.compareArray(actual, expectedOpsForDayToMonthBalancing, "order of operations with largestUnit = months, smallestUnit = days");
-actual.splice(0, actual.length); // clear
-
-const expectedOpsForDayToWeekBalancing = expected.concat([
-  // BalanceDurationRelative
-  "get options.relativeTo.calendar.dateAdd",   // 12.b
-  "call options.relativeTo.calendar.dateAdd",  // 12.c MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",  // 12.f.iv MoveRelativeDate
-]);
-const instance8 = new Temporal.Duration(0, 0, 0, 0, /* hours = */ 8 * 24);
-instance8.round(createOptionsObserver({ largestUnit: "weeks", smallestUnit: "days", relativeTo }));
-assert.compareArray(actual, expectedOpsForDayToWeekBalancing, "order of operations with largestUnit = weeks, smallestUnit = days");
-actual.splice(0, actual.length); // clear
+// basic order of operations with ZonedDateTime relativeTo:
+instance.round(createOptionsObserver({ relativeTo: zonedRelativeTo }));
+assert.compareArray(actual, expectedOpsForZonedRelativeTo, "order of operations for ZonedDateTime relativeTo");

--- a/test/built-ins/Temporal/Duration/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/order-of-operations.js
@@ -8,9 +8,8 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.Duration(1, 2, 1, 4, 5, 6, 7, 987, 654, 321);
-const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
 const expected = [
+  // ToTemporalDurationRecord
   "get fields.days",
   "get fields.days.valueOf",
   "call fields.days.valueOf",
@@ -41,8 +40,75 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // ToRelativeTemporalObject
+  "get options.relativeTo",
 ];
 const actual = [];
+
+const simpleFields = TemporalHelpers.propertyBagObserver(actual, {
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 1,
+  hours: 1,
+  minutes: 1,
+  seconds: 1,
+  milliseconds: 1,
+  microseconds: 1,
+  nanoseconds: 1,
+}, "fields");
+
+function createOptionsObserver(relativeTo = undefined) {
+  return TemporalHelpers.propertyBagObserver(actual, { relativeTo }, "options");
+}
+
+// basic order of observable operations, without any calendar units:
+const simpleInstance = new Temporal.Duration(0, 0, 0, 1, 1, 1, 1, 1, 1, 1);
+simpleInstance.subtract(simpleFields, createOptionsObserver());
+assert.compareArray(actual, expected, "order of operations");
+actual.splice(0); // clear
+
+const expectedOpsForPlainRelativeTo = expected.concat([
+  // ToRelativeTemporalObject
+  "get options.relativeTo.calendar",
+  "has options.relativeTo.calendar.calendar",
+  "get options.relativeTo.calendar.fields",
+  "call options.relativeTo.calendar.fields",
+  // PrepareTemporalFields
+  "get options.relativeTo.day",
+  "get options.relativeTo.day.valueOf",
+  "call options.relativeTo.day.valueOf",
+  "get options.relativeTo.hour",
+  "get options.relativeTo.microsecond",
+  "get options.relativeTo.millisecond",
+  "get options.relativeTo.minute",
+  "get options.relativeTo.month",
+  "get options.relativeTo.month.valueOf",
+  "call options.relativeTo.month.valueOf",
+  "get options.relativeTo.monthCode",
+  "get options.relativeTo.monthCode.toString",
+  "call options.relativeTo.monthCode.toString",
+  "get options.relativeTo.nanosecond",
+  "get options.relativeTo.second",
+  "get options.relativeTo.year",
+  "get options.relativeTo.year.valueOf",
+  "call options.relativeTo.year.valueOf",
+  // InterpretTemporalDateTimeFields
+  "get options.relativeTo.calendar.dateFromFields",
+  "call options.relativeTo.calendar.dateFromFields",
+  // ToRelativeTemporalObject again
+  "get options.relativeTo.offset",
+  "get options.relativeTo.timeZone",
+  // AddDuration
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.calendar.dateUntil",
+  "call options.relativeTo.calendar.dateUntil",
+]);
+
+const instance = new Temporal.Duration(1, 2, 1, 4, 5, 6, 7, 987, 654, 321);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,
@@ -55,6 +121,138 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microseconds: 1,
   nanoseconds: 1,
 }, "fields");
-const result = instance.subtract(fields, { relativeTo });
-TemporalHelpers.assertDuration(result, 0, 1, 0, 3, 4, 5, 6, 986, 653, 320);
-assert.compareArray(actual, expected, "order of operations");
+
+const plainRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2000,
+  month: 1,
+  monthCode: "M01",
+  day: 1,
+  calendar: TemporalHelpers.calendarObserver(actual, "options.relativeTo.calendar"),
+}, "options.relativeTo");
+
+instance.subtract(fields, createOptionsObserver(plainRelativeTo));
+assert.compareArray(actual, expectedOpsForPlainRelativeTo, "order of operations with PlainDate relativeTo");
+actual.splice(0); // clear
+
+const expectedOpsForZonedRelativeTo = expected.concat([
+  // ToRelativeTemporalObject
+  "get options.relativeTo.calendar",
+  "has options.relativeTo.calendar.calendar",
+  "get options.relativeTo.calendar.fields",
+  "call options.relativeTo.calendar.fields",
+  // PrepareTemporalFields
+  "get options.relativeTo.day",
+  "get options.relativeTo.day.valueOf",
+  "call options.relativeTo.day.valueOf",
+  "get options.relativeTo.hour",
+  "get options.relativeTo.hour.valueOf",
+  "call options.relativeTo.hour.valueOf",
+  "get options.relativeTo.microsecond",
+  "get options.relativeTo.microsecond.valueOf",
+  "call options.relativeTo.microsecond.valueOf",
+  "get options.relativeTo.millisecond",
+  "get options.relativeTo.millisecond.valueOf",
+  "call options.relativeTo.millisecond.valueOf",
+  "get options.relativeTo.minute",
+  "get options.relativeTo.minute.valueOf",
+  "call options.relativeTo.minute.valueOf",
+  "get options.relativeTo.month",
+  "get options.relativeTo.month.valueOf",
+  "call options.relativeTo.month.valueOf",
+  "get options.relativeTo.monthCode",
+  "get options.relativeTo.monthCode.toString",
+  "call options.relativeTo.monthCode.toString",
+  "get options.relativeTo.nanosecond",
+  "get options.relativeTo.nanosecond.valueOf",
+  "call options.relativeTo.nanosecond.valueOf",
+  "get options.relativeTo.second",
+  "get options.relativeTo.second.valueOf",
+  "call options.relativeTo.second.valueOf",
+  "get options.relativeTo.year",
+  "get options.relativeTo.year.valueOf",
+  "call options.relativeTo.year.valueOf",
+  // InterpretTemporalDateTimeFields
+  "get options.relativeTo.calendar.dateFromFields",
+  "call options.relativeTo.calendar.dateFromFields",
+  // ToRelativeTemporalObject again
+  "get options.relativeTo.offset",
+  "get options.relativeTo.timeZone",
+  "has options.relativeTo.timeZone.timeZone",
+  "get options.relativeTo.offset.toString",
+  "call options.relativeTo.offset.toString",
+  // InterpretISODateTimeOffset
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  // AddDuration → AddZonedDateTime 1
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // AddDuration → AddZonedDateTime 2
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // AddDuration → DifferenceZonedDateTime
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  // AddDuration → DifferenceZonedDateTime → DifferenceISODateTime
+  "get options.relativeTo.calendar.dateUntil",
+  "call options.relativeTo.calendar.dateUntil",
+  // AddDuration → DifferenceZonedDateTime → AddZonedDateTime
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // AddDuration → DifferenceZonedDateTime → NanosecondsToDays
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  // AddDuration → DifferenceZonedDateTime → NanosecondsToDays → DifferenceISODateTime
+  "get options.relativeTo.calendar.dateUntil",
+  "call options.relativeTo.calendar.dateUntil",
+  // AddDuration → DifferenceZonedDateTime → NanosecondsToDays → AddZonedDateTime 1
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // AddDuration → DifferenceZonedDateTime → NanosecondsToDays → AddZonedDateTime 2
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+]);
+
+const zonedRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2000,
+  month: 1,
+  monthCode: "M01",
+  day: 1,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0,
+  microsecond: 0,
+  nanosecond: 0,
+  offset: "+00:00",
+  calendar: TemporalHelpers.calendarObserver(actual, "options.relativeTo.calendar"),
+  timeZone: TemporalHelpers.timeZoneObserver(actual, "options.relativeTo.timeZone"),
+}, "options.relativeTo");
+
+instance.subtract(fields, createOptionsObserver(zonedRelativeTo));
+assert.compareArray(actual, expectedOpsForZonedRelativeTo, "order of operations with ZonedDateTime relativeTo");

--- a/test/built-ins/Temporal/Duration/prototype/toString/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/toString/order-of-operations.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+description: Properties on objects passed to toString() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+];
+const actual = [];
+
+const instance = new Temporal.Duration(1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+
+instance.toString(
+  TemporalHelpers.propertyBagObserver(actual, {
+    fractionalSecondDigits: 3,
+    roundingMode: "halfExpand",
+    smallestUnit: "millisecond",
+  }, "options"),
+);
+assert.compareArray(actual, expected, "order of operations");
+actual.splice(0); // clear
+
+const expectedForFractionalSecondDigits = [
+  "get options.smallestUnit",
+  "get options.fractionalSecondDigits",
+  "get options.fractionalSecondDigits.toString",
+  "call options.fractionalSecondDigits.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+];
+
+instance.toString(
+  TemporalHelpers.propertyBagObserver(actual, {
+    fractionalSecondDigits: "auto",
+    roundingMode: "halfExpand",
+    smallestUnit: undefined,
+  }, "options"),
+);
+assert.compareArray(actual, expectedForFractionalSecondDigits, "order of operations with smallestUnit undefined");

--- a/test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js
@@ -9,6 +9,138 @@ features: [Temporal]
 ---*/
 
 const expected = [
+  "get options.relativeTo",
+  "get options.unit",
+  "get options.unit.toString",
+  "call options.unit.toString",
+];
+const actual = [];
+
+function createOptionsObserver({ unit = "nanoseconds", roundingMode = "halfExpand", roundingIncrement = 1, relativeTo = undefined } = {}) {
+  return TemporalHelpers.propertyBagObserver(actual, {
+    unit,
+    roundingMode,
+    roundingIncrement,
+    relativeTo,
+  }, "options");
+}
+
+const instance = new Temporal.Duration(0, 0, 0, 0, 2400);
+
+// basic order of observable operations, with no relativeTo
+instance.total(createOptionsObserver({ unit: "nanoseconds" }));
+assert.compareArray(actual, expected, "order of operations");
+actual.splice(0); // clear
+
+const expectedOpsForPlainRelativeTo = [
+  // ToRelativeTemporalObject
+  "get options.relativeTo",
+  "get options.relativeTo.calendar",
+  "has options.relativeTo.calendar.calendar",
+  "get options.relativeTo.calendar.fields",
+  "call options.relativeTo.calendar.fields",
+  "get options.relativeTo.day",
+  "get options.relativeTo.day.valueOf",
+  "call options.relativeTo.day.valueOf",
+  "get options.relativeTo.hour",
+  "get options.relativeTo.microsecond",
+  "get options.relativeTo.millisecond",
+  "get options.relativeTo.minute",
+  "get options.relativeTo.month",
+  "get options.relativeTo.month.valueOf",
+  "call options.relativeTo.month.valueOf",
+  "get options.relativeTo.monthCode",
+  "get options.relativeTo.monthCode.toString",
+  "call options.relativeTo.monthCode.toString",
+  "get options.relativeTo.nanosecond",
+  "get options.relativeTo.second",
+  "get options.relativeTo.year",
+  "get options.relativeTo.year.valueOf",
+  "call options.relativeTo.year.valueOf",
+  "get options.relativeTo.calendar.dateFromFields",
+  "call options.relativeTo.calendar.dateFromFields",
+  "get options.relativeTo.offset",
+  "get options.relativeTo.timeZone",
+  // GetTemporalUnit
+  "get options.unit",
+  "get options.unit.toString",
+  "call options.unit.toString",
+];
+
+const plainRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2001,
+  month: 5,
+  monthCode: "M05",
+  day: 2,
+  calendar: TemporalHelpers.calendarObserver(actual, "options.relativeTo.calendar"),
+}, "options.relativeTo");
+
+// basic order of observable operations, without rounding:
+instance.total(createOptionsObserver({ unit: "nanoseconds", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForPlainRelativeTo, "order of operations for PlainDate relativeTo");
+actual.splice(0, actual.length); // clear
+
+// code path through RoundDuration that rounds to the nearest year:
+const expectedOpsForYearRounding = expectedOpsForPlainRelativeTo.concat([
+  "get options.relativeTo.calendar.dateAdd",     // 9.b
+  "call options.relativeTo.calendar.dateAdd",    // 9.c
+  "call options.relativeTo.calendar.dateAdd",    // 9.e
+  "call options.relativeTo.calendar.dateAdd",    // 9.j
+  "get options.relativeTo.calendar.dateUntil",   // 9.m
+  "call options.relativeTo.calendar.dateUntil",  // 9.m
+  "call options.relativeTo.calendar.dateAdd",    // 9.r
+  "call options.relativeTo.calendar.dateAdd",    // 9.w MoveRelativeDate
+]);
+instance.total(createOptionsObserver({ unit: "years", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with unit = years");
+actual.splice(0, actual.length); // clear
+
+// code path through Duration.prototype.total that rounds to the nearest month:
+const expectedOpsForMonthRounding = expectedOpsForPlainRelativeTo.concat([
+  // UnbalanceDurationRelative
+  "get options.relativeTo.calendar.dateAdd",     // 9.b
+  "get options.relativeTo.calendar.dateUntil",   // 9.c
+  "call options.relativeTo.calendar.dateAdd",    // 9.d.i
+  "call options.relativeTo.calendar.dateUntil",  // 9.d.iv
+  // RoundDuration
+  "get options.relativeTo.calendar.dateAdd",     // 10.b
+  "call options.relativeTo.calendar.dateAdd",    // 10.c
+  "call options.relativeTo.calendar.dateAdd",    // 10.e
+  "call options.relativeTo.calendar.dateAdd",    // 10.k MoveRelativeDate
+], Array(2).fill("call options.relativeTo.calendar.dateAdd")); // 2× 10.n.iii MoveRelativeDate
+const instance2 = new Temporal.Duration(1, 0, 0, 62);
+instance2.total(createOptionsObserver({ unit: "months", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with unit = months");
+actual.splice(0, actual.length); // clear
+
+// code path through Duration.prototype.total that rounds to the nearest week:
+const expectedOpsForWeekRounding = expectedOpsForPlainRelativeTo.concat([
+  // UnbalanceDurationRelative
+  "get options.relativeTo.calendar.dateAdd",   // 10.b
+  "call options.relativeTo.calendar.dateAdd",  // 10.c.i MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",  // 10.d.i MoveRelativeDate
+  // RoundDuration
+  "get options.relativeTo.calendar.dateAdd",   // 11.c
+  "call options.relativeTo.calendar.dateAdd",  // 11.d MoveRelativeDate
+], Array(58).fill("call options.relativeTo.calendar.dateAdd"));  // 58× 11.g.iii MoveRelativeDate (52 + 4 + 2)
+const instance3 = new Temporal.Duration(1, 1, 0, 15);
+instance3.total(createOptionsObserver({ unit: "weeks", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with unit = weeks");
+actual.splice(0, actual.length); // clear
+
+// code path through UnbalanceDurationRelative that rounds to the nearest day:
+const expectedOpsForDayRounding = expectedOpsForPlainRelativeTo.concat([
+  "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
+  "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
+  "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
+]);
+const instance4 = new Temporal.Duration(1, 1, 1)
+instance4.total(createOptionsObserver({ unit: "days", relativeTo: plainRelativeTo }));
+assert.compareArray(actual, expectedOpsForDayRounding, "order of operations with unit = days");
+actual.splice(0, actual.length);  // clear
+
+const expectedOpsForZonedRelativeTo = [
   // ToRelativeTemporalObject
   "get options.relativeTo",
   "get options.relativeTo.calendar",
@@ -49,14 +181,24 @@ const expected = [
   "call options.relativeTo.calendar.dateFromFields",
   "get options.relativeTo.offset",
   "get options.relativeTo.timeZone",
+  "has options.relativeTo.timeZone.timeZone",
+  "get options.relativeTo.offset.toString",
+  "call options.relativeTo.offset.toString",
+  // InterpretISODateTimeOffset
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
   // GetTemporalUnit
   "get options.unit",
   "get options.unit.toString",
   "call options.unit.toString",
+  // RoundDuration → ToTemporalDate
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
 ];
-const actual = [];
 
-const relativeTo = TemporalHelpers.propertyBagObserver(actual, {
+const zonedRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
   year: 2001,
   month: 5,
   monthCode: "M05",
@@ -67,81 +209,11 @@ const relativeTo = TemporalHelpers.propertyBagObserver(actual, {
   millisecond: 987,
   microsecond: 654,
   nanosecond: 321,
+  offset: "+00:00",
   calendar: TemporalHelpers.calendarObserver(actual, "options.relativeTo.calendar"),
+  timeZone: TemporalHelpers.timeZoneObserver(actual, "options.relativeTo.timeZone"),
 }, "options.relativeTo");
 
-function createOptionsObserver({ unit = "nanoseconds", roundingMode = "halfExpand", roundingIncrement = 1, relativeTo = undefined } = {}) {
-  return TemporalHelpers.propertyBagObserver(actual, {
-    unit,
-    roundingMode,
-    roundingIncrement,
-    relativeTo,
-  }, "options");
-}
-
-const instance = new Temporal.Duration(0, 0, 0, 0, 2400);
-
 // basic order of observable operations, without rounding:
-instance.total(createOptionsObserver({ unit: "nanoseconds", relativeTo }));
-assert.compareArray(actual, expected, "order of operations");
-actual.splice(0, actual.length); // clear
-
-// code path through RoundDuration that rounds to the nearest year:
-const expectedOpsForYearRounding = expected.concat([
-  "get options.relativeTo.calendar.dateAdd",     // 9.b
-  "call options.relativeTo.calendar.dateAdd",    // 9.c
-  "call options.relativeTo.calendar.dateAdd",    // 9.e
-  "call options.relativeTo.calendar.dateAdd",    // 9.j
-  "get options.relativeTo.calendar.dateUntil",   // 9.m
-  "call options.relativeTo.calendar.dateUntil",  // 9.m
-  "call options.relativeTo.calendar.dateAdd",    // 9.r
-  "call options.relativeTo.calendar.dateAdd",    // 9.w MoveRelativeDate
-]);
-instance.total(createOptionsObserver({ unit: "years", relativeTo }));
-assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with unit = years");
-actual.splice(0, actual.length); // clear
-
-// code path through Duration.prototype.total that rounds to the nearest month:
-const expectedOpsForMonthRounding = expected.concat([
-  // UnbalanceDurationRelative
-  "get options.relativeTo.calendar.dateAdd",     // 9.b
-  "get options.relativeTo.calendar.dateUntil",   // 9.c
-  "call options.relativeTo.calendar.dateAdd",    // 9.d.i
-  "call options.relativeTo.calendar.dateUntil",  // 9.d.iv
-  // RoundDuration
-  "get options.relativeTo.calendar.dateAdd",     // 10.b
-  "call options.relativeTo.calendar.dateAdd",    // 10.c
-  "call options.relativeTo.calendar.dateAdd",    // 10.e
-  "call options.relativeTo.calendar.dateAdd",    // 10.k MoveRelativeDate
-], Array(2).fill("call options.relativeTo.calendar.dateAdd")); // 2× 10.n.iii MoveRelativeDate
-const instance2 = new Temporal.Duration(1, 0, 0, 62);
-instance2.total(createOptionsObserver({ unit: "months", relativeTo }));
-assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with unit = months");
-actual.splice(0, actual.length); // clear
-
-// code path through Duration.prototype.total that rounds to the nearest week:
-const expectedOpsForWeekRounding = expected.concat([
-  // UnbalanceDurationRelative
-  "get options.relativeTo.calendar.dateAdd",   // 10.b
-  "call options.relativeTo.calendar.dateAdd",  // 10.c.i MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",  // 10.d.i MoveRelativeDate
-  // RoundDuration
-  "get options.relativeTo.calendar.dateAdd",   // 11.c
-  "call options.relativeTo.calendar.dateAdd",  // 11.d MoveRelativeDate
-], Array(58).fill("call options.relativeTo.calendar.dateAdd"));  // 58× 11.g.iii MoveRelativeDate (52 + 4 + 2)
-const instance3 = new Temporal.Duration(1, 1, 0, 15);
-instance3.total(createOptionsObserver({ unit: "weeks", relativeTo }));
-assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with unit = weeks");
-actual.splice(0, actual.length); // clear
-
-// code path through UnbalanceDurationRelative that rounds to the nearest day:
-const expectedOpsForDayRounding = expected.concat([
-  "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
-]);
-const instance4 = new Temporal.Duration(1, 1, 1)
-instance4.total(createOptionsObserver({ unit: "days", relativeTo }));
-assert.compareArray(actual, expectedOpsForDayRounding, "order of operations with unit = days");
-actual.splice(0, actual.length);  // clear
+instance.total(createOptionsObserver({ unit: "nanoseconds", relativeTo: zonedRelativeTo }));
+assert.compareArray(actual, expectedOpsForZonedRelativeTo, "order of operations for ZonedDateTime relativeTo");

--- a/test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/order-of-operations.js
@@ -78,7 +78,7 @@ const plainRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
 // basic order of observable operations, without rounding:
 instance.total(createOptionsObserver({ unit: "nanoseconds", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForPlainRelativeTo, "order of operations for PlainDate relativeTo");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expectedOpsForPlainRelativeTo.concat([
@@ -93,7 +93,7 @@ const expectedOpsForYearRounding = expectedOpsForPlainRelativeTo.concat([
 ]);
 instance.total(createOptionsObserver({ unit: "years", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with unit = years");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through Duration.prototype.total that rounds to the nearest month:
 const expectedOpsForMonthRounding = expectedOpsForPlainRelativeTo.concat([
@@ -111,7 +111,7 @@ const expectedOpsForMonthRounding = expectedOpsForPlainRelativeTo.concat([
 const instance2 = new Temporal.Duration(1, 0, 0, 62);
 instance2.total(createOptionsObserver({ unit: "months", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with unit = months");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through Duration.prototype.total that rounds to the nearest week:
 const expectedOpsForWeekRounding = expectedOpsForPlainRelativeTo.concat([
@@ -126,7 +126,7 @@ const expectedOpsForWeekRounding = expectedOpsForPlainRelativeTo.concat([
 const instance3 = new Temporal.Duration(1, 1, 0, 15);
 instance3.total(createOptionsObserver({ unit: "weeks", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with unit = weeks");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through UnbalanceDurationRelative that rounds to the nearest day:
 const expectedOpsForDayRounding = expectedOpsForPlainRelativeTo.concat([
@@ -138,7 +138,7 @@ const expectedOpsForDayRounding = expectedOpsForPlainRelativeTo.concat([
 const instance4 = new Temporal.Duration(1, 1, 1)
 instance4.total(createOptionsObserver({ unit: "days", relativeTo: plainRelativeTo }));
 assert.compareArray(actual, expectedOpsForDayRounding, "order of operations with unit = days");
-actual.splice(0, actual.length);  // clear
+actual.splice(0);  // clear
 
 const expectedOpsForZonedRelativeTo = [
   // ToRelativeTemporalObject

--- a/test/built-ins/Temporal/Instant/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/order-of-operations.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: Properties on objects passed to since() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get other.toString",
+  "call other.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+];
+const actual = [];
+
+const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
+instance.since(
+  TemporalHelpers.toPrimitiveObserver(actual, "1970-01-01T00:00Z", "other"),
+  TemporalHelpers.propertyBagObserver(actual, {
+    largestUnit: "hours",
+    roundingIncrement: 1,
+    roundingMode: "halfExpand",
+    smallestUnit: "minutes",
+  }, "options"),
+);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/Instant/prototype/toString/order-of-operations.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/order-of-operations.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: Properties on objects passed to toString() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.timeZone",
+  "has options.timeZone.timeZone",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.timeZone.getOffsetNanosecondsFor",
+  "call options.timeZone.getOffsetNanosecondsFor",
+  "get options.timeZone.getOffsetNanosecondsFor",
+  "call options.timeZone.getOffsetNanosecondsFor",
+];
+const actual = [];
+
+const instance = new Temporal.Instant(0n);
+
+instance.toString(
+  TemporalHelpers.propertyBagObserver(actual, {
+    fractionalSecondDigits: 3,
+    roundingMode: "halfExpand",
+    smallestUnit: "millisecond",
+    timeZone: TemporalHelpers.timeZoneObserver(actual, "options.timeZone"),
+  }, "options"),
+);
+assert.compareArray(actual, expected, "order of operations");
+actual.splice(0); // clear
+
+const expectedForFractionalSecondDigits = [
+  "get options.timeZone",
+  "get options.smallestUnit",
+  "get options.fractionalSecondDigits",
+  "get options.fractionalSecondDigits.toString",
+  "call options.fractionalSecondDigits.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+];
+
+instance.toString(
+  TemporalHelpers.propertyBagObserver(actual, {
+    fractionalSecondDigits: "auto",
+    roundingMode: "halfExpand",
+    smallestUnit: undefined,
+    timeZone: undefined,
+  }, "options"),
+);
+assert.compareArray(actual, expectedForFractionalSecondDigits, "order of operations with smallestUnit undefined");

--- a/test/built-ins/Temporal/Instant/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/order-of-operations.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: Properties on objects passed to until() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get other.toString",
+  "call other.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+];
+const actual = [];
+
+const instance = new Temporal.Instant(0n);
+instance.until(
+  TemporalHelpers.toPrimitiveObserver(actual, "2001-09-09T01:46:40Z", "other"),
+  TemporalHelpers.propertyBagObserver(actual, {
+    largestUnit: "hours",
+    roundingIncrement: 1,
+    roundingMode: "halfExpand",
+    smallestUnit: "minutes",
+  }, "options"),
+);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDate/from/observable-get-overflow-argument-string.js
+++ b/test/built-ins/Temporal/PlainDate/from/observable-get-overflow-argument-string.js
@@ -28,6 +28,6 @@ const result = Temporal.PlainDate.from("2021-05-17", object);
 assert.compareArray(actual, expected, "Successful call");
 TemporalHelpers.assertPlainDate(result, 2021, 5, "M05", 17);
 
-actual.splice(0, actual.length);  // empty it for the next check
+actual.splice(0);  // empty it for the next check
 assert.throws(RangeError, () => Temporal.PlainDate.from(7, object));
 assert.compareArray(actual, expected, "Failing call");

--- a/test/built-ins/Temporal/PlainDate/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/from/order-of-operations.js
@@ -22,6 +22,10 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // inside Calendar.p.dateFromFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -30,7 +34,8 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   monthCode: "M01",
   day: 1.7,
 }, "fields");
-const result = Temporal.PlainDate.from(fields);
-TemporalHelpers.assertPlainDate(result, 1, 1, "M01", 1);
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+const result = Temporal.PlainDate.from(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDate/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/from/order-of-operations.js
@@ -10,6 +10,9 @@ features: [Temporal]
 
 const expected = [
   "get fields.calendar",
+  "has fields.calendar.calendar",
+  "get fields.calendar.fields",
+  "call fields.calendar.fields",
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -22,17 +25,22 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  "get fields.calendar.dateFromFields",
+  "call fields.calendar.dateFromFields",
   // inside Calendar.p.dateFromFields
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "fields.calendar");
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
   day: 1.7,
+  calendar,
 }, "fields");
 
 const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");

--- a/test/built-ins/Temporal/PlainDate/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/add/order-of-operations.js
@@ -8,8 +8,8 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainDate(2000, 5, 2);
 const expected = [
+  // ToTemporalDuration
   "get fields.days",
   "get fields.days.valueOf",
   "call fields.days.valueOf",
@@ -40,12 +40,21 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // CalendarDateAdd
+  "get this.calendar.dateAdd",
+  "call this.calendar.dateAdd",
   // inside Calendar.p.dateAdd
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainDate(2000, 5, 2, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,

--- a/test/built-ins/Temporal/PlainDate/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/add/order-of-operations.js
@@ -40,6 +40,10 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // inside Calendar.p.dateAdd
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -54,7 +58,10 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microseconds: 1,
   nanoseconds: 1,
 }, "fields");
-const result = instance.add(fields);
-TemporalHelpers.assertPlainDate(result, 2001, 6, "M06", 10);
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+instance.add(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDate/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/order-of-operations.js
@@ -90,12 +90,12 @@ function createOptionsObserver({ smallestUnit = "days", largestUnit = "auto", ro
 }
 
 // clear any observable things that happened while constructing the objects
-actual.splice(0, actual.length);
+actual.splice(0);
 
 // basic order of observable operations, without rounding:
 instance.since(otherDatePropertyBag, createOptionsObserver());
 assert.compareArray(actual, expected, "order of operations");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat([
@@ -110,7 +110,7 @@ const expectedOpsForYearRounding = expected.concat([
 ]);
 instance.since(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat([
@@ -121,7 +121,7 @@ const expectedOpsForMonthRounding = expected.concat([
 ]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
 instance.since(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest week:
 const expectedOpsForWeekRounding = expected.concat([
@@ -130,4 +130,3 @@ const expectedOpsForWeekRounding = expected.concat([
 ]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
 instance.since(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual.slice(expected.length), expectedOpsForWeekRounding.slice(expected.length), "order of operations with smallestUnit = weeks");
-actual.slice(0, actual.length); // clear

--- a/test/built-ins/Temporal/PlainDate/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/subtract/order-of-operations.js
@@ -8,8 +8,8 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainDate(2000, 5, 2);
 const expected = [
+  // ToTemporalDuration
   "get fields.days",
   "get fields.days.valueOf",
   "call fields.days.valueOf",
@@ -40,12 +40,21 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // CalendarDateAdd
+  "get this.calendar.dateAdd",
+  "call this.calendar.dateAdd",
   // inside Calendar.p.dateAdd
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainDate(2000, 5, 2, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,

--- a/test/built-ins/Temporal/PlainDate/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/subtract/order-of-operations.js
@@ -40,6 +40,10 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // inside Calendar.p.dateAdd
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -54,7 +58,10 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microseconds: 1,
   nanoseconds: 1,
 }, "fields");
-const result = instance.subtract(fields);
-TemporalHelpers.assertPlainDate(result, 1999, 3, "M03", 25);
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+instance.subtract(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDate/prototype/toString/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toString/order-of-operations.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tostring
+description: Properties on an object passed to toString() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.calendarName",
+  "get options.calendarName.toString",
+  "call options.calendarName.toString",
+  "get this.calendar[Symbol.toPrimitive]",
+  "get this.calendar.toString",
+  "call this.calendar.toString",
+];
+const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainDate(2000, 5, 2, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  calendarName: "auto",
+}, "options");
+
+instance.toString(options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDate/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/order-of-operations.js
@@ -90,12 +90,12 @@ function createOptionsObserver({ smallestUnit = "days", largestUnit = "auto", ro
 }
 
 // clear any observable things that happened while constructing the objects
-actual.splice(0, actual.length);
+actual.splice(0);
 
 // basic order of observable operations, without rounding:
 instance.until(otherDatePropertyBag, createOptionsObserver());
 assert.compareArray(actual, expected, "order of operations");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat([
@@ -110,7 +110,7 @@ const expectedOpsForYearRounding = expected.concat([
 ]);
 instance.until(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat([
@@ -121,7 +121,7 @@ const expectedOpsForMonthRounding = expected.concat([
 ]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
 instance.until(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest week:
 const expectedOpsForWeekRounding = expected.concat([
@@ -130,4 +130,3 @@ const expectedOpsForWeekRounding = expected.concat([
 ]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
 instance.until(otherDatePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual.slice(expected.length), expectedOpsForWeekRounding.slice(expected.length), "order of operations with smallestUnit = weeks");
-actual.slice(0, actual.length); // clear

--- a/test/built-ins/Temporal/PlainDate/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/with/order-of-operations.js
@@ -24,6 +24,10 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // inside Calendar.p.dateFromFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -32,7 +36,10 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   monthCode: "M01",
   day: 1.7,
 }, "fields");
-const result = instance.with(fields);
-TemporalHelpers.assertPlainDate(result, 1, 1, "M01", 1);
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+instance.with(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDate/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/with/order-of-operations.js
@@ -8,10 +8,14 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainDate(2000, 5, 2);
 const expected = [
+  // RejectObjectWithCalendarOrTimeZone
   "get fields.calendar",
   "get fields.timeZone",
+  // CalendarFields
+  "get this.calendar.fields",
+  "call this.calendar.fields",
+  // PrepareTemporalFields
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -24,12 +28,33 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // PrepareTemporalFields on receiver
+  "get this.calendar.day",
+  "call this.calendar.day",
+  "get this.calendar.month",
+  "call this.calendar.month",
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  // CalendarMergeFields
+  "get this.calendar.mergeFields",
+  "call this.calendar.mergeFields",
+  // CalendarDateFromFields
+  "get this.calendar.dateFromFields",
+  "call this.calendar.dateFromFields",
   // inside Calendar.p.dateFromFields
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainDate(2000, 5, 2, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,

--- a/test/built-ins/Temporal/PlainDateTime/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/order-of-operations.js
@@ -9,7 +9,13 @@ features: [Temporal]
 ---*/
 
 const expected = [
+  // GetTemporalCalendarWithISODefault
   "get fields.calendar",
+  "has fields.calendar.calendar",
+  // CalendarFields
+  "get fields.calendar.fields",
+  "call fields.calendar.fields",
+  // PrepareTemporalFields
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -44,12 +50,15 @@ const expected = [
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
+  "get fields.calendar.dateFromFields",
+  "call fields.calendar.dateFromFields",
   // inside Calendar.p.dateFromFields
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
@@ -61,6 +70,7 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   millisecond: 1.7,
   microsecond: 1.7,
   nanosecond: 1.7,
+  calendar: TemporalHelpers.calendarObserver(actual, "fields.calendar"),
 }, "fields");
 
 const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");

--- a/test/built-ins/Temporal/PlainDateTime/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/order-of-operations.js
@@ -40,6 +40,14 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // InterpretTemporalDateTimeFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  // inside Calendar.p.dateFromFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -54,7 +62,8 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microsecond: 1.7,
   nanosecond: 1.7,
 }, "fields");
-const result = Temporal.PlainDateTime.from(fields);
-TemporalHelpers.assertPlainDateTime(result, 1, 1, "M01", 1, 1, 1, 1, 1, 1, 1);
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+Temporal.PlainDateTime.from(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/add/order-of-operations.js
@@ -40,6 +40,10 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // inside Calendar.p.dateAdd
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -54,7 +58,8 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microseconds: 1,
   nanoseconds: 1,
 }, "fields");
-const result = instance.add(fields);
-TemporalHelpers.assertPlainDateTime(result, 2001, 6, "M06", 10, 13, 35, 57, 988, 655, 322);
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+instance.add(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/add/order-of-operations.js
@@ -8,8 +8,8 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 const expected = [
+  // ToTemporalDurationRecord
   "get fields.days",
   "get fields.days.valueOf",
   "call fields.days.valueOf",
@@ -40,12 +40,21 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // AddDateTime
+  "get this.calendar.dateAdd",
+  "call this.calendar.dateAdd",
   // inside Calendar.p.dateAdd
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/calendar-checked.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/calendar-checked.js
@@ -23,7 +23,7 @@ assert.compareArray(actual, []);
 assert.sameValue(dt1.equals(dt2), true, "same calendar string");
 assert.compareArray(actual, ["get calendar1.toString", "call calendar1.toString", "get calendar2.toString", "call calendar2.toString"]);
 
-actual.splice(0, actual.length);  // empty it for the next check
+actual.splice(0);  // empty it for the next check
 assert.sameValue(dt1.equals(dt3), false, "different calendar string");
 assert.compareArray(actual, ["get calendar1.toString", "call calendar1.toString", "get calendar3.toString", "call calendar3.toString"]);
 

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/order-of-operations.js
@@ -114,12 +114,12 @@ function createOptionsObserver({ smallestUnit = "nanoseconds", largestUnit = "au
 }
 
 // clear any observable things that happened while constructing the objects
-actual.splice(0, actual.length);
+actual.splice(0);
 
 // basic order of observable operations, without rounding:
 instance.since(otherDateTimePropertyBag, createOptionsObserver());
 assert.compareArray(actual, expected, "order of operations");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat([
@@ -134,7 +134,7 @@ const expectedOpsForYearRounding = expected.concat([
 ]);
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat([
@@ -145,7 +145,7 @@ const expectedOpsForMonthRounding = expected.concat([
 ]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest week:
 const expectedOpsForWeekRounding = expected.concat([
@@ -154,4 +154,3 @@ const expectedOpsForWeekRounding = expected.concat([
 ]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual.slice(expected.length), expectedOpsForWeekRounding.slice(expected.length), "order of operations with smallestUnit = weeks");
-actual.slice(0, actual.length); // clear

--- a/test/built-ins/Temporal/PlainDateTime/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/subtract/order-of-operations.js
@@ -40,6 +40,10 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // inside Calendar.p.dateAdd
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -54,7 +58,8 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microseconds: 1,
   nanoseconds: 1,
 }, "fields");
-const result = instance.subtract(fields);
-TemporalHelpers.assertPlainDateTime(result, 1999, 3, "M03", 25, 11, 33, 55, 986, 653, 320);
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+instance.subtract(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/subtract/order-of-operations.js
@@ -8,8 +8,8 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 const expected = [
+  // ToTemporalDurationRecord
   "get fields.days",
   "get fields.days.valueOf",
   "call fields.days.valueOf",
@@ -40,12 +40,21 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // AddDateTime
+  "get this.calendar.dateAdd",
+  "call this.calendar.dateAdd",
   // inside Calendar.p.dateAdd
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toString/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toString/order-of-operations.js
@@ -1,0 +1,61 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: Properties on objects passed to toString() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.calendarName",
+  "get options.calendarName.toString",
+  "call options.calendarName.toString",
+  "get this.calendar[Symbol.toPrimitive]",
+  "get this.calendar.toString",
+  "call this.calendar.toString",
+];
+const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainDateTime(1990, 11, 3, 15, 54, 37, 123, 456, 789, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
+const expectedForSmallestUnit = [
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+].concat(expected);
+
+instance.toString(
+  TemporalHelpers.propertyBagObserver(actual, {
+    fractionalSecondDigits: 3,
+    roundingMode: "halfExpand",
+    smallestUnit: "millisecond",
+    calendarName: "auto",
+  }, "options"),
+);
+assert.compareArray(actual, expectedForSmallestUnit, "order of operations");
+actual.splice(0); // clear
+
+const expectedForFractionalSecondDigits = [
+  "get options.smallestUnit",
+  "get options.fractionalSecondDigits",
+  "get options.fractionalSecondDigits.toString",
+  "call options.fractionalSecondDigits.toString",
+].concat(expected);
+
+instance.toString(
+  TemporalHelpers.propertyBagObserver(actual, {
+    fractionalSecondDigits: "auto",
+    roundingMode: "halfExpand",
+    smallestUnit: undefined,
+    calendarName: "auto",
+  }, "options"),
+);
+assert.compareArray(actual, expectedForFractionalSecondDigits, "order of operations with smallestUnit undefined");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/order-of-operations.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tozoneddatetime
+description: Properties on an object passed to toZonedDateTime() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  // ToTemporalTimeZone
+  "has timeZone.timeZone",
+  // ToTemporalDisambiguation
+  "get options.disambiguation",
+  "get options.disambiguation.toString",
+  "call options.disambiguation.toString",
+  // BuiltinTimeZoneGetInstantFor
+  "get timeZone.getPossibleInstantsFor",
+  "call timeZone.getPossibleInstantsFor",
+];
+const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
+const timeZone = TemporalHelpers.timeZoneObserver(actual, "timeZone");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { disambiguation: "compatible" }, "options");
+
+instance.toZonedDateTime(timeZone, options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/order-of-operations.js
@@ -114,12 +114,12 @@ function createOptionsObserver({ smallestUnit = "nanoseconds", largestUnit = "au
 }
 
 // clear any observable things that happened while constructing the objects
-actual.splice(0, actual.length);
+actual.splice(0);
 
 // basic order of observable operations, without rounding:
 instance.until(otherDateTimePropertyBag, createOptionsObserver());
 assert.compareArray(actual, expected, "order of operations");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat([
@@ -134,7 +134,7 @@ const expectedOpsForYearRounding = expected.concat([
 ]);
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat([
@@ -145,7 +145,7 @@ const expectedOpsForMonthRounding = expected.concat([
 ]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = years");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest week:
 const expectedOpsForWeekRounding = expected.concat([
@@ -154,4 +154,3 @@ const expectedOpsForWeekRounding = expected.concat([
 ]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual.slice(expected.length), expectedOpsForWeekRounding.slice(expected.length), "order of operations with smallestUnit = weeks");
-actual.slice(0, actual.length); // clear

--- a/test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js
@@ -42,6 +42,14 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // InterpretTemporalDateTimeFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  // inside Calendar.p.dateFromFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -56,7 +64,8 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microsecond: 1.7,
   nanosecond: 1.7,
 }, "fields");
-const result = instance.with(fields);
-TemporalHelpers.assertPlainDateTime(result, 1, 1, "M01", 1, 1, 1, 1, 1, 1, 1);
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+instance.with(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js
@@ -8,10 +8,14 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 const expected = [
+  // RejectObjectWithCalendarOrTimeZone
   "get fields.calendar",
   "get fields.timeZone",
+  // CalendarFields
+  "get this.calendar.fields",
+  "call this.calendar.fields",
+  // PrepareTemporalFields
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -42,16 +46,36 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // PrepareTemporalFields on receiver
+  "get this.calendar.day",
+  "call this.calendar.day",
+  "get this.calendar.month",
+  "call this.calendar.month",
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  // CalendarMergeFields
+  "get this.calendar.mergeFields",
+  "call this.calendar.mergeFields",
   // InterpretTemporalDateTimeFields
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
+  "get this.calendar.dateFromFields",
+  "call this.calendar.dateFromFields",
   // inside Calendar.p.dateFromFields
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,

--- a/test/built-ins/Temporal/PlainMonthDay/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/order-of-operations.js
@@ -10,6 +10,12 @@ features: [Temporal]
 
 const expected = [
   "get fields.calendar",
+  // ToTemporalCalendarWithISODefault
+  "has fields.calendar.calendar",
+  // CalendarFields
+  "get fields.calendar.fields",
+  "call fields.calendar.fields",
+  // PrepareTemporalFields
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -22,17 +28,22 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // CalendarMonthDayFromFields
+  "get fields.calendar.monthDayFromFields",
+  "call fields.calendar.monthDayFromFields",
   // inside Calendar.p.monthDayFromFields
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
   day: 1.7,
+  calendar: TemporalHelpers.calendarObserver(actual, "fields.calendar"),
 }, "fields");
 
 const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");

--- a/test/built-ins/Temporal/PlainMonthDay/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/order-of-operations.js
@@ -22,6 +22,10 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // inside Calendar.p.monthDayFromFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -30,7 +34,8 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   monthCode: "M01",
   day: 1.7,
 }, "fields");
-const result = Temporal.PlainMonthDay.from(fields);
-TemporalHelpers.assertPlainMonthDay(result, "M01", 1);
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+Temporal.PlainMonthDay.from(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/toString/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/toString/order-of-operations.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.tostring
+description: Properties on an object passed to toString() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.calendarName",
+  "get options.calendarName.toString",
+  "call options.calendarName.toString",
+  "get this.calendar[Symbol.toPrimitive]",
+  "get this.calendar.toString",
+  "call this.calendar.toString",
+];
+const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainMonthDay(5, 2, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  calendarName: "auto",
+}, "options");
+
+instance.toString(options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/with/order-of-operations.js
@@ -8,10 +8,14 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainMonthDay(5, 2);
 const expected = [
+  // RejectObjectWithCalendarOrTimeZone
   "get fields.calendar",
   "get fields.timeZone",
+  // CalendarFields
+  "get this.calendar.fields",
+  "call this.calendar.fields",
+  // PrepareTemporalFields
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -24,12 +28,29 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // PrepareTemporalFields on receiver
+  "get this.calendar.day",
+  "call this.calendar.day",
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  // CalendarMergeFields
+  "get this.calendar.mergeFields",
+  "call this.calendar.mergeFields",
+  // CalendarMonthDayFromFields
+  "get this.calendar.monthDayFromFields",
+  "call this.calendar.monthDayFromFields",
   // inside Calendar.p.monthDayFromFields
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainMonthDay(5, 2, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/with/order-of-operations.js
@@ -24,6 +24,10 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // inside Calendar.p.monthDayFromFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -32,6 +36,8 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   monthCode: "M01",
   day: 1.7,
 }, "fields");
-const result = instance.with(fields);
-TemporalHelpers.assertPlainMonthDay(result, "M01", 1);
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+instance.with(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainTime/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainTime/from/order-of-operations.js
@@ -9,6 +9,9 @@ features: [Temporal]
 ---*/
 
 const expected = [
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
   "get fields.calendar",
   "get fields.hour",
   "get fields.hour.valueOf",
@@ -38,7 +41,10 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microsecond: 1.7,
   nanosecond: 1.7,
 }, "fields");
-const result = Temporal.PlainTime.from(fields);
-TemporalHelpers.assertPlainTime(result, 1, 1, 1, 1, 1, 1);
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+const result = Temporal.PlainTime.from(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainTime/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainTime/from/order-of-operations.js
@@ -13,6 +13,9 @@ const expected = [
   "get options.overflow.toString",
   "call options.overflow.toString",
   "get fields.calendar",
+  "get fields.calendar.toString",
+  "call fields.calendar.toString",
+  // ToTemporalTimeRecord
   "get fields.hour",
   "get fields.hour.valueOf",
   "call fields.hour.valueOf",
@@ -33,6 +36,7 @@ const expected = [
   "call fields.second.valueOf",
 ];
 const actual = [];
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   hour: 1.7,
   minute: 1.7,
@@ -40,6 +44,7 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   millisecond: 1.7,
   microsecond: 1.7,
   nanosecond: 1.7,
+  calendar: "iso8601",
 }, "fields");
 
 const options = TemporalHelpers.propertyBagObserver(actual, {

--- a/test/built-ins/Temporal/PlainTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/order-of-operations.js
@@ -1,0 +1,70 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: Properties on an object passed to since() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  // ToTemporalTime
+  "get other.calendar",
+  "get other.calendar.toString",
+  "call other.calendar.toString",
+  "get other.hour",
+  "get other.hour.valueOf",
+  "call other.hour.valueOf",
+  "get other.microsecond",
+  "get other.microsecond.valueOf",
+  "call other.microsecond.valueOf",
+  "get other.millisecond",
+  "get other.millisecond.valueOf",
+  "call other.millisecond.valueOf",
+  "get other.minute",
+  "get other.minute.valueOf",
+  "call other.minute.valueOf",
+  "get other.nanosecond",
+  "get other.nanosecond.valueOf",
+  "call other.nanosecond.valueOf",
+  "get other.second",
+  "get other.second.valueOf",
+  "call other.second.valueOf",
+  // GetDifferenceSettings
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+];
+const actual = [];
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const other = TemporalHelpers.propertyBagObserver(actual, {
+  hour: 1.7,
+  minute: 1.7,
+  second: 1.7,
+  millisecond: 1.7,
+  microsecond: 1.7,
+  nanosecond: 1.7,
+  calendar: "iso8601",
+}, "other");
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "nanoseconds",
+  largestUnit: "hours",
+  roundingMode: "trunc",
+  roundingIncrement: 1,
+}, "options");
+
+const result = instance.since(other, options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainTime/prototype/toString/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toString/order-of-operations.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tostring
+description: Properties on objects passed to toString() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+];
+const actual = [];
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+instance.toString(
+  TemporalHelpers.propertyBagObserver(actual, {
+    fractionalSecondDigits: 3,
+    roundingMode: "halfExpand",
+    smallestUnit: "millisecond",
+  }, "options"),
+);
+assert.compareArray(actual, expected, "order of operations");
+actual.splice(0); // clear
+
+const expectedForFractionalSecondDigits = [
+  "get options.smallestUnit",
+  "get options.fractionalSecondDigits",
+  "get options.fractionalSecondDigits.toString",
+  "call options.fractionalSecondDigits.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+];
+
+instance.toString(
+  TemporalHelpers.propertyBagObserver(actual, {
+    fractionalSecondDigits: "auto",
+    roundingMode: "halfExpand",
+    smallestUnit: undefined,
+  }, "options"),
+);
+assert.compareArray(actual, expectedForFractionalSecondDigits, "order of operations with smallestUnit undefined");

--- a/test/built-ins/Temporal/PlainTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/order-of-operations.js
@@ -1,0 +1,70 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: Properties on an object passed to until() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  // ToTemporalTime
+  "get other.calendar",
+  "get other.calendar.toString",
+  "call other.calendar.toString",
+  "get other.hour",
+  "get other.hour.valueOf",
+  "call other.hour.valueOf",
+  "get other.microsecond",
+  "get other.microsecond.valueOf",
+  "call other.microsecond.valueOf",
+  "get other.millisecond",
+  "get other.millisecond.valueOf",
+  "call other.millisecond.valueOf",
+  "get other.minute",
+  "get other.minute.valueOf",
+  "call other.minute.valueOf",
+  "get other.nanosecond",
+  "get other.nanosecond.valueOf",
+  "call other.nanosecond.valueOf",
+  "get other.second",
+  "get other.second.valueOf",
+  "call other.second.valueOf",
+  // GetDifferenceSettings
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+  "get options.largestUnit",
+  "get options.largestUnit.toString",
+  "call options.largestUnit.toString",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+];
+const actual = [];
+
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const other = TemporalHelpers.propertyBagObserver(actual, {
+  hour: 1.7,
+  minute: 1.7,
+  second: 1.7,
+  millisecond: 1.7,
+  microsecond: 1.7,
+  nanosecond: 1.7,
+  calendar: "iso8601",
+}, "other");
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "nanoseconds",
+  largestUnit: "hours",
+  roundingMode: "trunc",
+  roundingIncrement: 1,
+}, "options");
+
+const result = instance.until(other, options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainTime/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/with/order-of-operations.js
@@ -10,8 +10,10 @@ features: [Temporal]
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 const expected = [
+  // RejectObjectWithCalendarOrTimeZone
   "get fields.calendar",
   "get fields.timeZone",
+  // ToTemporalTimeRecord
   "get fields.hour",
   "get fields.hour.valueOf",
   "call fields.hour.valueOf",
@@ -30,8 +32,13 @@ const expected = [
   "get fields.second",
   "get fields.second.valueOf",
   "call fields.second.valueOf",
+  // ToTemporalOverflow
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   hour: 1.7,
   minute: 1.7,
@@ -40,7 +47,10 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microsecond: 1.7,
   nanosecond: 1.7,
 }, "fields");
-const result = instance.with(fields);
-TemporalHelpers.assertPlainTime(result, 1, 1, 1, 1, 1, 1);
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+}, "options");
+
+const result = instance.with(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainYearMonth/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/order-of-operations.js
@@ -9,7 +9,13 @@ features: [Temporal]
 ---*/
 
 const expected = [
+  // GetTemporalCalendarWithISODefault
   "get fields.calendar",
+  "has fields.calendar.calendar",
+  // CalendarFields
+  "get fields.calendar.fields",
+  "call fields.calendar.fields",
+  // PrepareTemporalFields
   "get fields.month",
   "get fields.month.valueOf",
   "call fields.month.valueOf",
@@ -19,16 +25,21 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // CalendarYearMonthFromFields
+  "get fields.calendar.yearMonthFromFields",
+  "call fields.calendar.yearMonthFromFields",
   // inside Calendar.p.yearMonthFromFields
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,
   monthCode: "M01",
+  calendar: TemporalHelpers.calendarObserver(actual, "fields.calendar"),
 }, "fields");
 
 const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");

--- a/test/built-ins/Temporal/PlainYearMonth/from/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/order-of-operations.js
@@ -19,6 +19,10 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // inside Calendar.p.yearMonthFromFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -26,7 +30,8 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   month: 1.7,
   monthCode: "M01",
 }, "fields");
-const result = Temporal.PlainYearMonth.from(fields);
-TemporalHelpers.assertPlainYearMonth(result, 1, 1, "M01");
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+Temporal.PlainYearMonth.from(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/order-of-operations.js
@@ -40,6 +40,17 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // CopyDataProperties
+  "ownKeys options",
+  "getOwnPropertyDescriptor options.overflow",
+  "get options.overflow",
+  // inside Calendar.p.dateAdd
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  // inside Calendar.p.yearMonthFromFields
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -54,7 +65,8 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microseconds: 1,
   nanoseconds: 1,
 }, "fields");
-const result = instance.add(fields);
-TemporalHelpers.assertPlainYearMonth(result, 2001, 6, "M06");
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+instance.add(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/add/order-of-operations.js
@@ -8,8 +8,8 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainYearMonth(2000, 5);
 const expected = [
+  // ToTemporalDuration
   "get fields.days",
   "get fields.days.valueOf",
   "call fields.days.valueOf",
@@ -40,19 +40,47 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // CalendarFields
+  "get this.calendar.fields",
+  "call this.calendar.fields",
+  // PrepareTemporalFields on receiver
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  // CalendarDateFromFields
+  "get this.calendar.dateFromFields",
+  "call this.calendar.dateFromFields",
   // CopyDataProperties
   "ownKeys options",
   "getOwnPropertyDescriptor options.overflow",
   "get options.overflow",
+  // CalendarDateAdd
+  "get this.calendar.dateAdd",
+  "call this.calendar.dateAdd",
   // inside Calendar.p.dateAdd
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
+  // PrepareTemporalFields on added date
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  // CalendarYearMonthFromFields
+  "get this.calendar.yearMonthFromFields",
+  "call this.calendar.yearMonthFromFields",
   // inside Calendar.p.yearMonthFromFields
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/compare-calendar.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/compare-calendar.js
@@ -36,7 +36,7 @@ const ym6 = new Temporal.PlainYearMonth(2000, 1, new CustomCalendar("e"), 1);
 assert.sameValue(ym5.equals(ym6), false);
 assert.compareArray(actual, ["d", "e"], "order of operations");
 
-actual.splice(0, actual.length); // empty it for the next check
+actual.splice(0); // empty it for the next check
 const ym7 = new Temporal.PlainYearMonth(2000, 1, new CustomCalendar("f"), 1);
 const ym8 = new Temporal.PlainYearMonth(2000, 1, new CustomCalendar("f"), 1);
 assert.sameValue(ym7.equals(ym8), true);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/order-of-operations.js
@@ -101,7 +101,7 @@ function createOptionsObserver({ smallestUnit = "months", largestUnit = "auto", 
 }
 
 // clear any observable things that happened while constructing the objects
-actual.splice(0, actual.length);
+actual.splice(0);
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat([
@@ -116,7 +116,7 @@ const expectedOpsForYearRounding = expected.concat([
 ]);
 instance.since(otherYearMonthPropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat([
@@ -127,4 +127,3 @@ const expectedOpsForMonthRounding = expected.concat([
 ]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
 instance.since(otherYearMonthPropertyBag, createOptionsObserver({ smallestUnit: "months", roundingIncrement: 2 }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
-actual.splice(0, actual.length); // clear

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/order-of-operations.js
@@ -8,8 +8,8 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainYearMonth(2000, 5);
 const expected = [
+  // ToTemporalDuration
   "get fields.days",
   "get fields.days.valueOf",
   "call fields.days.valueOf",
@@ -40,19 +40,50 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // CalendarFields
+  "get this.calendar.fields",
+  "call this.calendar.fields",
+  // PrepareTemporalFields on receiver
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  // CalendarDaysInMonth
+  "get this.calendar.daysInMonth",
+  "call this.calendar.daysInMonth",
+  // CalendarDateFromFields
+  "get this.calendar.dateFromFields",
+  "call this.calendar.dateFromFields",
   // CopyDataProperties
   "ownKeys options",
   "getOwnPropertyDescriptor options.overflow",
   "get options.overflow",
+  // CalendarDateAdd
+  "get this.calendar.dateAdd",
+  "call this.calendar.dateAdd",
   // inside Calendar.p.dateAdd
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
+  // PrepareTemporalFields on added date
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  // CalendarYearMonthFromFields
+  "get this.calendar.yearMonthFromFields",
+  "call this.calendar.yearMonthFromFields",
   // inside Calendar.p.yearMonthFromFields
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   years: 1,
   months: 1,

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/subtract/order-of-operations.js
@@ -40,6 +40,17 @@ const expected = [
   "get fields.years",
   "get fields.years.valueOf",
   "call fields.years.valueOf",
+  // CopyDataProperties
+  "ownKeys options",
+  "getOwnPropertyDescriptor options.overflow",
+  "get options.overflow",
+  // inside Calendar.p.dateAdd
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  // inside Calendar.p.yearMonthFromFields
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -54,7 +65,8 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   microseconds: 1,
   nanoseconds: 1,
 }, "fields");
-const result = instance.subtract(fields);
-TemporalHelpers.assertPlainYearMonth(result, 1999, 4, "M04");
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+instance.subtract(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/toString/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/toString/order-of-operations.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.tostring
+description: Properties on an object passed to toString() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.calendarName",
+  "get options.calendarName.toString",
+  "call options.calendarName.toString",
+  "get this.calendar[Symbol.toPrimitive]",
+  "get this.calendar.toString",
+  "call this.calendar.toString",
+];
+const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  calendarName: "auto",
+}, "options");
+
+instance.toString(options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/order-of-operations.js
@@ -101,7 +101,7 @@ function createOptionsObserver({ smallestUnit = "months", largestUnit = "auto", 
 }
 
 // clear any observable things that happened while constructing the objects
-actual.splice(0, actual.length);
+actual.splice(0);
 
 // code path through RoundDuration that rounds to the nearest year:
 const expectedOpsForYearRounding = expected.concat([
@@ -116,7 +116,7 @@ const expectedOpsForYearRounding = expected.concat([
 ]);
 instance.until(otherYearMonthPropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat([
@@ -127,4 +127,4 @@ const expectedOpsForMonthRounding = expected.concat([
 ]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
 instance.until(otherYearMonthPropertyBag, createOptionsObserver({ smallestUnit: "months", roundingIncrement: 2 }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/with/order-of-operations.js
@@ -8,10 +8,14 @@ includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const instance = new Temporal.PlainYearMonth(2000, 5);
 const expected = [
+  // RejectObjectWithCalendarOrTimeZone
   "get fields.calendar",
   "get fields.timeZone",
+  // CalendarFields
+  "get this.calendar.fields",
+  "call this.calendar.fields",
+  // PrepareTemporalFields
   "get fields.month",
   "get fields.month.valueOf",
   "call fields.month.valueOf",
@@ -21,12 +25,31 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // PrepareTemporalFields on receiver
+  "get this.calendar.month",
+  "call this.calendar.month",
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  // CalendarMergeFields
+  "get this.calendar.mergeFields",
+  "call this.calendar.mergeFields",
+  // CalendarYearMonthFromFields
+  "get this.calendar.yearMonthFromFields",
+  "call this.calendar.yearMonthFromFields",
   // inside Calendar.p.yearMonthFromFields
   "get options.overflow",
   "get options.overflow.toString",
   "call options.overflow.toString",
 ];
 const actual = [];
+
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,
   month: 1.7,

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/with/order-of-operations.js
@@ -21,6 +21,10 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
+  // inside Calendar.p.yearMonthFromFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
 ];
 const actual = [];
 const fields = TemporalHelpers.propertyBagObserver(actual, {
@@ -28,7 +32,8 @@ const fields = TemporalHelpers.propertyBagObserver(actual, {
   month: 1.7,
   monthCode: "M01",
 }, "fields");
-const result = instance.with(fields);
-TemporalHelpers.assertPlainYearMonth(result, 1, 1, "M01");
-assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+instance.with(fields, options);
 assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/order-of-operations.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/order-of-operations.js
@@ -1,0 +1,85 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: Properties on an object passed to getInstantFor() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  // GetTemporalCalendarWithISODefault
+  "get fields.calendar",
+  "has fields.calendar.calendar",
+  // CalendarFields
+  "get fields.calendar.fields",
+  "call fields.calendar.fields",
+  // PrepareTemporalFields
+  "get fields.day",
+  "get fields.day.valueOf",
+  "call fields.day.valueOf",
+  "get fields.hour",
+  "get fields.hour.valueOf",
+  "call fields.hour.valueOf",
+  "get fields.microsecond",
+  "get fields.microsecond.valueOf",
+  "call fields.microsecond.valueOf",
+  "get fields.millisecond",
+  "get fields.millisecond.valueOf",
+  "call fields.millisecond.valueOf",
+  "get fields.minute",
+  "get fields.minute.valueOf",
+  "call fields.minute.valueOf",
+  "get fields.month",
+  "get fields.month.valueOf",
+  "call fields.month.valueOf",
+  "get fields.monthCode",
+  "get fields.monthCode.toString",
+  "call fields.monthCode.toString",
+  "get fields.nanosecond",
+  "get fields.nanosecond.valueOf",
+  "call fields.nanosecond.valueOf",
+  "get fields.second",
+  "get fields.second.valueOf",
+  "call fields.second.valueOf",
+  "get fields.year",
+  "get fields.year.valueOf",
+  "call fields.year.valueOf",
+  // InterpretTemporalDateTimeFields
+  "get fields.calendar.dateFromFields",
+  "call fields.calendar.dateFromFields",
+  // ToTemporalDisambiguation
+  "get options.disambiguation",
+  "get options.disambiguation.toString",
+  "call options.disambiguation.toString",
+  // BuiltinTimeZoneGetInstantFor
+  "get this.getPossibleInstantsFor",
+  "call this.getPossibleInstantsFor",
+];
+const actual = [];
+
+const instance = new Temporal.TimeZone("UTC");
+TemporalHelpers.observeProperty(actual, instance, "getPossibleInstantsFor", function getPossibleInstantsFor(...args) {
+  actual.push("call this.getPossibleInstantsFor");
+  return Temporal.TimeZone.prototype.getPossibleInstantsFor.apply(instance, args);
+}, "this");
+
+const fields = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2000,
+  month: 5,
+  monthCode: "M05",
+  day: 2,
+  hour: 12,
+  minute: 34,
+  second: 56,
+  millisecond: 987,
+  microsecond: 654,
+  nanosecond: 321,
+  calendar: TemporalHelpers.calendarObserver(actual, "fields.calendar"),
+}, "fields");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { disambiguation: "compatible" }, "options");
+
+instance.getInstantFor(fields, options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/ZonedDateTime/compare/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/order-of-operations.js
@@ -1,0 +1,145 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: Properties on objects passed to compare() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get one.calendar",
+  "has one.calendar.calendar",
+  "get one.calendar.fields",
+  "call one.calendar.fields",
+  // PrepareTemporalFields
+  "get one.day",
+  "get one.day.valueOf",
+  "call one.day.valueOf",
+  "get one.hour",
+  "get one.hour.valueOf",
+  "call one.hour.valueOf",
+  "get one.microsecond",
+  "get one.microsecond.valueOf",
+  "call one.microsecond.valueOf",
+  "get one.millisecond",
+  "get one.millisecond.valueOf",
+  "call one.millisecond.valueOf",
+  "get one.minute",
+  "get one.minute.valueOf",
+  "call one.minute.valueOf",
+  "get one.month",
+  "get one.month.valueOf",
+  "call one.month.valueOf",
+  "get one.monthCode",
+  "get one.monthCode.toString",
+  "call one.monthCode.toString",
+  "get one.nanosecond",
+  "get one.nanosecond.valueOf",
+  "call one.nanosecond.valueOf",
+  "get one.second",
+  "get one.second.valueOf",
+  "call one.second.valueOf",
+  "get one.year",
+  "get one.year.valueOf",
+  "call one.year.valueOf",
+  "get one.timeZone",
+  "get one.offset",
+  "get one.offset.toString",
+  "call one.offset.toString",
+  "has one.timeZone.timeZone",
+  // InterpretTemporalDateTimeFields
+  "get one.calendar.dateFromFields",
+  "call one.calendar.dateFromFields",
+  // InterpretISODateTimeOffset
+  "get one.timeZone.getPossibleInstantsFor",
+  "call one.timeZone.getPossibleInstantsFor",
+  "get one.timeZone.getOffsetNanosecondsFor",
+  "call one.timeZone.getOffsetNanosecondsFor",
+  // Same set of operations, for the other argument:
+  "get two.calendar",
+  "has two.calendar.calendar",
+  "get two.calendar.fields",
+  "call two.calendar.fields",
+  // PrepareTemporalFields
+  "get two.day",
+  "get two.day.valueOf",
+  "call two.day.valueOf",
+  "get two.hour",
+  "get two.hour.valueOf",
+  "call two.hour.valueOf",
+  "get two.microsecond",
+  "get two.microsecond.valueOf",
+  "call two.microsecond.valueOf",
+  "get two.millisecond",
+  "get two.millisecond.valueOf",
+  "call two.millisecond.valueOf",
+  "get two.minute",
+  "get two.minute.valueOf",
+  "call two.minute.valueOf",
+  "get two.month",
+  "get two.month.valueOf",
+  "call two.month.valueOf",
+  "get two.monthCode",
+  "get two.monthCode.toString",
+  "call two.monthCode.toString",
+  "get two.nanosecond",
+  "get two.nanosecond.valueOf",
+  "call two.nanosecond.valueOf",
+  "get two.second",
+  "get two.second.valueOf",
+  "call two.second.valueOf",
+  "get two.year",
+  "get two.year.valueOf",
+  "call two.year.valueOf",
+  "get two.timeZone",
+  "get two.offset",
+  "get two.offset.toString",
+  "call two.offset.toString",
+  "has two.timeZone.timeZone",
+  // InterpretTemporalDateTimeFields
+  "get two.calendar.dateFromFields",
+  "call two.calendar.dateFromFields",
+  // InterpretISODateTimeOffset
+  "get two.timeZone.getPossibleInstantsFor",
+  "call two.timeZone.getPossibleInstantsFor",
+  "get two.timeZone.getOffsetNanosecondsFor",
+  "call two.timeZone.getOffsetNanosecondsFor",
+];
+const actual = [];
+
+const one = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2001,
+  month: 5,
+  monthCode: "M05",
+  day: 2,
+  hour: 6,
+  minute: 54,
+  second: 32,
+  millisecond: 987,
+  microsecond: 654,
+  nanosecond: 321,
+  offset: "+00:00",
+  calendar: TemporalHelpers.calendarObserver(actual, "one.calendar"),
+  timeZone: TemporalHelpers.timeZoneObserver(actual, "one.timeZone"),
+}, "one");
+
+const two = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2014,
+  month: 7,
+  monthCode: "M07",
+  day: 19,
+  hour: 12,
+  minute: 34,
+  second: 56,
+  millisecond: 123,
+  microsecond: 456,
+  nanosecond: 789,
+  offset: "+00:00",
+  calendar: TemporalHelpers.calendarObserver(actual, "two.calendar"),
+  timeZone: TemporalHelpers.timeZoneObserver(actual, "two.timeZone"),
+}, "two");
+
+Temporal.ZonedDateTime.compare(one, two);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/ZonedDateTime/from/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/order-of-operations.js
@@ -1,0 +1,103 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: Properties on objects passed to from() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get item.calendar",
+  "has item.calendar.calendar",
+  "get item.calendar.fields",
+  "call item.calendar.fields",
+  // PrepareTemporalFields
+  "get item.day",
+  "get item.day.valueOf",
+  "call item.day.valueOf",
+  "get item.hour",
+  "get item.hour.valueOf",
+  "call item.hour.valueOf",
+  "get item.microsecond",
+  "get item.microsecond.valueOf",
+  "call item.microsecond.valueOf",
+  "get item.millisecond",
+  "get item.millisecond.valueOf",
+  "call item.millisecond.valueOf",
+  "get item.minute",
+  "get item.minute.valueOf",
+  "call item.minute.valueOf",
+  "get item.month",
+  "get item.month.valueOf",
+  "call item.month.valueOf",
+  "get item.monthCode",
+  "get item.monthCode.toString",
+  "call item.monthCode.toString",
+  "get item.nanosecond",
+  "get item.nanosecond.valueOf",
+  "call item.nanosecond.valueOf",
+  "get item.second",
+  "get item.second.valueOf",
+  "call item.second.valueOf",
+  "get item.year",
+  "get item.year.valueOf",
+  "call item.year.valueOf",
+  "get item.timeZone",
+  "get item.offset",
+  "get item.offset.toString",
+  "call item.offset.toString",
+  "has item.timeZone.timeZone",
+  // InterpretTemporalDateTimeFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  "get item.calendar.dateFromFields",
+  "call item.calendar.dateFromFields",
+  // inside calendar.dateFromFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  // ToTemporalDisambiguation
+  "get options.disambiguation",
+  "get options.disambiguation.toString",
+  "call options.disambiguation.toString",
+  // ToTemporalOffset
+  "get options.offset",
+  "get options.offset.toString",
+  "call options.offset.toString",
+  // InterpretISODateTimeOffset
+  "get item.timeZone.getPossibleInstantsFor",
+  "call item.timeZone.getPossibleInstantsFor",
+  "get item.timeZone.getOffsetNanosecondsFor",
+  "call item.timeZone.getOffsetNanosecondsFor",
+];
+const actual = [];
+
+const from = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2001,
+  month: 5,
+  monthCode: "M05",
+  day: 2,
+  hour: 6,
+  minute: 54,
+  second: 32,
+  millisecond: 987,
+  microsecond: 654,
+  nanosecond: 321,
+  offset: "+00:00",
+  calendar: TemporalHelpers.calendarObserver(actual, "item.calendar"),
+  timeZone: TemporalHelpers.timeZoneObserver(actual, "item.timeZone"),
+}, "item");
+
+function createOptionsObserver({ overflow = "constrain", disambiguation = "compatible", offset = "reject" } = {}) {
+  return TemporalHelpers.propertyBagObserver(actual, {
+    overflow,
+    disambiguation,
+    offset,
+  }, "options");
+}
+
+Temporal.ZonedDateTime.from(from, createOptionsObserver());
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/add/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/add/order-of-operations.js
@@ -1,0 +1,80 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: Properties on objects passed to add() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  // ToTemporalDurationRecord
+  "get duration.days",
+  "get duration.days.valueOf",
+  "call duration.days.valueOf",
+  "get duration.hours",
+  "get duration.hours.valueOf",
+  "call duration.hours.valueOf",
+  "get duration.microseconds",
+  "get duration.microseconds.valueOf",
+  "call duration.microseconds.valueOf",
+  "get duration.milliseconds",
+  "get duration.milliseconds.valueOf",
+  "call duration.milliseconds.valueOf",
+  "get duration.minutes",
+  "get duration.minutes.valueOf",
+  "call duration.minutes.valueOf",
+  "get duration.months",
+  "get duration.months.valueOf",
+  "call duration.months.valueOf",
+  "get duration.nanoseconds",
+  "get duration.nanoseconds.valueOf",
+  "call duration.nanoseconds.valueOf",
+  "get duration.seconds",
+  "get duration.seconds.valueOf",
+  "call duration.seconds.valueOf",
+  "get duration.weeks",
+  "get duration.weeks.valueOf",
+  "call duration.weeks.valueOf",
+  "get duration.years",
+  "get duration.years.valueOf",
+  "call duration.years.valueOf",
+  // AddZonedDateTime
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.calendar.dateAdd",
+  "call this.calendar.dateAdd",
+  // ... inside Calendar.p.dateAdd
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  // AddZonedDateTime again
+  "get this.timeZone.getPossibleInstantsFor",
+  "call this.timeZone.getPossibleInstantsFor",
+];
+const actual = [];
+
+const timeZone = TemporalHelpers.timeZoneObserver(actual, "this.timeZone");
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
+const duration = TemporalHelpers.propertyBagObserver(actual, {
+  years: 1,
+  months: 1,
+  weeks: 1,
+  days: 1,
+  hours: 1,
+  minutes: 1,
+  seconds: 1,
+  milliseconds: 1,
+  microseconds: 1,
+  nanoseconds: 1,
+}, "duration");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+instance.add(duration, options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/order-of-operations.js
@@ -1,0 +1,103 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: Properties on objects passed to equals() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get other.calendar",
+  "has other.calendar.calendar",
+  "get other.calendar.fields",
+  "call other.calendar.fields",
+  // PrepareTemporalFields
+  "get other.day",
+  "get other.day.valueOf",
+  "call other.day.valueOf",
+  "get other.hour",
+  "get other.hour.valueOf",
+  "call other.hour.valueOf",
+  "get other.microsecond",
+  "get other.microsecond.valueOf",
+  "call other.microsecond.valueOf",
+  "get other.millisecond",
+  "get other.millisecond.valueOf",
+  "call other.millisecond.valueOf",
+  "get other.minute",
+  "get other.minute.valueOf",
+  "call other.minute.valueOf",
+  "get other.month",
+  "get other.month.valueOf",
+  "call other.month.valueOf",
+  "get other.monthCode",
+  "get other.monthCode.toString",
+  "call other.monthCode.toString",
+  "get other.nanosecond",
+  "get other.nanosecond.valueOf",
+  "call other.nanosecond.valueOf",
+  "get other.second",
+  "get other.second.valueOf",
+  "call other.second.valueOf",
+  "get other.year",
+  "get other.year.valueOf",
+  "call other.year.valueOf",
+  "get other.timeZone",
+  "get other.offset",
+  "get other.offset.toString",
+  "call other.offset.toString",
+  "has other.timeZone.timeZone",
+  // InterpretTemporalDateTimeFields
+  "get other.calendar.dateFromFields",
+  "call other.calendar.dateFromFields",
+  // InterpretISODateTimeOffset
+  "get other.timeZone.getPossibleInstantsFor",
+  "call other.timeZone.getPossibleInstantsFor",
+  "get other.timeZone.getOffsetNanosecondsFor",
+  "call other.timeZone.getOffsetNanosecondsFor",
+  // TimeZoneEquals
+  "get this.timeZone[Symbol.toPrimitive]",
+  "get this.timeZone.toString",
+  "call this.timeZone.toString",
+  "get other.timeZone[Symbol.toPrimitive]",
+  "get other.timeZone.toString",
+  "call other.timeZone.toString",
+  // CalendarEquals
+  "get this.calendar[Symbol.toPrimitive]",
+  "get this.calendar.toString",
+  "call this.calendar.toString",
+  "get other.calendar[Symbol.toPrimitive]",
+  "get other.calendar.toString",
+  "call other.calendar.toString",
+];
+const actual = [];
+
+const other = TemporalHelpers.propertyBagObserver(actual, {
+  year: 2001,
+  month: 5,
+  monthCode: "M05",
+  day: 2,
+  hour: 6,
+  minute: 54,
+  second: 32,
+  millisecond: 987,
+  microsecond: 654,
+  nanosecond: 321,
+  offset: "+00:00",
+  calendar: TemporalHelpers.calendarObserver(actual, "other.calendar"),
+  timeZone: TemporalHelpers.timeZoneObserver(actual, "other.timeZone"),
+}, "other");
+
+const instance = new Temporal.ZonedDateTime(
+  988786472_987_654_321n,  /* 2001-05-02T06:54:32.987654321Z */
+  TemporalHelpers.timeZoneObserver(actual, "this.timeZone"),
+  TemporalHelpers.calendarObserver(actual, "this.calendar"),
+);
+// clear any observable operations that happen due to time zone or calendar
+// calls on the constructor
+actual.splice(0);
+
+instance.equals(other);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
@@ -46,11 +46,15 @@ const expected = [
   "call other.year.valueOf",
   "get other.timeZone",
   "get other.offset",
+  "get other.offset.toString",
+  "call other.offset.toString",
   "has other.timeZone.timeZone",
   "get other.calendar.dateFromFields",
   "call other.calendar.dateFromFields",
   "get other.timeZone.getPossibleInstantsFor",
   "call other.timeZone.getPossibleInstantsFor",
+  "get other.timeZone.getOffsetNanosecondsFor",
+  "call other.timeZone.getOffsetNanosecondsFor",
   // CalendarEquals
   "get this.calendar[Symbol.toPrimitive]",
   "get this.calendar.toString",
@@ -89,6 +93,7 @@ const otherDateTimePropertyBag = TemporalHelpers.propertyBagObserver(actual, {
   millisecond: 250,
   microsecond: 500,
   nanosecond: 750,
+  offset: "+00:00",
   calendar: TemporalHelpers.calendarObserver(actual, "other.calendar"),
   timeZone: TemporalHelpers.timeZoneObserver(actual, "other.timeZone"),
 }, "other");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
@@ -111,12 +111,12 @@ function createOptionsObserver({ smallestUnit = "nanoseconds", largestUnit = "au
 }
 
 // clear any observable things that happened while constructing the objects
-actual.splice(0, actual.length);
+actual.splice(0);
 
 // basic order of observable operations, without rounding:
 instance.since(otherDateTimePropertyBag, createOptionsObserver());
 assert.compareArray(actual, expected, "order of operations");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // Making largestUnit a calendar unit adds the following observable operations:
 const expectedOpsForCalendarDifference = [
@@ -216,7 +216,7 @@ const expectedOpsForYearRounding = expected.concat(expectedOpsForCalendarDiffere
 ]);
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat(expectedOpsForCalendarDifference, [
@@ -227,7 +227,7 @@ const expectedOpsForMonthRounding = expected.concat(expectedOpsForCalendarDiffer
 ]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest week:
 const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDifference, [
@@ -236,4 +236,3 @@ const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDiffere
 ]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual.slice(expected.length), expectedOpsForWeekRounding.slice(expected.length), "order of operations with smallestUnit = weeks");
-actual.slice(0, actual.length); // clear

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/subtract/order-of-operations.js
@@ -1,0 +1,80 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: Properties on objects passed to subtract() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  // ToTemporalDurationRecord
+  "get duration.days",
+  "get duration.days.valueOf",
+  "call duration.days.valueOf",
+  "get duration.hours",
+  "get duration.hours.valueOf",
+  "call duration.hours.valueOf",
+  "get duration.microseconds",
+  "get duration.microseconds.valueOf",
+  "call duration.microseconds.valueOf",
+  "get duration.milliseconds",
+  "get duration.milliseconds.valueOf",
+  "call duration.milliseconds.valueOf",
+  "get duration.minutes",
+  "get duration.minutes.valueOf",
+  "call duration.minutes.valueOf",
+  "get duration.months",
+  "get duration.months.valueOf",
+  "call duration.months.valueOf",
+  "get duration.nanoseconds",
+  "get duration.nanoseconds.valueOf",
+  "call duration.nanoseconds.valueOf",
+  "get duration.seconds",
+  "get duration.seconds.valueOf",
+  "call duration.seconds.valueOf",
+  "get duration.weeks",
+  "get duration.weeks.valueOf",
+  "call duration.weeks.valueOf",
+  "get duration.years",
+  "get duration.years.valueOf",
+  "call duration.years.valueOf",
+  // AddZonedDateTime
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.calendar.dateAdd",
+  "call this.calendar.dateAdd",
+  // ... inside Calendar.p.dateAdd
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  // AddZonedDateTime again
+  "get this.timeZone.getPossibleInstantsFor",
+  "call this.timeZone.getPossibleInstantsFor",
+];
+const actual = [];
+
+const timeZone = TemporalHelpers.timeZoneObserver(actual, "this.timeZone");
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
+const duration = TemporalHelpers.propertyBagObserver(actual, {
+  years: 1,
+  months: 1,
+  weeks: 1,
+  days: 1,
+  hours: 1,
+  minutes: 1,
+  seconds: 1,
+  milliseconds: 1,
+  microseconds: 1,
+  nanoseconds: 1,
+}, "duration");
+
+const options = TemporalHelpers.propertyBagObserver(actual, { overflow: "constrain" }, "options");
+
+instance.subtract(duration, options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/toString/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/toString/order-of-operations.js
@@ -1,0 +1,79 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: Properties on objects passed to toString() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.calendarName",
+  "get options.calendarName.toString",
+  "call options.calendarName.toString",
+  "get options.timeZoneName",
+  "get options.timeZoneName.toString",
+  "call options.timeZoneName.toString",
+  "get options.offset",
+  "get options.offset.toString",
+  "call options.offset.toString",
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone[Symbol.toPrimitive]",
+  "get this.timeZone.toString",
+  "call this.timeZone.toString",
+  "get this.calendar[Symbol.toPrimitive]",
+  "get this.calendar.toString",
+  "call this.calendar.toString",
+];
+const actual = [];
+
+const timeZone = TemporalHelpers.timeZoneObserver(actual, "this.timeZone");
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
+const expectedForSmallestUnit = [
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+].concat(expected);
+
+instance.toString(
+  TemporalHelpers.propertyBagObserver(actual, {
+    fractionalSecondDigits: 3,
+    roundingMode: "halfExpand",
+    smallestUnit: "millisecond",
+    offset: "auto",
+    timeZoneName: "auto",
+    calendarName: "auto",
+  }, "options"),
+);
+assert.compareArray(actual, expectedForSmallestUnit, "order of operations");
+actual.splice(0); // clear
+
+const expectedForFractionalSecondDigits = [
+  "get options.smallestUnit",
+  "get options.fractionalSecondDigits",
+  "get options.fractionalSecondDigits.toString",
+  "call options.fractionalSecondDigits.toString",
+].concat(expected);
+
+instance.toString(
+  TemporalHelpers.propertyBagObserver(actual, {
+    fractionalSecondDigits: "auto",
+    roundingMode: "halfExpand",
+    smallestUnit: undefined,
+    offset: "auto",
+    timeZoneName: "auto",
+    calendarName: "auto",
+  }, "options"),
+);
+assert.compareArray(actual, expectedForFractionalSecondDigits, "order of operations with smallestUnit undefined");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
@@ -111,12 +111,12 @@ function createOptionsObserver({ smallestUnit = "nanoseconds", largestUnit = "au
 }
 
 // clear any observable things that happened while constructing the objects
-actual.splice(0, actual.length);
+actual.splice(0);
 
 // basic order of observable operations, without rounding:
 instance.until(otherDateTimePropertyBag, createOptionsObserver());
 assert.compareArray(actual, expected, "order of operations");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // Making largestUnit a calendar unit adds the following observable operations:
 const expectedOpsForCalendarDifference = [
@@ -216,7 +216,7 @@ const expectedOpsForYearRounding = expected.concat(expectedOpsForCalendarDiffere
 ]);
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "years" }));
 assert.compareArray(actual, expectedOpsForYearRounding, "order of operations with smallestUnit = years");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest month:
 const expectedOpsForMonthRounding = expected.concat(expectedOpsForCalendarDifference, [
@@ -227,7 +227,7 @@ const expectedOpsForMonthRounding = expected.concat(expectedOpsForCalendarDiffer
 ]);  // (10.n.iii MoveRelativeDate not called because weeks == 0)
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "months" }));
 assert.compareArray(actual, expectedOpsForMonthRounding, "order of operations with smallestUnit = months");
-actual.splice(0, actual.length); // clear
+actual.splice(0); // clear
 
 // code path through RoundDuration that rounds to the nearest week:
 const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDifference, [
@@ -236,4 +236,3 @@ const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDiffere
 ]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual.slice(expected.length), expectedOpsForWeekRounding.slice(expected.length), "order of operations with smallestUnit = weeks");
-actual.slice(0, actual.length); // clear

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
@@ -46,11 +46,15 @@ const expected = [
   "call other.year.valueOf",
   "get other.timeZone",
   "get other.offset",
+  "get other.offset.toString",
+  "call other.offset.toString",
   "has other.timeZone.timeZone",
   "get other.calendar.dateFromFields",
   "call other.calendar.dateFromFields",
   "get other.timeZone.getPossibleInstantsFor",
   "call other.timeZone.getPossibleInstantsFor",
+  "get other.timeZone.getOffsetNanosecondsFor",
+  "call other.timeZone.getOffsetNanosecondsFor",
   // CalendarEquals
   "get this.calendar[Symbol.toPrimitive]",
   "get this.calendar.toString",
@@ -89,6 +93,7 @@ const otherDateTimePropertyBag = TemporalHelpers.propertyBagObserver(actual, {
   millisecond: 250,
   microsecond: 500,
   nanosecond: 750,
+  offset: "+00:00",
   calendar: TemporalHelpers.calendarObserver(actual, "other.calendar"),
   timeZone: TemporalHelpers.timeZoneObserver(actual, "other.timeZone"),
 }, "other");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/with/order-of-operations.js
@@ -1,0 +1,137 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.with
+description: Properties on objects passed to with() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  // RejectObjectWithCalendarOrTimeZone
+  "get fields.calendar",
+  "get fields.timeZone",
+  // CalendarFields / PrepareTemporalFields
+  "get this.calendar.fields",
+  "call this.calendar.fields",
+  "get fields.day",
+  "get fields.day.valueOf",
+  "call fields.day.valueOf",
+  "get fields.hour",
+  "get fields.hour.valueOf",
+  "call fields.hour.valueOf",
+  "get fields.microsecond",
+  "get fields.microsecond.valueOf",
+  "call fields.microsecond.valueOf",
+  "get fields.millisecond",
+  "get fields.millisecond.valueOf",
+  "call fields.millisecond.valueOf",
+  "get fields.minute",
+  "get fields.minute.valueOf",
+  "call fields.minute.valueOf",
+  "get fields.month",
+  "get fields.month.valueOf",
+  "call fields.month.valueOf",
+  "get fields.monthCode",
+  "get fields.monthCode.toString",
+  "call fields.monthCode.toString",
+  "get fields.nanosecond",
+  "get fields.nanosecond.valueOf",
+  "call fields.nanosecond.valueOf",
+  "get fields.second",
+  "get fields.second.valueOf",
+  "call fields.second.valueOf",
+  "get fields.year",
+  "get fields.year.valueOf",
+  "call fields.year.valueOf",
+  "get fields.offset",
+  "get fields.offset.toString",
+  "call fields.offset.toString",
+  // options
+  "get options.disambiguation",
+  "get options.disambiguation.toString",
+  "call options.disambiguation.toString",
+  "get options.offset",
+  "get options.offset.toString",
+  "call options.offset.toString",
+  // PrepareTemporalFields
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.calendar.day",
+  "call this.calendar.day",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.hour
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.microsecond
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.millisecond
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.minute
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.calendar.month",
+  "call this.calendar.month",
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.nanosecond
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.second
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.offset
+  "call this.timeZone.getOffsetNanosecondsFor",
+  // CalendarMergeFields
+  "get this.calendar.mergeFields",
+  "call this.calendar.mergeFields",
+  // InterpretTemporalDateTimeFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  "get this.calendar.dateFromFields",
+  "call this.calendar.dateFromFields",
+  // Calendar.p.dateFromFields
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
+  // InterpretISODateTimeOffset
+  "get this.timeZone.getPossibleInstantsFor",
+  "call this.timeZone.getPossibleInstantsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+];
+const actual = [];
+
+const timeZone = TemporalHelpers.timeZoneObserver(actual, "this.timeZone");
+const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
+const instance = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+// clear observable operations that occurred during the constructor call
+actual.splice(0);
+
+const fields = TemporalHelpers.propertyBagObserver(actual, {
+  year: 1.7,
+  month: 1.7,
+  monthCode: "M01",
+  day: 1.7,
+  hour: 1.7,
+  minute: 1.7,
+  second: 1.7,
+  millisecond: 1.7,
+  microsecond: 1.7,
+  nanosecond: 1.7,
+  offset: "+00:00",
+}, "fields");
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  overflow: "constrain",
+  disambiguation: "compatible",
+  offset: "prefer",
+}, "options");
+
+instance.with(fields, options);
+assert.compareArray(actual, expected, "order of operations");


### PR DESCRIPTION
Add more tests for user-observable order of operations, and improve the ones that were already there. I'm planning to present a normative change to the proposal that will reorder some of these operations, so it's important to have coverage in place first, for the current state of the proposal.

I'd recommend reviewing this commit-by-commit. Most of the changes within each individual commit are quite similar to each other, so it should be sufficient to check a representative sample.

One thing to pay special attention to while reviewing, is that PlainYearMonth.subtract subtracts its duration from the end of the month, while PlainYearMonth.add adds its duration to the beginning of the month. This results in an extra call to the calendar's `daysInMonth` method.