### PR TITLE
Support running Temporal tests in Node 19 (cont'd for staging tests)

### DIFF
--- a/test/staging/Intl402/Temporal/old/date-time-format.js
+++ b/test/staging/Intl402/Temporal/old/date-time-format.js
@@ -1,4 +1,3 @@
-
 // Copyright (C) 2018 Bloomberg LP. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
@@ -9,15 +8,14 @@ includes: [deepEqual.js]
 features: [Temporal]
 ---*/
 
-//should return an Array"
+// should return an Array
 
 assert(Array.isArray(Intl.DateTimeFormat.supportedLocalesOf()));
-var onlyOnce = value => {
+var onlyOnce = (value) => {
   var obj = {
     calls: 0,
     toString() {
-      if (++this.calls > 1)
-        throw new RangeError("prop read twice");
+      if (++this.calls > 1) throw new RangeError("prop read twice");
       return value;
     }
   };
@@ -28,8 +26,7 @@ var optionsUS = {
   calls: 0,
   value: "America/New_York",
   get timeZone() {
-    if (++this.calls > 1)
-      throw new RangeError("prop read twice");
+    if (++this.calls > 1) throw new RangeError("prop read twice");
     return this.value;
   },
   set timeZone(val) {
@@ -54,41 +51,41 @@ var t2 = "2020-02-20T15:44:56-05:00[America/New_York]";
 var start = new Date("1922-12-30");
 var end = new Date("1991-12-26");
 
-//should work for Instant 
+// should work for Instant
 assert.sameValue(us.format(Temporal.Instant.from(t1)), "11/18/1976, 9:23:30 AM");
 assert.sameValue(at.format(Temporal.Instant.from(t1)), "18.11.1976, 15:23:30");
-  
-//should work for ZonedDateTime 
+
+// should work for ZonedDateTime
 assert.sameValue(us2.format(Temporal.ZonedDateTime.from(t1)), "11/18/1976, 2:23:30 PM UTC");
 assert.sameValue(at2.format(Temporal.ZonedDateTime.from(t1)), "18.11.1976, 14:23:30 UTC");
-  
-//should work for DateTime 
+
+// should work for DateTime
 assert.sameValue(us.format(Temporal.PlainDateTime.from(t1)), "11/18/1976, 2:23:30 PM");
 assert.sameValue(at.format(Temporal.PlainDateTime.from(t1)), "18.11.1976, 14:23:30");
-  
-//should work for Time 
+
+// should work for Time
 assert.sameValue(us.format(Temporal.PlainTime.from(t1)), "2:23:30 PM");
 assert.sameValue(at.format(Temporal.PlainTime.from(t1)), "14:23:30");
 
-//should work for Date 
+// should work for Date
 assert.sameValue(us.format(Temporal.PlainDate.from(t1)), "11/18/1976");
 assert.sameValue(at.format(Temporal.PlainDate.from(t1)), "18.11.1976");
-  
-//should work for YearMonth 
+
+// should work for YearMonth
 var t = Temporal.PlainDate.from(t1);
 assert.sameValue(us.format(t.withCalendar(usCalendar).toPlainYearMonth()), "11/1976");
 assert.sameValue(at.format(t.withCalendar(atCalendar).toPlainYearMonth()), "11.1976");
-  
-//should work for MonthDay 
+
+// should work for MonthDay
 var t = Temporal.PlainDate.from(t1);
 assert.sameValue(us.format(t.withCalendar(usCalendar).toPlainMonthDay()), "11/18");
 assert.sameValue(at.format(t.withCalendar(atCalendar).toPlainMonthDay()), "18.11.");
-  
-//should not break legacy Date 
+
+// should not break legacy Date
 assert.sameValue(us.format(start), "12/29/1922");
 assert.sameValue(at.format(start), "30.12.1922");
 
-//should work for Instant 
+// should work for Instant
 assert.deepEqual(us.formatToParts(Temporal.Instant.from(t2)), [
   {
     type: "month",
@@ -189,7 +186,7 @@ assert.deepEqual(at.formatToParts(Temporal.Instant.from(t2)), [
     value: "56"
   }
 ]);
-//should work for ZonedDateTime 
+// should work for ZonedDateTime
 assert.deepEqual(us2.formatToParts(Temporal.ZonedDateTime.from(t2)), [
   {
     type: "month",
@@ -306,7 +303,7 @@ assert.deepEqual(at2.formatToParts(Temporal.ZonedDateTime.from(t2)), [
     value: "GMT-5"
   }
 ]);
-//should work for DateTime 
+// should work for DateTime
 assert.deepEqual(us.formatToParts(Temporal.PlainDateTime.from(t2)), [
   {
     type: "month",
@@ -407,7 +404,7 @@ assert.deepEqual(at.formatToParts(Temporal.PlainDateTime.from(t2)), [
     value: "56"
   }
 ]);
-//should work for Time 
+// should work for Time
 assert.deepEqual(us.formatToParts(Temporal.PlainTime.from(t2)), [
   {
     type: "hour",
@@ -460,7 +457,7 @@ assert.deepEqual(at.formatToParts(Temporal.PlainTime.from(t2)), [
     value: "56"
   }
 ]);
-//should work for Date 
+// should work for Date
 assert.deepEqual(us.formatToParts(Temporal.PlainDate.from(t2)), [
   {
     type: "month",
@@ -505,7 +502,7 @@ assert.deepEqual(at.formatToParts(Temporal.PlainDate.from(t2)), [
     value: "2020"
   }
 ]);
-//should work for YearMonth 
+// should work for YearMonth
 var t = Temporal.PlainDate.from(t2);
 assert.deepEqual(us.formatToParts(t.withCalendar(usCalendar).toPlainYearMonth()), [
   {
@@ -535,7 +532,7 @@ assert.deepEqual(at.formatToParts(t.withCalendar(atCalendar).toPlainYearMonth())
     value: "2020"
   }
 ]);
-//should work for MonthDay 
+// should work for MonthDay
 var t = Temporal.PlainDate.from(t2);
 assert.deepEqual(us.formatToParts(t.withCalendar(usCalendar).toPlainMonthDay()), [
   {
@@ -569,7 +566,7 @@ assert.deepEqual(at.formatToParts(t.withCalendar(atCalendar).toPlainMonthDay()),
     value: "."
   }
 ]);
-//should not break legacy Date 
+// should not break legacy Date
 assert.deepEqual(us.formatToParts(end), [
   {
     type: "month",
@@ -614,55 +611,92 @@ assert.deepEqual(at.formatToParts(end), [
     value: "1991"
   }
 ]);
-//formatRange 
-//should work for Instant 
-assert.sameValue(us.formatRange(Temporal.Instant.from(t1), Temporal.Instant.from(t2)), "11/18/1976, 9:23:30 AM \u2013 2/20/2020, 3:44:56 PM");
-assert.sameValue(at.formatRange(Temporal.Instant.from(t1), Temporal.Instant.from(t2)), "18.11.1976, 15:23:30 \u2013 20.2.2020, 21:44:56");
+// formatRange
+// should work for Instant
+assert.sameValue(
+  us.formatRange(Temporal.Instant.from(t1), Temporal.Instant.from(t2)),
+  "11/18/1976, 9:23:30 AM \u2013 2/20/2020, 3:44:56 PM"
+);
+assert.sameValue(
+  at.formatRange(Temporal.Instant.from(t1), Temporal.Instant.from(t2)),
+  "18.11.1976, 15:23:30 \u2013 20.2.2020, 21:44:56"
+);
 
-//should work for ZonedDateTime 
+// should work for ZonedDateTime
 var zdt1 = Temporal.ZonedDateTime.from(t1);
 var zdt2 = Temporal.ZonedDateTime.from(t2).withTimeZone(zdt1.timeZone);
 assert.sameValue(us2.formatRange(zdt1, zdt2), "11/18/1976, 2:23:30 PM UTC \u2013 2/20/2020, 8:44:56 PM UTC");
 assert.sameValue(at2.formatRange(zdt1, zdt2), "18.11.1976, 14:23:30 UTC \u2013 20.2.2020, 20:44:56 UTC");
 
-//should work for DateTime 
-assert.sameValue(us.formatRange(Temporal.PlainDateTime.from(t1), Temporal.PlainDateTime.from(t2)), "11/18/1976, 2:23:30 PM \u2013 2/20/2020, 3:44:56 PM");
-assert.sameValue(at.formatRange(Temporal.PlainDateTime.from(t1), Temporal.PlainDateTime.from(t2)), "18.11.1976, 14:23:30 \u2013 20.2.2020, 15:44:56");
+// should work for DateTime
+assert.sameValue(
+  us.formatRange(Temporal.PlainDateTime.from(t1), Temporal.PlainDateTime.from(t2)),
+  "11/18/1976, 2:23:30 PM \u2013 2/20/2020, 3:44:56 PM"
+);
+assert.sameValue(
+  at.formatRange(Temporal.PlainDateTime.from(t1), Temporal.PlainDateTime.from(t2)),
+  "18.11.1976, 14:23:30 \u2013 20.2.2020, 15:44:56"
+);
 
-//should work for Time 
-assert.sameValue(us.formatRange(Temporal.PlainTime.from(t1), Temporal.PlainTime.from(t2)), "2:23:30 PM \u2013 3:44:56 PM");
+// should work for Time
+assert.sameValue(
+  us.formatRange(Temporal.PlainTime.from(t1), Temporal.PlainTime.from(t2)),
+  "2:23:30 PM \u2013 3:44:56 PM"
+);
 assert.sameValue(at.formatRange(Temporal.PlainTime.from(t1), Temporal.PlainTime.from(t2)), "14:23:30 \u2013 15:44:56");
 
-//should work for Date 
-assert.sameValue(us.formatRange(Temporal.PlainDate.from(t1), Temporal.PlainDate.from(t2)), "11/18/1976 \u2013 2/20/2020");
-assert.sameValue(at.formatRange(Temporal.PlainDate.from(t1), Temporal.PlainDate.from(t2)), "18.11.1976 \u2013 20.02.2020");
+// should work for Date
+assert.sameValue(
+  us.formatRange(Temporal.PlainDate.from(t1), Temporal.PlainDate.from(t2)),
+  "11/18/1976 \u2013 2/20/2020"
+);
+assert.sameValue(
+  at.formatRange(Temporal.PlainDate.from(t1), Temporal.PlainDate.from(t2)),
+  "18.11.1976 \u2013 20.02.2020"
+);
 
-//should work for YearMonth 
+// should work for YearMonth
 var date1 = Temporal.PlainDate.from(t1);
 var date2 = Temporal.PlainDate.from(t2);
-assert.sameValue(us.formatRange(date1.withCalendar(usCalendar).toPlainYearMonth(), date2.withCalendar(usCalendar).toPlainYearMonth()), "11/1976 \u2013 2/2020");
-assert.sameValue(at.formatRange(date1.withCalendar(atCalendar).toPlainYearMonth(), date2.withCalendar(atCalendar).toPlainYearMonth()), "11.1976 \u2013 02.2020");
+assert.sameValue(
+  us.formatRange(date1.withCalendar(usCalendar).toPlainYearMonth(), date2.withCalendar(usCalendar).toPlainYearMonth()),
+  "11/1976 \u2013 2/2020"
+);
+assert.sameValue(
+  at.formatRange(date1.withCalendar(atCalendar).toPlainYearMonth(), date2.withCalendar(atCalendar).toPlainYearMonth()),
+  "11.1976 \u2013 02.2020"
+);
 
-//should work for MonthDay 
+// should work for MonthDay
 var date1 = Temporal.PlainDate.from(t1);
 var date2 = Temporal.PlainDate.from(t2);
-assert.sameValue(us.formatRange(date2.withCalendar(usCalendar).toPlainMonthDay(), date1.withCalendar(usCalendar).toPlainMonthDay()), "2/20 \u2013 11/18");
-assert.sameValue(at.formatRange(date2.withCalendar(atCalendar).toPlainMonthDay(), date1.withCalendar(atCalendar).toPlainMonthDay()), "20.02. \u2013 18.11.");
+assert.sameValue(
+  us.formatRange(date2.withCalendar(usCalendar).toPlainMonthDay(), date1.withCalendar(usCalendar).toPlainMonthDay()),
+  "2/20 \u2013 11/18"
+);
+assert.sameValue(
+  at.formatRange(date2.withCalendar(atCalendar).toPlainMonthDay(), date1.withCalendar(atCalendar).toPlainMonthDay()),
+  "20.02. \u2013 18.11."
+);
 
-//should not break legacy Date 
+// should not break legacy Date
 assert.sameValue(us.formatRange(start, end), "12/29/1922 \u2013 12/25/1991");
 assert.sameValue(at.formatRange(start, end), "30.12.1922 \u2013 26.12.1991");
 
-//should throw a TypeError when called with dissimilar types", () => assert.throws(TypeError, () => us.formatRange(Temporal.Instant.from(t1), Temporal.PlainDateTime.from(t2))));
-//should throw a RangeError when called with different calendars 
-assert.throws(RangeError, () => us.formatRange(Temporal.PlainDateTime.from(t1), Temporal.PlainDateTime.from(t2).withCalendar("japanese")));
-assert.throws(RangeError, () => us.formatRange(Temporal.PlainDate.from(t1), Temporal.PlainDate.from(t2).withCalendar("japanese")));
+// should throw a TypeError when called with dissimilar types", () => assert.throws(TypeError, () => us.formatRange(Temporal.Instant.from(t1), Temporal.PlainDateTime.from(t2))));
+// should throw a RangeError when called with different calendars
+assert.throws(RangeError, () =>
+  us.formatRange(Temporal.PlainDateTime.from(t1), Temporal.PlainDateTime.from(t2).withCalendar("japanese"))
+);
+assert.throws(RangeError, () =>
+  us.formatRange(Temporal.PlainDate.from(t1), Temporal.PlainDate.from(t2).withCalendar("japanese"))
+);
 
-//throws for two ZonedDateTimes with different time zones 
+// throws for two ZonedDateTimes with different time zones
 assert.throws(RangeError, () => us2.formatRange(Temporal.ZonedDateTime.from(t1), Temporal.ZonedDateTime.from(t2)));
 
-//formatRangeToParts 
-//should work for Instant 
+// formatRangeToParts
+// should work for Instant
 assert.deepEqual(us.formatRangeToParts(Temporal.Instant.from(t1), Temporal.Instant.from(t2)), [
   {
     type: "month",
@@ -918,7 +952,7 @@ assert.deepEqual(at.formatRangeToParts(Temporal.Instant.from(t1), Temporal.Insta
   }
 ]);
 
-//should work for ZonedDateTime 
+// should work for ZonedDateTime
 var zdt1 = Temporal.ZonedDateTime.from(t1);
 var zdt2 = Temporal.ZonedDateTime.from(t2).withTimeZone(zdt1.timeZone);
 assert.deepEqual(us2.formatRangeToParts(zdt1, zdt2), [
@@ -1215,7 +1249,7 @@ assert.deepEqual(at2.formatRangeToParts(zdt1, zdt2), [
     source: "endRange"
   }
 ]);
-//should work for DateTime 
+// should work for DateTime
 assert.deepEqual(us.formatRangeToParts(Temporal.PlainDateTime.from(t1), Temporal.PlainDateTime.from(t2)), [
   {
     type: "month",
@@ -1470,7 +1504,7 @@ assert.deepEqual(at.formatRangeToParts(Temporal.PlainDateTime.from(t1), Temporal
     source: "endRange"
   }
 ]);
-//should work for Time 
+// should work for Time
 assert.deepEqual(us.formatRangeToParts(Temporal.PlainTime.from(t1), Temporal.PlainTime.from(t2)), [
   {
     type: "hour",
@@ -1605,7 +1639,7 @@ assert.deepEqual(at.formatRangeToParts(Temporal.PlainTime.from(t1), Temporal.Pla
     source: "endRange"
   }
 ]);
-//should work for Date 
+// should work for Date
 assert.deepEqual(us.formatRangeToParts(Temporal.PlainDate.from(t1), Temporal.PlainDate.from(t2)), [
   {
     type: "month",
@@ -1720,166 +1754,190 @@ assert.deepEqual(at.formatRangeToParts(Temporal.PlainDate.from(t1), Temporal.Pla
     source: "endRange"
   }
 ]);
-//should work for YearMonth 
+// should work for YearMonth
 var date1 = Temporal.PlainDate.from(t1);
 var date2 = Temporal.PlainDate.from(t2);
-assert.deepEqual(us.formatRangeToParts(date1.withCalendar(usCalendar).toPlainYearMonth(), date2.withCalendar(usCalendar).toPlainYearMonth()), [
-  {
-    type: "month",
-    value: "11",
-    source: "startRange"
-  },
-  {
-    type: "literal",
-    value: "/",
-    source: "startRange"
-  },
-  {
-    type: "year",
-    value: "1976",
-    source: "startRange"
-  },
-  {
-    type: "literal",
-    value: " \u2013 ",
-    source: "shared"
-  },
-  {
-    type: "month",
-    value: "2",
-    source: "endRange"
-  },
-  {
-    type: "literal",
-    value: "/",
-    source: "endRange"
-  },
-  {
-    type: "year",
-    value: "2020",
-    source: "endRange"
-  }
-]);
-assert.deepEqual(at.formatRangeToParts(date1.withCalendar(atCalendar).toPlainYearMonth(), date2.withCalendar(atCalendar).toPlainYearMonth()), [
-  {
-    type: "month",
-    value: "11",
-    source: "startRange"
-  },
-  {
-    type: "literal",
-    value: ".",
-    source: "startRange"
-  },
-  {
-    type: "year",
-    value: "1976",
-    source: "startRange"
-  },
-  {
-    type: "literal",
-    value: " \u2013 ",
-    source: "shared"
-  },
-  {
-    type: "month",
-    value: "02",
-    source: "endRange"
-  },
-  {
-    type: "literal",
-    value: ".",
-    source: "endRange"
-  },
-  {
-    type: "year",
-    value: "2020",
-    source: "endRange"
-  }
-]);
-//should work for MonthDay 
+assert.deepEqual(
+  us.formatRangeToParts(
+    date1.withCalendar(usCalendar).toPlainYearMonth(),
+    date2.withCalendar(usCalendar).toPlainYearMonth()
+  ),
+  [
+    {
+      type: "month",
+      value: "11",
+      source: "startRange"
+    },
+    {
+      type: "literal",
+      value: "/",
+      source: "startRange"
+    },
+    {
+      type: "year",
+      value: "1976",
+      source: "startRange"
+    },
+    {
+      type: "literal",
+      value: " \u2013 ",
+      source: "shared"
+    },
+    {
+      type: "month",
+      value: "2",
+      source: "endRange"
+    },
+    {
+      type: "literal",
+      value: "/",
+      source: "endRange"
+    },
+    {
+      type: "year",
+      value: "2020",
+      source: "endRange"
+    }
+  ]
+);
+assert.deepEqual(
+  at.formatRangeToParts(
+    date1.withCalendar(atCalendar).toPlainYearMonth(),
+    date2.withCalendar(atCalendar).toPlainYearMonth()
+  ),
+  [
+    {
+      type: "month",
+      value: "11",
+      source: "startRange"
+    },
+    {
+      type: "literal",
+      value: ".",
+      source: "startRange"
+    },
+    {
+      type: "year",
+      value: "1976",
+      source: "startRange"
+    },
+    {
+      type: "literal",
+      value: " \u2013 ",
+      source: "shared"
+    },
+    {
+      type: "month",
+      value: "02",
+      source: "endRange"
+    },
+    {
+      type: "literal",
+      value: ".",
+      source: "endRange"
+    },
+    {
+      type: "year",
+      value: "2020",
+      source: "endRange"
+    }
+  ]
+);
+// should work for MonthDay
 var date1 = Temporal.PlainDate.from(t1);
 var date2 = Temporal.PlainDate.from(t2);
-assert.deepEqual(us.formatRangeToParts(date2.withCalendar(usCalendar).toPlainMonthDay(), date1.withCalendar(usCalendar).toPlainMonthDay()), [
-  {
-    type: "month",
-    value: "2",
-    source: "startRange"
-  },
-  {
-    type: "literal",
-    value: "/",
-    source: "startRange"
-  },
-  {
-    type: "day",
-    value: "20",
-    source: "startRange"
-  },
-  {
-    type: "literal",
-    value: " \u2013 ",
-    source: "shared"
-  },
-  {
-    type: "month",
-    value: "11",
-    source: "endRange"
-  },
-  {
-    type: "literal",
-    value: "/",
-    source: "endRange"
-  },
-  {
-    type: "day",
-    value: "18",
-    source: "endRange"
-  }
-]);
-assert.deepEqual(at.formatRangeToParts(date2.withCalendar(atCalendar).toPlainMonthDay(), date1.withCalendar(atCalendar).toPlainMonthDay()), [
-  {
-    type: "day",
-    value: "20",
-    source: "startRange"
-  },
-  {
-    type: "literal",
-    value: ".",
-    source: "startRange"
-  },
-  {
-    type: "month",
-    value: "02",
-    source: "startRange"
-  },
-  {
-    type: "literal",
-    value: ". \u2013 ",
-    source: "shared"
-  },
-  {
-    type: "day",
-    value: "18",
-    source: "endRange"
-  },
-  {
-    type: "literal",
-    value: ".",
-    source: "endRange"
-  },
-  {
-    type: "month",
-    value: "11",
-    source: "endRange"
-  },
-  {
-    type: "literal",
-    value: ".",
-    source: "shared"
-  }
-]);
-//should not break legacy Date 
+assert.deepEqual(
+  us.formatRangeToParts(
+    date2.withCalendar(usCalendar).toPlainMonthDay(),
+    date1.withCalendar(usCalendar).toPlainMonthDay()
+  ),
+  [
+    {
+      type: "month",
+      value: "2",
+      source: "startRange"
+    },
+    {
+      type: "literal",
+      value: "/",
+      source: "startRange"
+    },
+    {
+      type: "day",
+      value: "20",
+      source: "startRange"
+    },
+    {
+      type: "literal",
+      value: " \u2013 ",
+      source: "shared"
+    },
+    {
+      type: "month",
+      value: "11",
+      source: "endRange"
+    },
+    {
+      type: "literal",
+      value: "/",
+      source: "endRange"
+    },
+    {
+      type: "day",
+      value: "18",
+      source: "endRange"
+    }
+  ]
+);
+assert.deepEqual(
+  at.formatRangeToParts(
+    date2.withCalendar(atCalendar).toPlainMonthDay(),
+    date1.withCalendar(atCalendar).toPlainMonthDay()
+  ),
+  [
+    {
+      type: "day",
+      value: "20",
+      source: "startRange"
+    },
+    {
+      type: "literal",
+      value: ".",
+      source: "startRange"
+    },
+    {
+      type: "month",
+      value: "02",
+      source: "startRange"
+    },
+    {
+      type: "literal",
+      value: ". \u2013 ",
+      source: "shared"
+    },
+    {
+      type: "day",
+      value: "18",
+      source: "endRange"
+    },
+    {
+      type: "literal",
+      value: ".",
+      source: "endRange"
+    },
+    {
+      type: "month",
+      value: "11",
+      source: "endRange"
+    },
+    {
+      type: "literal",
+      value: ".",
+      source: "shared"
+    }
+  ]
+);
+// should not break legacy Date
 assert.deepEqual(us.formatRangeToParts(start, end), [
   {
     type: "month",
@@ -1994,10 +2052,16 @@ assert.deepEqual(at.formatRangeToParts(start, end), [
     source: "endRange"
   }
 ]);
-//should throw a TypeError when called with dissimilar types
+// should throw a TypeError when called with dissimilar types
 assert.throws(TypeError, () => at.formatRangeToParts(Temporal.Instant.from(t1), Temporal.PlainDateTime.from(t2)));
-//should throw a RangeError when called with different calendars 
-assert.throws(RangeError, () => at.formatRangeToParts(Temporal.PlainDateTime.from(t1), Temporal.PlainDateTime.from(t2).withCalendar("japanese")));
-assert.throws(RangeError, () => at.formatRangeToParts(Temporal.PlainDate.from(t1), Temporal.PlainDate.from(t2).withCalendar("japanese")));
-//throws for two ZonedDateTimes with different time zones 
-assert.throws(RangeError, () => us2.formatRangeToParts(Temporal.ZonedDateTime.from(t1), Temporal.ZonedDateTime.from(t2)));
+// should throw a RangeError when called with different calendars
+assert.throws(RangeError, () =>
+  at.formatRangeToParts(Temporal.PlainDateTime.from(t1), Temporal.PlainDateTime.from(t2).withCalendar("japanese"))
+);
+assert.throws(RangeError, () =>
+  at.formatRangeToParts(Temporal.PlainDate.from(t1), Temporal.PlainDate.from(t2).withCalendar("japanese"))
+);
+// throws for two ZonedDateTimes with different time zones
+assert.throws(RangeError, () =>
+  us2.formatRangeToParts(Temporal.ZonedDateTime.from(t1), Temporal.ZonedDateTime.from(t2))
+);

--- a/test/staging/Intl402/Temporal/old/date-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/date-toLocaleString.js
@@ -21,16 +21,16 @@ function maybeGetWeekdayOnlyFormat() {
 }
 
 var date = Temporal.PlainDate.from("1976-11-18T15:23:30");
-assert.sameValue(`${ date.toLocaleString("en", { timeZone: "America/New_York" }) }`, "11/18/1976")
-assert.sameValue(`${ date.toLocaleString("de", { timeZone: "Europe/Vienna" }) }`, "18.11.1976")
+assert.sameValue(`${ date.toLocaleString("en-US", { timeZone: "America/New_York" }) }`, "11/18/1976");
+assert.sameValue(`${ date.toLocaleString("de-AT", { timeZone: "Europe/Vienna" }) }`, "18.11.1976");
 var fmt = maybeGetWeekdayOnlyFormat();
 if (fmt) assert.sameValue(fmt.format(date), "Thursday");
 
 // should ignore units not in the data type
-assert.sameValue(date.toLocaleString("en", { timeZoneName: "long" }), "11/18/1976");
-assert.sameValue(date.toLocaleString("en", { hour: "numeric" }), "11/18/1976");
-assert.sameValue(date.toLocaleString("en", { minute: "numeric" }), "11/18/1976");
-assert.sameValue(date.toLocaleString("en", { second: "numeric" }), "11/18/1976");
+assert.sameValue(date.toLocaleString("en-US", { timeZoneName: "long" }), "11/18/1976");
+assert.sameValue(date.toLocaleString("en-US", { hour: "numeric" }), "11/18/1976");
+assert.sameValue(date.toLocaleString("en-US", { minute: "numeric" }), "11/18/1976");
+assert.sameValue(date.toLocaleString("en-US", { second: "numeric" }), "11/18/1976");
 
 // works when the object's calendar is the same as the locale's calendar
 var d = Temporal.PlainDate.from({

--- a/test/staging/Intl402/Temporal/old/datetime-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/datetime-toLocaleString.js
@@ -8,21 +8,21 @@ features: [Temporal]
 ---*/
 
 function maybeGetWeekdayOnlyFormat() {
-  const fmt = new Intl.DateTimeFormat('en', { weekday: 'long', timeZone: 'Europe/Vienna' });
+  const fmt = new Intl.DateTimeFormat("en", { weekday: "long", timeZone: "Europe/Vienna" });
   if (
-    ['era', 'year', 'month', 'day', 'hour', 'minute', 'second', 'timeZoneName'].some(
+    ["era", "year", "month", "day", "hour", "minute", "second", "timeZoneName"].some(
       (prop) => prop in fmt.resolvedOptions()
     )
   ) {
-   //no weekday-only format available 
+    // no weekday-only format available
     return null;
   }
   return fmt;
 }
 
 var datetime = Temporal.PlainDateTime.from("1976-11-18T15:23:30");
-assert.sameValue(`${ datetime.toLocaleString("en", { timeZone: "America/New_York" }) }`, "11/18/1976, 3:23:30 PM")
-assert.sameValue(`${ datetime.toLocaleString("de", { timeZone: "Europe/Vienna" }) }`, "18.11.1976, 15:23:30")
+assert.sameValue(`${datetime.toLocaleString("en", { timeZone: "America/New_York" })}`, "11/18/1976, 3:23:30 PM");
+assert.sameValue(`${datetime.toLocaleString("de", { timeZone: "Europe/Vienna" })}`, "18.11.1976, 15:23:30");
 var fmt = maybeGetWeekdayOnlyFormat();
 if (fmt) assert.sameValue(fmt.format(datetime), "Thursday");
 
@@ -31,7 +31,7 @@ assert.sameValue(datetime.toLocaleString("en", { timeZoneName: "long" }), "11/18
 
 // should use compatible disambiguation option
 var dstStart = new Temporal.PlainDateTime(2020, 3, 8, 2, 30);
-assert.sameValue(`${ dstStart.toLocaleString("en", { timeZone: "America/Los_Angeles" }) }`, "3/8/2020, 3:30:00 AM");
+assert.sameValue(`${dstStart.toLocaleString("en", { timeZone: "America/Los_Angeles" })}`, "3/8/2020, 3:30:00 AM");
 
 // works when the object's calendar is the same as the locale's calendar
 var dt = Temporal.PlainDateTime.from({

--- a/test/staging/Intl402/Temporal/old/datetime-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/datetime-toLocaleString.js
@@ -8,7 +8,7 @@ features: [Temporal]
 ---*/
 
 function maybeGetWeekdayOnlyFormat() {
-  const fmt = new Intl.DateTimeFormat("en", { weekday: "long", timeZone: "Europe/Vienna" });
+  const fmt = new Intl.DateTimeFormat("en-US", { weekday: "long", timeZone: "Europe/Vienna" });
   if (
     ["era", "year", "month", "day", "hour", "minute", "second", "timeZoneName"].some(
       (prop) => prop in fmt.resolvedOptions()
@@ -21,17 +21,17 @@ function maybeGetWeekdayOnlyFormat() {
 }
 
 var datetime = Temporal.PlainDateTime.from("1976-11-18T15:23:30");
-assert.sameValue(`${datetime.toLocaleString("en", { timeZone: "America/New_York" })}`, "11/18/1976, 3:23:30 PM");
-assert.sameValue(`${datetime.toLocaleString("de", { timeZone: "Europe/Vienna" })}`, "18.11.1976, 15:23:30");
+assert.sameValue(`${datetime.toLocaleString("en-US", { timeZone: "America/New_York" })}`, "11/18/1976, 3:23:30 PM");
+assert.sameValue(`${datetime.toLocaleString("de-AT", { timeZone: "Europe/Vienna" })}`, "18.11.1976, 15:23:30");
 var fmt = maybeGetWeekdayOnlyFormat();
 if (fmt) assert.sameValue(fmt.format(datetime), "Thursday");
 
 // should ignore units not in the data type
-assert.sameValue(datetime.toLocaleString("en", { timeZoneName: "long" }), "11/18/1976, 3:23:30 PM");
+assert.sameValue(datetime.toLocaleString("en-US", { timeZoneName: "long" }), "11/18/1976, 3:23:30 PM");
 
 // should use compatible disambiguation option
 var dstStart = new Temporal.PlainDateTime(2020, 3, 8, 2, 30);
-assert.sameValue(`${dstStart.toLocaleString("en", { timeZone: "America/Los_Angeles" })}`, "3/8/2020, 3:30:00 AM");
+assert.sameValue(`${dstStart.toLocaleString("en-US", { timeZone: "America/Los_Angeles" })}`, "3/8/2020, 3:30:00 AM");
 
 // works when the object's calendar is the same as the locale's calendar
 var dt = Temporal.PlainDateTime.from({

--- a/test/staging/Intl402/Temporal/old/datetime-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/datetime-toLocaleString.js
@@ -7,6 +7,14 @@ description: datetime.toLocaleString()
 features: [Temporal]
 ---*/
 
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDayPeriodSpace =
+  new Intl.DateTimeFormat("en-US", { timeStyle: "short" })
+    .formatToParts(0)
+    .find((part, i, parts) => part.type === "literal" && parts[i + 1].type === "dayPeriod")?.value || "";
+
 function maybeGetWeekdayOnlyFormat() {
   const fmt = new Intl.DateTimeFormat("en-US", { weekday: "long", timeZone: "Europe/Vienna" });
   if (
@@ -21,17 +29,26 @@ function maybeGetWeekdayOnlyFormat() {
 }
 
 var datetime = Temporal.PlainDateTime.from("1976-11-18T15:23:30");
-assert.sameValue(`${datetime.toLocaleString("en-US", { timeZone: "America/New_York" })}`, "11/18/1976, 3:23:30 PM");
+assert.sameValue(
+  `${datetime.toLocaleString("en-US", { timeZone: "America/New_York" })}`,
+  `11/18/1976, 3:23:30${usDayPeriodSpace}PM`
+);
 assert.sameValue(`${datetime.toLocaleString("de-AT", { timeZone: "Europe/Vienna" })}`, "18.11.1976, 15:23:30");
 var fmt = maybeGetWeekdayOnlyFormat();
 if (fmt) assert.sameValue(fmt.format(datetime), "Thursday");
 
 // should ignore units not in the data type
-assert.sameValue(datetime.toLocaleString("en-US", { timeZoneName: "long" }), "11/18/1976, 3:23:30 PM");
+assert.sameValue(
+  datetime.toLocaleString("en-US", { timeZoneName: "long" }),
+  `11/18/1976, 3:23:30${usDayPeriodSpace}PM`
+);
 
 // should use compatible disambiguation option
 var dstStart = new Temporal.PlainDateTime(2020, 3, 8, 2, 30);
-assert.sameValue(`${dstStart.toLocaleString("en-US", { timeZone: "America/Los_Angeles" })}`, "3/8/2020, 3:30:00 AM");
+assert.sameValue(
+  `${dstStart.toLocaleString("en-US", { timeZone: "America/Los_Angeles" })}`,
+  `3/8/2020, 3:30:00${usDayPeriodSpace}AM`
+);
 
 // works when the object's calendar is the same as the locale's calendar
 var dt = Temporal.PlainDateTime.from({
@@ -45,12 +62,12 @@ var dt = Temporal.PlainDateTime.from({
   calendar: "japanese"
 });
 var result = dt.toLocaleString("en-US-u-ca-japanese");
-assert(result === "11/18/51, 3:23:30 PM" || result === "11/18/51 S, 3:23:30 PM");
+assert(result === `11/18/51, 3:23:30${usDayPeriodSpace}PM` || result === `11/18/51 S, 3:23:30${usDayPeriodSpace}PM`);
 
 // adopts the locale's calendar when the object's calendar is ISO
 var dt = Temporal.PlainDateTime.from("1976-11-18T15:23:30");
 var result = dt.toLocaleString("en-US-u-ca-japanese");
-assert(result === "11/18/51, 3:23:30 PM" || result === "11/18/51 S, 3:23:30 PM");
+assert(result === `11/18/51, 3:23:30${usDayPeriodSpace}PM` || result === `11/18/51 S, 3:23:30${usDayPeriodSpace}PM`);
 
 // throws when the calendars are different and not ISO
 var dt = Temporal.PlainDateTime.from({

--- a/test/staging/Intl402/Temporal/old/instant-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/instant-toLocaleString.js
@@ -8,24 +8,23 @@ features: [Temporal]
 ---*/
 
 function maybeGetWeekdayOnlyFormat() {
-  const fmt = new Intl.DateTimeFormat('en', { weekday: 'long', timeZone: 'Europe/Vienna' });
+  const fmt = new Intl.DateTimeFormat("en", { weekday: "long", timeZone: "Europe/Vienna" });
   if (
-    ['era', 'year', 'month', 'day', 'hour', 'minute', 'second', 'timeZoneName'].some(
+    ["era", "year", "month", "day", "hour", "minute", "second", "timeZoneName"].some(
       (prop) => prop in fmt.resolvedOptions()
     )
   ) {
-   //no weekday-only format available 
+    // no weekday-only format available
     return null;
   }
   return fmt;
 }
 
 var instant = Temporal.Instant.from("1976-11-18T14:23:30Z");
-assert.sameValue(`${ instant.toLocaleString("en", { timeZone: "America/New_York" }) }`, "11/18/1976, 9:23:30 AM")
-assert.sameValue(`${ instant.toLocaleString("de", { timeZone: "Europe/Vienna" }) }`, "18.11.1976, 15:23:30")
+assert.sameValue(`${instant.toLocaleString("en", { timeZone: "America/New_York" })}`, "11/18/1976, 9:23:30 AM");
+assert.sameValue(`${instant.toLocaleString("de", { timeZone: "Europe/Vienna" })}`, "18.11.1976, 15:23:30");
 var fmt = maybeGetWeekdayOnlyFormat();
-if (fmt)
-  assert.sameValue(fmt.format(instant), "Thursday");
+if (fmt) assert.sameValue(fmt.format(instant), "Thursday");
 
 // outputs timeZoneName if requested
 var str = instant.toLocaleString("en", {

--- a/test/staging/Intl402/Temporal/old/instant-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/instant-toLocaleString.js
@@ -8,7 +8,7 @@ features: [Temporal]
 ---*/
 
 function maybeGetWeekdayOnlyFormat() {
-  const fmt = new Intl.DateTimeFormat("en", { weekday: "long", timeZone: "Europe/Vienna" });
+  const fmt = new Intl.DateTimeFormat("en-US", { weekday: "long", timeZone: "Europe/Vienna" });
   if (
     ["era", "year", "month", "day", "hour", "minute", "second", "timeZoneName"].some(
       (prop) => prop in fmt.resolvedOptions()
@@ -21,13 +21,13 @@ function maybeGetWeekdayOnlyFormat() {
 }
 
 var instant = Temporal.Instant.from("1976-11-18T14:23:30Z");
-assert.sameValue(`${instant.toLocaleString("en", { timeZone: "America/New_York" })}`, "11/18/1976, 9:23:30 AM");
-assert.sameValue(`${instant.toLocaleString("de", { timeZone: "Europe/Vienna" })}`, "18.11.1976, 15:23:30");
+assert.sameValue(`${instant.toLocaleString("en-US", { timeZone: "America/New_York" })}`, "11/18/1976, 9:23:30 AM");
+assert.sameValue(`${instant.toLocaleString("de-AT", { timeZone: "Europe/Vienna" })}`, "18.11.1976, 15:23:30");
 var fmt = maybeGetWeekdayOnlyFormat();
 if (fmt) assert.sameValue(fmt.format(instant), "Thursday");
 
 // outputs timeZoneName if requested
-var str = instant.toLocaleString("en", {
+var str = instant.toLocaleString("en-US", {
   timeZone: "America/New_York",
   timeZoneName: "short"
 });

--- a/test/staging/Intl402/Temporal/old/instant-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/instant-toLocaleString.js
@@ -7,6 +7,14 @@ description: Instant.toLocaleString()
 features: [Temporal]
 ---*/
 
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDayPeriodSpace =
+  new Intl.DateTimeFormat("en-US", { timeStyle: "short" })
+    .formatToParts(0)
+    .find((part, i, parts) => part.type === "literal" && parts[i + 1].type === "dayPeriod")?.value || "";
+
 function maybeGetWeekdayOnlyFormat() {
   const fmt = new Intl.DateTimeFormat("en-US", { weekday: "long", timeZone: "Europe/Vienna" });
   if (
@@ -21,7 +29,10 @@ function maybeGetWeekdayOnlyFormat() {
 }
 
 var instant = Temporal.Instant.from("1976-11-18T14:23:30Z");
-assert.sameValue(`${instant.toLocaleString("en-US", { timeZone: "America/New_York" })}`, "11/18/1976, 9:23:30 AM");
+assert.sameValue(
+  `${instant.toLocaleString("en-US", { timeZone: "America/New_York" })}`,
+  `11/18/1976, 9:23:30${usDayPeriodSpace}AM`
+);
 assert.sameValue(`${instant.toLocaleString("de-AT", { timeZone: "Europe/Vienna" })}`, "18.11.1976, 15:23:30");
 var fmt = maybeGetWeekdayOnlyFormat();
 if (fmt) assert.sameValue(fmt.format(instant), "Thursday");

--- a/test/staging/Intl402/Temporal/old/monthday-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/monthday-toLocaleString.js
@@ -7,25 +7,25 @@ description: monthday.toLocaleString()
 features: [Temporal]
 ---*/
 
-var calendar = new Intl.DateTimeFormat("en").resolvedOptions().calendar;
+var calendar = new Intl.DateTimeFormat("en-US").resolvedOptions().calendar;
 var monthday = Temporal.PlainMonthDay.from({
   monthCode: "M11",
   day: 18,
   calendar
 });
-assert.sameValue(`${ monthday.toLocaleString("en", { timeZone: "America/New_York" }) }`, "11/18")
-assert.sameValue(`${ monthday.toLocaleString("de", {
+assert.sameValue(`${ monthday.toLocaleString("en-US", { timeZone: "America/New_York" }) }`, "11/18");
+assert.sameValue(`${ monthday.toLocaleString("de-AT", {
   timeZone: "Europe/Vienna",
   calendar
-}) }`, "18.11.")
+}) }`, "18.11.");
 
 // should ignore units not in the data type
-assert.sameValue(monthday.toLocaleString("en", { timeZoneName: "long" }), "11/18");
-assert.sameValue(monthday.toLocaleString("en", { year: "numeric" }), "11/18");
-assert.sameValue(monthday.toLocaleString("en", { hour: "numeric" }), "11/18");
-assert.sameValue(monthday.toLocaleString("en", { minute: "numeric" }), "11/18");
-assert.sameValue(monthday.toLocaleString("en", { second: "numeric" }), "11/18");
-assert.sameValue(monthday.toLocaleString("en", { weekday: "long" }), "11/18");
+assert.sameValue(monthday.toLocaleString("en-US", { timeZoneName: "long" }), "11/18");
+assert.sameValue(monthday.toLocaleString("en-US", { year: "numeric" }), "11/18");
+assert.sameValue(monthday.toLocaleString("en-US", { hour: "numeric" }), "11/18");
+assert.sameValue(monthday.toLocaleString("en-US", { minute: "numeric" }), "11/18");
+assert.sameValue(monthday.toLocaleString("en-US", { second: "numeric" }), "11/18");
+assert.sameValue(monthday.toLocaleString("en-US", { weekday: "long" }), "11/18");
 
 // works when the object's calendar is the same as the locale's calendar
 var md = Temporal.PlainMonthDay.from({

--- a/test/staging/Intl402/Temporal/old/time-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/time-toLocaleString.js
@@ -8,12 +8,12 @@ features: [Temporal]
 ---*/
 
 var time = Temporal.PlainTime.from("1976-11-18T15:23:30");
-assert.sameValue(`${time.toLocaleString("en", { timeZone: "America/New_York" })}`, "3:23:30 PM");
-assert.sameValue(`${time.toLocaleString("de", { timeZone: "Europe/Vienna" })}`, "15:23:30");
+assert.sameValue(`${time.toLocaleString("en-US", { timeZone: "America/New_York" })}`, "3:23:30 PM");
+assert.sameValue(`${time.toLocaleString("de-AT", { timeZone: "Europe/Vienna" })}`, "15:23:30");
 
 // should ignore units not in the data type
-assert.sameValue(time.toLocaleString("en", { timeZoneName: "long" }), "3:23:30 PM");
-assert.sameValue(time.toLocaleString("en", { year: "numeric" }), "3:23:30 PM");
-assert.sameValue(time.toLocaleString("en", { month: "numeric" }), "3:23:30 PM");
-assert.sameValue(time.toLocaleString("en", { day: "numeric" }), "3:23:30 PM");
-assert.sameValue(time.toLocaleString("en", { weekday: "long" }), "3:23:30 PM");
+assert.sameValue(time.toLocaleString("en-US", { timeZoneName: "long" }), "3:23:30 PM");
+assert.sameValue(time.toLocaleString("en-US", { year: "numeric" }), "3:23:30 PM");
+assert.sameValue(time.toLocaleString("en-US", { month: "numeric" }), "3:23:30 PM");
+assert.sameValue(time.toLocaleString("en-US", { day: "numeric" }), "3:23:30 PM");
+assert.sameValue(time.toLocaleString("en-US", { weekday: "long" }), "3:23:30 PM");

--- a/test/staging/Intl402/Temporal/old/time-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/time-toLocaleString.js
@@ -8,8 +8,8 @@ features: [Temporal]
 ---*/
 
 var time = Temporal.PlainTime.from("1976-11-18T15:23:30");
-assert.sameValue(`${ time.toLocaleString("en", { timeZone: "America/New_York" }) }`, "3:23:30 PM")
-assert.sameValue(`${ time.toLocaleString("de", { timeZone: "Europe/Vienna" }) }`, "15:23:30")
+assert.sameValue(`${time.toLocaleString("en", { timeZone: "America/New_York" })}`, "3:23:30 PM");
+assert.sameValue(`${time.toLocaleString("de", { timeZone: "Europe/Vienna" })}`, "15:23:30");
 
 // should ignore units not in the data type
 assert.sameValue(time.toLocaleString("en", { timeZoneName: "long" }), "3:23:30 PM");

--- a/test/staging/Intl402/Temporal/old/time-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/time-toLocaleString.js
@@ -7,13 +7,21 @@ description: time.toLocaleString()
 features: [Temporal]
 ---*/
 
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDayPeriodSpace =
+  new Intl.DateTimeFormat("en-US", { timeStyle: "short" })
+    .formatToParts(0)
+    .find((part, i, parts) => part.type === "literal" && parts[i + 1].type === "dayPeriod")?.value || "";
+
 var time = Temporal.PlainTime.from("1976-11-18T15:23:30");
-assert.sameValue(`${time.toLocaleString("en-US", { timeZone: "America/New_York" })}`, "3:23:30 PM");
+assert.sameValue(`${time.toLocaleString("en-US", { timeZone: "America/New_York" })}`, `3:23:30${usDayPeriodSpace}PM`);
 assert.sameValue(`${time.toLocaleString("de-AT", { timeZone: "Europe/Vienna" })}`, "15:23:30");
 
 // should ignore units not in the data type
-assert.sameValue(time.toLocaleString("en-US", { timeZoneName: "long" }), "3:23:30 PM");
-assert.sameValue(time.toLocaleString("en-US", { year: "numeric" }), "3:23:30 PM");
-assert.sameValue(time.toLocaleString("en-US", { month: "numeric" }), "3:23:30 PM");
-assert.sameValue(time.toLocaleString("en-US", { day: "numeric" }), "3:23:30 PM");
-assert.sameValue(time.toLocaleString("en-US", { weekday: "long" }), "3:23:30 PM");
+assert.sameValue(time.toLocaleString("en-US", { timeZoneName: "long" }), `3:23:30${usDayPeriodSpace}PM`);
+assert.sameValue(time.toLocaleString("en-US", { year: "numeric" }), `3:23:30${usDayPeriodSpace}PM`);
+assert.sameValue(time.toLocaleString("en-US", { month: "numeric" }), `3:23:30${usDayPeriodSpace}PM`);
+assert.sameValue(time.toLocaleString("en-US", { day: "numeric" }), `3:23:30${usDayPeriodSpace}PM`);
+assert.sameValue(time.toLocaleString("en-US", { weekday: "long" }), `3:23:30${usDayPeriodSpace}PM`);

--- a/test/staging/Intl402/Temporal/old/yearmonth-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/yearmonth-toLocaleString.js
@@ -7,15 +7,15 @@ description: yearmonth.toLocaleString()
 features: [Temporal]
 ---*/
 
-var calendar = new Intl.DateTimeFormat("en").resolvedOptions().calendar;
+var calendar = new Intl.DateTimeFormat("en-US").resolvedOptions().calendar;
 var yearmonth = Temporal.PlainYearMonth.from({
   year: 1976,
   month: 11,
   calendar
 });
-assert.sameValue(`${yearmonth.toLocaleString("en", { timeZone: "America/New_York" })}`, "11/1976");
+assert.sameValue(`${yearmonth.toLocaleString("en-US", { timeZone: "America/New_York" })}`, "11/1976");
 assert.sameValue(
-  `${yearmonth.toLocaleString("de", {
+  `${yearmonth.toLocaleString("de-AT", {
     timeZone: "Europe/Vienna",
     calendar
   })}`,
@@ -23,12 +23,12 @@ assert.sameValue(
 );
 
 // should ignore units not in the data type
-assert.sameValue(yearmonth.toLocaleString("en", { timeZoneName: "long" }), "11/1976");
-assert.sameValue(yearmonth.toLocaleString("en", { day: "numeric" }), "11/1976");
-assert.sameValue(yearmonth.toLocaleString("en", { hour: "numeric" }), "11/1976");
-assert.sameValue(yearmonth.toLocaleString("en", { minute: "numeric" }), "11/1976");
-assert.sameValue(yearmonth.toLocaleString("en", { second: "numeric" }), "11/1976");
-assert.sameValue(yearmonth.toLocaleString("en", { weekday: "long" }), "11/1976");
+assert.sameValue(yearmonth.toLocaleString("en-US", { timeZoneName: "long" }), "11/1976");
+assert.sameValue(yearmonth.toLocaleString("en-US", { day: "numeric" }), "11/1976");
+assert.sameValue(yearmonth.toLocaleString("en-US", { hour: "numeric" }), "11/1976");
+assert.sameValue(yearmonth.toLocaleString("en-US", { minute: "numeric" }), "11/1976");
+assert.sameValue(yearmonth.toLocaleString("en-US", { second: "numeric" }), "11/1976");
+assert.sameValue(yearmonth.toLocaleString("en-US", { weekday: "long" }), "11/1976");
 
 // works when the object's calendar is the same as the locale's calendar
 var ym = Temporal.PlainYearMonth.from({

--- a/test/staging/Intl402/Temporal/old/yearmonth-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/yearmonth-toLocaleString.js
@@ -1,4 +1,3 @@
-
 // Copyright (C) 2018 Bloomberg LP. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
@@ -14,11 +13,14 @@ var yearmonth = Temporal.PlainYearMonth.from({
   month: 11,
   calendar
 });
-assert.sameValue(`${ yearmonth.toLocaleString("en", { timeZone: "America/New_York" }) }`, "11/1976")
-assert.sameValue(`${ yearmonth.toLocaleString("de", {
-  timeZone: "Europe/Vienna",
-  calendar
-}) }`, "11.1976")
+assert.sameValue(`${yearmonth.toLocaleString("en", { timeZone: "America/New_York" })}`, "11/1976");
+assert.sameValue(
+  `${yearmonth.toLocaleString("de", {
+    timeZone: "Europe/Vienna",
+    calendar
+  })}`,
+  "11.1976"
+);
 
 // should ignore units not in the data type
 assert.sameValue(yearmonth.toLocaleString("en", { timeZoneName: "long" }), "11/1976");

--- a/test/staging/Intl402/Temporal/old/yearmonth-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/yearmonth-toLocaleString.js
@@ -7,6 +7,17 @@ description: yearmonth.toLocaleString()
 features: [Temporal]
 ---*/
 
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+// Workarounds for https://unicode-org.atlassian.net/browse/CLDR-16243
+const deMonthDayRangeSeparator = new Intl.DateTimeFormat("de-AT", { month: "numeric", day: "numeric" })
+  .formatRangeToParts(1 * 86400 * 1000, 90 * 86400 * 1000)
+  .find((part) => part.type === "literal" && part.source === "shared").value;
+const deMonthYearSeparator = new Intl.DateTimeFormat("de-AT", { year: "numeric", month: "numeric" })
+  .formatToParts(0)
+  .find((part) => part.type === "literal").value;
+
 var calendar = new Intl.DateTimeFormat("en-US").resolvedOptions().calendar;
 var yearmonth = Temporal.PlainYearMonth.from({
   year: 1976,
@@ -15,11 +26,8 @@ var yearmonth = Temporal.PlainYearMonth.from({
 });
 assert.sameValue(`${yearmonth.toLocaleString("en-US", { timeZone: "America/New_York" })}`, "11/1976");
 assert.sameValue(
-  `${yearmonth.toLocaleString("de-AT", {
-    timeZone: "Europe/Vienna",
-    calendar
-  })}`,
-  "11.1976"
+  `${yearmonth.toLocaleString("de-AT", { timeZone: "Europe/Vienna", calendar })}`,
+  `11${deMonthYearSeparator}1976`
 );
 
 // should ignore units not in the data type

--- a/test/staging/Intl402/Temporal/old/zoneddatetime-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/zoneddatetime-toLocaleString.js
@@ -8,27 +8,30 @@ features: [Temporal]
 ---*/
 
 function maybeGetWeekdayOnlyFormat() {
-  const fmt = new Intl.DateTimeFormat('en', { weekday: 'long', timeZone: 'Europe/Vienna' });
+  const fmt = new Intl.DateTimeFormat("en", { weekday: "long", timeZone: "Europe/Vienna" });
   if (
-    ['era', 'year', 'month', 'day', 'hour', 'minute', 'second', 'timeZoneName'].some(
+    ["era", "year", "month", "day", "hour", "minute", "second", "timeZoneName"].some(
       (prop) => prop in fmt.resolvedOptions()
     )
   ) {
-   //no weekday-only format available 
+    // no weekday-only format available
     return null;
   }
   return fmt;
 }
 
 var zdt = Temporal.ZonedDateTime.from("1976-11-18T15:23:30+01:00[Europe/Vienna]");
-assert.sameValue(zdt.toLocaleString("en"), "11/18/1976, 3:23:30 PM GMT+1")
-assert.sameValue(zdt.toLocaleString("de"), "18.11.1976, 15:23:30 MEZ")
+assert.sameValue(zdt.toLocaleString("en"), "11/18/1976, 3:23:30 PM GMT+1");
+assert.sameValue(zdt.toLocaleString("de"), "18.11.1976, 15:23:30 MEZ");
 
 const fmt = maybeGetWeekdayOnlyFormat();
-//uses only the options in resolvedOptions 
-if (fmt) assert.sameValue(fmt.format(zdt), 'Thursday');
+// uses only the options in resolvedOptions
+if (fmt) assert.sameValue(fmt.format(zdt), "Thursday");
 // can override the style of the time zone name
-assert.sameValue(zdt.toLocaleString("en", { timeZoneName: "long" }), "11/18/1976, 3:23:30 PM Central European Standard Time");
+assert.sameValue(
+  zdt.toLocaleString("en", { timeZoneName: "long" }),
+  "11/18/1976, 3:23:30 PM Central European Standard Time"
+);
 
 // works if the time zone given in options agrees with the object's time zone
 assert.sameValue(zdt.toLocaleString("en", { timeZone: "Europe/Vienna" }), "11/18/1976, 3:23:30 PM GMT+1");

--- a/test/staging/Intl402/Temporal/old/zoneddatetime-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/zoneddatetime-toLocaleString.js
@@ -8,7 +8,7 @@ features: [Temporal]
 ---*/
 
 function maybeGetWeekdayOnlyFormat() {
-  const fmt = new Intl.DateTimeFormat("en", { weekday: "long", timeZone: "Europe/Vienna" });
+  const fmt = new Intl.DateTimeFormat("en-US", { weekday: "long", timeZone: "Europe/Vienna" });
   if (
     ["era", "year", "month", "day", "hour", "minute", "second", "timeZoneName"].some(
       (prop) => prop in fmt.resolvedOptions()
@@ -21,23 +21,23 @@ function maybeGetWeekdayOnlyFormat() {
 }
 
 var zdt = Temporal.ZonedDateTime.from("1976-11-18T15:23:30+01:00[Europe/Vienna]");
-assert.sameValue(zdt.toLocaleString("en"), "11/18/1976, 3:23:30 PM GMT+1");
-assert.sameValue(zdt.toLocaleString("de"), "18.11.1976, 15:23:30 MEZ");
+assert.sameValue(zdt.toLocaleString("en-US"), "11/18/1976, 3:23:30 PM GMT+1");
+assert.sameValue(zdt.toLocaleString("de-AT"), "18.11.1976, 15:23:30 MEZ");
 
 const fmt = maybeGetWeekdayOnlyFormat();
 // uses only the options in resolvedOptions
 if (fmt) assert.sameValue(fmt.format(zdt), "Thursday");
 // can override the style of the time zone name
 assert.sameValue(
-  zdt.toLocaleString("en", { timeZoneName: "long" }),
+  zdt.toLocaleString("en-US", { timeZoneName: "long" }),
   "11/18/1976, 3:23:30 PM Central European Standard Time"
 );
 
 // works if the time zone given in options agrees with the object's time zone
-assert.sameValue(zdt.toLocaleString("en", { timeZone: "Europe/Vienna" }), "11/18/1976, 3:23:30 PM GMT+1");
+assert.sameValue(zdt.toLocaleString("en-US", { timeZone: "Europe/Vienna" }), "11/18/1976, 3:23:30 PM GMT+1");
 
 // throws if the time zone given in options disagrees with the object's time zone
-assert.throws(RangeError, () => zdt.toLocaleString("en", { timeZone: "America/New_York" }));
+assert.throws(RangeError, () => zdt.toLocaleString("en-US", { timeZone: "America/New_York" }));
 
 // works when the object's calendar is the same as the locale's calendar
 var zdt = new Temporal.ZonedDateTime(0n, "UTC", "japanese");

--- a/test/staging/Intl402/Temporal/old/zoneddatetime-toLocaleString.js
+++ b/test/staging/Intl402/Temporal/old/zoneddatetime-toLocaleString.js
@@ -7,6 +7,14 @@ description: zoneddatetime.toLocaleString()
 features: [Temporal]
 ---*/
 
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDayPeriodSpace =
+  new Intl.DateTimeFormat("en-US", { timeStyle: "short" })
+    .formatToParts(0)
+    .find((part, i, parts) => part.type === "literal" && parts[i + 1].type === "dayPeriod")?.value || "";
+
 function maybeGetWeekdayOnlyFormat() {
   const fmt = new Intl.DateTimeFormat("en-US", { weekday: "long", timeZone: "Europe/Vienna" });
   if (
@@ -21,7 +29,7 @@ function maybeGetWeekdayOnlyFormat() {
 }
 
 var zdt = Temporal.ZonedDateTime.from("1976-11-18T15:23:30+01:00[Europe/Vienna]");
-assert.sameValue(zdt.toLocaleString("en-US"), "11/18/1976, 3:23:30 PM GMT+1");
+assert.sameValue(zdt.toLocaleString("en-US"), `11/18/1976, 3:23:30${usDayPeriodSpace}PM GMT+1`);
 assert.sameValue(zdt.toLocaleString("de-AT"), "18.11.1976, 15:23:30 MEZ");
 
 const fmt = maybeGetWeekdayOnlyFormat();
@@ -30,11 +38,14 @@ if (fmt) assert.sameValue(fmt.format(zdt), "Thursday");
 // can override the style of the time zone name
 assert.sameValue(
   zdt.toLocaleString("en-US", { timeZoneName: "long" }),
-  "11/18/1976, 3:23:30 PM Central European Standard Time"
+  `11/18/1976, 3:23:30${usDayPeriodSpace}PM Central European Standard Time`
 );
 
 // works if the time zone given in options agrees with the object's time zone
-assert.sameValue(zdt.toLocaleString("en-US", { timeZone: "Europe/Vienna" }), "11/18/1976, 3:23:30 PM GMT+1");
+assert.sameValue(
+  zdt.toLocaleString("en-US", { timeZone: "Europe/Vienna" }),
+  `11/18/1976, 3:23:30${usDayPeriodSpace}PM GMT+1`
+);
 
 // throws if the time zone given in options disagrees with the object's time zone
 assert.throws(RangeError, () => zdt.toLocaleString("en-US", { timeZone: "America/New_York" }));
@@ -42,12 +53,16 @@ assert.throws(RangeError, () => zdt.toLocaleString("en-US", { timeZone: "America
 // works when the object's calendar is the same as the locale's calendar
 var zdt = new Temporal.ZonedDateTime(0n, "UTC", "japanese");
 var result = zdt.toLocaleString("en-US-u-ca-japanese");
-assert(result === "1/1/45, 12:00:00 AM UTC" || result === "1/1/45 S, 12:00:00 AM UTC");
+assert(
+  result === `1/1/45, 12:00:00${usDayPeriodSpace}AM UTC` || result === `1/1/45 S, 12:00:00${usDayPeriodSpace}AM UTC`
+);
 
 // adopts the locale's calendar when the object's calendar is ISO
 var zdt = Temporal.ZonedDateTime.from("1976-11-18T15:23:30+00:00[UTC]");
 var result = zdt.toLocaleString("en-US-u-ca-japanese");
-assert(result === "11/18/51, 3:23:30 PM UTC" || result === "11/18/51 S, 3:23:30 PM UTC");
+assert(
+  result === `11/18/51, 3:23:30${usDayPeriodSpace}PM UTC` || result === `11/18/51 S, 3:23:30${usDayPeriodSpace}PM UTC`
+);
 
 // throws when the calendars are different and not ISO
 var zdt = new Temporal.ZonedDateTime(0n, "UTC", "gregory");


### PR DESCRIPTION
Following up from #3750, this PR supports running Temporal "staging" tests (https://github.com/tc39/test262/tree/main/test/staging) under Node 19.

For context, `Intl.DateTimeFormat` implementations in Node 19 have ICU format changes:
- replace some spaces with non-breaking-space unicode characters
- change German date separators (these may be bugs)
- months in German are shown with a leading zero, but only in Year/Month formats (also may be a bug)

This PR makes affected tests more resilient to `Intl.DateTimeFormat` output changes between Node versions. They'll continue to work even if the behavior (e.g. in German) turns out to be a bug and is fixed in the platform.