### PR TITLE
Temporal: Regularize tests and expand coverage

### DIFF
--- a/test/built-ins/Temporal/Calendar/from/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/Calendar/from/calendar-temporal-object.js
@@ -5,16 +5,35 @@
 esid: sec-temporal.calendar.from
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.calendar.from step 1:
-      1. Return ? ToTemporalCalendar(_item_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const newCalendar = Temporal.Calendar.from(temporalObject);
-  assert.sameValue(newCalendar, calendar, "calendar object retrieved from internal slot");
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const result = Temporal.Calendar.from(arg);
+  assert.sameValue(result, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.dateAdd(arg, new Temporal.Duration());
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.dateAdd(arg, new Temporal.Duration());
+TemporalHelpers.assertPlainDate(result1, 1976, 11, "M11", 18, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.dateAdd(arg, new Temporal.Duration());
+TemporalHelpers.assertPlainDate(result2, 1976, 11, "M11", 18, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-propertybag-calendar-case-insensitive.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: The calendar name is case-insensitive
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Calendar("iso8601");
+
+const calendar = "IsO8601";
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.dateUntil(arg, new Temporal.PlainDate(1976, 11, 19));
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (first argument)");
+const result2 = instance.dateUntil(new Temporal.PlainDate(1976, 11, 19), arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (second argument)");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result3 = instance.dateUntil(arg, new Temporal.PlainDate(1976, 11, 19));
+TemporalHelpers.assertDuration(result3, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (nested property, first argument)");
+const result4 = instance.dateUntil(new Temporal.PlainDate(1976, 11, 19), arg);
+TemporalHelpers.assertDuration(result4, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (nested property, second argument)");

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.day(arg);
-assert.sameValue(result, 18, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.day(arg);
+assert.sameValue(result1, 18, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.day(arg);
+assert.sameValue(result2, 18, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.dayOfWeek(arg);
-assert.sameValue(result, 4, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.dayOfWeek(arg);
+assert.sameValue(result1, 4, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.dayOfWeek(arg);
+assert.sameValue(result2, 4, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.daysInMonth(arg);
-assert.sameValue(result, 30, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.daysInMonth(arg);
+assert.sameValue(result1, 30, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.daysInMonth(arg);
+assert.sameValue(result2, 30, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.daysInWeek(arg);
-assert.sameValue(result, 7, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.daysInWeek(arg);
+assert.sameValue(result1, 7, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.daysInWeek(arg);
+assert.sameValue(result2, 7, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.daysInYear(arg);
-assert.sameValue(result, 366, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.daysInYear(arg);
+assert.sameValue(result1, 366, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.daysInYear(arg);
+assert.sameValue(result2, 366, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.inLeapYear(arg);
-assert.sameValue(result, true, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.inLeapYear(arg);
+assert.sameValue(result1, true, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.inLeapYear(arg);
+assert.sameValue(result2, true, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.month(arg);
-assert.sameValue(result, 11, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.month(arg);
+assert.sameValue(result1, 11, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.month(arg);
+assert.sameValue(result2, 11, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.monthCode(arg);
-assert.sameValue(result, "M11", `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.monthCode(arg);
+assert.sameValue(result1, "M11", "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.monthCode(arg);
+assert.sameValue(result2, "M11", "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.monthsInYear(arg);
-assert.sameValue(result, 12, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.monthsInYear(arg);
+assert.sameValue(result1, 12, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.monthsInYear(arg);
+assert.sameValue(result2, 12, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.weekOfYear(arg);
-assert.sameValue(result, 47, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.weekOfYear(arg);
+assert.sameValue(result1, 47, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.weekOfYear(arg);
+assert.sameValue(result2, 47, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.year(arg);
-assert.sameValue(result, 1976, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.year(arg);
+assert.sameValue(result1, 1976, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.year(arg);
+assert.sameValue(result2, 1976, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-propertybag-calendar-case-insensitive.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.calendar.prototype.dayofyear
+esid: sec-temporal.calendar.prototype.yearofweek
 description: The calendar name is case-insensitive
 features: [Temporal]
 ---*/
@@ -12,9 +12,9 @@ const instance = new Temporal.Calendar("iso8601");
 const calendar = "IsO8601";
 
 let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result1 = instance.dayOfYear(arg);
-assert.sameValue(result1, 323, "Calendar is case-insensitive");
+const result1 = instance.yearOfWeek(arg);
+assert.sameValue(result1, 1976, "Calendar is case-insensitive");
 
 arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
-const result2 = instance.dayOfYear(arg);
-assert.sameValue(result2, 323, "Calendar is case-insensitive (nested property)");
+const result2 = instance.yearOfWeek(arg);
+assert.sameValue(result2, 1976, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/Instant/prototype/toZonedDateTime/calendar-case-insensitive.js
@@ -9,6 +9,6 @@ features: [Temporal]
 
 const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
 
-const arg = "iSo8601";;
+const arg = "iSo8601";
 const result = instance.toZonedDateTime({ calendar: arg, timeZone: "UTC" });
 assert.sameValue(result.calendar.id, "iso8601", "Calendar is case-insensitive");

--- a/test/built-ins/Temporal/Now/plainDate/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/Now/plainDate/calendar-temporal-object.js
@@ -5,18 +5,35 @@
 esid: sec-temporal.now.plaindate
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.now.plaindate step 1:
-      1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
-    sec-temporal-systemdatetime step 3:
-      3. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const result = Temporal.Now.plainDate(temporalObject);
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const result = Temporal.Now.plainDate(arg);
   assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/Now/plainDateTime/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/Now/plainDateTime/calendar-temporal-object.js
@@ -5,18 +5,35 @@
 esid: sec-temporal.now.plaindatetime
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.now.plaindatetime step 1:
-      1. Return ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
-    sec-temporal-systemdatetime step 3:
-      3. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
-features: [Temporal, arrow-function]
+includes: [compareArray.js]
+features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const result = Temporal.Now.plainDateTime(temporalObject);
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const result = Temporal.Now.plainDateTime(arg);
   assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/Now/zonedDateTime/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/Now/zonedDateTime/calendar-temporal-object.js
@@ -5,18 +5,35 @@
 esid: sec-temporal.now.zoneddatetime
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.now.zoneddatetime step 1:
-      1. Return ? SystemZonedDateTime(_temporalTimeZoneLike_, _calendar_).
-    sec-temporal-systemzoneddatetime step 3:
-      3. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const result = Temporal.Now.zonedDateTime(temporalObject);
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const result = Temporal.Now.zonedDateTime(arg);
   assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/PlainDate/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/PlainDate/calendar-temporal-object.js
@@ -5,18 +5,35 @@
 esid: sec-temporal.plaindate
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.plaindate step 5:
-      5. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-    sec-temporal-totemporalcalendarwithisodefault step 2:
-      2. Return ? ToTemporalCalendar(_temporalCalendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const result = new Temporal.PlainDate(2000, 5, 2, temporalObject);
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const result = new Temporal.PlainDate(2000, 5, 2, arg);
   assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-case-insensitive.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.compare
+description: The calendar name is case-insensitive
+features: [Temporal]
+---*/
+
+const calendar = "IsO8601";
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18));
+assert.sameValue(result1, 0, "Calendar is case-insensitive (first argument)");
+const result2 = Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg);
+assert.sameValue(result2, 0, "Calendar is case-insensitive (second argument)");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result3 = Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18));
+assert.sameValue(result3, 0, "Calendar is case-insensitive (nested property, first argument)");
+const result4 = Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg);
+assert.sameValue(result4, 0, "Calendar is case-insensitive (nested property, second argument)");

--- a/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-case-insensitive.js
@@ -10,6 +10,10 @@ features: [Temporal]
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = Temporal.PlainDate.from(arg);
-TemporalHelpers.assertPlainDate(result, 1976, 11, "M11", 18, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = Temporal.PlainDate.from(arg);
+TemporalHelpers.assertPlainDate(result1, 1976, 11, "M11", 18, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = Temporal.PlainDate.from(arg);
+TemporalHelpers.assertPlainDate(result2, 1976, 11, "M11", 18, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.PlainDate(1976, 11, 18);
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.equals(arg);
-assert.sameValue(result, true, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.equals(arg);
+assert.sameValue(result1, true, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.equals(arg);
+assert.sameValue(result2, true, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.PlainDate(1976, 11, 18);
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.since(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.since(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.PlainDate(1976, 11, 18);
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.until(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.until(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-case-insensitive.js
@@ -9,6 +9,6 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDate(1976, 11, 18, { id: "replace-me" });
 
-const arg = "iSo8601";;
+const arg = "iSo8601";
 const result = instance.withCalendar(arg);
 assert.sameValue(result.calendar.id, "iso8601", "Calendar is case-insensitive");

--- a/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/withCalendar/calendar-temporal-object.js
@@ -5,17 +5,36 @@
 esid: sec-temporal.plaindate.prototype.withcalendar
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.plaindate.prototype.withcalendar step 3:
-      3. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const plainDate = new Temporal.PlainDate(2000, 5, 2);
-  const result = plainDate.withCalendar(temporalObject);
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const instance = new Temporal.PlainDate(1976, 11, 18, { id: "replace-me" });
+  const result = instance.withCalendar(arg);
   assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/PlainDateTime/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/PlainDateTime/calendar-temporal-object.js
@@ -5,18 +5,35 @@
 esid: sec-temporal.plaindatetime
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.plaindatetime step 11:
-      11. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-    sec-temporal-totemporalcalendarwithisodefault step 2:
-      2. Return ? ToTemporalCalendar(_temporalCalendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const result = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, temporalObject);
-  assert.sameValue(result.calendar, calendar, 'Temporal object coerced to calendar');
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const result = new Temporal.PlainDateTime(2000, 5, 2, 15, 23, 30, 987, 654, 321, arg);
+  assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-case-insensitive.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: The calendar name is case-insensitive
+features: [Temporal]
+---*/
+
+const calendar = "IsO8601";
+
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18));
+assert.sameValue(result1, 0, "Calendar is case-insensitive (first argument)");
+const result2 = Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg);
+assert.sameValue(result2, 0, "Calendar is case-insensitive (second argument)");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result3 = Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18));
+assert.sameValue(result3, 0, "Calendar is case-insensitive (nested property, first argument)");
+const result4 = Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg);
+assert.sameValue(result4, 0, "Calendar is case-insensitive (nested property, second argument)");

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-case-insensitive.js
@@ -10,6 +10,10 @@ features: [Temporal]
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = Temporal.PlainDateTime.from(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = Temporal.PlainDateTime.from(arg);
+TemporalHelpers.assertPlainDateTime(result1, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = Temporal.PlainDateTime.from(arg);
+TemporalHelpers.assertPlainDateTime(result2, 1976, 11, "M11", 18, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.PlainDateTime(1976, 11, 18);
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.equals(arg);
-assert.sameValue(result, true, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.equals(arg);
+assert.sameValue(result1, true, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.equals(arg);
+assert.sameValue(result2, true, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.PlainDateTime(1976, 11, 18);
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.since(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.since(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.PlainDateTime(1976, 11, 18);
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.until(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.until(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-case-insensitive.js
@@ -9,6 +9,6 @@ features: [Temporal]
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789, { id: "replace-me" });
 
-const arg = "iSo8601";;
+const arg = "iSo8601";
 const result = instance.withCalendar(arg);
 assert.sameValue(result.calendar.id, "iso8601", "Calendar is case-insensitive");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withCalendar/calendar-temporal-object.js
@@ -5,17 +5,36 @@
 esid: sec-temporal.plaindatetime.prototype.withcalendar
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.plaindatetime.prototype.withcalendar step 3:
-      3. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
-  const result = plainDateTime.withCalendar(temporalObject);
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789, { id: "replace-me" });
+  const result = instance.withCalendar(arg);
   assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 32
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.withPlainDate(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.withPlainDate(arg);
+TemporalHelpers.assertPlainDateTime(result1, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.withPlainDate(arg);
+TemporalHelpers.assertPlainDateTime(result2, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainMonthDay/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/PlainMonthDay/calendar-temporal-object.js
@@ -5,18 +5,35 @@
 esid: sec-temporal.plainmonthday
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.plainmonthday step 5:
-      5. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-    sec-temporal-totemporalcalendarwithisodefault step 2:
-      2. Return ? ToTemporalCalendar(_temporalCalendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const result = new Temporal.PlainMonthDay(5, 2, temporalObject);
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const result = new Temporal.PlainMonthDay(12, 15, arg, 1972);
   assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-propertybag-calendar-case-insensitive.js
@@ -10,6 +10,10 @@ features: [Temporal]
 
 const calendar = "IsO8601";
 
-const arg = { monthCode: "M11", day: 18, calendar };
-const result = Temporal.PlainMonthDay.from(arg);
-TemporalHelpers.assertPlainMonthDay(result, "M11", 18, `Calendar created from string "${calendar}"`);
+let arg = { monthCode: "M11", day: 18, calendar };
+const result1 = Temporal.PlainMonthDay.from(arg);
+TemporalHelpers.assertPlainMonthDay(result1, "M11", 18, "Calendar is case-insensitive");
+
+arg = { monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = Temporal.PlainMonthDay.from(arg);
+TemporalHelpers.assertPlainMonthDay(result2, "M11", 18, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.PlainMonthDay(11, 18);
 
 const calendar = "IsO8601";
 
-const arg = { monthCode: "M11", day: 18, calendar };
-const result = instance.equals(arg);
-assert.sameValue(result, true, `Calendar created from string "${calendar}"`);
+let arg = { monthCode: "M11", day: 18, calendar };
+const result1 = instance.equals(arg);
+assert.sameValue(result1, true, "Calendar is case-insensitive");
+
+arg = { monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.equals(arg);
+assert.sameValue(result2, true, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.toPlainDateTime(arg);
-TemporalHelpers.assertPlainDateTime(result, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.toPlainDateTime(arg);
+TemporalHelpers.assertPlainDateTime(result1, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.toPlainDateTime(arg);
+TemporalHelpers.assertPlainDateTime(result2, 1976, 11, "M11", 18, 12, 34, 56, 987, 654, 321, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" });
-assert.sameValue(result.epochNanoseconds, 217_168_496_987_654_321n, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" });
+assert.sameValue(result1.epochNanoseconds, 217_168_496_987_654_321n, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" });
+assert.sameValue(result2.epochNanoseconds, 217_168_496_987_654_321n, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainYearMonth/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/PlainYearMonth/calendar-temporal-object.js
@@ -5,18 +5,35 @@
 esid: sec-temporal.plainyearmonth
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.plainyearmonth step 5:
-      5. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-    sec-temporal-totemporalcalendarwithisodefault step 2:
-      2. Return ? ToTemporalCalendar(_temporalCalendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const result = new Temporal.PlainYearMonth(2000, 5, temporalObject);
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const result = new Temporal.PlainYearMonth(2000, 5, arg, 1);
   assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-propertybag-calendar-case-insensitive.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: The calendar name is case-insensitive
+features: [Temporal]
+---*/
+
+const calendar = "IsO8601";
+
+let arg = { year: 2019, monthCode: "M06", calendar };
+const result1 = Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6));
+assert.sameValue(result1, 0, "Calendar is case-insensitive (first argument)");
+const result2 = Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg);
+assert.sameValue(result2, 0, "Calendar is case-insensitive (second argument)");
+
+arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+const result3 = Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6));
+assert.sameValue(result3, 0, "Calendar is case-insensitive (nested property, first argument)");
+const result4 = Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg);
+assert.sameValue(result4, 0, "Calendar is case-insensitive (nested property, second argument)");

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-propertybag-calendar-case-insensitive.js
@@ -10,6 +10,10 @@ features: [Temporal]
 
 const calendar = "IsO8601";
 
-const arg = { year: 2019, monthCode: "M06", calendar };
-const result = Temporal.PlainYearMonth.from(arg);
-TemporalHelpers.assertPlainYearMonth(result, 2019, 6, "M06", `Calendar created from string "${calendar}"`);
+let arg = { year: 2019, monthCode: "M06", calendar };
+const result1 = Temporal.PlainYearMonth.from(arg);
+TemporalHelpers.assertPlainYearMonth(result1, 2019, 6, "M06", "Calendar is case-insensitive");
+
+arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+const result2 = Temporal.PlainYearMonth.from(arg);
+TemporalHelpers.assertPlainYearMonth(result2, 2019, 6, "M06", "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.PlainYearMonth(2019, 6);
 
 const calendar = "IsO8601";
 
-const arg = { year: 2019, monthCode: "M06", calendar };
-const result = instance.equals(arg);
-assert.sameValue(result, true, `Calendar created from string "${calendar}"`);
+let arg = { year: 2019, monthCode: "M06", calendar };
+const result1 = instance.equals(arg);
+assert.sameValue(result1, true, "Calendar is case-insensitive");
+
+arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+const result2 = instance.equals(arg);
+assert.sameValue(result2, true, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.PlainYearMonth(2019, 6);
 
 const calendar = "IsO8601";
 
-const arg = { year: 2019, monthCode: "M06", calendar };
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `Calendar created from string "${calendar}"`);
+let arg = { year: 2019, monthCode: "M06", calendar };
+const result1 = instance.since(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+const result2 = instance.since(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.PlainYearMonth(2019, 6);
 
 const calendar = "IsO8601";
 
-const arg = { year: 2019, monthCode: "M06", calendar };
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `Calendar created from string "${calendar}"`);
+let arg = { year: 2019, monthCode: "M06", calendar };
+const result1 = instance.until(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg = { year: 2019, monthCode: "M06", calendar: { calendar } };
+const result2 = instance.until(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.TimeZone("UTC");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.getInstantFor(arg);
-assert.sameValue(result.epochNanoseconds, 217_123_200_000_000_000n, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.getInstantFor(arg);
+assert.sameValue(result1.epochNanoseconds, 217_123_200_000_000_000n, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.getInstantFor(arg);
+assert.sameValue(result2.epochNanoseconds, 217_123_200_000_000_000n, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-case-insensitive.js
@@ -9,6 +9,6 @@ features: [Temporal]
 
 const instance = new Temporal.TimeZone("UTC");
 
-const arg = "iSo8601";;
+const arg = "iSo8601";
 const result = instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg);
 assert.sameValue(result.calendar.id, "iso8601", "Calendar is case-insensitive");

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/calendar-temporal-object.js
@@ -2,21 +2,39 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.tozoneddatetime
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.instant.prototype.tozoneddatetime step 6:
-      6. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const instant = new Temporal.Instant(1_000_000_000_987_654_321n);
-  const timezone = new Temporal.TimeZone("UTC");
-  const result = timezone.getPlainDateTimeFor(instant, temporalObject);
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const instance = new Temporal.TimeZone("UTC");
+  const result = instance.getPlainDateTimeFor(new Temporal.Instant(0n), arg);
   assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.TimeZone("UTC");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.getPossibleInstantsFor(arg);
-assert.compareArray(result.map(i => i.epochNanoseconds), [217_123_200_000_000_000n], `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.getPossibleInstantsFor(arg);
+assert.compareArray(result1.map(i => i.epochNanoseconds), [217_123_200_000_000_000n], "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.getPossibleInstantsFor(arg);
+assert.compareArray(result2.map(i => i.epochNanoseconds), [217_123_200_000_000_000n], "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/ZonedDateTime/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/ZonedDateTime/calendar-temporal-object.js
@@ -5,18 +5,35 @@
 esid: sec-temporal.zoneddatetime
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.zoneddatetime step 5:
-      5. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-    sec-temporal-totemporalcalendarwithisodefault step 2:
-      2. Return ? ToTemporalCalendar(_temporalCalendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const result = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", temporalObject);
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const result = new Temporal.ZonedDateTime(0n, "UTC", arg);
   assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-propertybag-calendar-case-insensitive.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: The calendar name is case-insensitive
+features: [Temporal]
+---*/
+
+const calendar = "IsO8601";
+
+const timeZone = new Temporal.TimeZone("UTC");
+const datetime = new Temporal.ZonedDateTime(0n, timeZone);
+
+let arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
+const result1 = Temporal.ZonedDateTime.compare(arg, datetime);
+assert.sameValue(result1, 0, "Calendar is case-insensitive (first argument)");
+const result2 = Temporal.ZonedDateTime.compare(datetime, arg);
+assert.sameValue(result2, 0, "Calendar is case-insensitive (second argument)");
+
+arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar: { calendar } };
+const result3 = Temporal.ZonedDateTime.compare(arg, datetime);
+assert.sameValue(result3, 0, "Calendar is case-insensitive (nested property, first argument)");
+const result4 = Temporal.ZonedDateTime.compare(datetime, arg);
+assert.sameValue(result4, 0, "Calendar is case-insensitive (nested property, second argument)");

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-propertybag-calendar-case-insensitive.js
@@ -10,6 +10,10 @@ features: [Temporal]
 const calendar = "IsO8601";
 
 const timeZone = new Temporal.TimeZone("UTC");
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
-const result = Temporal.ZonedDateTime.from(arg);
-assert.sameValue(result.calendar.id, "iso8601", `Calendar created from string "${calendar}"`);
+let arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
+const result1 = Temporal.ZonedDateTime.from(arg);
+assert.sameValue(result1.calendar.id, "iso8601", "Calendar is case-insensitive");
+
+arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar: { calendar } };
+const result2 = Temporal.ZonedDateTime.from(arg);
+assert.sameValue(result2.calendar.id, "iso8601", "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
 const calendar = "IsO8601";
 
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
-const result = instance.equals(arg);
-assert.sameValue(result, true, `Calendar created from string "${calendar}"`);
+let arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
+const result1 = instance.equals(arg);
+assert.sameValue(result1, true, "Calendar is case-insensitive");
+
+arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar: { calendar } };
+const result2 = instance.equals(arg);
+assert.sameValue(result2, true, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-propertybag-calendar-case-insensitive.js
@@ -13,6 +13,10 @@ const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
 const calendar = "IsO8601";
 
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
-const result = instance.since(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `Calendar created from string "${calendar}"`);
+let arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
+const result1 = instance.since(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar: { calendar } };
+const result2 = instance.since(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-propertybag-calendar-case-insensitive.js
@@ -13,6 +13,10 @@ const instance = new Temporal.ZonedDateTime(0n, timeZone);
 
 const calendar = "IsO8601";
 
-const arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
-const result = instance.until(arg);
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, `Calendar created from string "${calendar}"`);
+let arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar };
+const result1 = instance.until(arg);
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive");
+
+arg = { year: 1970, monthCode: "M01", day: 1, timeZone, calendar: { calendar } };
+const result2 = instance.until(arg);
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "Calendar is case-insensitive (nested property)");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-case-insensitive.js
@@ -9,6 +9,6 @@ features: [Temporal]
 
 const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", { id: "replace-me" });
 
-const arg = "IsO8601";;
+const arg = "iSo8601";
 const result = instance.withCalendar(arg);
 assert.sameValue(result.calendar.id, "iso8601", "Calendar is case-insensitive");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-temporal-object.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withCalendar/calendar-temporal-object.js
@@ -5,17 +5,36 @@
 esid: sec-temporal.zoneddatetime.prototype.withcalendar
 description: Fast path for converting other Temporal objects to Temporal.Calendar by reading internal slots
 info: |
-    sec-temporal.zoneddatetime.prototype.withcalendar step 3:
-      3. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
-    sec-temporal-totemporalcalendar step 1.a:
-      a. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+    sec-temporal-totemporalcalendar step 1.b:
+      b. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
         i. Return _temporalCalendarLike_.[[Calendar]].
-includes: [compareArray.js, temporalHelpers.js]
+includes: [compareArray.js]
 features: [Temporal]
 ---*/
 
-TemporalHelpers.checkToTemporalCalendarFastPath((temporalObject, calendar) => {
-  const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
-  const result = zonedDateTime.withCalendar(temporalObject);
+const plainDate = new Temporal.PlainDate(2000, 5, 2);
+const plainDateTime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const plainTime = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const plainMonthDay = new Temporal.PlainMonthDay(5, 2);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 5);
+const zonedDateTime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+[plainDate, plainDateTime, plainTime, plainMonthDay, plainYearMonth, zonedDateTime].forEach((arg) => {
+  const actual = [];
+  const expected = [];
+
+  const calendar = arg.getISOFields().calendar;
+
+  Object.defineProperty(arg, "calendar", {
+    get() {
+      actual.push("get calendar");
+      return calendar;
+    },
+  });
+
+  const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", { id: "replace-me" });
+  const result = instance.withCalendar(arg);
   assert.sameValue(result.calendar, calendar, "Temporal object coerced to calendar");
+
+  assert.compareArray(actual, expected, "calendar getter not called");
 });

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-propertybag-calendar-case-insensitive.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-propertybag-calendar-case-insensitive.js
@@ -12,6 +12,10 @@ const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, timeZone
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.withPlainDate(arg);
-assert.sameValue(result.epochNanoseconds, 217_129_600_000_000_000n, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.withPlainDate(arg);
+assert.sameValue(result1.epochNanoseconds, 217_129_600_000_000_000n, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.withPlainDate(arg);
+assert.sameValue(result2.epochNanoseconds, 217_129_600_000_000_000n, "Calendar is case-insensitive (nested property)");

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-propertybag-calendar-case-insensitive.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.era(arg);
-assert.sameValue(result, undefined, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.era(arg);
+assert.sameValue(result1, undefined, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.era(arg);
+assert.sameValue(result2, undefined, "Calendar is case-insensitive (nested property)");

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-propertybag-calendar-case-insensitive.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-propertybag-calendar-case-insensitive.js
@@ -11,6 +11,10 @@ const instance = new Temporal.Calendar("iso8601");
 
 const calendar = "IsO8601";
 
-const arg = { year: 1976, monthCode: "M11", day: 18, calendar };
-const result = instance.eraYear(arg);
-assert.sameValue(result, undefined, `Calendar created from string "${calendar}"`);
+let arg = { year: 1976, monthCode: "M11", day: 18, calendar };
+const result1 = instance.eraYear(arg);
+assert.sameValue(result1, undefined, "Calendar is case-insensitive");
+
+arg = { year: 1976, monthCode: "M11", day: 18, calendar: { calendar } };
+const result2 = instance.eraYear(arg);
+assert.sameValue(result2, undefined, "Calendar is case-insensitive (nested property)");


### PR DESCRIPTION
Improvements to "calendar-case-insensitive" tests and some of the "calendar-temporal-object" tests. These refactors are in preparation for tests that I'm writing for upcoming normative changes.