### PR TITLE
Fix more 402 Temporal tests broken by ICU72/CLDR42

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js
+++ b/test/intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js
@@ -8,7 +8,15 @@ locale: [en]
 features: [Temporal]
 ---*/
 
-const formatter = new Intl.DateTimeFormat("en", { timeZone: "Pacific/Apia" });
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDayPeriodSpace =
+  new Intl.DateTimeFormat("en-US", { timeStyle: "short" })
+    .formatToParts(0)
+    .find((part, i, parts) => part.type === "literal" && parts[i + 1].type === "dayPeriod")?.value || "";
+
+const formatter = new Intl.DateTimeFormat("en-US", { timeZone: "Pacific/Apia" });
 
 const date = new Temporal.PlainDate(2021, 8, 4);
 const dateResult = formatter.format(date);
@@ -16,10 +24,14 @@ assert.sameValue(dateResult, "8/4/2021", "plain date");
 
 const datetime1 = new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789);
 const datetimeResult1 = formatter.format(datetime1);
-assert.sameValue(datetimeResult1, "8/4/2021, 12:30:45 AM", "plain datetime close to beginning of day");
+assert.sameValue(
+  datetimeResult1,
+  `8/4/2021, 12:30:45${usDayPeriodSpace}AM`,
+  "plain datetime close to beginning of day"
+);
 const datetime2 = new Temporal.PlainDateTime(2021, 8, 4, 23, 30, 45, 123, 456, 789);
 const datetimeResult2 = formatter.format(datetime2);
-assert.sameValue(datetimeResult2, "8/4/2021, 11:30:45 PM", "plain datetime close to end of day");
+assert.sameValue(datetimeResult2, `8/4/2021, 11:30:45${usDayPeriodSpace}PM`, "plain datetime close to end of day");
 
 const monthDay = new Temporal.PlainMonthDay(8, 4, "gregory");
 const monthDayResult = formatter.format(monthDay);
@@ -27,10 +39,10 @@ assert.sameValue(monthDayResult, "8/4", "plain month-day");
 
 const time1 = new Temporal.PlainTime(0, 30, 45, 123, 456, 789);
 const timeResult1 = formatter.format(time1);
-assert.sameValue(timeResult1, "12:30:45 AM", "plain time close to beginning of day");
+assert.sameValue(timeResult1, `12:30:45${usDayPeriodSpace}AM`, "plain time close to beginning of day");
 const time2 = new Temporal.PlainTime(23, 30, 45, 123, 456, 789);
 const timeResult2 = formatter.format(time2);
-assert.sameValue(timeResult2, "11:30:45 PM", "plain time close to end of day");
+assert.sameValue(timeResult2, `11:30:45${usDayPeriodSpace}PM`, "plain time close to end of day");
 
 const month = new Temporal.PlainYearMonth(2021, 8, "gregory");
 const monthResult = formatter.format(month);

--- a/test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-resolved-time-zone.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-resolved-time-zone.js
@@ -8,29 +8,49 @@ locale: [en]
 features: [Temporal, Intl.DateTimeFormat-formatRange]
 ---*/
 
-const formatter = new Intl.DateTimeFormat("en", { timeZone: "Pacific/Apia" });
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDayPeriodSpace =
+  new Intl.DateTimeFormat("en-US", { timeStyle: "short" })
+    .formatToParts(0)
+    .find((part, i, parts) => part.type === "literal" && parts[i + 1].type === "dayPeriod")?.value || "";
+
+const usDateRangeSeparator = new Intl.DateTimeFormat("en-US", { dateStyle: "short" })
+  .formatRangeToParts(1 * 86400 * 1000, 366 * 86400 * 1000)
+  .find((part) => part.type === "literal" && part.source === "shared").value;
+
+const formatter = new Intl.DateTimeFormat("en-US", { timeZone: "Pacific/Apia" });
 
 const date1 = new Temporal.PlainDate(2021, 8, 4);
 const date2 = new Temporal.PlainDate(2021, 8, 5);
 const dateResult = formatter.formatRange(date1, date2);
-assert.sameValue(dateResult, "8/4/2021 – 8/5/2021", "plain dates");
+assert.sameValue(dateResult, `8/4/2021${usDateRangeSeparator}8/5/2021`, "plain dates");
 
 const datetime1 = new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789);
 const datetime2 = new Temporal.PlainDateTime(2021, 8, 4, 23, 30, 45, 123, 456, 789);
 const datetimeResult = formatter.formatRange(datetime1, datetime2);
