### PR TITLE
Update Intl.DurationFormat test with recent default digital style change

### DIFF
--- a/test/intl402/DurationFormat/prototype/format/style-options-en.js
+++ b/test/intl402/DurationFormat/prototype/format/style-options-en.js
@@ -12,7 +12,7 @@ const testData = {
   "long" : "1 year, 2 months, 3 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds, 8 microseconds, 9 nanoseconds",
   "short": "1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns",
   "narrow":"1y 2m 3w 3d 4h 5m 6s 7ms 8μs 9ns",
-  "digital":"1 yr 2 mths 3 wks 3 days 4:05:06",
+  "digital":"1 yr, 2 mths, 3 wks, 3 days, 4:05:06",
 }
 
 const duration = {


### PR DESCRIPTION
When the provided `style` is digital, the default `listStyle` has been changed from "narrow" to "short". In the "en" locale, this adds commas between the units.

https://github.com/tc39/proposal-intl-duration-format/commit/7495e32