### PR TITLE
Temporal: Test throwing on time-zone-to-calendar conversion and vice versa

### DIFF
--- a/test/built-ins/Temporal/Calendar/from/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/from/calendar-wrong-type.js
@@ -15,10 +15,12 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
   assert.throws(RangeError, () => Temporal.Calendar.from(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Calendar.from({ calendar: arg }), `${description} does not convert to a valid ISO string (in property bag)`);
 }
 
 const typeErrorTests = [
@@ -27,4 +29,5 @@ const typeErrorTests = [
 
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => Temporal.Calendar.from(arg), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Calendar.from({ calendar: arg }), `${description} is not a valid object and does not convert to a string (in property bag)`);
 }

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [calendar, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/compare/relativeto-propertybag-timezone-wrong-type.js
@@ -16,6 +16,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-calendar-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [calendar, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/add/relativeto-propertybag-timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [calendar, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-calendar-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [calendar, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/subtract/relativeto-propertybag-timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-calendar-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [calendar, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-propertybag-timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Instant/prototype/toString/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toString/timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-wrong-type.js
@@ -17,10 +17,12 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
   assert.throws(RangeError, () => instance.toZonedDateTime({ calendar: arg, timeZone: "UTC" }), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.toZonedDateTime({ calendar: { calendar: arg }, timeZone: "UTC" }), `${description} does not convert to a valid ISO string (in property bag)`);
 }
 
 const typeErrorTests = [
@@ -29,4 +31,5 @@ const typeErrorTests = [
 
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => instance.toZonedDateTime({ calendar: arg, timeZone: "UTC" }), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.toZonedDateTime({ calendar: { calendar: arg }, timeZone: "UTC" }), `${description} is not a valid object and does not convert to a string (in property bag)`);
 }

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO/timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Now/plainDate/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDate/calendar-wrong-type.js
@@ -15,10 +15,12 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
   assert.throws(RangeError, () => Temporal.Now.plainDate(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.plainDate({ calendar: arg }), `${description} does not convert to a valid ISO string (in property bag)`);
 }
 
 const typeErrorTests = [
@@ -27,4 +29,5 @@ const typeErrorTests = [
 
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => Temporal.Now.plainDate(arg), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.plainDate({ calendar: arg }), `${description} is not a valid object and does not convert to a string (in property bag)`);
 }

--- a/test/built-ins/Temporal/Now/plainDate/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDate/timezone-wrong-type.js
@@ -16,6 +16,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Now/plainDateISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateISO/timezone-wrong-type.js
@@ -16,6 +16,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Now/plainDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/calendar-wrong-type.js
@@ -15,10 +15,12 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
   assert.throws(RangeError, () => Temporal.Now.plainDateTime(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.plainDateTime({ calendar: arg }), `${description} does not convert to a valid ISO string (in property bag)`);
 }
 
 const typeErrorTests = [
@@ -27,4 +29,5 @@ const typeErrorTests = [
 
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => Temporal.Now.plainDateTime(arg), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.plainDateTime({ calendar: arg }), `${description} is not a valid object and does not convert to a string (in property bag)`);
 }

--- a/test/built-ins/Temporal/Now/plainDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/timezone-wrong-type.js
@@ -16,6 +16,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainDateTimeISO/timezone-wrong-type.js
@@ -16,6 +16,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Now/plainTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/plainTimeISO/timezone-wrong-type.js
@@ -16,6 +16,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Now/zonedDateTime/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/calendar-wrong-type.js
@@ -15,10 +15,12 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
   assert.throws(RangeError, () => Temporal.Now.zonedDateTime(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => Temporal.Now.zonedDateTime({ calendar: arg }), `${description} does not convert to a valid ISO string (in property bag)`);
 }
 
 const typeErrorTests = [
@@ -27,4 +29,5 @@ const typeErrorTests = [
 
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => Temporal.Now.zonedDateTime(arg), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => Temporal.Now.zonedDateTime({ calendar: arg }), `${description} is not a valid object and does not convert to a string (in property bag)`);
 }

--- a/test/built-ins/Temporal/Now/zonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/timezone-wrong-type.js
@@ -16,6 +16,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/Now/zonedDateTimeISO/timezone-wrong-type.js
@@ -16,6 +16,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-wrong-type.js
@@ -15,6 +15,7 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [calendar, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-wrong-type.js
@@ -17,10 +17,12 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
   assert.throws(RangeError, () => instance.withCalendar(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.withCalendar({ calendar: arg }), `${description} does not convert to a valid ISO string (in property bag)`);
 }
 
 const typeErrorTests = [
@@ -29,4 +31,5 @@ const typeErrorTests = [
 
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => instance.withCalendar(arg), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.withCalendar({ calendar: arg }), `${description} is not a valid object and does not convert to a string (in property bag)`);
 }

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-wrong-type.js
@@ -15,6 +15,7 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [calendar, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-wrong-type.js
@@ -17,10 +17,12 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
   assert.throws(RangeError, () => instance.withCalendar(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.withCalendar({ calendar: arg }), `${description} does not convert to a valid ISO string (in property bag)`);
 }
 
 const typeErrorTests = [
@@ -29,4 +31,5 @@ const typeErrorTests = [
 
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => instance.withCalendar(arg), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.withCalendar({ calendar: arg }), `${description} is not a valid object and does not convert to a string (in property bag)`);
 }

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-wrong-type.js
@@ -15,6 +15,7 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [calendar, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/TimeZone/from/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/from/timezone-wrong-type.js
@@ -16,6 +16,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-wrong-type.js
@@ -17,10 +17,12 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
   assert.throws(RangeError, () => instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.getPlainDateTimeFor(new Temporal.Instant(0n), { calendar: arg }), `${description} does not convert to a valid ISO string (in property bag)`);
 }
 
 const typeErrorTests = [
@@ -29,4 +31,5 @@ const typeErrorTests = [
 
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.getPlainDateTimeFor(new Temporal.Instant(0n), { calendar: arg }), `${description} is not a valid object and does not convert to a string (in property bag)`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-wrong-type.js
@@ -17,6 +17,7 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [calendar, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-timezone-wrong-type.js
@@ -16,6 +16,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-wrong-type.js
@@ -17,10 +17,12 @@ const rangeErrorTests = [
   ["", "empty string"],
   [1, "number that doesn't convert to a valid ISO string"],
   [1n, "bigint"],
+  [new Temporal.TimeZone("UTC"), "time zone instance"],
 ];
 
 for (const [arg, description] of rangeErrorTests) {
   assert.throws(RangeError, () => instance.withCalendar(arg), `${description} does not convert to a valid ISO string`);
+  assert.throws(RangeError, () => instance.withCalendar({ calendar: arg }), `${description} does not convert to a valid ISO string (in property bag)`);
 }
 
 const typeErrorTests = [
@@ -29,4 +31,5 @@ const typeErrorTests = [
 
 for (const [arg, description] of typeErrorTests) {
   assert.throws(TypeError, () => instance.withCalendar(arg), `${description} is not a valid object and does not convert to a string`);
+  assert.throws(TypeError, () => instance.withCalendar({ calendar: arg }), `${description} is not a valid object and does not convert to a string (in property bag)`);
 }

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone/timezone-wrong-type.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone/timezone-wrong-type.js
@@ -18,6 +18,7 @@ const rangeErrorTests = [
   [1, "number that doesn't convert to a valid ISO string"],
   [19761118, "number that would convert to a valid ISO string in other contexts"],
   [1n, "bigint"],
+  [new Temporal.Calendar("iso8601"), "calendar instance"],
 ];
 
 for (const [timeZone, description] of rangeErrorTests) {


### PR DESCRIPTION
This contains tests for the normative PR https://github.com/tc39/proposal-temporal/pull/2433, which is to be presented for consensus to TC39 in the upcoming plenary meeting. That PR changes ToTemporalCalendar to throw when it encounters a Temporal.TimeZone instance, and ToTemporalTimeZone to throw when it encounters a Temporal.Calendar instance.