### PR TITLE
Temporal: Adjustments to order-of-operations tests

### DIFF
--- a/test/built-ins/Temporal/PlainDate/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/with/order-of-operations.js
@@ -15,7 +15,16 @@ const expected = [
   // CalendarFields
   "get this.calendar.fields",
   "call this.calendar.fields",
-  // PrepareTemporalFields
+  // PrepareTemporalFields on receiver
+  "get this.calendar.day",
+  "call this.calendar.day",
+  "get this.calendar.month",
+  "call this.calendar.month",
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  // PrepareTemporalFields on argument
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -28,15 +37,6 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
-  // PrepareTemporalFields on receiver
-  "get this.calendar.day",
-  "call this.calendar.day",
-  "get this.calendar.month",
-  "call this.calendar.month",
-  "get this.calendar.monthCode",
-  "call this.calendar.monthCode",
-  "get this.calendar.year",
-  "call this.calendar.year",
   // CalendarMergeFields
   "get this.calendar.mergeFields",
   "call this.calendar.mergeFields",

--- a/test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js
@@ -15,7 +15,16 @@ const expected = [
   // CalendarFields
   "get this.calendar.fields",
   "call this.calendar.fields",
-  // PrepareTemporalFields
+  // PrepareTemporalFields on receiver
+  "get this.calendar.day",
+  "call this.calendar.day",
+  "get this.calendar.month",
+  "call this.calendar.month",
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  // PrepareTemporalFields on argument
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -46,15 +55,6 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
-  // PrepareTemporalFields on receiver
-  "get this.calendar.day",
-  "call this.calendar.day",
-  "get this.calendar.month",
-  "call this.calendar.month",
-  "get this.calendar.monthCode",
-  "call this.calendar.monthCode",
-  "get this.calendar.year",
-  "call this.calendar.year",
   // CalendarMergeFields
   "get this.calendar.mergeFields",
   "call this.calendar.mergeFields",

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/with/order-of-operations.js
@@ -15,7 +15,12 @@ const expected = [
   // CalendarFields
   "get this.calendar.fields",
   "call this.calendar.fields",
-  // PrepareTemporalFields
+  // PrepareTemporalFields on receiver
+  "get this.calendar.day",
+  "call this.calendar.day",
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  // PrepareTemporalFields on argument
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -28,11 +33,6 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
-  // PrepareTemporalFields on receiver
-  "get this.calendar.day",
-  "call this.calendar.day",
-  "get this.calendar.monthCode",
-  "call this.calendar.monthCode",
   // CalendarMergeFields
   "get this.calendar.mergeFields",
   "call this.calendar.mergeFields",

--- a/test/built-ins/Temporal/PlainTime/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/with/order-of-operations.js
@@ -13,6 +13,10 @@ const expected = [
   // RejectObjectWithCalendarOrTimeZone
   "get fields.calendar",
   "get fields.timeZone",
+  // ToTemporalOverflow
+  "get options.overflow",
+  "get options.overflow.toString",
+  "call options.overflow.toString",
   // ToTemporalTimeRecord
   "get fields.hour",
   "get fields.hour.valueOf",
@@ -32,10 +36,6 @@ const expected = [
   "get fields.second",
   "get fields.second.valueOf",
   "call fields.second.valueOf",
-  // ToTemporalOverflow
-  "get options.overflow",
-  "get options.overflow.toString",
-  "call options.overflow.toString",
 ];
 const actual = [];
 

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/order-of-operations.js
@@ -45,19 +45,21 @@ const expected = [
   "get options.smallestUnit",
   "get options.smallestUnit.toString",
   "call options.smallestUnit.toString",
-  // CalendarFields / PrepareTemporalFields / CalendarDateFromFields
+  // CalendarFields
   "get this.calendar.fields",
   "call this.calendar.fields",
-  "get other.calendar.monthCode",
-  "call other.calendar.monthCode",
-  "get other.calendar.year",
-  "call other.calendar.year",
-  "get this.calendar.dateFromFields",
-  "call this.calendar.dateFromFields",
+  // PrepareTemporalFields / CalendarDateFromFields (receiver)
   "get this.calendar.monthCode",
   "call this.calendar.monthCode",
   "get this.calendar.year",
   "call this.calendar.year",
+  "get this.calendar.dateFromFields",
+  "call this.calendar.dateFromFields",
+  // PrepareTemporalFields / CalendarDateFromFields (argument)
+  "get other.calendar.monthCode",
+  "call other.calendar.monthCode",
+  "get other.calendar.year",
+  "call other.calendar.year",
   "get this.calendar.dateFromFields",
   "call this.calendar.dateFromFields",
   // CopyDataProperties

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/order-of-operations.js
@@ -45,19 +45,21 @@ const expected = [
   "get options.smallestUnit",
   "get options.smallestUnit.toString",
   "call options.smallestUnit.toString",
-  // CalendarFields / PrepareTemporalFields / CalendarDateFromFields
+  // CalendarFields
   "get this.calendar.fields",
   "call this.calendar.fields",
-  "get other.calendar.monthCode",
-  "call other.calendar.monthCode",
-  "get other.calendar.year",
-  "call other.calendar.year",
-  "get this.calendar.dateFromFields",
-  "call this.calendar.dateFromFields",
+  // PrepareTemporalFields / CalendarDateFromFields (receiver)
   "get this.calendar.monthCode",
   "call this.calendar.monthCode",
   "get this.calendar.year",
   "call this.calendar.year",
+  "get this.calendar.dateFromFields",
+  "call this.calendar.dateFromFields",
+  // PrepareTemporalFields / CalendarDateFromFields (argument)
+  "get other.calendar.monthCode",
+  "call other.calendar.monthCode",
+  "get other.calendar.year",
+  "call other.calendar.year",
   "get this.calendar.dateFromFields",
   "call this.calendar.dateFromFields",
   // CopyDataProperties

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/with/order-of-operations.js
@@ -15,7 +15,14 @@ const expected = [
   // CalendarFields
   "get this.calendar.fields",
   "call this.calendar.fields",
-  // PrepareTemporalFields
+  // PrepareTemporalFields on receiver
+  "get this.calendar.month",
+  "call this.calendar.month",
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  // PrepareTemporalFields on argument
   "get fields.month",
   "get fields.month.valueOf",
   "call fields.month.valueOf",
@@ -25,13 +32,6 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
-  // PrepareTemporalFields on receiver
-  "get this.calendar.month",
-  "call this.calendar.month",
-  "get this.calendar.monthCode",
-  "call this.calendar.monthCode",
-  "get this.calendar.year",
-  "call this.calendar.year",
   // CalendarMergeFields
   "get this.calendar.mergeFields",
   "call this.calendar.mergeFields",

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/with/copies-merge-fields-object.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/with/copies-merge-fields-object.js
@@ -46,7 +46,6 @@ const expected = [
   "get second",
   "get second.valueOf",
   "call second.valueOf",
-  "get timeZone",
   "get year",
   "get year.valueOf",
   "call year.valueOf",

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/with/order-of-operations.js
@@ -12,9 +12,41 @@ const expected = [
   // RejectObjectWithCalendarOrTimeZone
   "get fields.calendar",
   "get fields.timeZone",
-  // CalendarFields / PrepareTemporalFields
+  // CalendarFields
   "get this.calendar.fields",
   "call this.calendar.fields",
+  // PrepareTemporalFields on receiver
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.calendar.day",
+  "call this.calendar.day",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.hour
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.microsecond
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.millisecond
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.minute
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.calendar.month",
+  "call this.calendar.month",
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.calendar.monthCode",
+  "call this.calendar.monthCode",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.nanosecond
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.offset
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.second
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.calendar.year",
+  "call this.calendar.year",
+  // PrepareTemporalFields on argument
   "get fields.day",
   "get fields.day.valueOf",
   "call fields.day.valueOf",
@@ -48,37 +80,6 @@ const expected = [
   "get fields.year",
   "get fields.year.valueOf",
   "call fields.year.valueOf",
-  // PrepareTemporalFields
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
-  "get this.calendar.day",
-  "call this.calendar.day",
-  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.hour
-  "call this.timeZone.getOffsetNanosecondsFor",
-  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.microsecond
-  "call this.timeZone.getOffsetNanosecondsFor",
-  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.millisecond
-  "call this.timeZone.getOffsetNanosecondsFor",
-  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.minute
-  "call this.timeZone.getOffsetNanosecondsFor",
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
-  "get this.calendar.month",
-  "call this.calendar.month",
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
-  "get this.calendar.monthCode",
-  "call this.calendar.monthCode",
-  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.nanosecond
-  "call this.timeZone.getOffsetNanosecondsFor",
-  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.offset
-  "call this.timeZone.getOffsetNanosecondsFor",
-  "get this.timeZone.getOffsetNanosecondsFor",  // ZonedDateTime.p.second
-  "call this.timeZone.getOffsetNanosecondsFor",
-  "get this.timeZone.getOffsetNanosecondsFor",
-  "call this.timeZone.getOffsetNanosecondsFor",
-  "get this.calendar.year",
-  "call this.calendar.year",
   // CalendarMergeFields
   "get this.calendar.mergeFields",
   "call this.calendar.mergeFields",


### PR DESCRIPTION
The with() methods, as well as PlainYearMonth's since() and until(), were adjusted to read the receiver's fields before the fields of any objects provided as arguments. This change is observable, so affects several tests that test the observed order of operations.

Normative PR: https://github.com/tc39/proposal-temporal/pull/2478