### PR TITLE
Intl: Add substantive tests for Array.prototype.toLocaleString

### DIFF
--- a/test/built-ins/Array/prototype/toLocaleString/invoke-element-tolocalestring.js
+++ b/test/built-ins/Array/prototype/toLocaleString/invoke-element-tolocalestring.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2022 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.prototype.tolocalestring
+description: >
+    The toLocaleString method of each non-undefined non-null element
+    must be called with no arguments.
+info: |
+    Array.prototype.toLocaleString ( [ _reserved1_ [ , _reserved2_ ] ] )
+
+    4. Let _R_ be the empty String.
+    5. Let _k_ be 0.
+    6. Repeat, while _k_ &lt; _len_,
+      a. If _k_ &gt; 0, then
+        i. Set _R_ to the string-concatenation of _R_ and _separator_.
+      b. Let _nextElement_ be ? Get(_array_, ! ToString(_k_)).
+      c. If _nextElement_ is not *undefined* or *null*, then
+        i. Let _S_ be ? ToString(? Invoke(_nextElement_, *"toLocaleString"*)).
+        ii. Set _R_ to the string-concatenation of _R_ and _S_.
+      d. Increase _k_ by 1.
+    7. Return _R_.
+includes: [compareArray.js]
+---*/
+
+const unique = {
+  toString() {
+    return "<sentinel object>";
+  }
+};
+
+const testCases = [
+  { label: "no arguments", args: [] },
+  { label: "undefined locale", args: [undefined] },
+  { label: "string locale", args: ["ar"] },
+  { label: "object locale", args: [unique] },
+  { label: "undefined locale and options", args: [undefined, unique] },
+  { label: "string locale and options", args: ["zh", unique] },
+  { label: "object locale and options", args: [unique, unique] },
+  { label: "extra arguments", args: [unique, unique, unique] },
+];
+
+for (const { label, args } of testCases) {
+  assert.sameValue([undefined].toLocaleString(...args), "",
+    `must skip undefined elements when provided ${label}`);
+}
+for (const { label, args, expectedArgs } of testCases) {
+  assert.sameValue([null].toLocaleString(...args), "",
+    `must skip null elements when provided ${label}`);
+}
+
+if (typeof Intl !== "object") {
+  for (const { label, args } of testCases) {
+    const spy = {
+      toLocaleString(...receivedArgs) {
+        assert.compareArray(receivedArgs, [],
+          `must invoke element toLocaleString with no arguments when provided ${label}`);
+        return "ok";
+      }
+    };
+    assert.sameValue([spy].toLocaleString(...args), "ok");
+  }
+}

--- a/test/intl402/Array/prototype/toLocaleString/invoke-element-tolocalestring.js
+++ b/test/intl402/Array/prototype/toLocaleString/invoke-element-tolocalestring.js
@@ -20,6 +20,7 @@ info: |
         ii. Set _R_ to the string-concatenation of _R_ and _S_.
       d. Increase _k_ by 1.
     7. Return _R_.
