### PR TITLE
Fix ArrayBuffer#transfer tests to preserve maxByteLength

### DIFF
--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-larger.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-larger.js
@@ -44,7 +44,7 @@ assert.throws(TypeError, function() {
 
 assert.sameValue(dest.resizable, true, 'dest.resizable');
 assert.sameValue(dest.byteLength, 5, 'dest.byteLength');
-assert.sameValue(dest.maxByteLength, 5, 'dest.maxByteLength');
+assert.sameValue(dest.maxByteLength, 8, 'dest.maxByteLength');
 
 var destArray = new Uint8Array(dest);
 

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-same.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-same.js
@@ -46,7 +46,7 @@ assert.throws(TypeError, function() {
 
 assert.sameValue(dest.resizable, true, 'dest.resizable');
 assert.sameValue(dest.byteLength, 4, 'dest.byteLength');
-assert.sameValue(dest.maxByteLength, 4, 'dest.maxByteLength');
+assert.sameValue(dest.maxByteLength, 8, 'dest.maxByteLength');
 
 var destArray = new Uint8Array(dest);
 

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-smaller.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-smaller.js
@@ -44,7 +44,7 @@ assert.throws(TypeError, function() {
 
 assert.sameValue(dest.resizable, true, 'dest.resizable');
 assert.sameValue(dest.byteLength, 3, 'dest.byteLength');
-assert.sameValue(dest.maxByteLength, 3, 'dest.maxByteLength');
+assert.sameValue(dest.maxByteLength, 8, 'dest.maxByteLength');
 
 var destArray = new Uint8Array(dest);
 

--- a/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-zero.js
+++ b/test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-zero.js
@@ -44,4 +44,4 @@ assert.throws(TypeError, function() {
 
 assert.sameValue(dest.resizable, true, 'dest.resizable');
 assert.sameValue(dest.byteLength, 0, 'dest.byteLength');
-assert.sameValue(dest.maxByteLength, 0, 'dest.maxByteLength');
+assert.sameValue(dest.maxByteLength, 8, 'dest.maxByteLength');


### PR DESCRIPTION
My bad, I missed this last time.