-assert.sameValue(datetimeResult, "8/4/2021, 12:30:45 AM – 11:30:45 PM", "plain datetimes");
+assert.sameValue(
+  datetimeResult,
+  `8/4/2021, 12:30:45${usDayPeriodSpace}AM${usDateRangeSeparator}11:30:45${usDayPeriodSpace}PM`,
+  "plain datetimes"
+);
 
 const monthDay1 = new Temporal.PlainMonthDay(8, 4, "gregory");
 const monthDay2 = new Temporal.PlainMonthDay(8, 5, "gregory");
 const monthDayResult = formatter.formatRange(monthDay1, monthDay2);
-assert.sameValue(monthDayResult, "8/4 – 8/5", "plain month-days");
+assert.sameValue(monthDayResult, `8/4${usDateRangeSeparator}8/5`, "plain month-days");
 
 const time1 = new Temporal.PlainTime(0, 30, 45, 123, 456, 789);
 const time2 = new Temporal.PlainTime(23, 30, 45, 123, 456, 789);
 const timeResult = formatter.formatRange(time1, time2);
-assert.sameValue(timeResult, "12:30:45 AM – 11:30:45 PM", "plain times");
+assert.sameValue(
+  timeResult,
+  `12:30:45${usDayPeriodSpace}AM${usDateRangeSeparator}11:30:45${usDayPeriodSpace}PM`,
+  "plain times"
+);
 
 const month1 = new Temporal.PlainYearMonth(2021, 8, "gregory");
 const month2 = new Temporal.PlainYearMonth(2021, 9, "gregory");
 const monthResult = formatter.formatRange(month1, month2);
-assert.sameValue(monthResult, "8/2021 – 9/2021", "plain year-months");
+assert.sameValue(monthResult, `8/2021${usDateRangeSeparator}9/2021`, "plain year-months");

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-resolved-time-zone.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-resolved-time-zone.js
@@ -9,7 +9,18 @@ includes: [deepEqual.js]
 features: [Temporal, Intl.DateTimeFormat-formatRange]
 ---*/
 
-const formatter = new Intl.DateTimeFormat("en", { timeZone: "Pacific/Apia" });
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDayPeriodSpace =
+  new Intl.DateTimeFormat('en-US', { timeStyle: 'short' })
+    .formatToParts(0)
+    .find((part, i, parts) => part.type === 'literal' && parts[i + 1].type === 'dayPeriod')?.value || '';
+const usDateRangeSeparator = new Intl.DateTimeFormat('en-US', { dateStyle: 'short' })
+  .formatRangeToParts(1 * 86400 * 1000, 366 * 86400 * 1000)
+  .find((part) => part.type === 'literal' && part.source === 'shared').value;
+
+const formatter = new Intl.DateTimeFormat('en-US', { timeZone: 'Pacific/Apia' });
 
 const date1 = new Temporal.PlainDate(2021, 8, 4);
 const date2 = new Temporal.PlainDate(2021, 8, 5);
