### PR TITLE
Update ArrayBuffer.prototype.transfer tests

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -248,6 +248,10 @@ json-modules
 # https://github.com/tc39/proposal-resizablearraybuffer
 resizable-arraybuffer
 
+# ArrayBuffer transfer
+# https://github.com/tc39/proposal-arraybuffer-transfer
+arraybuffer-transfer
+
 # Temporal
 # https://github.com/tc39/proposal-temporal
 Temporal

--- a/test/built-ins/ArrayBuffer/prototype/transfer/descriptor.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/descriptor.js
@@ -12,7 +12,7 @@ info: |
     Annex B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
     [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js]
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 verifyProperty(ArrayBuffer.prototype, 'transfer', {

--- a/test/built-ins/ArrayBuffer/prototype/transfer/extensible.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/extensible.js
@@ -9,7 +9,7 @@ info: |
   17 ECMAScript Standard Built-in Objects:
     Unless specified otherwise, the [[Extensible]] internal slot
     of a built-in object initially has the value true.
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 assert(Object.isExtensible(ArrayBuffer.prototype.transfer));

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-larger.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-larger.js
@@ -24,7 +24,7 @@ info: |
       this method as a zero-copy move or a realloc.
   14. Perform ! DetachArrayBuffer(O).
   15. Return new.
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 var source = new ArrayBuffer(4);

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-same.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-same.js
@@ -26,7 +26,7 @@ info: |
       this method as a zero-copy move or a realloc.
   14. Perform ! DetachArrayBuffer(O).
   15. Return new.
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 var source = new ArrayBuffer(4);

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-smaller.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-smaller.js
@@ -24,7 +24,7 @@ info: |
       this method as a zero-copy move or a realloc.
   14. Perform ! DetachArrayBuffer(O).
   15. Return new.
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 var source = new ArrayBuffer(4);

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-zero.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-zero.js
@@ -24,7 +24,7 @@ info: |
       this method as a zero-copy move or a realloc.
   14. Perform ! DetachArrayBuffer(O).
   15. Return new.
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 var source = new ArrayBuffer(4);

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-larger.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-larger.js
@@ -42,7 +42,7 @@ assert.throws(TypeError, function() {
   source.slice();
 });
 
-assert.sameValue(dest.resizable, false, 'dest.resizable');
+assert.sameValue(dest.resizable, true, 'dest.resizable');
 assert.sameValue(dest.byteLength, 5, 'dest.byteLength');
 assert.sameValue(dest.maxByteLength, 5, 'dest.maxByteLength');
 

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-larger.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-larger.js
@@ -24,7 +24,7 @@ info: |
       this method as a zero-copy move or a realloc.
   14. Perform ! DetachArrayBuffer(O).
   15. Return new.
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 var source = new ArrayBuffer(4, { maxByteLength: 8 });

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-same.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-same.js
@@ -44,7 +44,7 @@ assert.throws(TypeError, function() {
   source.slice();
 });
 
-assert.sameValue(dest.resizable, false, 'dest.resizable');
+assert.sameValue(dest.resizable, true, 'dest.resizable');
 assert.sameValue(dest.byteLength, 4, 'dest.byteLength');
 assert.sameValue(dest.maxByteLength, 4, 'dest.maxByteLength');
 

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-same.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-same.js
@@ -26,7 +26,7 @@ info: |
       this method as a zero-copy move or a realloc.
   14. Perform ! DetachArrayBuffer(O).
   15. Return new.
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 var source = new ArrayBuffer(4, { maxByteLength: 8 });

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-smaller.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-smaller.js
@@ -42,7 +42,7 @@ assert.throws(TypeError, function() {
   source.slice();
 });
 
-assert.sameValue(dest.resizable, false, 'dest.resizable');
+assert.sameValue(dest.resizable, true, 'dest.resizable');
 assert.sameValue(dest.byteLength, 3, 'dest.byteLength');
 assert.sameValue(dest.maxByteLength, 3, 'dest.maxByteLength');
 

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-smaller.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-smaller.js
@@ -24,7 +24,7 @@ info: |
       this method as a zero-copy move or a realloc.
   14. Perform ! DetachArrayBuffer(O).
   15. Return new.
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 var source = new ArrayBuffer(4, { maxByteLength: 8 });

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-zero.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-zero.js
@@ -42,6 +42,6 @@ assert.throws(TypeError, function() {
   source.slice();
 });
 
-assert.sameValue(dest.resizable, false, 'dest.resizable');
+assert.sameValue(dest.resizable, true, 'dest.resizable');
 assert.sameValue(dest.byteLength, 0, 'dest.byteLength');
 assert.sameValue(dest.maxByteLength, 0, 'dest.maxByteLength');

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-zero.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-zero.js
@@ -24,7 +24,7 @@ info: |
       this method as a zero-copy move or a realloc.
   14. Perform ! DetachArrayBuffer(O).
   15. Return new.
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 var source = new ArrayBuffer(4, { maxByteLength: 8 });

--- a/test/built-ins/ArrayBuffer/prototype/transfer/length.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/length.js
@@ -19,7 +19,7 @@ info: |
     object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
     [[Configurable]]: true }.
 includes: [propertyHelper.js]
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 verifyProperty(ArrayBuffer.prototype.transfer, 'length', {

--- a/test/built-ins/ArrayBuffer/prototype/transfer/name.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/name.js
@@ -15,7 +15,7 @@ info: |
     Unless otherwise specified, the name property of a built-in Function
     object, if it exists, has the attributes { [[Writable]]: false,
     [[Enumerable]]: false, [[Configurable]]: true }.
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 includes: [propertyHelper.js]
 ---*/
 

--- a/test/built-ins/ArrayBuffer/prototype/transfer/new-length-excessive.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/new-length-excessive.js
@@ -17,7 +17,7 @@ info: |
   6. Else, let newByteLength be ? ToIntegerOrInfinity(newLength).
   7. Let new be ? Construct(%ArrayBuffer%, « 𝔽(newByteLength) »).
   [...]
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 var ab = new ArrayBuffer(0);

--- a/test/built-ins/ArrayBuffer/prototype/transfer/new-length-non-number.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/new-length-non-number.js
@@ -14,7 +14,7 @@ info: |
      O.[[ArrayBufferByteLength]].
   6. Else, let newByteLength be ? ToIntegerOrInfinity(newLength).
   [...]
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 var log = [];

--- a/test/built-ins/ArrayBuffer/prototype/transfer/nonconstructor.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/nonconstructor.js
@@ -11,7 +11,7 @@ info: |
     Built-in function objects that are not identified as constructors do not
     implement the [[Construct]] internal method unless otherwise specified
     in the description of a particular function.
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 assert.sameValue(

--- a/test/built-ins/ArrayBuffer/prototype/transfer/this-is-detached.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/this-is-detached.js
@@ -13,7 +13,7 @@ info: |
   4. If IsDetachedBuffer(O) is true, throw a TypeError exception.
   [...]
 includes: [detachArrayBuffer.js]
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 assert.sameValue(typeof ArrayBuffer.prototype.transfer, 'function');

--- a/test/built-ins/ArrayBuffer/prototype/transfer/this-is-not-arraybuffer-object.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/this-is-not-arraybuffer-object.js
@@ -10,7 +10,7 @@ info: |
   1. Let O be the this value.
   2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
   [...]
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, arraybuffer-transfer]
 ---*/
 
 assert.sameValue(typeof ArrayBuffer.prototype.transfer, 'function');


### PR DESCRIPTION
This PR updates the existing transfer tests as well as add a new feature flag for it, since the proposal was split from resizable buffers.