### PR TITLE
Temporal: Reconcile yearOfWeek tests with changes to YYYY-MM-DD+UU fmt

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-string-date-with-utc-offset.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-string-date-with-utc-offset.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.yearofweek
+description: UTC offset not valid with format that does not include a time
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const validStrings = [
+  "2000-05-02T00+00:00",
+  "2000-05-02T00+00:00[UTC]",
+  "2000-05-02T00+00:00[!UTC]",
+  "2000-05-02T00-02:30[America/St_Johns]",
+];
+
+for (const arg of validStrings) {
+  const result = instance.yearOfWeek(arg);
+
+  assert.sameValue(
+    result,
+    2000,
+    `"${arg}" is a valid UTC offset with time for PlainDate`
+  );
+}
+
+const invalidStrings = [
+  "2022-09-15Z",
+  "2022-09-15Z[UTC]",
+  "2022-09-15Z[Europe/Vienna]",
+  "2022-09-15+00:00",
+  "2022-09-15+00:00[UTC]",
+  "2022-09-15-02:30",
+  "2022-09-15-02:30[America/St_Johns]",
+];
+
+for (const arg of invalidStrings) {
+  assert.throws(
+    RangeError,
+    () => instance.yearOfWeek(arg),
+    `"${arg}" UTC offset without time is not valid for PlainDate`
+  );
+}

--- a/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-string-time-zone-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-string-time-zone-annotation.js
@@ -8,14 +8,10 @@ features: [Temporal]
 ---*/
 
 const tests = [
-  ["2000-05-02[Asia/Kolkata]", "named, with no time and no offset"],
-  ["2000-05-02[!Europe/Vienna]", "named, with !, no time, and no offset"],
-  ["2000-05-02[+00:00]", "numeric, with no time and no offset"],
-  ["2000-05-02[!-02:30]", "numeric, with !, no time, and no offset"],
-  ["2000-05-02+00:00[UTC]", "named, with offset and no time"],
-  ["2000-05-02+00:00[!Africa/Abidjan]", "named, with offset, !, and no time"],
-  ["2000-05-02+00:00[-08:00]", "numeric, with offset and no time"],
-  ["2000-05-02+00:00[!+01:00]", "numeric, with offset, !, and no time"],
+  ["2000-05-02[Asia/Kolkata]", "named, with no time"],
+  ["2000-05-02[!Europe/Vienna]", "named, with ! and no time"],
+  ["2000-05-02[+00:00]", "numeric, with no time"],
+  ["2000-05-02[!-02:30]", "numeric, with ! and no time"],
   ["2000-05-02T15:23[America/Sao_Paulo]", "named, with no offset"],
   ["2000-05-02T15:23[!Asia/Tokyo]", "named, with ! and no offset"],
   ["2000-05-02T15:23[-02:30]", "numeric, with no offset"],


### PR DESCRIPTION
This reconciles changes made in two normative PRs to the Temporal proposal which each had their own separate PRs for tests. The yearOfWeek tests were written before the changes to the ISO 8601 grammar which disallowed the YYYY-MM-DD+UU format. This brings the yearOfWeek tests in line with the tests for the other calendar methods.

See: #3696, #3699