@@ -20,7 +31,7 @@ assert.deepEqual(dateResult, [
   { type: "day", value: "4", source: "startRange" },
   { type: "literal", value: "/", source: "startRange" },
   { type: "year", value: "2021", source: "startRange" },
-  { type: "literal", value: " – ", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "8", source: "endRange" },
   { type: "literal", value: "/", source: "endRange" },
   { type: "day", value: "5", source: "endRange" },
@@ -43,15 +54,15 @@ assert.deepEqual(datetimeResult, [
   { type: "minute", value: "30", source: "startRange" },
   { type: "literal", value: ":", source: "startRange" },
   { type: "second", value: "45", source: "startRange" },
-  { type: "literal", value: " ", source: "startRange" },
+  { type: "literal", value: usDayPeriodSpace, source: "startRange" },
   { type: "dayPeriod", value: "AM", source: "startRange" },
-  { type: "literal", value: " – ", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "hour", value: "11", source: "endRange" },
   { type: "literal", value: ":", source: "endRange" },
   { type: "minute", value: "30", source: "endRange" },
   { type: "literal", value: ":", source: "endRange" },
   { type: "second", value: "45", source: "endRange" },
-  { type: "literal", value: " ", source: "endRange" },
+  { type: "literal", value: usDayPeriodSpace, source: "endRange" },
   { type: "dayPeriod", value: "PM", source: "endRange" },
 ], "plain datetimes");
 
@@ -62,7 +73,7 @@ assert.deepEqual(monthDayResult, [
   { type: "month", value: "8", source: "startRange" },
   { type: "literal", value: "/", source: "startRange" },
   { type: "day", value: "4", source: "startRange" },
-  { type: "literal", value: " – ", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "8", source: "endRange" },
   { type: "literal", value: "/", source: "endRange" },
   { type: "day", value: "5", source: "endRange" },
@@ -77,15 +88,15 @@ assert.deepEqual(timeResult, [
   { type: "minute", value: "30", source: "startRange" },
   { type: "literal", value: ":", source: "startRange" },
   { type: "second", value: "45", source: "startRange" },
-  { type: "literal", value: " ", source: "startRange" },
+  { type: "literal", value: usDayPeriodSpace, source: "startRange" },
   { type: "dayPeriod", value: "AM", source: "startRange" },
-  { type: "literal", value: " – ", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "hour", value: "11", source: "endRange" },
   { type: "literal", value: ":", source: "endRange" },
   { type: "minute", value: "30", source: "endRange" },
   { type: "literal", value: ":", source: "endRange" },
   { type: "second", value: "45", source: "endRange" },
-  { type: "literal", value: " ", source: "endRange" },
+  { type: "literal", value: usDayPeriodSpace, source: "endRange" },
   { type: "dayPeriod", value: "PM", source: "endRange" },
 ], "plain times");
 
@@ -96,7 +107,7 @@ assert.deepEqual(monthResult, [
   { type: "month", value: "8", source: "startRange" },
   { type: "literal", value: "/", source: "startRange" },
   { type: "year", value: "2021", source: "startRange" },
-  { type: "literal", value: " – ", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "9", source: "endRange" },
   { type: "literal", value: "/", source: "endRange" },
   { type: "year", value: "2021", source: "endRange" },

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-resolved-time-zone.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-resolved-time-zone.js
@@ -9,7 +9,15 @@ includes: [deepEqual.js]
 features: [Temporal]
 ---*/
 
-const formatter = new Intl.DateTimeFormat("en", { timeZone: "Pacific/Apia" });
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDayPeriodSpace =
+  new Intl.DateTimeFormat("en-US", { timeStyle: "short" })
+    .formatToParts(0)
+    .find((part, i, parts) => part.type === "literal" && parts[i + 1].type === "dayPeriod")?.value || "";
+
+const formatter = new Intl.DateTimeFormat("en-US", { timeZone: "Pacific/Apia" });
 
 const date = new Temporal.PlainDate(2021, 8, 4);
 const dateResult = formatter.formatToParts(date);
@@ -35,7 +43,7 @@ assert.deepEqual(datetimeResult1, [
   { type: "minute", value: "30" },
   { type: "literal", value: ":" },
   { type: "second", value: "45" },
-  { type: "literal", value: " " },
+  { type: "literal", value: usDayPeriodSpace },
   { type: "dayPeriod", value: "AM" },
 ], "plain datetime close to beginning of day");
 const datetime2 = new Temporal.PlainDateTime(2021, 8, 4, 23, 30, 45, 123, 456, 789);
@@ -52,7 +60,7 @@ assert.deepEqual(datetimeResult2, [
   { type: "minute", value: "30" },
   { type: "literal", value: ":" },
   { type: "second", value: "45" },
-  { type: "literal", value: " " },
+  { type: "literal", value: usDayPeriodSpace },
   { type: "dayPeriod", value: "PM" },
 ], "plain datetime close to end of day");
 
@@ -72,7 +80,7 @@ assert.deepEqual(timeResult1, [
   { type: "minute", value: "30" },
   { type: "literal", value: ":" },
   { type: "second", value: "45" },
-  { type: "literal", value: " " },
+  { type: "literal", value: usDayPeriodSpace },
   { type: "dayPeriod", value: "AM" },
 ], "plain time close to beginning of day");
 const time2 = new Temporal.PlainTime(23, 30, 45, 123, 456, 789);
@@ -83,7 +91,7 @@ assert.deepEqual(timeResult2, [
   { type: "minute", value: "30" },
   { type: "literal", value: ":" },
   { type: "second", value: "45" },
-  { type: "literal", value: " " },
+  { type: "literal", value: usDayPeriodSpace },
   { type: "dayPeriod", value: "PM" },
 ], "plain time close to end of day");
 


### PR DESCRIPTION
Fixes 4 more Temporal-related tests that break in ICU 72 / CLDR 42.

Follows up on https://github.com/tc39/test262/pull/3676#issuecomment-1302685505 and #3751.