### PR TITLE
Add a feature for `with`

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -383,6 +383,7 @@ Uint32Array
 Uint8ClampedArray
 WeakMap
 WeakSet
+with
 __proto__
 __getter__
 __setter__

--- a/test/built-ins/Function/StrictFunction_reservedwords_with.js
+++ b/test/built-ins/Function/StrictFunction_reservedwords_with.js
@@ -14,6 +14,7 @@ info: |
          If strict is true, the Early Error rules for UniqueFormalParameters:FormalParameters are applied.
       ...
     ...
+features: [with]
 ---*/
 
 assert.throws(SyntaxError, function() {

--- a/test/built-ins/Proxy/has/call-with.js
+++ b/test/built-ins/Proxy/has/call-with.js
@@ -11,7 +11,7 @@ info: |
     9. Let booleanTrapResult be ToBoolean(Call(trap, handler, «target, P»)).
     ...
 flags: [noStrict]
-features: [Proxy]
+features: [Proxy, with]
 ---*/
 
 var _handler, _target, _prop;

--- a/test/built-ins/Proxy/has/null-handler-using-with.js
+++ b/test/built-ins/Proxy/has/null-handler-using-with.js
@@ -5,7 +5,7 @@ es6id: 9.5.7
 description: >
     Throws a TypeError exception if handler is null.
 flags: [noStrict]
-features: [Proxy]
+features: [Proxy, with]
 ---*/
 
 var p = Proxy.revocable({}, {});

--- a/test/built-ins/Proxy/has/return-false-target-not-extensible-using-with.js
+++ b/test/built-ins/Proxy/has/return-false-target-not-extensible-using-with.js
@@ -19,7 +19,7 @@ info: |
             iv. If extensibleTarget is false, throw a TypeError exception.
     ...
 flags: [noStrict]
-features: [Proxy]
+features: [Proxy, with]
 ---*/
 
 var target = {};

--- a/test/built-ins/Proxy/has/return-false-target-prop-exists-using-with.js
+++ b/test/built-ins/Proxy/has/return-false-target-prop-exists-using-with.js
@@ -11,7 +11,7 @@ info: |
     ...
     12. Return booleanTrapResult.
 flags: [noStrict]
-features: [Proxy]
+features: [Proxy, with]
 ---*/
 
 var target = {

--- a/test/built-ins/Proxy/has/return-false-targetdesc-not-configurable-using-with.js
+++ b/test/built-ins/Proxy/has/return-false-targetdesc-not-configurable-using-with.js
@@ -16,7 +16,7 @@ info: |
             exception.
     ...
 flags: [noStrict]
-features: [Proxy]
+features: [Proxy, with]
 ---*/
 
 var target = {};

--- a/test/built-ins/Proxy/has/return-is-abrupt-with.js
+++ b/test/built-ins/Proxy/has/return-is-abrupt-with.js
@@ -12,7 +12,7 @@ info: |
     10. ReturnIfAbrupt(booleanTrapResult).
     ...
 flags: [noStrict]
-features: [Proxy]
+features: [Proxy, with]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/built-ins/Proxy/has/return-true-target-prop-exists-using-with.js
+++ b/test/built-ins/Proxy/has/return-true-target-prop-exists-using-with.js
@@ -6,7 +6,7 @@ description: >
     The result of [[HasProperty]] is a Boolean value and will affect has
     checkings. True returned when target property exists;
 flags: [noStrict]
-features: [Proxy]
+features: [Proxy, with]
 ---*/
 
 var target = {

--- a/test/built-ins/Proxy/has/trap-is-not-callable-using-with.js
+++ b/test/built-ins/Proxy/has/trap-is-not-callable-using-with.js
@@ -16,7 +16,7 @@ info: |
         5. If IsCallable(func) is false, throw a TypeError exception.
         ...
 flags: [noStrict]
-features: [Proxy]
+features: [Proxy, with]
 ---*/
 
 var target = {};

--- a/test/built-ins/Proxy/has/trap-is-undefined-using-with.js
+++ b/test/built-ins/Proxy/has/trap-is-undefined-using-with.js
@@ -12,7 +12,7 @@ info: |
         a. Return target.[[HasProperty]](P).
     ...
 flags: [noStrict]
-features: [Proxy]
+features: [Proxy, with]
 ---*/
 
 var target = Object.create(Array.prototype);

--- a/test/built-ins/String/S15.5.5.1_A4_T1.js
+++ b/test/built-ins/String/S15.5.5.1_A4_T1.js
@@ -6,6 +6,7 @@ info: length property has the attributes {ReadOnly}
 es5id: 15.5.5.1_A4_T1
 description: Checking if varying the length property of String fails
 flags: [noStrict]
+features: [with]
 ---*/
 
 var __str__instance = new String("globglob");

--- a/test/built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/infinity-with-detached-buffer.js
+++ b/test/built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/infinity-with-detached-buffer.js
@@ -22,7 +22,7 @@ info: |
 
 flags: [noStrict]
 includes: [testBigIntTypedArray.js, detachArrayBuffer.js]
-features: [align-detached-buffer-semantics-with-web-reality, BigInt, TypedArray]
+features: [align-detached-buffer-semantics-with-web-reality, BigInt, TypedArray, with]
 ---*/
 testWithBigIntTypedArrayConstructors(function(TA) {
   let counter = 0;

--- a/test/built-ins/TypedArrayConstructors/internals/HasProperty/infinity-with-detached-buffer.js
+++ b/test/built-ins/TypedArrayConstructors/internals/HasProperty/infinity-with-detached-buffer.js
@@ -23,7 +23,7 @@ info: |
 
 flags: [noStrict]
 includes: [testTypedArray.js, detachArrayBuffer.js]
-features: [align-detached-buffer-semantics-with-web-reality, TypedArray]
+features: [align-detached-buffer-semantics-with-web-reality, TypedArray, with]
 ---*/
 
 testWithTypedArrayConstructors(function(TA) {

--- a/test/language/comments/hashbang/use-strict.js
+++ b/test/language/comments/hashbang/use-strict.js
@@ -11,7 +11,7 @@ info: |
     HashbangComment::
       #! SingleLineCommentChars[opt]
 flags: [raw]
-features: [hashbang]
+features: [hashbang, with]
 ---*/
 
 with ({}) {}

--- a/test/language/eval-code/direct/global-env-rec-with.js
+++ b/test/language/eval-code/direct/global-env-rec-with.js
@@ -5,6 +5,7 @@ es5id: 10.4.2-1-4
 description: >
     Direct call to eval has context set to local context (with block)
 flags: [noStrict]
+features: [with]
 ---*/
 
 var __10_4_2_1_4 = "str";

--- a/test/language/eval-code/indirect/always-non-strict.js
+++ b/test/language/eval-code/indirect/always-non-strict.js
@@ -8,6 +8,7 @@ info: |
     contains a Use Strict Directive or if the call to eval is a direct eval
     that is contained in strict mode code.
 flags: [onlyStrict]
+features: [with]
 ---*/
 
 var count = 0;

--- a/test/language/eval-code/indirect/global-env-rec-with.js
+++ b/test/language/eval-code/indirect/global-env-rec-with.js
@@ -6,6 +6,7 @@ description: >
     Indirect call to eval has context set to global context (with
     block)
 flags: [noStrict]
+features: [with]
 ---*/
 
 var __10_4_2_1_4 = "str";

--- a/test/language/expressions/arrow-function/arrow/capturing-closure-variables-2.js
+++ b/test/language/expressions/arrow-function/arrow/capturing-closure-variables-2.js
@@ -5,6 +5,7 @@
 description: Capturing closure variables - with
 es6id: 14.2
 flags: [noStrict]
+features: [with]
 ---*/
 
 function foo(){

--- a/test/language/expressions/arrow-function/unscopables-with-in-nested-fn.js
+++ b/test/language/expressions/arrow-function/unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (arrow function expression)
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
-features: [globalThis, Symbol.unscopables]
+features: [globalThis, Symbol.unscopables, with]
 flags: [generated, noStrict]
 info: |
     ArrowFunction : ArrowParameters => ConciseBody

--- a/test/language/expressions/arrow-function/unscopables-with.js
+++ b/test/language/expressions/arrow-function/unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (arrow function expression)
 esid: sec-arrow-function-definitions-runtime-semantics-evaluation
-features: [globalThis, Symbol.unscopables]
+features: [globalThis, Symbol.unscopables, with]
 flags: [generated, noStrict]
 info: |
     ArrowFunction : ArrowParameters => ConciseBody

--- a/test/language/expressions/assignment/S11.13.1_A5_T1.js
+++ b/test/language/expressions/assignment/S11.13.1_A5_T1.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding function environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/assignment/S11.13.1_A5_T2.js
+++ b/test/language/expressions/assignment/S11.13.1_A5_T2.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding global environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/assignment/S11.13.1_A5_T3.js
+++ b/test/language/expressions/assignment/S11.13.1_A5_T3.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding object environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {x: 0};

--- a/test/language/expressions/assignment/S11.13.1_A6_T3.js
+++ b/test/language/expressions/assignment/S11.13.1_A6_T3.js
@@ -10,6 +10,7 @@ description: >
     declarative environment record. PutValue(lref, rval) uses the initially
     created Reference even if a more local binding is available.
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testAssignment() {

--- a/test/language/expressions/assignment/assignment-operator-calls-putvalue-lref--rval-.js
+++ b/test/language/expressions/assignment/assignment-operator-calls-putvalue-lref--rval-.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var count = 0;

--- a/test/language/expressions/async-arrow-function/unscopables-with-in-nested-fn.js
+++ b/test/language/expressions/async-arrow-function/unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async arrow function expression)
 esid: sec-async-arrow-function-definitions
-features: [globalThis, Symbol.unscopables, async-functions]
+features: [globalThis, Symbol.unscopables, async-functions, with]
 flags: [generated, noStrict, async]
 info: |
     14.7 Async Arrow Function Definitions

--- a/test/language/expressions/async-arrow-function/unscopables-with.js
+++ b/test/language/expressions/async-arrow-function/unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async arrow function expression)
 esid: sec-async-arrow-function-definitions
-features: [globalThis, Symbol.unscopables, async-functions]
+features: [globalThis, Symbol.unscopables, async-functions, with]
 flags: [generated, noStrict, async]
 info: |
     14.7 Async Arrow Function Definitions

--- a/test/language/expressions/async-function/named-unscopables-with-in-nested-fn.js
+++ b/test/language/expressions/async-function/named-unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async function named expression)
 esid: sec-async-function-definitions
-features: [globalThis, Symbol.unscopables, async-functions]
+features: [globalThis, Symbol.unscopables, async-functions, with]
 flags: [generated, noStrict, async]
 info: |
     14.6 Async Function Definitions

--- a/test/language/expressions/async-function/named-unscopables-with.js
+++ b/test/language/expressions/async-function/named-unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async function named expression)
 esid: sec-async-function-definitions
-features: [globalThis, Symbol.unscopables, async-functions]
+features: [globalThis, Symbol.unscopables, async-functions, with]
 flags: [generated, noStrict, async]
 info: |
     14.6 Async Function Definitions

--- a/test/language/expressions/async-function/nameless-unscopables-with-in-nested-fn.js
+++ b/test/language/expressions/async-function/nameless-unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async function nameless expression)
 esid: sec-async-function-definitions
-features: [globalThis, Symbol.unscopables, async-functions]
+features: [globalThis, Symbol.unscopables, async-functions, with]
 flags: [generated, noStrict, async]
 info: |
     14.6 Async Function Definitions

--- a/test/language/expressions/async-function/nameless-unscopables-with.js
+++ b/test/language/expressions/async-function/nameless-unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async function nameless expression)
 esid: sec-async-function-definitions
-features: [globalThis, Symbol.unscopables, async-functions]
+features: [globalThis, Symbol.unscopables, async-functions, with]
 flags: [generated, noStrict, async]
 info: |
     14.6 Async Function Definitions

--- a/test/language/expressions/async-generator/named-unscopables-with-in-nested-fn.js
+++ b/test/language/expressions/async-generator/named-unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async generator named function expression)
 esid: sec-asyncgenerator-definitions-evaluation
-features: [globalThis, Symbol.unscopables, async-iteration]
+features: [globalThis, Symbol.unscopables, async-iteration, with]
 flags: [generated, noStrict, async]
 info: |
     AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier

--- a/test/language/expressions/async-generator/named-unscopables-with.js
+++ b/test/language/expressions/async-generator/named-unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async generator named function expression)
 esid: sec-asyncgenerator-definitions-evaluation
-features: [globalThis, Symbol.unscopables, async-iteration]
+features: [globalThis, Symbol.unscopables, async-iteration, with]
 flags: [generated, noStrict, async]
 info: |
     AsyncGeneratorExpression : async [no LineTerminator here] function * BindingIdentifier

--- a/test/language/expressions/async-generator/unscopables-with-in-nested-fn.js
+++ b/test/language/expressions/async-generator/unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async generator function expression)
 esid: sec-asyncgenerator-definitions-evaluation
-features: [globalThis, Symbol.unscopables, async-iteration]
+features: [globalThis, Symbol.unscopables, async-iteration, with]
 flags: [generated, noStrict, async]
 info: |
     AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {

--- a/test/language/expressions/async-generator/unscopables-with.js
+++ b/test/language/expressions/async-generator/unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async generator function expression)
 esid: sec-asyncgenerator-definitions-evaluation
-features: [globalThis, Symbol.unscopables, async-iteration]
+features: [globalThis, Symbol.unscopables, async-iteration, with]
 flags: [generated, noStrict, async]
 info: |
     AsyncGeneratorExpression : async [no LineTerminator here] function * ( FormalParameters ) {

--- a/test/language/expressions/call/eval-strictness-inherit-non-strict.js
+++ b/test/language/expressions/call/eval-strictness-inherit-non-strict.js
@@ -13,6 +13,7 @@ info: |
               let strictCaller be true. Otherwise let strictCaller be false.
           [...]
 flags: [noStrict]
+features: [with]
 ---*/
 
 var count = 0;

--- a/test/language/expressions/call/eval-strictness-inherit-strict.js
+++ b/test/language/expressions/call/eval-strictness-inherit-strict.js
@@ -13,6 +13,7 @@ info: |
               let strictCaller be true. Otherwise let strictCaller be false.
           [...]
 flags: [onlyStrict]
+features: [with]
 ---*/
 
 assert.throws(SyntaxError, function() {

--- a/test/language/expressions/call/tco-non-eval-with.js
+++ b/test/language/expressions/call/tco-non-eval-with.js
@@ -22,7 +22,7 @@ info: |
     ...
 
 flags: [noStrict]
-features: [tail-call-optimization]
+features: [tail-call-optimization, with]
 includes: [tcoHelper.js]
 ---*/
 

--- a/test/language/expressions/call/with-base-obj.js
+++ b/test/language/expressions/call/with-base-obj.js
@@ -14,6 +14,7 @@ info: |
   [...]
   8. Return ? EvaluateDirectCall(func, thisValue, Arguments, tailCall).
 flags: [noStrict]
+features: [with]
 ---*/
 
 var viaMember, viaCall;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.10_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.10_T1.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding function environment record is not changed.
     Check operator is "x ^= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.10_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.10_T2.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding global environment record is not changed.
     Check operator is "x ^= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.10_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.10_T3.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding object environment record is not changed.
     Check operator is "x ^= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.11_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.11_T1.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding function environment record is not changed.
     Check operator is "x |= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.11_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.11_T2.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding global environment record is not changed.
     Check operator is "x |= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.11_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.11_T3.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding object environment record is not changed.
     Check operator is "x |= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.1_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.1_T1.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding function environment record is not changed.
     Check operator is "x *= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.1_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.1_T2.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding global environment record is not changed.
     Check operator is "x *= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.1_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.1_T3.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding object environment record is not changed.
     Check operator is "x *= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.2_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.2_T1.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding function environment record is not changed.
     Check operator is "x /= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.2_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.2_T2.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding global environment record is not changed.
     Check operator is "x /= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.2_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.2_T3.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding object environment record is not changed.
     Check operator is "x /= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.3_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.3_T1.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding function environment record is not changed.
     Check operator is "x %= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.3_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.3_T2.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding global environment record is not changed.
     Check operator is "x %= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.3_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.3_T3.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding object environment record is not changed.
     Check operator is "x %= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.4_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.4_T1.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding function environment record is not changed.
     Check operator is "x += y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.4_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.4_T2.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding global environment record is not changed.
     Check operator is "x += y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.4_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.4_T3.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding object environment record is not changed.
     Check operator is "x += y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.5_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.5_T1.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding function environment record is not changed.
     Check operator is "x -= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.5_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.5_T2.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding global environment record is not changed.
     Check operator is "x -= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.5_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.5_T3.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding object environment record is not changed.
     Check operator is "x -= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.6_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.6_T1.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding function environment record is not changed.
     Check operator is "x <<= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.6_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.6_T2.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding global environment record is not changed.
     Check operator is "x <<= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.6_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.6_T3.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding object environment record is not changed.
     Check operator is "x <<= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.7_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.7_T1.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding function environment record is not changed.
     Check operator is "x >>= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.7_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.7_T2.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding global environment record is not changed.
     Check operator is "x >>= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.7_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.7_T3.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding object environment record is not changed.
     Check operator is "x >>= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.8_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.8_T1.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding function environment record is not changed.
     Check operator is "x >>>= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.8_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.8_T2.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding global environment record is not changed.
     Check operator is "x >>>= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.8_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.8_T3.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding object environment record is not changed.
     Check operator is "x >>>= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.9_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.9_T1.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding function environment record is not changed.
     Check operator is "x &= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.9_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.9_T2.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding global environment record is not changed.
     Check operator is "x &= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/compound-assignment/S11.13.2_A5.9_T3.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A5.9_T3.js
@@ -12,6 +12,7 @@ description: >
     Binding in surrounding object environment record is not changed.
     Check operator is "x &= y".
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--10.js
+++ b/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--10.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var count = 0;

--- a/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--12.js
+++ b/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--12.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--14.js
+++ b/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--14.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--16.js
+++ b/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--16.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--18.js
+++ b/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--18.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--2.js
+++ b/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--2.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--20.js
+++ b/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--20.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--4.js
+++ b/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--4.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--6.js
+++ b/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--6.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--8.js
+++ b/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v--8.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v-.js
+++ b/test/language/expressions/compound-assignment/compound-assignment-operator-calls-putvalue-lref--v-.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/delete/11.4.1-4.a-5.js
+++ b/test/language/expressions/delete/11.4.1-4.a-5.js
@@ -10,6 +10,7 @@ description: >
     delete operator returns false when deleting the declaration of the environment object
     inside 'with'
 flags: [noStrict]
+features: [with]
 ---*/
 
 var o = new Object();

--- a/test/language/expressions/delete/11.4.1-4.a-6.js
+++ b/test/language/expressions/delete/11.4.1-4.a-6.js
@@ -8,6 +8,7 @@ info: |
 esid: sec-delete-operator-runtime-semantics-evaluation
 description: delete operator returns true when deleting a property inside 'with'
 flags: [noStrict]
+features: [with]
 ---*/
 
 var o = new Object();

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-assignment-expr-not-optional.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if AssignmentExpression is omitted (nested with syntax)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 negative:
   phase: parse

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-assignment-expr-not-optional.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-assignment-expr-not-optional.js
@@ -4,7 +4,7 @@
 /*---
 description: It's a SyntaxError if AssignmentExpression is omitted (nested with syntax in the expression position)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 negative:
   phase: parse

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-no-new-call-expression.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested with syntax in the expression position)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 negative:
   phase: parse

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-no-rest-param.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall is not extensible - no rest parameter (nested with syntax in the expression position)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 negative:
   phase: parse

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-not-extensible-args.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-not-extensible-args.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall is not extensible - no arguments list (nested with syntax in the expression position)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 negative:
   phase: parse

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-no-new-call-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-no-new-call-expression.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall is a CallExpression, it can't be preceded by the new keyword (nested with syntax)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 negative:
   phase: parse

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-no-rest-param.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-no-rest-param.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall is not extensible - no rest parameter (nested with syntax)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 negative:
   phase: parse

--- a/test/language/expressions/dynamic-import/syntax/invalid/nested-with-not-extensible-args.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/nested-with-not-extensible-args.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall is not extensible - no arguments list (nested with syntax)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 negative:
   phase: parse

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-empty-str-is-valid-assign-expr.js
@@ -4,7 +4,7 @@
 /*---
 description: Calling import('') (nested with syntax)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 info: |
     ImportCall :

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-empty-str-is-valid-assign-expr.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-empty-str-is-valid-assign-expr.js
@@ -4,7 +4,7 @@
 /*---
 description: Calling import('') (nested with syntax in the expression position)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 info: |
     ImportCall :

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-nested-imports.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-nested-imports.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall is a CallExpression can be nested in other import calls (nested with syntax in the expression position)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 info: |
     ImportCall :

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-script-code-valid.js
@@ -4,7 +4,7 @@
 /*---
 description: import() can be used in script code (nested with syntax in the expression position)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 info: |
     ImportCall :

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-trailing-comma-first.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-trailing-comma-first.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall trailing comma following first parameter (nested with syntax in the expression position)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [import-assertions, dynamic-import]
+features: [import-assertions, dynamic-import, with]
 flags: [generated, noStrict]
 info: |
     ImportCall :

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-trailing-comma-second.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-trailing-comma-second.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall trailing comma following second parameter (nested with syntax in the expression position)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [import-assertions, dynamic-import]
+features: [import-assertions, dynamic-import, with]
 flags: [generated, noStrict]
 info: |
     ImportCall :

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-nested-imports.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-nested-imports.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall is a CallExpression can be nested in other import calls (nested with syntax)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 info: |
     ImportCall :

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-script-code-valid.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-script-code-valid.js
@@ -4,7 +4,7 @@
 /*---
 description: import() can be used in script code (nested with syntax)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [dynamic-import]
+features: [dynamic-import, with]
 flags: [generated, noStrict]
 info: |
     ImportCall :

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-trailing-comma-first.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-trailing-comma-first.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall trailing comma following first parameter (nested with syntax)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [import-assertions, dynamic-import]
+features: [import-assertions, dynamic-import, with]
 flags: [generated, noStrict]
 info: |
     ImportCall :

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-trailing-comma-second.js
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-trailing-comma-second.js
@@ -4,7 +4,7 @@
 /*---
 description: ImportCall trailing comma following second parameter (nested with syntax)
 esid: sec-import-call-runtime-semantics-evaluation
-features: [import-assertions, dynamic-import]
+features: [import-assertions, dynamic-import, with]
 flags: [generated, noStrict]
 info: |
     ImportCall :

--- a/test/language/expressions/function/unscopables-with-in-nested-fn.js
+++ b/test/language/expressions/function/unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (function expression)
 esid: sec-function-definitions-runtime-semantics-evaluation
-features: [globalThis, Symbol.unscopables]
+features: [globalThis, Symbol.unscopables, with]
 flags: [generated, noStrict]
 info: |
     FunctionExpression : function ( FormalParameters ) { FunctionBody }

--- a/test/language/expressions/function/unscopables-with.js
+++ b/test/language/expressions/function/unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (function expression)
 esid: sec-function-definitions-runtime-semantics-evaluation
-features: [globalThis, Symbol.unscopables]
+features: [globalThis, Symbol.unscopables, with]
 flags: [generated, noStrict]
 info: |
     FunctionExpression : function ( FormalParameters ) { FunctionBody }

--- a/test/language/expressions/generators/unscopables-with-in-nested-fn.js
+++ b/test/language/expressions/generators/unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (generator function expression)
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
-features: [globalThis, Symbol.unscopables, generators]
+features: [globalThis, Symbol.unscopables, generators, with]
 flags: [generated, noStrict]
 info: |
     GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }

--- a/test/language/expressions/generators/unscopables-with.js
+++ b/test/language/expressions/generators/unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (generator function expression)
 esid: sec-generator-function-definitions-runtime-semantics-evaluation
-features: [globalThis, Symbol.unscopables, generators]
+features: [globalThis, Symbol.unscopables, generators, with]
 flags: [generated, noStrict]
 info: |
     GeneratorExpression : function * ( FormalParameters ) { GeneratorBody }

--- a/test/language/expressions/object/prop-def-id-eval-error-2.js
+++ b/test/language/expressions/object/prop-def-id-eval-error-2.js
@@ -6,7 +6,7 @@ description: >
     Errors thrown during IdentifierReference evaluation are forwarded to the
     runtime.
 flags: [noStrict]
-features: [Proxy]
+features: [Proxy, with]
 ---*/
 
 var p = new Proxy({}, {

--- a/test/language/expressions/object/prop-def-id-eval-error.js
+++ b/test/language/expressions/object/prop-def-id-eval-error.js
@@ -6,7 +6,7 @@ description: >
     Errors thrown during IdentifierReference evaluation are forwarded to the
     runtime.
 flags: [noStrict]
-features: [Symbol, Symbol.unscopables]
+features: [Symbol, Symbol.unscopables, with]
 ---*/
 
 var obj = {

--- a/test/language/expressions/postfix-decrement/S11.3.2_A5_T1.js
+++ b/test/language/expressions/postfix-decrement/S11.3.2_A5_T1.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding function environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/postfix-decrement/S11.3.2_A5_T2.js
+++ b/test/language/expressions/postfix-decrement/S11.3.2_A5_T2.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding global environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/postfix-decrement/S11.3.2_A5_T3.js
+++ b/test/language/expressions/postfix-decrement/S11.3.2_A5_T3.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding object environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/postfix-decrement/operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js
+++ b/test/language/expressions/postfix-decrement/operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/postfix-increment/S11.3.1_A5_T1.js
+++ b/test/language/expressions/postfix-increment/S11.3.1_A5_T1.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding function environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/postfix-increment/S11.3.1_A5_T2.js
+++ b/test/language/expressions/postfix-increment/S11.3.1_A5_T2.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding global environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/postfix-increment/S11.3.1_A5_T3.js
+++ b/test/language/expressions/postfix-increment/S11.3.1_A5_T3.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding object environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/postfix-increment/operator-x-postfix-increment-calls-putvalue-lhs-newvalue-.js
+++ b/test/language/expressions/postfix-increment/operator-x-postfix-increment-calls-putvalue-lhs-newvalue-.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/prefix-decrement/S11.4.5_A5_T1.js
+++ b/test/language/expressions/prefix-decrement/S11.4.5_A5_T1.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding function environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/prefix-decrement/S11.4.5_A5_T2.js
+++ b/test/language/expressions/prefix-decrement/S11.4.5_A5_T2.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding global environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/prefix-decrement/S11.4.5_A5_T3.js
+++ b/test/language/expressions/prefix-decrement/S11.4.5_A5_T3.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding object environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/prefix-decrement/operator-prefix-decrement-x-calls-putvalue-lhs-newvalue-.js
+++ b/test/language/expressions/prefix-decrement/operator-prefix-decrement-x-calls-putvalue-lhs-newvalue-.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/prefix-increment/S11.4.4_A5_T1.js
+++ b/test/language/expressions/prefix-increment/S11.4.4_A5_T1.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding function environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 function testFunction() {

--- a/test/language/expressions/prefix-increment/S11.4.4_A5_T2.js
+++ b/test/language/expressions/prefix-increment/S11.4.4_A5_T2.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding global environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/expressions/prefix-increment/S11.4.4_A5_T3.js
+++ b/test/language/expressions/prefix-increment/S11.4.4_A5_T3.js
@@ -11,6 +11,7 @@ description: >
     created Reference even if the environment binding is no longer present.
     Binding in surrounding object environment record is not changed.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var outerScope = {

--- a/test/language/expressions/prefix-increment/operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js
+++ b/test/language/expressions/prefix-increment/operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js
@@ -15,6 +15,7 @@ info: |
   Let stillExists be ? HasProperty(bindings, N).
   If stillExists is false and S is true, throw a ReferenceError exception.
 flags: [noStrict]
+features: [with]
 ---*/
 var count = 0;
 var scope = {

--- a/test/language/expressions/yield/from-with.js
+++ b/test/language/expressions/yield/from-with.js
@@ -6,7 +6,7 @@ description: >
     The operand to a `yield` expression should honor the semantics of the
     `with` statement.
 flags: [noStrict]
-features: [generators]
+features: [generators, with]
 ---*/
 
 function* g() {

--- a/test/language/identifier-resolution/S10.2.2_A1_T5.js
+++ b/test/language/identifier-resolution/S10.2.2_A1_T5.js
@@ -9,6 +9,7 @@ info: |
 es5id: 10.2.2_A1_T5
 description: Checking scope chain containing function declarations and "with"
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/identifier-resolution/S10.2.2_A1_T6.js
+++ b/test/language/identifier-resolution/S10.2.2_A1_T6.js
@@ -9,6 +9,7 @@ info: |
 es5id: 10.2.2_A1_T6
 description: Checking scope chain containing function declarations and "with"
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/identifier-resolution/S10.2.2_A1_T7.js
+++ b/test/language/identifier-resolution/S10.2.2_A1_T7.js
@@ -9,6 +9,7 @@ info: |
 es5id: 10.2.2_A1_T7
 description: Checking scope chain containing function declarations and "with"
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/identifier-resolution/S10.2.2_A1_T8.js
+++ b/test/language/identifier-resolution/S10.2.2_A1_T8.js
@@ -9,6 +9,7 @@ info: |
 es5id: 10.2.2_A1_T8
 description: Checking scope chain containing function declarations and "with"
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/identifier-resolution/S10.2.2_A1_T9.js
+++ b/test/language/identifier-resolution/S10.2.2_A1_T9.js
@@ -9,6 +9,7 @@ info: |
 es5id: 10.2.2_A1_T9
 description: Checking scope chain containing function declarations and "with"
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/identifiers/val-with-via-escape-hex4.js
+++ b/test/language/identifiers/val-with-via-escape-hex4.js
@@ -9,6 +9,7 @@ description: >
 negative:
   phase: parse
   type: SyntaxError
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/async-function/unscopables-with-in-nested-fn.js
+++ b/test/language/statements/async-function/unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async function declaration)
 esid: sec-async-function-definitions
-features: [globalThis, Symbol.unscopables, async-functions]
+features: [globalThis, Symbol.unscopables, async-functions, with]
 flags: [generated, noStrict, async]
 info: |
     14.6 Async Function Definitions

--- a/test/language/statements/async-function/unscopables-with.js
+++ b/test/language/statements/async-function/unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async function declaration)
 esid: sec-async-function-definitions
-features: [globalThis, Symbol.unscopables, async-functions]
+features: [globalThis, Symbol.unscopables, async-functions, with]
 flags: [generated, noStrict, async]
 info: |
     14.6 Async Function Definitions

--- a/test/language/statements/async-generator/unscopables-with-in-nested-fn.js
+++ b/test/language/statements/async-generator/unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async generator function declaration)
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
-features: [globalThis, Symbol.unscopables, async-iteration]
+features: [globalThis, Symbol.unscopables, async-iteration, with]
 flags: [generated, noStrict, async]
 info: |
     AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier

--- a/test/language/statements/async-generator/unscopables-with.js
+++ b/test/language/statements/async-generator/unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (async generator function declaration)
 esid: sec-asyncgenerator-definitions-instantiatefunctionobject
-features: [globalThis, Symbol.unscopables, async-iteration]
+features: [globalThis, Symbol.unscopables, async-iteration, with]
 flags: [generated, noStrict, async]
 info: |
     AsyncGeneratorDeclaration : async [no LineTerminator here] function * BindingIdentifier

--- a/test/language/statements/class/strict-mode/with.js
+++ b/test/language/statements/class/strict-mode/with.js
@@ -7,6 +7,7 @@ description: >
 negative:
   phase: parse
   type: SyntaxError
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/function/S13.2.2_A17_T2.js
+++ b/test/language/statements/function/S13.2.2_A17_T2.js
@@ -6,6 +6,7 @@ info: FunctionExpression containing "with" statement is admitted
 es5id: 13.2.2_A17_T2
 description: Throwing an exception within "with" statement
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1="alert";

--- a/test/language/statements/function/S13.2.2_A17_T3.js
+++ b/test/language/statements/function/S13.2.2_A17_T3.js
@@ -10,6 +10,7 @@ description: >
     getRight in statement resolves within with(__obj) scope and
     searchs getRight in __obj first
 flags: [noStrict]
+features: [with]
 ---*/
 
 p1="alert";

--- a/test/language/statements/function/S13.2.2_A18_T1.js
+++ b/test/language/statements/function/S13.2.2_A18_T1.js
@@ -8,6 +8,7 @@ info: |
 es5id: 13.2.2_A18_T1
 description: "Object is declared with \"var __obj={callee:\"a\"}\""
 flags: [noStrict]
+features: [with]
 ---*/
 
 var callee=0, b;

--- a/test/language/statements/function/S13.2.2_A18_T2.js
+++ b/test/language/statements/function/S13.2.2_A18_T2.js
@@ -8,6 +8,7 @@ info: |
 es5id: 13.2.2_A18_T2
 description: "Object is declared with \"__obj={callee:\"a\"}\""
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.callee = 0;

--- a/test/language/statements/function/S13.2.2_A19_T1.js
+++ b/test/language/statements/function/S13.2.2_A19_T1.js
@@ -6,6 +6,7 @@ info: Function's scope chain is started when it is declared
 es5id: 13.2.2_A19_T1
 description: Function is declared in the global scope
 flags: [noStrict]
+features: [with]
 ---*/
 
 var a = 1;

--- a/test/language/statements/function/S13.2.2_A19_T2.js
+++ b/test/language/statements/function/S13.2.2_A19_T2.js
@@ -6,6 +6,7 @@ info: Function's scope chain is started when it is declared
 es5id: 13.2.2_A19_T2
 description: Function is declared in the object scope. Using "with" statement
 flags: [noStrict]
+features: [with]
 ---*/
 
 var a = 1;

--- a/test/language/statements/function/S13.2.2_A19_T3.js
+++ b/test/language/statements/function/S13.2.2_A19_T3.js
@@ -8,6 +8,7 @@ description: >
     Function is declared in the object scope and then an exception is
     thrown
 flags: [noStrict]
+features: [with]
 ---*/
 
 var a = 1;

--- a/test/language/statements/function/S13.2.2_A19_T4.js
+++ b/test/language/statements/function/S13.2.2_A19_T4.js
@@ -8,6 +8,7 @@ description: >
     Function is declared in the hierarchical object scope and then an
     exception is thrown
 flags: [noStrict]
+features: [with]
 ---*/
 
 var a = 1;

--- a/test/language/statements/function/S13.2.2_A19_T5.js
+++ b/test/language/statements/function/S13.2.2_A19_T5.js
@@ -8,6 +8,7 @@ description: >
     Function is declared in the object scope, then an exception is
     thrown and the object is deleted
 flags: [noStrict]
+features: [with]
 ---*/
 
 var a = 1;

--- a/test/language/statements/function/S13.2.2_A19_T6.js
+++ b/test/language/statements/function/S13.2.2_A19_T6.js
@@ -8,6 +8,7 @@ description: >
     Function is declared in the "object->do-while" scope, then the
     object is deleted and another object with the same name is declared
 flags: [noStrict]
+features: [with]
 ---*/
 
 var a = 1;

--- a/test/language/statements/function/S13.2.2_A19_T7.js
+++ b/test/language/statements/function/S13.2.2_A19_T7.js
@@ -6,6 +6,7 @@ info: Function's scope chain is started when it is declared
 es5id: 13.2.2_A19_T7
 description: Function is declared in the object scope as a variable
 flags: [noStrict]
+features: [with]
 ---*/
 
 var a = 1;

--- a/test/language/statements/function/S13.2.2_A19_T8.js
+++ b/test/language/statements/function/S13.2.2_A19_T8.js
@@ -6,6 +6,7 @@ info: Function's scope chain is started when it is declared
 es5id: 13.2.2_A19_T8
 description: Function is declared multiply times
 flags: [noStrict]
+features: [with]
 ---*/
 
 //////////////////////////////////////////////////////////////////////////////

--- a/test/language/statements/function/unscopables-with-in-nested-fn.js
+++ b/test/language/statements/function/unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (function declaration)
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
-features: [globalThis, Symbol.unscopables]
+features: [globalThis, Symbol.unscopables, with]
 flags: [generated, noStrict]
 info: |
     FunctionDeclaration :

--- a/test/language/statements/function/unscopables-with.js
+++ b/test/language/statements/function/unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (function declaration)
 esid: sec-function-definitions-runtime-semantics-instantiatefunctionobject
-features: [globalThis, Symbol.unscopables]
+features: [globalThis, Symbol.unscopables, with]
 flags: [generated, noStrict]
 info: |
     FunctionDeclaration :

--- a/test/language/statements/generators/unscopables-with-in-nested-fn.js
+++ b/test/language/statements/generators/unscopables-with-in-nested-fn.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (generator function declaration)
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
-features: [globalThis, Symbol.unscopables, generators]
+features: [globalThis, Symbol.unscopables, generators, with]
 flags: [generated, noStrict]
 info: |
     GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }

--- a/test/language/statements/generators/unscopables-with.js
+++ b/test/language/statements/generators/unscopables-with.js
@@ -4,7 +4,7 @@
 /*---
 description: Symbol.unscopables behavior across scope boundaries (generator function declaration)
 esid: sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject
-features: [globalThis, Symbol.unscopables, generators]
+features: [globalThis, Symbol.unscopables, generators, with]
 flags: [generated, noStrict]
 info: |
     GeneratorDeclaration : function * ( FormalParameters ) { GeneratorBody }

--- a/test/language/statements/try/S12.14_A14.js
+++ b/test/language/statements/try/S12.14_A14.js
@@ -8,6 +8,7 @@ info: |
 es5id: 12.14_A14
 description: Using try/catch/finally in With and With in try/catch/finally
 flags: [noStrict]
+features: [with]
 ---*/
 
 var myObj = {p1: 'a',

--- a/test/language/statements/variable/binding-resolution.js
+++ b/test/language/statements/variable/binding-resolution.js
@@ -12,6 +12,7 @@ info: |
    3. Let rhs be the result of evaluating Initializer.
    [...]
 flags: [noStrict]
+features: [with]
 ---*/
 
 var obj = { test262id: 1 };

--- a/test/language/statements/with/12.10-0-1.js
+++ b/test/language/statements/with/12.10-0-1.js
@@ -7,6 +7,7 @@ description: >
     with does not change declaration scope - vars in with are visible
     outside
 flags: [noStrict]
+features: [with]
 ---*/
 
   var o = {};

--- a/test/language/statements/with/12.10-0-10.js
+++ b/test/language/statements/with/12.10-0-10.js
@@ -5,6 +5,7 @@
 es5id: 12.10-0-10
 description: with introduces scope - name lookup finds function parameter
 flags: [noStrict]
+features: [with]
 ---*/
 
   function f(o) {

--- a/test/language/statements/with/12.10-0-11.js
+++ b/test/language/statements/with/12.10-0-11.js
@@ -5,6 +5,7 @@
 es5id: 12.10-0-11
 description: with introduces scope - name lookup finds inner variable
 flags: [noStrict]
+features: [with]
 ---*/
 
   function f(o) {

--- a/test/language/statements/with/12.10-0-12.js
+++ b/test/language/statements/with/12.10-0-12.js
@@ -5,6 +5,7 @@
 es5id: 12.10-0-12
 description: with introduces scope - name lookup finds property
 flags: [noStrict]
+features: [with]
 ---*/
 
   function f(o) {

--- a/test/language/statements/with/12.10-0-3.js
+++ b/test/language/statements/with/12.10-0-3.js
@@ -5,6 +5,7 @@
 es5id: 12.10-0-3
 description: with introduces scope - that is captured by function expression
 flags: [noStrict]
+features: [with]
 ---*/
 
   var o = {prop: "12.10-0-3 before"};

--- a/test/language/statements/with/12.10-0-7.js
+++ b/test/language/statements/with/12.10-0-7.js
@@ -5,6 +5,7 @@
 es5id: 12.10-0-7
 description: with introduces scope - scope removed when exiting with statement
 flags: [noStrict]
+features: [with]
 ---*/
 
   var o = {foo: 1};

--- a/test/language/statements/with/12.10-0-8.js
+++ b/test/language/statements/with/12.10-0-8.js
@@ -5,6 +5,7 @@
 es5id: 12.10-0-8
 description: with introduces scope - var initializer sets like named property
 flags: [noStrict]
+features: [with]
 ---*/
 
   var o = {foo: 42};

--- a/test/language/statements/with/12.10-0-9.js
+++ b/test/language/statements/with/12.10-0-9.js
@@ -5,6 +5,7 @@
 es5id: 12.10-0-9
 description: with introduces scope - name lookup finds outer variable
 flags: [noStrict]
+features: [with]
 ---*/
 
   function f(o) {

--- a/test/language/statements/with/12.10-2-1.js
+++ b/test/language/statements/with/12.10-2-1.js
@@ -5,6 +5,7 @@
 es5id: 12.10-2-1
 description: with - expression being Number
 flags: [noStrict]
+features: [with]
 ---*/
 
   var o = 2;

--- a/test/language/statements/with/12.10-2-2.js
+++ b/test/language/statements/with/12.10-2-2.js
@@ -5,6 +5,7 @@
 es5id: 12.10-2-2
 description: with - expression being Boolean
 flags: [noStrict]
+features: [with]
 ---*/
 
   var o = true;

--- a/test/language/statements/with/12.10-2-3.js
+++ b/test/language/statements/with/12.10-2-3.js
@@ -5,6 +5,7 @@
 es5id: 12.10-2-3
 description: with - expression being string
 flags: [noStrict]
+features: [with]
 ---*/
 
   var o = "str";

--- a/test/language/statements/with/12.10-2-4.js
+++ b/test/language/statements/with/12.10-2-4.js
@@ -6,6 +6,7 @@ info: ToObject conversion from undefined value must throw TypeError
 es5id: 12.10-2-4
 description: Trying to convert undefined to Object
 flags: [noStrict]
+features: [with]
 ---*/
 
 try{

--- a/test/language/statements/with/12.10-2-5.js
+++ b/test/language/statements/with/12.10-2-5.js
@@ -6,6 +6,7 @@ info: ToObject conversion from null value must throw TypeError
 es5id: 12.10-2-5
 description: Trying to convert null to Object
 flags: [noStrict]
+features: [with]
 ---*/
 
 try{

--- a/test/language/statements/with/12.10-7-1.js
+++ b/test/language/statements/with/12.10-7-1.js
@@ -5,6 +5,7 @@
 es5id: 12.10-7-1
 description: with introduces scope - restores the earlier environment on exit
 flags: [noStrict]
+features: [with]
 ---*/
 
   var a = 1;

--- a/test/language/statements/with/12.10.1-10-s.js
+++ b/test/language/statements/with/12.10.1-10-s.js
@@ -7,6 +7,7 @@ description: >
     with statement in strict mode throws SyntaxError (eval, where the
     container function is strict)
 flags: [onlyStrict]
+features: [with]
 ---*/
 
   // wrapping it in eval since this needs to be a syntax error. The

--- a/test/language/statements/with/12.10.1-11gs.js
+++ b/test/language/statements/with/12.10.1-11gs.js
@@ -8,6 +8,7 @@ negative:
   phase: parse
   type: SyntaxError
 flags: [onlyStrict]
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/12.10.1-12-s.js
+++ b/test/language/statements/with/12.10.1-12-s.js
@@ -5,6 +5,7 @@
 es5id: 12.10.1-12-s
 description: with statement in strict mode throws SyntaxError (strict eval)
 flags: [noStrict]
+features: [with]
 ---*/
 
 

--- a/test/language/statements/with/12.10.1-13-s.js
+++ b/test/language/statements/with/12.10.1-13-s.js
@@ -7,6 +7,7 @@ description: >
     Strict Mode - SyntaxError isn't thrown when WithStatement body is
     in strict mode code
 flags: [noStrict]
+features: [with]
 ---*/
 
         with ({}) {

--- a/test/language/statements/with/12.10.1-4-s.js
+++ b/test/language/statements/with/12.10.1-4-s.js
@@ -5,6 +5,7 @@
 es5id: 12.10.1-4-s
 description: with statement in strict mode throws SyntaxError (strict Function)
 flags: [noStrict]
+features: [with]
 ---*/
 
 

--- a/test/language/statements/with/12.10.1-5-s.js
+++ b/test/language/statements/with/12.10.1-5-s.js
@@ -7,6 +7,7 @@ description: >
     with statement allowed in nested Function even if its container
     Function is strict)
 flags: [onlyStrict]
+features: [with]
 ---*/
 
     Function("\'use strict\'; var f1 = Function( \"var o = {}; with (o) {};\")");

--- a/test/language/statements/with/12.10.1-8-s.js
+++ b/test/language/statements/with/12.10.1-8-s.js
@@ -7,6 +7,7 @@ description: >
     with statement in strict mode throws SyntaxError (function
     expression, where the container Function is strict)
 flags: [noStrict]
+features: [with]
 ---*/
 
 

--- a/test/language/statements/with/S12.10_A1.10_T1.js
+++ b/test/language/statements/with/S12.10_A1.10_T1.js
@@ -10,6 +10,7 @@ description: >
     Using interation statement within "with" statement leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.10_T2.js
+++ b/test/language/statements/with/S12.10_A1.10_T2.js
@@ -10,6 +10,7 @@ description: >
     Using iteration statement within "with" statement leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.10_T3.js
+++ b/test/language/statements/with/S12.10_A1.10_T3.js
@@ -11,6 +11,7 @@ description: >
     completion by exception  iteration statement inside with statement
     - exception completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.10_T4.js
+++ b/test/language/statements/with/S12.10_A1.10_T4.js
@@ -11,6 +11,7 @@ description: >
     completion by break  iteration statement inside with statement -
     break completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.10_T5.js
+++ b/test/language/statements/with/S12.10_A1.10_T5.js
@@ -10,6 +10,7 @@ description: >
     Using iteration statement within "with" statement leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.11_T1.js
+++ b/test/language/statements/with/S12.10_A1.11_T1.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared without the
     statement, leading to normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.11_T2.js
+++ b/test/language/statements/with/S12.10_A1.11_T2.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared without the
     statement, leading to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.11_T3.js
+++ b/test/language/statements/with/S12.10_A1.11_T3.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared without the
     statement, leading to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.11_T4.js
+++ b/test/language/statements/with/S12.10_A1.11_T4.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared without the
     statement, leading to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.11_T5.js
+++ b/test/language/statements/with/S12.10_A1.11_T5.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared without the
     statement, leading to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.12_T1.js
+++ b/test/language/statements/with/S12.10_A1.12_T1.js
@@ -10,6 +10,7 @@ description: >
     Calling a function without "with" statement declared within the
     statement, leading to normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.12_T2.js
+++ b/test/language/statements/with/S12.10_A1.12_T2.js
@@ -10,6 +10,7 @@ description: >
     Calling a function without "with" statement declared within the
     statement, leading to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.12_T3.js
+++ b/test/language/statements/with/S12.10_A1.12_T3.js
@@ -10,6 +10,7 @@ description: >
     Calling a function without "with" statement declared within the
     statement, leading to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.12_T4.js
+++ b/test/language/statements/with/S12.10_A1.12_T4.js
@@ -10,6 +10,7 @@ description: >
     Calling a function without "with" statement declared within the
     statement, leading to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.12_T5.js
+++ b/test/language/statements/with/S12.10_A1.12_T5.js
@@ -10,6 +10,7 @@ description: >
     Calling a function without "with" statement declared within the
     statement, leading to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.1_T1.js
+++ b/test/language/statements/with/S12.10_A1.1_T1.js
@@ -8,6 +8,7 @@ info: |
 es5id: 12.10_A1.1_T1
 description: Using "with" inside of global context leading to normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.1_T2.js
+++ b/test/language/statements/with/S12.10_A1.1_T2.js
@@ -10,6 +10,7 @@ description: >
     Using "with" inside of global context leading to completion by
     exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.1_T3.js
+++ b/test/language/statements/with/S12.10_A1.1_T3.js
@@ -10,6 +10,7 @@ description: >
     Using "with" inside of global context leading to completion by
     exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.2_T1.js
+++ b/test/language/statements/with/S12.10_A1.2_T1.js
@@ -11,6 +11,7 @@ description: >
     itself is declared within the function declaration, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.2_T2.js
+++ b/test/language/statements/with/S12.10_A1.2_T2.js
@@ -11,6 +11,7 @@ description: >
     itself is declared within the function declaration, leading to
     normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.2_T3.js
+++ b/test/language/statements/with/S12.10_A1.2_T3.js
@@ -11,6 +11,7 @@ description: >
     itself is declared within the function declaration, leading to
     normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.2_T4.js
+++ b/test/language/statements/with/S12.10_A1.2_T4.js
@@ -11,6 +11,7 @@ description: >
     itself is declared within the function declaration, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.2_T5.js
+++ b/test/language/statements/with/S12.10_A1.2_T5.js
@@ -11,6 +11,7 @@ description: >
     itself is declared within the function declaration, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.3_T1.js
+++ b/test/language/statements/with/S12.10_A1.3_T1.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within function constructor, leading to
     normal completition
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.3_T2.js
+++ b/test/language/statements/with/S12.10_A1.3_T2.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within function constructor, leading to
     normal completition by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.3_T3.js
+++ b/test/language/statements/with/S12.10_A1.3_T3.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within function constructor, leading to
     normal completition by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.3_T4.js
+++ b/test/language/statements/with/S12.10_A1.3_T4.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within function constructor, leading to
     completition by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.3_T5.js
+++ b/test/language/statements/with/S12.10_A1.3_T5.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within function constructor, leading to
     completition by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.4_T1.js
+++ b/test/language/statements/with/S12.10_A1.4_T1.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within iteration statement, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.4_T2.js
+++ b/test/language/statements/with/S12.10_A1.4_T2.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within iteration statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.4_T3.js
+++ b/test/language/statements/with/S12.10_A1.4_T3.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within iteration statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.4_T4.js
+++ b/test/language/statements/with/S12.10_A1.4_T4.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within iteration statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.4_T5.js
+++ b/test/language/statements/with/S12.10_A1.4_T5.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within iteration statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.5_T1.js
+++ b/test/language/statements/with/S12.10_A1.5_T1.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within "for-in" statement, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.5_T2.js
+++ b/test/language/statements/with/S12.10_A1.5_T2.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within "for-in" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.5_T3.js
+++ b/test/language/statements/with/S12.10_A1.5_T3.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within "for-in" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.5_T4.js
+++ b/test/language/statements/with/S12.10_A1.5_T4.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within "for-in" statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.5_T5.js
+++ b/test/language/statements/with/S12.10_A1.5_T5.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within "for-in" statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.6_T1.js
+++ b/test/language/statements/with/S12.10_A1.6_T1.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within another "with" statement, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.6_T2.js
+++ b/test/language/statements/with/S12.10_A1.6_T2.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within another "with" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.6_T3.js
+++ b/test/language/statements/with/S12.10_A1.6_T3.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within another "with" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.7_T1.js
+++ b/test/language/statements/with/S12.10_A1.7_T1.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared within the
     statement, leading to normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.7_T2.js
+++ b/test/language/statements/with/S12.10_A1.7_T2.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared within the
     statement, leading to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.7_T3.js
+++ b/test/language/statements/with/S12.10_A1.7_T3.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared within the
     statement, leading to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.7_T4.js
+++ b/test/language/statements/with/S12.10_A1.7_T4.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared within the
     statement, leading to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.7_T5.js
+++ b/test/language/statements/with/S12.10_A1.7_T5.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared within the
     statement, leading to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.8_T1.js
+++ b/test/language/statements/with/S12.10_A1.8_T1.js
@@ -10,6 +10,7 @@ description: >
     Declaring function constructor within "with" statement, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.8_T2.js
+++ b/test/language/statements/with/S12.10_A1.8_T2.js
@@ -10,6 +10,7 @@ description: >
     Declaring function constructor within "with" statement, leading to
     normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.8_T3.js
+++ b/test/language/statements/with/S12.10_A1.8_T3.js
@@ -10,6 +10,7 @@ description: >
     Declaring function constructor within "with" statement, leading to
     normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.8_T4.js
+++ b/test/language/statements/with/S12.10_A1.8_T4.js
@@ -10,6 +10,7 @@ description: >
     Declaring function constructor within "with" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.8_T5.js
+++ b/test/language/statements/with/S12.10_A1.8_T5.js
@@ -10,6 +10,7 @@ description: >
     Declaring function constructor within "with" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.9_T1.js
+++ b/test/language/statements/with/S12.10_A1.9_T1.js
@@ -10,6 +10,7 @@ description: >
     Using "for-in" statement within "with" statement, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.9_T2.js
+++ b/test/language/statements/with/S12.10_A1.9_T2.js
@@ -10,6 +10,7 @@ description: >
     Using "for-in" statement within "with" statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A1.9_T3.js
+++ b/test/language/statements/with/S12.10_A1.9_T3.js
@@ -10,6 +10,7 @@ description: >
     Using "for-in" statement within "with" statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.10_T1.js
+++ b/test/language/statements/with/S12.10_A3.10_T1.js
@@ -10,6 +10,7 @@ description: >
     Using iteration statement within "with" statement, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.10_T2.js
+++ b/test/language/statements/with/S12.10_A3.10_T2.js
@@ -10,6 +10,7 @@ description: >
     Using iteration statement within "with" statement, leading
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.10_T3.js
+++ b/test/language/statements/with/S12.10_A3.10_T3.js
@@ -10,6 +10,7 @@ description: >
     Using iteration statement within "with" statement, leading
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.10_T4.js
+++ b/test/language/statements/with/S12.10_A3.10_T4.js
@@ -10,6 +10,7 @@ description: >
     Using iteration statement within "with" statement, leading
     completion be break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.10_T5.js
+++ b/test/language/statements/with/S12.10_A3.10_T5.js
@@ -10,6 +10,7 @@ description: >
     Using iteration statement within "with" statement, leading
     completion be break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.11_T1.js
+++ b/test/language/statements/with/S12.10_A3.11_T1.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared without the
     statement, leading to normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.11_T2.js
+++ b/test/language/statements/with/S12.10_A3.11_T2.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared without the
     statement, leading to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.11_T3.js
+++ b/test/language/statements/with/S12.10_A3.11_T3.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared without the
     statement, leading to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.11_T4.js
+++ b/test/language/statements/with/S12.10_A3.11_T4.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared without the
     statement, leading to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.11_T5.js
+++ b/test/language/statements/with/S12.10_A3.11_T5.js
@@ -10,6 +10,7 @@ description: >
     Calling a function within "with" statement declared without the
     statement, leading to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.12_T1.js
+++ b/test/language/statements/with/S12.10_A3.12_T1.js
@@ -10,6 +10,7 @@ description: >
     Calling a function without "with" statement declared within the
     statement, leading to normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.12_T2.js
+++ b/test/language/statements/with/S12.10_A3.12_T2.js
@@ -10,6 +10,7 @@ description: >
     Calling a function without "with" statement declared within the
     statement, leading to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.12_T3.js
+++ b/test/language/statements/with/S12.10_A3.12_T3.js
@@ -10,6 +10,7 @@ description: >
     Calling a function without "with" statement declared within the
     statement, leading to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.12_T4.js
+++ b/test/language/statements/with/S12.10_A3.12_T4.js
@@ -10,6 +10,7 @@ description: >
     Calling a function without "with" statement declared within the
     statement, leading to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.12_T5.js
+++ b/test/language/statements/with/S12.10_A3.12_T5.js
@@ -10,6 +10,7 @@ description: >
     Calling a function without "with" statement declared within the
     statement, leading to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.1_T1.js
+++ b/test/language/statements/with/S12.10_A3.1_T1.js
@@ -8,6 +8,7 @@ info: |
 es5id: 12.10_A3.1_T1
 description: Using "with" statement within global context - normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.1_T2.js
+++ b/test/language/statements/with/S12.10_A3.1_T2.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within global context, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.1_T3.js
+++ b/test/language/statements/with/S12.10_A3.1_T3.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within global context, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.2_T1.js
+++ b/test/language/statements/with/S12.10_A3.2_T1.js
@@ -10,6 +10,7 @@ description: >
     Declaring "with" statement within a function body, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.2_T2.js
+++ b/test/language/statements/with/S12.10_A3.2_T2.js
@@ -10,6 +10,7 @@ description: >
     Declaring "with" statement within a function body, leading to
     normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.2_T3.js
+++ b/test/language/statements/with/S12.10_A3.2_T3.js
@@ -10,6 +10,7 @@ description: >
     Declaring "with" statement within a function body, leading to
     normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.2_T4.js
+++ b/test/language/statements/with/S12.10_A3.2_T4.js
@@ -10,6 +10,7 @@ description: >
     Declaring "with" statement within a function body, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.2_T5.js
+++ b/test/language/statements/with/S12.10_A3.2_T5.js
@@ -10,6 +10,7 @@ description: >
     Declaring "with" statement within a function body, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.3_T1.js
+++ b/test/language/statements/with/S12.10_A3.3_T1.js
@@ -10,6 +10,7 @@ description: >
     Declaring "with" statement within a function constructor, leading
     to normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.3_T2.js
+++ b/test/language/statements/with/S12.10_A3.3_T2.js
@@ -10,6 +10,7 @@ description: >
     Declaring "with" statement within a function constructor, leading
     to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.3_T3.js
+++ b/test/language/statements/with/S12.10_A3.3_T3.js
@@ -10,6 +10,7 @@ description: >
     Declaring "with" statement within a function constructor, leading
     to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.3_T4.js
+++ b/test/language/statements/with/S12.10_A3.3_T4.js
@@ -10,6 +10,7 @@ description: >
     Declaring "with" statement within a function constructor, leading
     to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.4_T1.js
+++ b/test/language/statements/with/S12.10_A3.4_T1.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within iteration statement, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.4_T2.js
+++ b/test/language/statements/with/S12.10_A3.4_T2.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within iteration statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.4_T3.js
+++ b/test/language/statements/with/S12.10_A3.4_T3.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within iteration statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.4_T4.js
+++ b/test/language/statements/with/S12.10_A3.4_T4.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within iteration statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.4_T5.js
+++ b/test/language/statements/with/S12.10_A3.4_T5.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within iteration statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.5_T1.js
+++ b/test/language/statements/with/S12.10_A3.5_T1.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within "for-in" statement, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.5_T2.js
+++ b/test/language/statements/with/S12.10_A3.5_T2.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within "for-in" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.5_T3.js
+++ b/test/language/statements/with/S12.10_A3.5_T3.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within "for-in" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.5_T4.js
+++ b/test/language/statements/with/S12.10_A3.5_T4.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within "for-in" statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.5_T5.js
+++ b/test/language/statements/with/S12.10_A3.5_T5.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within "for-in" statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.6_T1.js
+++ b/test/language/statements/with/S12.10_A3.6_T1.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within another "with" statement, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.6_T2.js
+++ b/test/language/statements/with/S12.10_A3.6_T2.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within another "with" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.6_T3.js
+++ b/test/language/statements/with/S12.10_A3.6_T3.js
@@ -10,6 +10,7 @@ description: >
     Using "with" statement within another "with" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.7_T1.js
+++ b/test/language/statements/with/S12.10_A3.7_T1.js
@@ -10,6 +10,7 @@ description: >
     Declaring and calling a function within "with" statement, leading
     to normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.7_T2.js
+++ b/test/language/statements/with/S12.10_A3.7_T2.js
@@ -10,6 +10,7 @@ description: >
     Declaring and calling a function within "with" statement, leading
     to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.7_T3.js
+++ b/test/language/statements/with/S12.10_A3.7_T3.js
@@ -10,6 +10,7 @@ description: >
     Declaring and calling a function within "with" statement, leading
     to normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.7_T4.js
+++ b/test/language/statements/with/S12.10_A3.7_T4.js
@@ -10,6 +10,7 @@ description: >
     Declaring and calling a function within "with" statement, leading
     to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.7_T5.js
+++ b/test/language/statements/with/S12.10_A3.7_T5.js
@@ -10,6 +10,7 @@ description: >
     Declaring and calling a function within "with" statement, leading
     to completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.8_T1.js
+++ b/test/language/statements/with/S12.10_A3.8_T1.js
@@ -10,6 +10,7 @@ description: >
     Declaring function constructor within "with" statement, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.8_T2.js
+++ b/test/language/statements/with/S12.10_A3.8_T2.js
@@ -10,6 +10,7 @@ description: >
     Declaring function constructor within "with" statement, leading to
     normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.8_T3.js
+++ b/test/language/statements/with/S12.10_A3.8_T3.js
@@ -10,6 +10,7 @@ description: >
     Declaring function constructor within "with" statement, leading to
     normal completion by "return"
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.8_T4.js
+++ b/test/language/statements/with/S12.10_A3.8_T4.js
@@ -10,6 +10,7 @@ description: >
     Declaring function constructor within "with" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.8_T5.js
+++ b/test/language/statements/with/S12.10_A3.8_T5.js
@@ -10,6 +10,7 @@ description: >
     Declaring function constructor within "with" statement, leading to
     completion by exception
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.9_T1.js
+++ b/test/language/statements/with/S12.10_A3.9_T1.js
@@ -10,6 +10,7 @@ description: >
     Using "for-in" statement within "with" statement, leading to
     normal completion
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.9_T2.js
+++ b/test/language/statements/with/S12.10_A3.9_T2.js
@@ -10,6 +10,7 @@ description: >
     Using "for-in" statement within "with" statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A3.9_T3.js
+++ b/test/language/statements/with/S12.10_A3.9_T3.js
@@ -10,6 +10,7 @@ description: >
     Using "for-in" statement within "with" statement, leading to
     completion by break
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A4_T1.js
+++ b/test/language/statements/with/S12.10_A4_T1.js
@@ -6,6 +6,7 @@ info: Changing property using "eval" statement containing "with" statement
 es5id: 12.10_A4_T1
 description: Changing string property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A4_T2.js
+++ b/test/language/statements/with/S12.10_A4_T2.js
@@ -6,6 +6,7 @@ info: Changing property using "eval" statement containing "with" statement
 es5id: 12.10_A4_T2
 description: Changing number property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 'a';

--- a/test/language/statements/with/S12.10_A4_T3.js
+++ b/test/language/statements/with/S12.10_A4_T3.js
@@ -6,6 +6,7 @@ info: Changing property using "eval" statement containing "with" statement
 es5id: 12.10_A4_T3
 description: Changing boolean property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 'a';

--- a/test/language/statements/with/S12.10_A4_T4.js
+++ b/test/language/statements/with/S12.10_A4_T4.js
@@ -6,6 +6,7 @@ info: Changing property using "eval" statement containing "with" statement
 es5id: 12.10_A4_T4
 description: Changing object property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 'a';

--- a/test/language/statements/with/S12.10_A4_T5.js
+++ b/test/language/statements/with/S12.10_A4_T5.js
@@ -6,6 +6,7 @@ info: Changing property using "eval" statement containing "with" statement
 es5id: 12.10_A4_T5
 description: Changing array property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 'a';

--- a/test/language/statements/with/S12.10_A4_T6.js
+++ b/test/language/statements/with/S12.10_A4_T6.js
@@ -6,6 +6,7 @@ info: Changing property using "eval" statement containing "with" statement
 es5id: 12.10_A4_T6
 description: Changing function property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 'a';

--- a/test/language/statements/with/S12.10_A5_T1.js
+++ b/test/language/statements/with/S12.10_A5_T1.js
@@ -6,6 +6,7 @@ info: Deleting property using "eval" statement containing "with" statement
 es5id: 12.10_A5_T1
 description: Deleting string property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 1;

--- a/test/language/statements/with/S12.10_A5_T2.js
+++ b/test/language/statements/with/S12.10_A5_T2.js
@@ -6,6 +6,7 @@ info: Deleting property using "eval" statement containing "with" statement
 es5id: 12.10_A5_T2
 description: Deleting number property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 'a';

--- a/test/language/statements/with/S12.10_A5_T3.js
+++ b/test/language/statements/with/S12.10_A5_T3.js
@@ -6,6 +6,7 @@ info: Deleting property using "eval" statement containing "with" statement
 es5id: 12.10_A5_T3
 description: Deleting boolean property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 'a';

--- a/test/language/statements/with/S12.10_A5_T4.js
+++ b/test/language/statements/with/S12.10_A5_T4.js
@@ -6,6 +6,7 @@ info: Deleting property using "eval" statement containing "with" statement
 es5id: 12.10_A5_T4
 description: Deleting object property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 'a';

--- a/test/language/statements/with/S12.10_A5_T5.js
+++ b/test/language/statements/with/S12.10_A5_T5.js
@@ -6,6 +6,7 @@ info: Deleting property using "eval" statement containing "with" statement
 es5id: 12.10_A5_T5
 description: Deleting array property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 'a';

--- a/test/language/statements/with/S12.10_A5_T6.js
+++ b/test/language/statements/with/S12.10_A5_T6.js
@@ -6,6 +6,7 @@ info: Deleting property using "eval" statement containing "with" statement
 es5id: 12.10_A5_T6
 description: Deleting function property
 flags: [noStrict]
+features: [with]
 ---*/
 
 this.p1 = 'a';

--- a/test/language/statements/with/binding-blocked-by-unscopables.js
+++ b/test/language/statements/with/binding-blocked-by-unscopables.js
@@ -20,7 +20,7 @@ info: |
     6. Set the withEnvironment flag of newEnv’s EnvironmentRecord to true.
     [...]
 flags: [noStrict]
-features: [Symbol.unscopables]
+features: [Symbol.unscopables, with]
 ---*/
 
 var x = 0;

--- a/test/language/statements/with/binding-not-blocked-by-unscopables-falsey-prop.js
+++ b/test/language/statements/with/binding-not-blocked-by-unscopables-falsey-prop.js
@@ -21,7 +21,7 @@ info: |
     6. Set the withEnvironment flag of newEnv’s EnvironmentRecord to true.
     [...]
 flags: [noStrict]
-features: [Symbol.unscopables]
+features: [Symbol.unscopables, with]
 ---*/
 
 var x = 0;

--- a/test/language/statements/with/binding-not-blocked-by-unscopables-non-obj.js
+++ b/test/language/statements/with/binding-not-blocked-by-unscopables-non-obj.js
@@ -20,7 +20,7 @@ info: |
     6. Set the withEnvironment flag of newEnv’s EnvironmentRecord to true.
     [...]
 flags: [noStrict]
-features: [Symbol.unscopables]
+features: [Symbol.unscopables, with]
 ---*/
 
 var test262ToString = {};

--- a/test/language/statements/with/cptn-abrupt-empty.js
+++ b/test/language/statements/with/cptn-abrupt-empty.js
@@ -12,6 +12,7 @@ info: |
     8. Set the running execution context's LexicalEnvironment to oldEnv.
     9. Return Completion(UpdateEmpty(C, undefined)).
 flags: [noStrict]
+features: [with]
 ---*/
 
 assert.sameValue(

--- a/test/language/statements/with/cptn-nrml.js
+++ b/test/language/statements/with/cptn-nrml.js
@@ -13,6 +13,7 @@ info: |
         NormalCompletion(undefined).
     11. Return Completion(C).
 flags: [noStrict]
+features: [with]
 ---*/
 
 assert.sameValue(eval('1; with({}) { }'), undefined);

--- a/test/language/statements/with/decl-async-fun.js
+++ b/test/language/statements/with/decl-async-fun.js
@@ -12,7 +12,7 @@ info: |
 negative:
   phase: parse
   type: SyntaxError
-features: [async-functions]
+features: [async-functions, with]
 flags: [noStrict]
 ---*/
 

--- a/test/language/statements/with/decl-async-gen.js
+++ b/test/language/statements/with/decl-async-gen.js
@@ -12,7 +12,7 @@ info: |
 negative:
   phase: parse
   type: SyntaxError
-features: [async-iteration]
+features: [async-iteration, with]
 flags: [noStrict]
 ---*/
 

--- a/test/language/statements/with/decl-cls.js
+++ b/test/language/statements/with/decl-cls.js
@@ -4,10 +4,11 @@
 description: Class declaration not allowed in statement position
 esid: sec-with-statement
 es6id: 13.11
-flags: [noStrict]
 negative:
   phase: parse
   type: SyntaxError
+flags: [noStrict]
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/decl-const.js
+++ b/test/language/statements/with/decl-const.js
@@ -4,10 +4,11 @@
 description: Lexical declaration (const) not allowed in statement position
 esid: sec-with-statement
 es6id: 13.11
-flags: [noStrict]
 negative:
   phase: parse
   type: SyntaxError
+flags: [noStrict]
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/decl-fun.js
+++ b/test/language/statements/with/decl-fun.js
@@ -4,10 +4,11 @@
 description: Function declaration not allowed in statement position
 esid: sec-with-statement
 es6id: 13.11
-flags: [noStrict]
 negative:
   phase: parse
   type: SyntaxError
+flags: [noStrict]
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/decl-gen.js
+++ b/test/language/statements/with/decl-gen.js
@@ -8,7 +8,7 @@ flags: [noStrict]
 negative:
   phase: parse
   type: SyntaxError
-features: [generators]
+features: [generators, with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/decl-let.js
+++ b/test/language/statements/with/decl-let.js
@@ -8,6 +8,7 @@ flags: [noStrict]
 negative:
   phase: parse
   type: SyntaxError
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/has-property-err.js
+++ b/test/language/statements/with/has-property-err.js
@@ -18,7 +18,7 @@ info: |
   2. Let bindings be the binding object for envRec.
   3. Let foundBinding be ? HasProperty(bindings, N).
 flags: [noStrict]
-features: [Proxy]
+features: [Proxy, with]
 ---*/
 
 var thrower = new Proxy({}, {

--- a/test/language/statements/with/labelled-fn-stmt.js
+++ b/test/language/statements/with/labelled-fn-stmt.js
@@ -19,6 +19,7 @@ info: |
 negative:
   phase: parse
   type: SyntaxError
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/let-array-with-newline.js
+++ b/test/language/statements/with/let-array-with-newline.js
@@ -13,6 +13,7 @@ negative:
   phase: parse
   type: SyntaxError
 flags: [noStrict]
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/let-block-with-newline.js
+++ b/test/language/statements/with/let-block-with-newline.js
@@ -10,6 +10,7 @@ info: |
     [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
     Expression[+In, ?Yield, ?Await] ;
 flags: [noStrict]
+features: [with]
 ---*/
 
 // Wrapped in an if-statement to avoid reference errors at runtime.

--- a/test/language/statements/with/let-identifier-with-newline.js
+++ b/test/language/statements/with/let-identifier-with-newline.js
@@ -10,6 +10,7 @@ info: |
     [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }]
     Expression[+In, ?Yield, ?Await] ;
 flags: [noStrict]
+features: [with]
 ---*/
 
 // Wrapped in an if-statement to avoid reference errors at runtime.

--- a/test/language/statements/with/scope-var-close.js
+++ b/test/language/statements/with/scope-var-close.js
@@ -12,6 +12,7 @@ info: |
     7. Let C be the result of evaluating Statement.
     8. Set the running execution context's LexicalEnvironment to oldEnv.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var probeBody;

--- a/test/language/statements/with/scope-var-open.js
+++ b/test/language/statements/with/scope-var-open.js
@@ -11,6 +11,7 @@ info: |
     6. Set the running execution context's LexicalEnvironment to newEnv.
     7. Let C be the result of evaluating Statement.
 flags: [noStrict]
+features: [with]
 ---*/
 
 var x = 0;

--- a/test/language/statements/with/stict-script.js
+++ b/test/language/statements/with/stict-script.js
@@ -10,6 +10,7 @@ negative:
   phase: parse
   type: SyntaxError
 flags: [onlyStrict]
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/strict-fn-decl-nested-1.js
+++ b/test/language/statements/with/strict-fn-decl-nested-1.js
@@ -10,6 +10,7 @@ negative:
   phase: parse
   type: SyntaxError
 flags: [noStrict]
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/strict-fn-decl-nested-2.js
+++ b/test/language/statements/with/strict-fn-decl-nested-2.js
@@ -9,6 +9,7 @@ negative:
   phase: parse
   type: SyntaxError
 flags: [noStrict]
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/strict-fn-decl.js
+++ b/test/language/statements/with/strict-fn-decl.js
@@ -4,10 +4,11 @@
 /*---
 es5id: 12.10.1-1-s
 description: with statement in strict mode throws SyntaxError (strict function)
-flags: [noStrict]
 negative:
   phase: parse
   type: SyntaxError
+flags: [noStrict]
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/strict-fn-expr.js
+++ b/test/language/statements/with/strict-fn-expr.js
@@ -9,6 +9,7 @@ negative:
   phase: parse
   type: SyntaxError
 flags: [onlyStrict]
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/strict-fn-method.js
+++ b/test/language/statements/with/strict-fn-method.js
@@ -10,6 +10,7 @@ negative:
   phase: parse
   type: SyntaxError
 flags: [onlyStrict]
+features: [with]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/statements/with/unscopables-get-err.js
+++ b/test/language/statements/with/unscopables-get-err.js
@@ -23,7 +23,7 @@ info: |
   5. Set the withEnvironment flag of newEnv’s EnvironmentRecord to true.
   [...]
 flags: [noStrict]
-features: [Symbol.unscopables]
+features: [Symbol.unscopables, with]
 ---*/
 
 var env = { x: 86 };

--- a/test/language/statements/with/unscopables-inc-dec.js
+++ b/test/language/statements/with/unscopables-inc-dec.js
@@ -17,7 +17,7 @@ info: |
   [...]
   6. Let unscopables be ? Get(bindings, @@unscopables).
 flags: [noStrict]
-features: [Symbol.unscopables]
+features: [Symbol.unscopables, with]
 ---*/
 
 var unscopablesGetterCalled = 0;

--- a/test/language/statements/with/unscopables-not-referenced-for-undef.js
+++ b/test/language/statements/with/unscopables-not-referenced-for-undef.js
@@ -26,7 +26,7 @@ info: |
   5. Set the withEnvironment flag of newEnv’s EnvironmentRecord to true.
   [...]
 flags: [noStrict]
-features: [Symbol.unscopables]
+features: [Symbol.unscopables, with]
 ---*/
 
 var x = 0;

--- a/test/language/statements/with/unscopables-prop-get-err.js
+++ b/test/language/statements/with/unscopables-prop-get-err.js
@@ -27,7 +27,7 @@ info: |
   5. Set the withEnvironment flag of newEnv’s EnvironmentRecord to true.
   [...]
 flags: [noStrict]
-features: [Symbol.unscopables]
+features: [Symbol.unscopables, with]
 ---*/
 
 var env = { x: 86 };


### PR DESCRIPTION
I'd like to propose adding a feature for tests containing the `with` language feature.

The use case that I have is pretty simple; in the [boa](https://github.com/boa-dev/boa) engine we currently do not have the `with` statement implemented and would like to ignore all tests containing it. This makes it a bit easier to see what features we have fully implemented right now, as some tests outside of the `test/language/statements/with` folder rely on the `with` statement and skew the results. It also makes it a bit easier to look for tests to fix in our overview.

I'd imagine that some engines may never want to implement `with` due to it's legacy nature. Making it easy to ignore while running the tests may also be nice for them.


I have added `with` to the feature list and added the feature to all tests that utilize it (that I could find using basic text search).