### PR TITLE
Improve NumberFormat and DateTimeFormat tests for OrdinaryHasInstance

### DIFF
--- a/test/intl402/DateTimeFormat/constructor-no-instanceof.js
+++ b/test/intl402/DateTimeFormat/constructor-no-instanceof.js
@@ -2,11 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-Intl.DateTimeFormat.prototype.resolvedOptions
+esid: sec-intl-datetimeformat-constructor
 description: >
-  Tests that Intl.DateTimeFormat.prototype.resolvedOptions calls
+  Tests that the Intl.DateTimeFormat constructor calls
   OrdinaryHasInstance instead of the instanceof operator which includes a
   Symbol.hasInstance lookup and call among other things.
+info: >
+  ChainDateTimeFormat ( dateTimeFormat, newTarget, this )
+  1.  If newTarget is undefined and ? OrdinaryHasInstance(%DateTimeFormat%, this) is true, then
+      a.  Perform ? DefinePropertyOrThrow(this, %Intl%.[[FallbackSymbol]], PropertyDescriptor{
+          [[Value]]: dateTimeFormat, [[Writable]]: false, [[Enumerable]]: false,
+          [[Configurable]]: false }).
+      b.  Return this.
 ---*/
 
 Object.defineProperty(Intl.DateTimeFormat, Symbol.hasInstance, {

--- a/test/intl402/DateTimeFormat/prototype/format/no-instanceof.js
+++ b/test/intl402/DateTimeFormat/prototype/format/no-instanceof.js
@@ -2,17 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-Intl.DateTimeFormat.prototype.resolvedOptions
+esid: sec-intl.datetimeformat.prototype.format
 description: >
-  Tests that Intl.DateTimeFormat.prototype.resolvedOptions calls
+  Tests that Intl.DateTimeFormat.prototype.format calls
   OrdinaryHasInstance instead of the instanceof operator which includes a
   Symbol.hasInstance lookup and call among other things.
+info: >
+  UnwrapDateTimeFormat ( dtf )
+  2.  If dtf does not have an [[InitializedDateTimeFormat]] internal slot and
+      ? OrdinaryHasInstance(%DateTimeFormat%, dtf) is true, then
+      a.  Return ? Get(dtf, %Intl%.[[FallbackSymbol]]).
 ---*/
 
-const dtf = new Intl.DateTimeFormat();
+const dtf = Object.create(Intl.DateTimeFormat.prototype);
 
 Object.defineProperty(Intl.DateTimeFormat, Symbol.hasInstance, {
     get() { throw new Test262Error(); }
 });
 
-dtf.format;
+assert.throws(TypeError, () => dtf.format);

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/no-instanceof.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/no-instanceof.js
@@ -2,17 +2,22 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-Intl.DateTimeFormat.prototype.resolvedOptions
+esid: sec-intl.datetimeformat.prototype.resolvedoptions
 description: >
   Tests that Intl.DateTimeFormat.prototype.resolvedOptions calls
   OrdinaryHasInstance instead of the instanceof operator which includes a
   Symbol.hasInstance lookup and call among other things.
+info: >
+  UnwrapDateTimeFormat ( dtf )
+  2.  If dtf does not have an [[InitializedDateTimeFormat]] internal slot and
+      ? OrdinaryHasInstance(%DateTimeFormat%, dtf) is true, then
+      a.  Return ? Get(dtf, %Intl%.[[FallbackSymbol]]).
 ---*/
 
-const dtf = new Intl.DateTimeFormat();
+const dtf = Object.create(Intl.DateTimeFormat.prototype);
 
 Object.defineProperty(Intl.DateTimeFormat, Symbol.hasInstance, {
     get() { throw new Test262Error(); }
 });
 
-dtf.resolvedOptions();
+assert.throws(TypeError, () => dtf.resolvedOptions());

--- a/test/intl402/NumberFormat/constructor-no-instanceof.js
+++ b/test/intl402/NumberFormat/constructor-no-instanceof.js
@@ -2,11 +2,18 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-Intl.NumberFormat.prototype.resolvedOptions
+esid: sec-intl-numberformat-constructor
 description: >
-  Tests that Intl.NumberFormat.prototype.resolvedOptions calls
+  Tests that the Intl.NumberFormat constructor calls
   OrdinaryHasInstance instead of the instanceof operator which includes a
   Symbol.hasInstance lookup and call among other things.
+info: >
+  ChainNumberFormat ( numberFormat, newTarget, this )
+  1.  If newTarget is undefined and ? OrdinaryHasInstance(%NumberFormat%, this) is true, then
+      a.  Perform ? DefinePropertyOrThrow(this, %Intl%.[[FallbackSymbol]], PropertyDescriptor{
+          [[Value]]: numberFormat, [[Writable]]: false, [[Enumerable]]: false,
+          [[Configurable]]: false }).
+      b.  Return this.
 ---*/
 
 Object.defineProperty(Intl.NumberFormat, Symbol.hasInstance, {

--- a/test/intl402/NumberFormat/prototype/format/no-instanceof.js
+++ b/test/intl402/NumberFormat/prototype/format/no-instanceof.js
@@ -2,17 +2,23 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-Intl.NumberFormat.prototype.resolvedOptions
+esid: sec-intl.numberformat.prototype.format
 description: >
-  Tests that Intl.NumberFormat.prototype.resolvedOptions calls
+  Tests that Intl.NumberFormat.prototype.format calls
   OrdinaryHasInstance instead of the instanceof operator which includes a
   Symbol.hasInstance lookup and call among other things.
+info: >
+  UnwrapNumberFormat ( nf )
+
+  2.  If nf does not have an [[InitializedNumberFormat]] internal slot and
+      ? OrdinaryHasInstance(%NumberFormat%, nf) is true, then
+      a.  Return ? Get(nf, %Intl%.[[FallbackSymbol]]).
 ---*/
 
-const nf = new Intl.NumberFormat();
+const nf = Object.create(Intl.NumberFormat.prototype);
 
 Object.defineProperty(Intl.NumberFormat, Symbol.hasInstance, {
     get() { throw new Test262Error(); }
 });
 
-nf.format;
+assert.throws(TypeError, () => nf.format);

--- a/test/intl402/NumberFormat/prototype/resolvedOptions/no-instanceof.js
+++ b/test/intl402/NumberFormat/prototype/resolvedOptions/no-instanceof.js
@@ -2,17 +2,23 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-Intl.NumberFormat.prototype.resolvedOptions
+esid: sec-intl.numberformat.prototype.resolvedoptions
 description: >
   Tests that Intl.NumberFormat.prototype.resolvedOptions calls
   OrdinaryHasInstance instead of the instanceof operator which includes a
   Symbol.hasInstance lookup and call among other things.
+info: >
+  UnwrapNumberFormat ( nf )
+
+  2.  If nf does not have an [[InitializedNumberFormat]] internal slot and
+      ? OrdinaryHasInstance(%NumberFormat%, nf) is true, then
+      a.  Return ? Get(nf, %Intl%.[[FallbackSymbol]]).
 ---*/
 
-const nf = new Intl.NumberFormat();
+const nf = Object.create(Intl.NumberFormat.prototype);
 
 Object.defineProperty(Intl.NumberFormat, Symbol.hasInstance, {
     get() { throw new Test262Error(); }
 });
 
-nf.resolvedOptions();
+assert.throws(TypeError, () => nf.resolvedOptions());


### PR DESCRIPTION
This ensures that the `OrdinaryHasInstance` is actually reached in the test. It also fixes some issues with the preamble.