+includes: [compareArray.js]
 ---*/
 
 const unique = {
@@ -51,12 +52,8 @@ for (const { label, args, expectedArgs } of testCases) {
 for (const { label, args, expectedArgs } of testCases) {
   const spy = {
     toLocaleString(...receivedArgs) {
-      assert.sameValue(receivedArgs.length, 2,
-        `must invoke element toLocaleString with two arguments when provided ${label}`);
-      assert.sameValue(receivedArgs[0], expectedArgs[0],
-        `must invoke element toLocaleString with expected first argument when provided ${label}`);
-      assert.sameValue(receivedArgs[1], expectedArgs[1],
-        `must invoke element toLocaleString with expected second argument when provided ${label}`);
+      assert.compareArray(receivedArgs, expectedArgs,
+        `must invoke element toLocaleString with expected arguments when provided ${label}`);
       return "ok";
     }
   };

--- a/test/intl402/Array/prototype/toLocaleString/invoke-element-tolocalestring.js
+++ b/test/intl402/Array/prototype/toLocaleString/invoke-element-tolocalestring.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2022 Richard Gibson. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sup-array.prototype.tolocalestring
+description: >
+    The toLocaleString method of each non-undefined non-null element
+    must be called with two arguments.
+info: |
+    Array.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )
+
+    4. Let _R_ be the empty String.
+    5. Let _k_ be 0.
+    6. Repeat, while _k_ &lt; _len_,
+      a. If _k_ &gt; 0, then
+        i. Set _R_ to the string-concatenation of _R_ and _separator_.
+      b. Let _nextElement_ be ? Get(_array_, ! ToString(_k_)).
+      c. If _nextElement_ is not *undefined* or *null*, then
+        i. Let _S_ be ? ToString(? Invoke(_nextElement_, *"toLocaleString"*, &laquo; _locales_, _options_ &raquo;)).
+        ii. Set _R_ to the string-concatenation of _R_ and _S_.
+      d. Increase _k_ by 1.
+    7. Return _R_.
+---*/
+
+const unique = {
+  toString() {
+    return "<sentinel object>";
+  }
+};
+
+const testCases = [
+  { label: "no arguments", args: [], expectedArgs: [undefined, undefined] },
+  { label: "undefined locale", args: [undefined], expectedArgs: [undefined, undefined] },
+  { label: "string locale", args: ["ar"], expectedArgs: ["ar", undefined] },
+  { label: "object locale", args: [unique], expectedArgs: [unique, undefined] },
+  { label: "undefined locale and options", args: [undefined, unique], expectedArgs: [undefined, unique] },
+  { label: "string locale and options", args: ["zh", unique], expectedArgs: ["zh", unique] },
+  { label: "object locale and options", args: [unique, unique], expectedArgs: [unique, unique] },
+  { label: "extra arguments", args: [unique, unique, unique], expectedArgs: [unique, unique] },
+];
+
+for (const { label, args, expectedArgs } of testCases) {
+  assert.sameValue([undefined].toLocaleString(...args), "",
+    `must skip undefined elements when provided ${label}`);
+}
+for (const { label, args, expectedArgs } of testCases) {
+  assert.sameValue([null].toLocaleString(...args), "",
+    `must skip null elements when provided ${label}`);
+}
+
+for (const { label, args, expectedArgs } of testCases) {
+  const spy = {
+    toLocaleString(...receivedArgs) {
+      assert.sameValue(receivedArgs.length, 2,
+        `must invoke element toLocaleString with two arguments when provided ${label}`);
+      assert.sameValue(receivedArgs[0], expectedArgs[0],
+        `must invoke element toLocaleString with expected first argument when provided ${label}`);
+      assert.sameValue(receivedArgs[1], expectedArgs[1],
+        `must invoke element toLocaleString with expected second argument when provided ${label}`);
+      return "ok";
+    }
+  };
+  assert.sameValue([spy].toLocaleString(...args), "ok");
+}


### PR DESCRIPTION
Several implementations get this method wrong, including [V8](https://bugs.chromium.org/p/v8/issues/detail?id=13564) and [GraalJS](https://github.com/oracle/graal/issues/5562).
```sh
$ npm run test:diff:v8

> test262@5.0.0 test:diff:v8
> test262-harness -t 8 --hostType=d8 --hostPath=v8 $(npm run --silent diff)

FAIL test/intl402/Array/prototype/toLocaleString/invoke-element-tolocalestring.js (strict mode)
  must invoke element toLocaleString with two arguments when provided no arguments Expected SameValue(«0», «2») to be true

FAIL test/intl402/Array/prototype/toLocaleString/invoke-element-tolocalestring.js (default)
  must invoke element toLocaleString with two arguments when provided no arguments Expected SameValue(«0», «2») to be true

Ran 2 tests
0 passed
2 failed
```