### PR TITLE
Push into calls array in calendar and timeZone observers.

### DIFF
--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -1498,7 +1498,7 @@ var TemporalHelpers = {
     // Automatically generate the other methods that don't need any custom code
     ["toString", "dateUntil", "era", "eraYear", "year", "month", "monthCode", "day", "daysInMonth", "fields", "mergeFields"].forEach((methodName) => {
       trackingMethods[methodName] = function (...args) {
-        actual.push(`call ${formatPropertyName(methodName, objectName)}`);
+        calls.push(`call ${formatPropertyName(methodName, objectName)}`);
         if (methodName in methodOverrides) {
           const value = methodOverrides[methodName];
           return typeof value === "function" ? value(...args) : value;
@@ -1509,11 +1509,11 @@ var TemporalHelpers = {
     return new Proxy(trackingMethods, {
       get(target, key, receiver) {
         const result = Reflect.get(target, key, receiver);
-        actual.push(`get ${formatPropertyName(key, objectName)}`);
+        calls.push(`get ${formatPropertyName(key, objectName)}`);
         return result;
       },
       has(target, key) {
-        actual.push(`has ${formatPropertyName(key, objectName)}`);
+        calls.push(`has ${formatPropertyName(key, objectName)}`);
         return Reflect.has(target, key);
       },
     });
@@ -1794,7 +1794,7 @@ var TemporalHelpers = {
     // Automatically generate the methods
     ["getOffsetNanosecondsFor", "getPossibleInstantsFor", "toString"].forEach((methodName) => {
       trackingMethods[methodName] = function (...args) {
-        actual.push(`call ${formatPropertyName(methodName, objectName)}`);
+        calls.push(`call ${formatPropertyName(methodName, objectName)}`);
         if (methodName in methodOverrides) {
           const value = methodOverrides[methodName];
           return typeof value === "function" ? value(...args) : value;
@@ -1805,11 +1805,11 @@ var TemporalHelpers = {
     return new Proxy(trackingMethods, {
       get(target, key, receiver) {
         const result = Reflect.get(target, key, receiver);
-        actual.push(`get ${formatPropertyName(key, objectName)}`);
+        calls.push(`get ${formatPropertyName(key, objectName)}`);
         return result;
       },
       has(target, key) {
-        actual.push(`has ${formatPropertyName(key, objectName)}`);
+        calls.push(`has ${formatPropertyName(key, objectName)}`);
         return Reflect.has(target, key);
       },
     });


### PR DESCRIPTION
These functions are currently pushing values into `actual` arrays that just happen to be defined in the test and end up in the global scope (e.g. https://github.com/tc39/test262/blob/780b7b806eb6c73122f82ec8dbbe7f74bb7475bf/test/built-ins/Temporal/PlainYearMonth/prototype/add/order-of-operations.js#L77). Other pieces of the observers push their recorded calls into the `calls` array, and in all current cases this array is the same as the previous `actual` array.