### PR TITLE
Swap call order of NumberFormat's notation and roundingIncrement options

### DIFF
--- a/test/intl402/NumberFormat/constructor-roundingIncrement.js
+++ b/test/intl402/NumberFormat/constructor-roundingIncrement.js
@@ -46,5 +46,5 @@ for (const [value, expected] of values) {
   assert("roundingIncrement" in resolvedOptions, "has property for value " + value);
   assert.sameValue(resolvedOptions.roundingIncrement, expected);
 
-  assert.compareArray(callOrder, ["roundingIncrement", "notation"]);
+  assert.compareArray(callOrder, ["notation", "roundingIncrement"]);
 }


### PR DESCRIPTION
The order in which these options are read was changed in commit: https://github.com/tc39/proposal-intl-numberformat-v3/commit/29acfc6c3fc9f9183f83ef49e74da747134d63c8