### PR TITLE
Fix Temporal test failures under Node 19

### DIFF
--- a/test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/resolved-time-zone.js
+++ b/test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/resolved-time-zone.js
@@ -8,10 +8,23 @@ locale: [en]
 features: [Temporal]
 ---*/
 
+// Using 24-hour clock to avoid format differences between Node 19 (which puts
+// "\u{202f}" before AM/PM) and previous versions that use regular spaces.
+const options = {
+  timeZone: "Pacific/Apia",
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+  hourCycle: "h23"
+};
+
 const datetime1 = new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789);
-const result1 = datetime1.toLocaleString("en", { timeZone: "Pacific/Apia" });
-assert.sameValue(result1, "8/4/2021, 12:30:45 AM");
+const result1 = datetime1.toLocaleString("en", options);
+assert.sameValue(result1, "8/4/2021, 00:30:45");
 
 const datetime2 = new Temporal.PlainDateTime(2021, 8, 4, 23, 30, 45, 123, 456, 789);
-const result2 = datetime2.toLocaleString("en", { timeZone: "Pacific/Apia" });
-assert.sameValue(result2, "8/4/2021, 11:30:45 PM");
+const result2 = datetime2.toLocaleString("en", options);
+assert.sameValue(result2, "8/4/2021, 23:30:45");

--- a/test/intl402/Temporal/PlainTime/prototype/toLocaleString/resolved-time-zone.js
+++ b/test/intl402/Temporal/PlainTime/prototype/toLocaleString/resolved-time-zone.js
@@ -8,10 +8,20 @@ locale: [en]
 features: [Temporal]
 ---*/
 
+// Using 24-hour clock to avoid format differences between Node 19 (which puts
+// "\u{202f}" before AM/PM) and previous versions that use regular spaces.
+const options = {
+  timeZone: "Pacific/Apia",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+  hourCycle: "h23"
+};
+
 const time1 = new Temporal.PlainTime(0, 30, 45, 123, 456, 789);
-const result1 = time1.toLocaleString("en", { timeZone: "Pacific/Apia" });
-assert.sameValue(result1, "12:30:45 AM");
+const result1 = time1.toLocaleString("en", options);
+assert.sameValue(result1, "00:30:45");
 
 const time2 = new Temporal.PlainTime(23, 30, 45, 123, 456, 789);
-const result2 = time2.toLocaleString("en", { timeZone: "Pacific/Apia" });
-assert.sameValue(result2, "11:30:45 PM");
+const result2 = time2.toLocaleString("en", options);
+assert.sameValue(result2, "23:30:45");


### PR DESCRIPTION
Node 19 includes an update to ICU that broke two Temporal tests. This PR changes those tests to use more Node-version-agnostic formats. 