### PR TITLE
Fix typos in String.prototype.isWellFormed/String.prototype.toWellFormed

### DIFF
--- a/test/built-ins/String/prototype/isWellFormed/to-string.js
+++ b/test/built-ins/String/prototype/isWellFormed/to-string.js
@@ -20,8 +20,8 @@ var obj = {
     }
 };
 
-asserts.throws(
-    function () { String.prototype.isWellFormed.call(obj); },
+assert.throws(
     Test262Error,
+    function () { String.prototype.isWellFormed.call(obj); },
     'coerces the receiver to a string'
 );

--- a/test/built-ins/String/prototype/toWellFormed/name.js
+++ b/test/built-ins/String/prototype/toWellFormed/name.js
@@ -17,5 +17,5 @@ verifyProperty(String.prototype.toWellFormed, 'name', {
   enumerable: false,
   writable: false,
   configurable: true,
-  value: 'isWellFormed'
+  value: 'toWellFormed'
 });

--- a/test/built-ins/String/prototype/toWellFormed/to-string.js
+++ b/test/built-ins/String/prototype/toWellFormed/to-string.js
@@ -20,8 +20,8 @@ var obj = {
     }
 };
 
-asserts.throws(
-    function () { String.prototype.toWellFormed.call(obj); },
+assert.throws(
     Test262Error,
+    function () { String.prototype.toWellFormed.call(obj); },
     'coerces the receiver to a string'
 );


### PR DESCRIPTION
1. `String.prototype.toWellFormed`'s name is "toWellFormed".

2. `asserts` does not exist in the test harness, and `assert.throws` expects the error type first.