### PR TITLE
Update Intl.NumberFormat test with recent reorder of option evaluation

### DIFF
--- a/test/intl402/NumberFormat/constructor-roundingIncrement.js
+++ b/test/intl402/NumberFormat/constructor-roundingIncrement.js
@@ -46,5 +46,5 @@ for (const [value, expected] of values) {
   assert("roundingIncrement" in resolvedOptions, "has property for value " + value);
   assert.sameValue(resolvedOptions.roundingIncrement, expected);
 
-  assert.compareArray(callOrder, ["notation", "roundingIncrement"]);
+  assert.compareArray(callOrder, ["roundingIncrement", "notation"]);
 }


### PR DESCRIPTION
The order of evaluation for "notation" and "roundingIncrement" changed
in https://github.com/tc39/proposal-intl-numberformat-v3/commit/a260aa3.