### PR TITLE
CI: Integrate ESMeta

### DIFF
--- a/.github/workflows/esmeta-test262.yml
+++ b/.github/workflows/esmeta-test262.yml
@@ -24,9 +24,8 @@ jobs:
           git clone --branch v0.1.0-rc8 --depth 1 https://github.com/es-meta/esmeta.git "${ESMETA_HOME}"
           cd "${ESMETA_HOME}" && git submodule update --init --depth 1
       - name: build esmeta
-        run: |
-          cd "${ESMETA_HOME}"
-          sbt assembly
+        working-directory: ${{ env.ESMETA_HOME }}
+        run: sbt assembly
       - name: run test262
         run: |
           git fetch origin main

--- a/.github/workflows/esmeta-test262.yml
+++ b/.github/workflows/esmeta-test262.yml
@@ -38,4 +38,3 @@ jobs:
           echo New or modified test files:
           echo "$paths"
           "${ESMETA_HOME}"/bin/esmeta test262-test -status -test262dir=$(pwd) $paths
-          

--- a/.github/workflows/esmeta-test262.yml
+++ b/.github/workflows/esmeta-test262.yml
@@ -1,0 +1,41 @@
+name: 'esmeta test262'
+
+on: [pull_request]
+
+jobs:
+  esmeta-test262:
+    name: 'esmeta test262'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v3
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Add to PATH
+        shell: bash
+        run: |
+          echo "ESMETA_HOME=$(pwd)/vendor/esmeta" >> $GITHUB_ENV
+      - name: download esmeta
+        run: |
+          mkdir -p "${ESMETA_HOME}"
+          git clone --branch v0.1.0-rc8 --depth 1 https://github.com/es-meta/esmeta.git "${ESMETA_HOME}"
+          cd "${ESMETA_HOME}" && git submodule update --init --depth 1
+      - name: build esmeta
+        run: |
+          cd "${ESMETA_HOME}"
+          sbt assembly
+      - name: run test262
+        run: |
+          git fetch origin main
+          paths=$(git diff --diff-filter ACMR --name-only origin/main.. -- test/)
+          if [ "$paths" == "" ]; then
+            echo No test files added or modified. Exiting.
+            exit 0
+          fi
+          echo New or modified test files:
+          echo "$paths"
+          "${ESMETA_HOME}"/bin/esmeta test262-test -status -test262dir=$(pwd) $paths
+          


### PR DESCRIPTION
Hi, this PR contains changes that integrate ESMeta's feature to test test262 changes. This PR heavily borrows from changes made at https://github.com/tc39/ecma262/pull/2926, which integrates ESMeta's type checker into ecma262's CI.

ESMeta is able to derive an interpreter from ECMAScript spec and execute JavaScript with it. With this change, we can confirm new or modified test files behave according to ECMAScript spec.

I could not test the changes by actually running CircleCI pipeline as that was not simply possible, but instead tested with local CircleCI cli. 

As I am not very experienced with both test262 and CircleCI, if there are any deficiencies please let me know. Thanks in advance.

cc @jhnaldo