### PR TITLE
Final batch of CLDR backwards-compatibility fixes

### DIFF
--- a/test/intl402/DateTimeFormat/prototype/format/timedatestyle-en.js
+++ b/test/intl402/DateTimeFormat/prototype/format/timedatestyle-en.js
@@ -8,6 +8,14 @@ features: [Intl.DateTimeFormat-datetimestyle]
 locale: [en-US]
 ---*/
 
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDayPeriodSpace =
+  new Intl.DateTimeFormat("en-US", { timeStyle: "short" })
+    .formatToParts(0)
+    .find((part, i, parts) => part.type === "literal" && parts[i + 1].type === "dayPeriod")?.value || "";
+
 const date = new Date("1886-05-01T14:12:47Z");
 const dateOptions = [
   ["full", "Saturday, May 1, 1886"],
@@ -17,10 +25,10 @@ const dateOptions = [
 ];
 
 const timeOptions = [
-  ["full", "2:12:47\u{202F}PM Coordinated Universal Time", "14:12:47 Coordinated Universal Time"],
-  ["long", "2:12:47\u{202F}PM UTC", "14:12:47 UTC"],
-  ["medium", "2:12:47\u{202F}PM", "14:12:47"],
-  ["short", "2:12\u{202F}PM", "14:12"],
+  ["full", `2:12:47${usDayPeriodSpace}PM Coordinated Universal Time`, "14:12:47 Coordinated Universal Time"],
+  ["long", `2:12:47${usDayPeriodSpace}PM UTC`, "14:12:47 UTC"],
+  ["medium", `2:12:47${usDayPeriodSpace}PM`, "14:12:47"],
+  ["short", `2:12${usDayPeriodSpace}PM`, "14:12"],
 ];
 
 const options12 = [

--- a/test/intl402/DateTimeFormat/prototype/formatRange/en-US.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRange/en-US.js
@@ -12,6 +12,13 @@ locale: [en-US]
 features: [Intl.DateTimeFormat-formatRange]
 ---*/
 
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDateRangeSeparator = new Intl.DateTimeFormat("en-US", { dateStyle: "short" })
+  .formatRangeToParts(1 * 86400 * 1000, 366 * 86400 * 1000)
+  .find((part) => part.type === "literal" && part.source === "shared").value;
+
 const date1 = new Date("2019-01-03T00:00:00");
 const date2 = new Date("2019-01-05T00:00:00");
 const date3 = new Date("2019-03-04T00:00:00");
@@ -19,18 +26,18 @@ const date4 = new Date("2020-03-04T00:00:00");
 
 let dtf = new Intl.DateTimeFormat("en-US");
 assert.sameValue(dtf.formatRange(date1, date1), "1/3/2019");
-assert.sameValue(dtf.formatRange(date1, date2), "1/3/2019\u{2009}\u{2013}\u{2009}1/5/2019");
-assert.sameValue(dtf.formatRange(date1, date3), "1/3/2019\u{2009}\u{2013}\u{2009}3/4/2019");
-assert.sameValue(dtf.formatRange(date1, date4), "1/3/2019\u{2009}\u{2013}\u{2009}3/4/2020");
-assert.sameValue(dtf.formatRange(date2, date3), "1/5/2019\u{2009}\u{2013}\u{2009}3/4/2019");
-assert.sameValue(dtf.formatRange(date2, date4), "1/5/2019\u{2009}\u{2013}\u{2009}3/4/2020");
-assert.sameValue(dtf.formatRange(date3, date4), "3/4/2019\u{2009}\u{2013}\u{2009}3/4/2020");
+assert.sameValue(dtf.formatRange(date1, date2), `1/3/2019${usDateRangeSeparator}1/5/2019`);
+assert.sameValue(dtf.formatRange(date1, date3), `1/3/2019${usDateRangeSeparator}3/4/2019`);
+assert.sameValue(dtf.formatRange(date1, date4), `1/3/2019${usDateRangeSeparator}3/4/2020`);
+assert.sameValue(dtf.formatRange(date2, date3), `1/5/2019${usDateRangeSeparator}3/4/2019`);
+assert.sameValue(dtf.formatRange(date2, date4), `1/5/2019${usDateRangeSeparator}3/4/2020`);
+assert.sameValue(dtf.formatRange(date3, date4), `3/4/2019${usDateRangeSeparator}3/4/2020`);
 
 dtf = new Intl.DateTimeFormat("en-US", {year: "numeric", month: "short", day: "numeric"});
 assert.sameValue(dtf.formatRange(date1, date1), "Jan 3, 2019");
-assert.sameValue(dtf.formatRange(date1, date2), "Jan 3\u{2009}\u{2013}\u{2009}5, 2019");
-assert.sameValue(dtf.formatRange(date1, date3), "Jan 3\u{2009}\u{2013}\u{2009}Mar 4, 2019");
-assert.sameValue(dtf.formatRange(date1, date4), "Jan 3, 2019\u{2009}\u{2013}\u{2009}Mar 4, 2020");
-assert.sameValue(dtf.formatRange(date2, date3), "Jan 5\u{2009}\u{2013}\u{2009}Mar 4, 2019");
-assert.sameValue(dtf.formatRange(date2, date4), "Jan 5, 2019\u{2009}\u{2013}\u{2009}Mar 4, 2020");
-assert.sameValue(dtf.formatRange(date3, date4), "Mar 4, 2019\u{2009}\u{2013}\u{2009}Mar 4, 2020");
+assert.sameValue(dtf.formatRange(date1, date2), `Jan 3${usDateRangeSeparator}5, 2019`);
+assert.sameValue(dtf.formatRange(date1, date3), `Jan 3${usDateRangeSeparator}Mar 4, 2019`);
+assert.sameValue(dtf.formatRange(date1, date4), `Jan 3, 2019${usDateRangeSeparator}Mar 4, 2020`);
+assert.sameValue(dtf.formatRange(date2, date3), `Jan 5${usDateRangeSeparator}Mar 4, 2019`);
+assert.sameValue(dtf.formatRange(date2, date4), `Jan 5, 2019${usDateRangeSeparator}Mar 4, 2020`);
+assert.sameValue(dtf.formatRange(date3, date4), `Mar 4, 2019${usDateRangeSeparator}Mar 4, 2020`);

--- a/test/intl402/DateTimeFormat/prototype/formatRange/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRange/fractionalSecondDigits.js
@@ -8,6 +8,13 @@ features: [Intl.DateTimeFormat-fractionalSecondDigits, Intl.DateTimeFormat-forma
 locale: [en-US]
 ---*/
 
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDateRangeSeparator = new Intl.DateTimeFormat("en-US", { dateStyle: "short" })
+  .formatRangeToParts(1 * 86400 * 1000, 366 * 86400 * 1000)
+  .find((part) => part.type === "literal" && part.source === "shared").value;
+
 const d1 = new Date(2019, 7, 10,  1, 2, 3, 234);
 const d2 = new Date(2019, 7, 10,  1, 2, 3, 567);
 const d3 = new Date(2019, 7, 10,  1, 2, 13, 987);
@@ -15,19 +22,19 @@ const d3 = new Date(2019, 7, 10,  1, 2, 13, 987);
 let dtf = new Intl.DateTimeFormat(
     'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: undefined});
 assert.sameValue(dtf.formatRange(d1, d2), "02:03", "no fractionalSecondDigits");
-assert.sameValue(dtf.formatRange(d1, d3), "02:03\u{2009}\u{2013}\u{2009}02:13", "no fractionalSecondDigits");
+assert.sameValue(dtf.formatRange(d1, d3), `02:03${usDateRangeSeparator}02:13`, "no fractionalSecondDigits");
 
 dtf = new Intl.DateTimeFormat(
     'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: 1});
-assert.sameValue(dtf.formatRange(d1, d2), "02:03.2\u{2009}\u{2013}\u{2009}02:03.5", "1 fractionalSecondDigits round down");
-assert.sameValue(dtf.formatRange(d1, d3), "02:03.2\u{2009}\u{2013}\u{2009}02:13.9", "1 fractionalSecondDigits round down");
+assert.sameValue(dtf.formatRange(d1, d2), `02:03.2${usDateRangeSeparator}02:03.5`, "1 fractionalSecondDigits round down");
+assert.sameValue(dtf.formatRange(d1, d3), `02:03.2${usDateRangeSeparator}02:13.9`, "1 fractionalSecondDigits round down");
 
 dtf = new Intl.DateTimeFormat(
     'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: 2});
-assert.sameValue(dtf.formatRange(d1, d2), "02:03.23\u{2009}\u{2013}\u{2009}02:03.56", "2 fractionalSecondDigits round down");
-assert.sameValue(dtf.formatRange(d1, d3), "02:03.23\u{2009}\u{2013}\u{2009}02:13.98", "2 fractionalSecondDigits round down");
+assert.sameValue(dtf.formatRange(d1, d2), `02:03.23${usDateRangeSeparator}02:03.56`, "2 fractionalSecondDigits round down");
+assert.sameValue(dtf.formatRange(d1, d3), `02:03.23${usDateRangeSeparator}02:13.98`, "2 fractionalSecondDigits round down");
 
 dtf = new Intl.DateTimeFormat(
     'en', { minute: "numeric", second: "numeric", fractionalSecondDigits: 3});
-assert.sameValue(dtf.formatRange(d1, d2), "02:03.234\u{2009}\u{2013}\u{2009}02:03.567", "3 fractionalSecondDigits round down");
-assert.sameValue(dtf.formatRange(d1, d3), "02:03.234\u{2009}\u{2013}\u{2009}02:13.987", "3 fractionalSecondDigits round down");
+assert.sameValue(dtf.formatRange(d1, d2), `02:03.234${usDateRangeSeparator}02:03.567`, "3 fractionalSecondDigits round down");
+assert.sameValue(dtf.formatRange(d1, d3), `02:03.234${usDateRangeSeparator}02:13.987`, "3 fractionalSecondDigits round down");

--- a/test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-resolved-time-zone.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-resolved-time-zone.js
@@ -15,7 +15,6 @@ const usDayPeriodSpace =
   new Intl.DateTimeFormat("en-US", { timeStyle: "short" })
     .formatToParts(0)
     .find((part, i, parts) => part.type === "literal" && parts[i + 1].type === "dayPeriod")?.value || "";
-
 const usDateRangeSeparator = new Intl.DateTimeFormat("en-US", { dateStyle: "short" })
   .formatRangeToParts(1 * 86400 * 1000, 366 * 86400 * 1000)
   .find((part) => part.type === "literal" && part.source === "shared").value;

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/en-US.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/en-US.js
@@ -12,6 +12,13 @@ locale: [en-US]
 features: [Intl.DateTimeFormat-formatRange]
 ---*/
 
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDateRangeSeparator = new Intl.DateTimeFormat("en-US", { dateStyle: "short" })
+  .formatRangeToParts(1 * 86400 * 1000, 366 * 86400 * 1000)
+  .find((part) => part.type === "literal" && part.source === "shared").value;
+
 function* zip(a, b) {
   assert.sameValue(a.length, b.length);
   for (let i = 0; i < a.length; ++i) {
@@ -46,7 +53,7 @@ compare(dtf.formatRangeToParts(date1, date2), [
   { type: "day", value: "3", source: "startRange" },
   { type: "literal", value: "/", source: "startRange" },
   { type: "year", value: "2019", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "1", source: "endRange" },
   { type: "literal", value: "/", source: "endRange" },
   { type: "day", value: "5", source: "endRange" },
@@ -59,7 +66,7 @@ compare(dtf.formatRangeToParts(date1, date3), [
   { type: "day", value: "3", source: "startRange" },
   { type: "literal", value: "/", source: "startRange" },
   { type: "year", value: "2019", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "3", source: "endRange" },
   { type: "literal", value: "/", source: "endRange" },
   { type: "day", value: "4", source: "endRange" },
@@ -72,7 +79,7 @@ compare(dtf.formatRangeToParts(date1, date4), [
   { type: "day", value: "3", source: "startRange" },
   { type: "literal", value: "/", source: "startRange" },
   { type: "year", value: "2019", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "3", source: "endRange" },
   { type: "literal", value: "/", source: "endRange" },
   { type: "day", value: "4", source: "endRange" },
@@ -85,7 +92,7 @@ compare(dtf.formatRangeToParts(date2, date3), [
   { type: "day", value: "5", source: "startRange" },
   { type: "literal", value: "/", source: "startRange" },
   { type: "year", value: "2019", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "3", source: "endRange" },
   { type: "literal", value: "/", source: "endRange" },
   { type: "day", value: "4", source: "endRange" },
@@ -98,7 +105,7 @@ compare(dtf.formatRangeToParts(date2, date4), [
   { type: "day", value: "5", source: "startRange" },
   { type: "literal", value: "/", source: "startRange" },
   { type: "year", value: "2019", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "3", source: "endRange" },
   { type: "literal", value: "/", source: "endRange" },
   { type: "day", value: "4", source: "endRange" },
@@ -111,7 +118,7 @@ compare(dtf.formatRangeToParts(date3, date4), [
   { type: "day", value: "4", source: "startRange" },
   { type: "literal", value: "/", source: "startRange" },
   { type: "year", value: "2019", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "3", source: "endRange" },
   { type: "literal", value: "/", source: "endRange" },
   { type: "day", value: "4", source: "endRange" },
@@ -131,7 +138,7 @@ compare(dtf.formatRangeToParts(date1, date2), [
   { type: "month", value: "Jan", source: "shared" },
   { type: "literal", value: " ", source: "shared" },
   { type: "day", value: "3", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "day", value: "5", source: "endRange" },
   { type: "literal", value: ", ", source: "shared" },
   { type: "year", value: "2019", source: "shared" },
@@ -140,7 +147,7 @@ compare(dtf.formatRangeToParts(date1, date3), [
   { type: "month", value: "Jan", source: "startRange" },
   { type: "literal", value: " ", source: "startRange" },
   { type: "day", value: "3", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "Mar", source: "endRange" },
   { type: "literal", value: " ", source: "endRange" },
   { type: "day", value: "4", source: "endRange" },
@@ -153,7 +160,7 @@ compare(dtf.formatRangeToParts(date1, date4), [
   { type: "day", value: "3", source: "startRange" },
   { type: "literal", value: ", ", source: "startRange" },
   { type: "year", value: "2019", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "Mar", source: "endRange" },
   { type: "literal", value: " ", source: "endRange" },
   { type: "day", value: "4", source: "endRange" },
@@ -164,7 +171,7 @@ compare(dtf.formatRangeToParts(date2, date3), [
   { type: "month", value: "Jan", source: "startRange" },
   { type: "literal", value: " ", source: "startRange" },
   { type: "day", value: "5", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "Mar", source: "endRange" },
   { type: "literal", value: " ", source: "endRange" },
   { type: "day", value: "4", source: "endRange" },
@@ -177,7 +184,7 @@ compare(dtf.formatRangeToParts(date2, date4), [
   { type: "day", value: "5", source: "startRange" },
   { type: "literal", value: ", ", source: "startRange" },
   { type: "year", value: "2019", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "Mar", source: "endRange" },
   { type: "literal", value: " ", source: "endRange" },
   { type: "day", value: "4", source: "endRange" },
@@ -190,7 +197,7 @@ compare(dtf.formatRangeToParts(date3, date4), [
   { type: "day", value: "4", source: "startRange" },
   { type: "literal", value: ", ", source: "startRange" },
   { type: "year", value: "2019", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "month", value: "Mar", source: "endRange" },
   { type: "literal", value: " ", source: "endRange" },
   { type: "day", value: "4", source: "endRange" },

--- a/test/intl402/DateTimeFormat/prototype/formatRangeToParts/fractionalSecondDigits.js
+++ b/test/intl402/DateTimeFormat/prototype/formatRangeToParts/fractionalSecondDigits.js
@@ -8,6 +8,13 @@ features: [Intl.DateTimeFormat-fractionalSecondDigits, Intl.DateTimeFormat-forma
 locale: [en-US]
 ---*/
 
+// Tolerate implementation variance by expecting consistency without being prescriptive.
+// TODO: can we change tests to be less reliant on CLDR formats while still testing that
+// Temporal and Intl are behaving as expected?
+const usDateRangeSeparator = new Intl.DateTimeFormat("en-US", { dateStyle: "short" })
+  .formatRangeToParts(1 * 86400 * 1000, 366 * 86400 * 1000)
+  .find((part) => part.type === "literal" && part.source === "shared").value;
+
 function* zip(a, b) {
   assert.sameValue(a.length, b.length);
   for (let i = 0; i < a.length; ++i) {
@@ -50,7 +57,7 @@ compare(dtf.formatRangeToParts(d1, d3), [
   { type: "minute", value: "02", source: "startRange" },
   { type: "literal", value: ":", source: "startRange" },
   { type: "second", value: "03", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "minute", value: "02", source: "endRange" },
   { type: "literal", value: ":", source: "endRange" },
   { type: "second", value: "13", source: "endRange" }
@@ -65,7 +72,7 @@ compare(dtf.formatRangeToParts(d1, d2), [
   { type: "second", value: "03", source: "startRange" },
   { type: "literal", value: ".", source: "startRange" },
   { type: "fractionalSecond", value: "2", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "minute", value: "02", source: "endRange" },
   { type: "literal", value: ":", source: "endRange" },
   { type: "second", value: "03", source: "endRange" },
@@ -79,7 +86,7 @@ compare(dtf.formatRangeToParts(d1, d3), [
   { type: "second", value: "03", source: "startRange" },
   { type: "literal", value: ".", source: "startRange" },
   { type: "fractionalSecond", value: "2", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "minute", value: "02", source: "endRange" },
   { type: "literal", value: ":", source: "endRange" },
   { type: "second", value: "13", source: "endRange" },
@@ -96,7 +103,7 @@ compare(dtf.formatRangeToParts(d1, d2), [
   { type: "second", value: "03", source: "startRange" },
   { type: "literal", value: ".", source: "startRange" },
   { type: "fractionalSecond", value: "23", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "minute", value: "02", source: "endRange" },
   { type: "literal", value: ":", source: "endRange" },
   { type: "second", value: "03", source: "endRange" },
@@ -110,7 +117,7 @@ compare(dtf.formatRangeToParts(d1, d3), [
   { type: "second", value: "03", source: "startRange" },
   { type: "literal", value: ".", source: "startRange" },
   { type: "fractionalSecond", value: "23", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "minute", value: "02", source: "endRange" },
   { type: "literal", value: ":", source: "endRange" },
   { type: "second", value: "13", source: "endRange" },
@@ -127,7 +134,7 @@ compare(dtf.formatRangeToParts(d1, d2), [
   { type: "second", value: "03", source: "startRange" },
   { type: "literal", value: ".", source: "startRange" },
   { type: "fractionalSecond", value: "234", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "minute", value: "02", source: "endRange" },
   { type: "literal", value: ":", source: "endRange" },
   { type: "second", value: "03", source: "endRange" },
@@ -141,7 +148,7 @@ compare(dtf.formatRangeToParts(d1, d3), [
   { type: "second", value: "03", source: "startRange" },
   { type: "literal", value: ".", source: "startRange" },
   { type: "fractionalSecond", value: "234", source: "startRange" },
-  { type: "literal", value: "\u2009\u2013\u2009", source: "shared" },
+  { type: "literal", value: usDateRangeSeparator, source: "shared" },
   { type: "minute", value: "02", source: "endRange" },
   { type: "literal", value: ":", source: "endRange" },
   { type: "second", value: "13", source: "endRange" },


### PR DESCRIPTION
Following up on #3751 and #3762, this commit makes a few tests work on both CLDR 42 and CLDR 41. Previously these tests were tied to a specific CLDR 42 format.