### PR TITLE
Array.fromAsync: Boilerplate tests

### DIFF
--- a/harness/isConstructor.js
+++ b/harness/isConstructor.js
@@ -5,6 +5,7 @@
 description: |
     Test if a given function is a constructor function.
 defines: [isConstructor]
+features: [Reflect.construct]
 ---*/
 
 function isConstructor(f) {

--- a/test/built-ins/Array/fromAsync/builtin.js
+++ b/test/built-ins/Array/fromAsync/builtin.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.fromasync
+description: Array.fromAsync meets the requirements for built-in objects
+info: |
+  Unless specified otherwise, a built-in object that is callable as a function
+  is a built-in function object with the characteristics described in 10.3.
+  Unless specified otherwise, the [[Extensible]] internal slot of a built-in
+  object initially has the value *true*.
+
+  Unless otherwise specified every built-in function and every built-in
+  constructor has the Function prototype object, which is the initial value of
+  the expression Function.prototype (20.2.3), as the value of its [[Prototype]]
+  internal slot.
+
+  Built-in functions that are not constructors do not have a "prototype"
+  property unless otherwise specified in the description of a particular
+  function.
+features: [Array.fromAsync]
+---*/
+
+assert(Object.isExtensible(Array.fromAsync), "Array.fromAsync is extensible");
+
+assert.sameValue(
+  Object.getPrototypeOf(Array.fromAsync),
+  Function.prototype,
+  "Prototype of Array.fromAsync is Function.prototype"
+);
+
+assert.sameValue(
+  Object.getOwnPropertyDescriptor(Array.fromAsync, "prototype"),
+  undefined,
+  "Array.fromAsync has no own prototype property"
+);

--- a/test/built-ins/Array/fromAsync/length.js
+++ b/test/built-ins/Array/fromAsync/length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.fromasync
+description: Value and property descriptor of Array.fromAsync.length
+info: |
+  Every built-in function object, including constructors, has a *"length"*
+  property whose value is a non-negative integral Number. Unless otherwise
+  specified, this value is equal to the number of required parameters shown in
+  the subclause heading for the function description. Optional parameters and
+  rest parameters are not included in the parameter count.
+
+  Unless otherwise specified, the *"length"* property of a built-in function
+  object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*,
+  [[Configurable]]: *true* }.
+includes: [propertyHelper.js]
+features: [Array.fromAsync]
+---*/
+
+verifyProperty(Array.fromAsync, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Array/fromAsync/name.js
+++ b/test/built-ins/Array/fromAsync/name.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.fromasync
+description: Value and property descriptor of Array.fromAsync.name
+info: |
+  Every built-in function object, including constructors, has a *"name"*
+  property whose value is a String. Unless otherwise specified, this value is
+  the name that is given to the function in this specification. [...]
+  For functions that are specified as properties of objects, the name value is
+  the property name string used to access the function.
+
+  Unless otherwise specified, the *"name"* property of a built-in function
+  object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Array.fromAsync]
+---*/
+
+verifyProperty(Array.fromAsync, "name", {
+  value: "fromAsync",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/test/built-ins/Array/fromAsync/not-a-constructor.js
+++ b/test/built-ins/Array/fromAsync/not-a-constructor.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.fromasync
+description: Array.fromAsync is not a constructor
+info: |
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in the
+  description of a particular function.
+includes: [isConstructor.js]
+features: [Array.fromAsync, Reflect.construct]
+---*/
+
+assert(!isConstructor(Array.fromAsync), "Array.fromAsync is not a constructor");
+
+assert.throws(TypeError, () => new Array.fromAsync(), "Array.fromAsync throws when constructed");

--- a/test/built-ins/Array/fromAsync/prop-desc.js
+++ b/test/built-ins/Array/fromAsync/prop-desc.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-array.fromasync
+description: Type and property descriptor of Array.fromAsync
+info: |
+  Every other data property described in clauses 19 through 28 and in Annex B.2
+  has the attributes { [[Writable]]: *true*, [[Enumerable]]: *false*,
+  [[Configurable]]: *true* } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [Array.fromAsync]
+---*/
+
+assert.sameValue(typeof Array.fromAsync, "function", "Array.fromAsync is callable");
+
+verifyProperty(Array, 'fromAsync', {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});


### PR DESCRIPTION
Here are some of the standard tests for property metadata of the Array.fromAsync property and for the built-in function object. These don't require doing anything asynchronously, so can be considered separately from the Async Helpers RFC.

See: #3725