### PR TITLE
Temporal: Tests for upper limit on rounding increments

### DIFF
--- a/test/built-ins/Temporal/Duration/prototype/round/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/roundingincrement-non-integer.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: Rounding for roundingIncrement option
+info: |
+    sec-temporal-totemporalroundingincrement:
+      3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1);
+const options = {
+  smallestUnit: "years",
+  roundingMode: "expand",
+  relativeTo: new Temporal.PlainDate(2000, 1, 1),
+};
+const result = instance.round({ ...options, roundingIncrement: 2.5 });
+TemporalHelpers.assertDuration(result, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 2.5 truncates to 2");
+const result2 = instance.round({ ...options, roundingIncrement: 1e9 + 0.5 });
+TemporalHelpers.assertDuration(result2, 1e9, 0, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 1e9 + 0.5 truncates to 1e9");

--- a/test/built-ins/Temporal/Duration/prototype/round/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/roundingincrement-out-of-range.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: RangeError thrown when roundingIncrement option out of range
+info: |
+    sec-temporal-totemporalroundingincrement:
+      4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1);
+const options = { smallestUnit: "years", relativeTo: new Temporal.PlainDate(2000, 1, 1) };
+assert.throws(RangeError, () => instance.round({ ...options, roundingIncrement: -Infinity }));
+assert.throws(RangeError, () => instance.round({ ...options, roundingIncrement: -1 }));
+assert.throws(RangeError, () => instance.round({ ...options, roundingIncrement: 0 }));
+assert.throws(RangeError, () => instance.round({ ...options, roundingIncrement: 1e9 + 1 }));
+assert.throws(RangeError, () => instance.round({ ...options, roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/Instant/prototype/round/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/Instant/prototype/round/roundingincrement-non-integer.js
@@ -5,11 +5,16 @@
 esid: sec-temporal.instant.prototype.round
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
 const instant = new Temporal.Instant(1_000_000_000_000_000_005n);
-const result = instant.round({ smallestUnit: "nanosecond", roundingIncrement: 2.5 });
-assert.sameValue(result.epochNanoseconds, 1_000_000_000_000_000_006n, "roundingIncrement 2.5 floors to 2");
+const result = instant.round({ smallestUnit: "nanosecond", roundingIncrement: 2.5, roundingMode: "expand" });
+assert.sameValue(result.epochNanoseconds, 1_000_000_000_000_000_006n, "roundingIncrement 2.5 truncates to 2");

--- a/test/built-ins/Temporal/Instant/prototype/round/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/Instant/prototype/round/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.instant.prototype.round
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -14,4 +19,6 @@ const instant = new Temporal.Instant(1_000_000_000_000_000_005n);
 assert.throws(RangeError, () => instant.round({ smallestUnit: "nanoseconds", roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => instant.round({ smallestUnit: "nanoseconds", roundingIncrement: -1 }));
 assert.throws(RangeError, () => instant.round({ smallestUnit: "nanoseconds", roundingIncrement: 0 }));
+assert.throws(RangeError, () => instant.round({ smallestUnit: "nanoseconds", roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => instant.round({ smallestUnit: "nanoseconds", roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => instant.round({ smallestUnit: "nanoseconds", roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/Instant/prototype/since/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/roundingincrement-non-integer.js
@@ -5,13 +5,18 @@
 esid: sec-temporal.instant.prototype.since
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
 const later = new Temporal.Instant(1_000_000_000_000_000_005n);
-const result = later.since(earlier, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 floors to 2");
+const result = later.since(earlier, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 truncates to 2");

--- a/test/built-ins/Temporal/Instant/prototype/since/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.instant.prototype.since
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.Instant(1_000_000_000_000_000_005n);
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/Instant/prototype/until/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/roundingincrement-non-integer.js
@@ -5,13 +5,18 @@
 esid: sec-temporal.instant.prototype.until
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.Instant(1_000_000_000_000_000_000n);
 const later = new Temporal.Instant(1_000_000_000_000_000_005n);
-const result = earlier.until(later, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 floors to 2");
+const result = earlier.until(later, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 truncates to 2");

--- a/test/built-ins/Temporal/Instant/prototype/until/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.instant.prototype.until
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.Instant(1_000_000_000_000_000_005n);
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/PlainDate/prototype/since/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/roundingincrement-non-integer.js
@@ -5,13 +5,20 @@
 esid: sec-temporal.plaindate.prototype.since
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.PlainDate(2000, 5, 2);
 const later = new Temporal.PlainDate(2000, 5, 7);
-const result = later.since(earlier, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, "roundingIncrement 2.5 floors to 2");
+const result = later.since(earlier, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, "roundingIncrement 2.5 truncates to 2");
+const result2 = later.since(earlier, { smallestUnit: "days", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 1e9, 0, 0, 0, 0, 0, 0, "roundingIncrement 1e9 + 0.5 truncates to 1e9");

--- a/test/built-ins/Temporal/PlainDate/prototype/since/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.plaindate.prototype.since
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.PlainDate(2000, 5, 7);
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/PlainDate/prototype/until/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/roundingincrement-non-integer.js
@@ -5,13 +5,20 @@
 esid: sec-temporal.plaindate.prototype.until
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.PlainDate(2000, 5, 2);
 const later = new Temporal.PlainDate(2000, 5, 7);
-const result = earlier.until(later, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, "roundingIncrement 2.5 floors to 2");
+const result = earlier.until(later, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, "roundingIncrement 2.5 truncates to 2");
+const result2 = earlier.until(later, { smallestUnit: "days", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 1e9, 0, 0, 0, 0, 0, 0, "roundingIncrement 1e9 + 0.5 truncates to 1e9");

--- a/test/built-ins/Temporal/PlainDate/prototype/until/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.plaindate.prototype.until
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.PlainDate(2000, 5, 7);
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/PlainDateTime/prototype/round/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/round/roundingincrement-non-integer.js
@@ -5,12 +5,17 @@
 esid: sec-temporal.plaindatetime.prototype.round
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 5);
-const result = datetime.round({ smallestUnit: "nanosecond", roundingIncrement: 2.5 });
-TemporalHelpers.assertPlainDateTime(result, 2000, 5, "M05", 2, 12, 34, 56, 0, 0, 6, "roundingIncrement 2.5 floors to 2");
+const result = datetime.round({ smallestUnit: "nanosecond", roundingIncrement: 2.5, roundingMode: "expand" });
+TemporalHelpers.assertPlainDateTime(result, 2000, 5, "M05", 2, 12, 34, 56, 0, 0, 6, "roundingIncrement 2.5 truncates to 2");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/round/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/round/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.plaindatetime.prototype.round
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -14,4 +19,6 @@ const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 5);
 assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: -1 }));
 assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: 0 }));
+assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/roundingincrement-non-integer.js
@@ -5,13 +5,20 @@
 esid: sec-temporal.plaindatetime.prototype.since
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 5);
-const result = later.since(earlier, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 floors to 2");
+const result = later.since(earlier, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 truncates to 2");
+const result2 = later.since(earlier, { smallestUnit: "days", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 1e9, 0, 0, 0, 0, 0, 0, "roundingIncrement 1e9 + 0.5 truncates to 1e9");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.plaindatetime.prototype.since
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 5);
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/roundingincrement-non-integer.js
@@ -5,13 +5,20 @@
 esid: sec-temporal.plaindatetime.prototype.until
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 5);
-const result = earlier.until(later, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 floors to 2");
+const result = earlier.until(later, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 truncates to 2");
+const result2 = earlier.until(later, { smallestUnit: "days", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 1e9, 0, 0, 0, 0, 0, 0, "roundingIncrement 1e9 + 0.5 truncates to 1e9");

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.plaindatetime.prototype.until
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 0, 0, 5);
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/PlainTime/prototype/round/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/round/roundingincrement-non-integer.js
@@ -5,12 +5,17 @@
 esid: sec-temporal.plaintime.prototype.round
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const time = new Temporal.PlainTime(12, 34, 56, 0, 0, 5);
-const result = time.round({ smallestUnit: "nanosecond", roundingIncrement: 2.5 });
-TemporalHelpers.assertPlainTime(result, 12, 34, 56, 0, 0, 6, "roundingIncrement 2.5 floors to 2");
+const result = time.round({ smallestUnit: "nanosecond", roundingIncrement: 2.5, roundingMode: "expand" });
+TemporalHelpers.assertPlainTime(result, 12, 34, 56, 0, 0, 6, "roundingIncrement 2.5 truncates to 2");

--- a/test/built-ins/Temporal/PlainTime/prototype/round/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/round/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.plaintime.prototype.round
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -14,4 +19,6 @@ const time = new Temporal.PlainTime(12, 34, 56, 0, 0, 5);
 assert.throws(RangeError, () => time.round({ smallestUnit: "nanoseconds", roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => time.round({ smallestUnit: "nanoseconds", roundingIncrement: -1 }));
 assert.throws(RangeError, () => time.round({ smallestUnit: "nanoseconds", roundingIncrement: 0 }));
+assert.throws(RangeError, () => time.round({ smallestUnit: "nanoseconds", roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => time.round({ smallestUnit: "nanoseconds", roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => time.round({ smallestUnit: "nanoseconds", roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/PlainTime/prototype/since/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/roundingincrement-non-integer.js
@@ -5,13 +5,18 @@
 esid: sec-temporal.plaintime.prototype.since
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainTime(12, 34, 56, 0, 0, 5);
-const result = later.since(earlier, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 floors to 2");
+const result = later.since(earlier, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 truncates to 2");

--- a/test/built-ins/Temporal/PlainTime/prototype/since/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.plaintime.prototype.since
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.PlainTime(12, 34, 56, 0, 0, 5);
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/PlainTime/prototype/until/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/roundingincrement-non-integer.js
@@ -5,13 +5,18 @@
 esid: sec-temporal.plaintime.prototype.until
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.PlainTime(12, 34, 56, 0, 0, 0);
 const later = new Temporal.PlainTime(12, 34, 56, 0, 0, 5);
-const result = earlier.until(later, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 floors to 2");
+const result = earlier.until(later, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 truncates to 2");

--- a/test/built-ins/Temporal/PlainTime/prototype/until/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.plaintime.prototype.until
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.PlainTime(12, 34, 56, 0, 0, 5);
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-non-integer.js
@@ -5,13 +5,20 @@
 esid: sec-temporal.plainyearmonth.prototype.since
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2000, 10);
-const result = later.since(earlier, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 2.5 floors to 2");
+const result = later.since(earlier, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 2.5 truncates to 2");
+const result2 = later.since(earlier, { smallestUnit: "months", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
+TemporalHelpers.assertDuration(result2, 0, 1e9, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 1e9 + 0.5 truncates to 1e9");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.plainyearmonth.prototype.since
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.PlainYearMonth(2000, 10);
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-non-integer.js
@@ -5,13 +5,20 @@
 esid: sec-temporal.plainyearmonth.prototype.until
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.PlainYearMonth(2000, 5);
 const later = new Temporal.PlainYearMonth(2000, 10);
-const result = earlier.until(later, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 2.5 floors to 2");
+const result = earlier.until(later, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 2.5 truncates to 2");
+const result2 = earlier.until(later, { smallestUnit: "months", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
+TemporalHelpers.assertDuration(result2, 0, 1e9, 0, 0, 0, 0, 0, 0, 0, 0, "roundingIncrement 1e9 + 0.5 truncates to 1e9");

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.plainyearmonth.prototype.until
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.PlainYearMonth(2000, 10);
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/roundingincrement-non-integer.js
@@ -5,11 +5,16 @@
 esid: sec-temporal.zoneddatetime.prototype.round
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
 const datetime = new Temporal.ZonedDateTime(1_000_000_000_000_000_005n, "UTC");
-const result = datetime.round({ smallestUnit: "nanosecond", roundingIncrement: 2.5 });
-assert.sameValue(result.epochNanoseconds, 1_000_000_000_000_000_006n, "roundingIncrement 2.5 floors to 2");
+const result = datetime.round({ smallestUnit: "nanosecond", roundingIncrement: 2.5, roundingMode: "expand" });
+assert.sameValue(result.epochNanoseconds, 1_000_000_000_000_000_006n, "roundingIncrement 2.5 truncates to 2");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.zoneddatetime.prototype.round
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -14,4 +19,6 @@ const datetime = new Temporal.ZonedDateTime(1_000_000_000_000_000_005n, "UTC");
 assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: -1 }));
 assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: 0 }));
+assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => datetime.round({ smallestUnit: "nanoseconds", roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/roundingincrement-non-integer.js
@@ -5,13 +5,20 @@
 esid: sec-temporal.zoneddatetime.prototype.since
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 const later = new Temporal.ZonedDateTime(1_000_000_000_000_000_005n, "UTC");
-const result = later.since(earlier, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 floors to 2");
+const result = later.since(earlier, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 truncates to 2");
+const result2 = later.since(earlier, { smallestUnit: "days", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 1e9, 0, 0, 0, 0, 0, 0, "roundingIncrement 1e9 + 0.5 truncates to 1e9");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.zoneddatetime.prototype.since
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.ZonedDateTime(1_000_000_000_000_000_005n, "UTC");
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => later.since(earlier, { roundingIncrement: Infinity }));

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/roundingincrement-non-integer.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/roundingincrement-non-integer.js
@@ -5,13 +5,20 @@
 esid: sec-temporal.zoneddatetime.prototype.until
 description: Rounding for roundingIncrement option
 info: |
-    sec-temporal-totemporalroundingincrement step 7:
-      7. Set _increment_ to floor(ℝ(_increment_)).
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 includes: [temporalHelpers.js]
 features: [Temporal]
 ---*/
 
 const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
 const later = new Temporal.ZonedDateTime(1_000_000_000_000_000_005n, "UTC");
-const result = earlier.until(later, { roundingIncrement: 2.5 });
-TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 floors to 2");
+const result = earlier.until(later, { roundingIncrement: 2.5, roundingMode: "trunc" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, "roundingIncrement 2.5 truncates to 2");
+const result2 = earlier.until(later, { smallestUnit: "days", roundingIncrement: 1e9 + 0.5, roundingMode: "expand" });
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 1e9, 0, 0, 0, 0, 0, 0, "roundingIncrement 1e9 + 0.5 truncates to 1e9");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/roundingincrement-out-of-range.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/roundingincrement-out-of-range.js
@@ -5,8 +5,13 @@
 esid: sec-temporal.zoneddatetime.prototype.until
 description: RangeError thrown when roundingIncrement option out of range
 info: |
-    sec-temporal-totemporalroundingincrement step 6:
-      6. If _increment_ < 1 or _increment_ > _maximum_, throw a *RangeError* exception.
+    ToTemporalRoundingIncrement ( _normalizedOptions_ )
+
+    1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+    2. If _increment_ is not finite, throw a *RangeError* exception.
+    3. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+    4. If _integerIncrement_ < 1 or _integerIncrement_ > 10<sup>9</sup>, throw a *RangeError* exception.
+    5. Return _integerIncrement_.
 features: [Temporal]
 ---*/
 
@@ -15,4 +20,6 @@ const later = new Temporal.ZonedDateTime(1_000_000_000_000_000_005n, "UTC");
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -Infinity }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: -1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 0.9 }));
+assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: 1e9 + 1 }));
 assert.throws(RangeError, () => earlier.until(later, { roundingIncrement: Infinity }));

--- a/test/staging/Temporal/Instant/old/round.js
+++ b/test/staging/Temporal/Instant/old/round.js
@@ -70,14 +70,6 @@ assert.sameValue(`${ inst.round({
   smallestUnit: "millisecond",
   roundingIncrement: 86400000
 }) }`, expected);
-assert.sameValue(`${ inst.round({
-  smallestUnit: "microsecond",
-  roundingIncrement: 86400000000
-}) }`, expected);
-assert.sameValue(`${ inst.round({
-  smallestUnit: "nanosecond",
-  roundingIncrement: 86400000000000
-}) }`, expected);
 
 // allows increments that divide evenly into solar days
 assert(inst.round({


### PR DESCRIPTION
Previously in a few cases (calendar units in Duration) the value for the roundingIncrement option had no upper limit, other than having to be finite. These tests cover a normative change limiting it to 1e9.

(Some of the tests edited in this PR are not affected by the normative change, but I went and fixed outdated comments in all the roundingIncrement tests)

Normative PR: https://github.com/tc39/proposal-temporal/pull/2480