### PR TITLE
Remove Python 2 CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ workflows:
   version: 2
   Tools:
     jobs:
-      - "Test262: verify tools; build & lint tests (Python 3)"
+      - "Test262: verify tools; build & lint tests"
   Tests execution:
     jobs:
       - "ChakraCore: New or modified tests execution"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,33 +37,6 @@ execution_steps: &execution_steps
     - run: hostPath=$HOME/.esvu/bin/$hostPath npm run ci
 
 jobs:
-  "Test262: verify tools; build & lint tests (Python 2)":
-    docker:
-      - image: cimg/python:2.7
-    working_directory: ~/test262
-    steps:
-      - checkout
-      - run:
-          name: "Install requirements for generation tool"
-          command: python -m pip install --user --requirement tools/generation/requirements.txt
-      - run:
-          name: "Install requirements for lint tool"
-          command: python -m pip install --user --requirement tools/lint/requirements.txt
-      - run:
-          name: "Test the generation tool"
-          command: ./tools/generation/test/run.py
-      - run:
-          name: "Test the lint tool"
-          command: ./tools/lint/test/run.py
-      - run:
-          name: "Build tests; check for new changes"
-          command: ./tools/scripts/ci_build.sh
-      - run:
-          name: "Lint tests"
-          command: ./tools/scripts/ci_lint.sh
-      # - run:
-      #     name: "Run deploy"
-      #     command: ./tools/scripts/deploy.sh
   "Test262: verify tools; build & lint tests (Python 3)":
     docker:
       - image: cimg/python:3.7.4
@@ -88,6 +61,9 @@ jobs:
       - run:
           name: "Lint tests"
           command: ./tools/scripts/ci_lint.sh
+      # - run:
+      #     name: "Run deploy"
+      #     command: ./tools/scripts/deploy.sh
   "V8: New or modified tests execution":
     docker:
       - image: *node_latest
@@ -170,7 +146,6 @@ workflows:
   version: 2
   Tools:
     jobs:
-      - "Test262: verify tools; build & lint tests (Python 2)"
       - "Test262: verify tools; build & lint tests (Python 3)"
   Tests execution:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ execution_steps: &execution_steps
     - run: hostPath=$HOME/.esvu/bin/$hostPath npm run ci
 
 jobs:
-  "Test262: verify tools; build & lint tests (Python 3)":
+  "Test262: verify tools; build & lint tests":
     docker:
       - image: cimg/python:3.7.4
     working_directory: ~/test262


### PR DESCRIPTION
The Python 2 and 3 jobs run essentially the same thing twice. I asked for a sign from implementations if any of them were relying on Python 2 for their test262 runners, but didn't hear of any that were.

The Python tools are changed so rarely that I think it's OK to drop this CI job. If a future change breaks Python 2 for someone, we can accept PRs to fix it on a best-effort basis, or reinstate this CI job if it's really necessary.

Closes: #3480