### PR TITLE
Reject exceptional input to `isConstructor`

### DIFF
--- a/harness/isConstructor.js
+++ b/harness/isConstructor.js
@@ -8,6 +8,10 @@ defines: [isConstructor]
 ---*/
 
 function isConstructor(f) {
+    if (typeof f !== "function") {
+      throw new Test262Error("isConstructor invoked with a non-function vale");
+    }
+
     try {
         Reflect.construct(function(){}, [], f);
     } catch (e) {

--- a/harness/isConstructor.js
+++ b/harness/isConstructor.js
@@ -9,7 +9,7 @@ defines: [isConstructor]
 
 function isConstructor(f) {
     if (typeof f !== "function") {
-      throw new Test262Error("isConstructor invoked with a non-function vale");
+      throw new Test262Error("isConstructor invoked with a non-function value");
     }
 
     try {

--- a/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls-argument.js
+++ b/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls-argument.js
@@ -40,10 +40,6 @@ var expected = [
 
 var then = Promise.prototype.then;
 Promise.prototype.then = function(resolve, reject) {
-  assert.sameValue(isConstructor(reject), false, 'isConstructor(reject) must return false');
-  assert.throws(TypeError, () => {
-    new reject();
-  }, '`new reject()` throws TypeError');
 
   assert.sameValue(
     resolve.length,
@@ -57,6 +53,12 @@ Promise.prototype.then = function(resolve, reject) {
   );
   if (calls === 0) {
     assert.throws(MyError, resolve, '`resolve()` throws `MyError`');
+    assert.sameValue(arguments.length, 1, '`then` invoked with one argument');
+  } else {
+    assert.sameValue(isConstructor(reject), false, 'isConstructor(reject) must return false');
+    assert.throws(TypeError, () => {
+      new reject();
+    }, '`new reject()` throws TypeError');
   }
 
   calls += 1;

--- a/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls-argument.js
+++ b/test/built-ins/Promise/prototype/finally/rejected-observable-then-calls-argument.js
@@ -59,6 +59,7 @@ Promise.prototype.then = function(resolve, reject) {
     assert.throws(TypeError, () => {
       new reject();
     }, '`new reject()` throws TypeError');
+    assert.sameValue(arguments.length, 2, '`then` invoked with two arguments');
   }
 
   calls += 1;

--- a/test/harness/isConstructor.js
+++ b/test/harness/isConstructor.js
@@ -13,16 +13,16 @@ features: [generators, Reflect.construct]
 
 assert.sameValue(typeof isConstructor, "function");
 
-assert.sameValue(isConstructor(), false);
-assert.sameValue(isConstructor(undefined), false);
-assert.sameValue(isConstructor(null), false);
-assert.sameValue(isConstructor(123), false);
-assert.sameValue(isConstructor(true), false);
-assert.sameValue(isConstructor(false), false);
-assert.sameValue(isConstructor("string"), false);
+assert.throws(Test262Error, () => isConstructor(), "no argument");
+assert.throws(Test262Error, () => isConstructor(undefined), "undefined");
+assert.throws(Test262Error, () => isConstructor(null), "null");
+assert.throws(Test262Error, () => isConstructor(123), "number");
+assert.throws(Test262Error, () => isConstructor(true), "boolean - true");
+assert.throws(Test262Error, () => isConstructor(false), "boolean - false");
+assert.throws(Test262Error, () => isConstructor("string"), "string");
 
-assert.sameValue(isConstructor({}), false);
-assert.sameValue(isConstructor([]), false);
+assert.throws(Test262Error, () => isConstructor({}), "Object instance");
+assert.throws(Test262Error, () => isConstructor([]), "Array instance");
 
 assert.sameValue(isConstructor(function(){}), true);
 assert.sameValue(isConstructor(function*(){}), false);


### PR DESCRIPTION
Prior to this commit, the `isConstructor` harness function would return `false` when invoked with a value that lacked a [[Call]] internal method. While it's true that such values are not constructors, there are no tests which intentionally use `isConstructor` to make such an assertion.

Extend `isConstructor` to throw an error when invoked with a non-function object.

---

After [suggesting](https://github.com/tc39/test262/pull/3747#pullrequestreview-1212093083) to @ptomato to explicitly verify the "callable" nature of a value in a new test, I couldn't think of any reason one would want to use `isConstructor` on a non-function value. And although the test code for the utility very explicitly supports the current behavior, the test description indicates that such input should be considered exceptional:

> Test if a given function is a constructor function.

For what it's worth, V8 is spuriously passing the following six tests due to the current behavior:

- [test/built-ins/FinalizationRegistry/prototype/cleanupSome/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/FinalizationRegistry/prototype/cleanupSome/not-a-constructor.js)
- [test/built-ins/String/prototype/isWellFormed/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/String/prototype/isWellFormed/not-a-constructor.js)
- [test/built-ins/String/prototype/toWellFormed/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/String/prototype/toWellFormed/not-a-constructor.js)
- [test/intl402/DurationFormat/prototype/format/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/intl402/DurationFormat/prototype/format/not-a-constructor.js)
- [test/intl402/DurationFormat/prototype/formatToParts/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/intl402/DurationFormat/prototype/formatToParts/not-a-constructor.js)
- [test/built-ins/Temporal/Calendar/prototype/yearOfWeek/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/not-a-constructor.js)

SpiderMonkey spuriously passes the following 13 tests:

- [test/built-ins/Array/prototype/findLastIndex/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/Array/prototype/findLastIndex/not-a-constructor.js)
- [test/built-ins/Array/prototype/findLast/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/Array/prototype/findLast/not-a-constructor.js)
- [test/built-ins/Array/prototype/toReversed/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/Array/prototype/toReversed/not-a-constructor.js)
- [test/built-ins/Array/prototype/toSorted/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/Array/prototype/toSorted/not-a-constructor.js)
- [test/built-ins/Array/prototype/toSpliced/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/Array/prototype/toSpliced/not-a-constructor.js)
- [test/built-ins/Array/prototype/with/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/Array/prototype/with/not-a-constructor.js)
- [test/built-ins/String/prototype/isWellFormed/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/String/prototype/isWellFormed/not-a-constructor.js)
- [test/built-ins/String/prototype/toWellFormed/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/String/prototype/toWellFormed/not-a-constructor.js)
- [test/built-ins/TypedArray/prototype/findLastIndex/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/TypedArray/prototype/findLastIndex/not-a-constructor.js)
- [test/built-ins/TypedArray/prototype/findLast/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/TypedArray/prototype/findLast/not-a-constructor.js)
- [test/built-ins/TypedArray/prototype/toReversed/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/TypedArray/prototype/toReversed/not-a-constructor.js)
- [test/built-ins/TypedArray/prototype/toSorted/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/TypedArray/prototype/toSorted/not-a-constructor.js)
- [test/built-ins/TypedArray/prototype/with/not-a-constructor.js](https://github.com/tc39/test262/blob/8cd563f97850226ca19570bff82f07cb761a534c/test/built-ins/TypedArray/prototype/with/not-a-constructor.js)