### PR TITLE
Temporal: Add Temporal era/eraYear tests

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/dateFromFields/one-of-era-erayear-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateFromFields/one-of-era-erayear-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.datefromfields
+description: Does not throw a RangeError if only one of era/eraYear fields is present
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const base = { year: 2000, month: 5, day: 2, era: 'ce' };
+const instance = new Temporal.Calendar('iso8601');
+TemporalHelpers.assertPlainDate(instance.dateFromFields({ ...base }), 2000, 5, 'M05', 2);
+
+const base2 = { year: 2000, month: 5, day: 2, eraYear: 1 };
+TemporalHelpers.assertPlainDate(instance.dateFromFields({ ...base }), 2000, 5, 'M05', 2);

--- a/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/one-of-era-erayear-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthDayFromFields/one-of-era-erayear-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthDayFromFields
+description: Does not throw a RangeError if only one of era/eraYear fields is present
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const base = { year: 2000, month: 5, day: 2, era: 'ce' };
+const instance = new Temporal.Calendar('iso8601');
+TemporalHelpers.assertPlainMonthDay(instance.monthDayFromFields({ ...base }), 'M05', 2);
+
+const base2 = { year: 2000, month: 5, day: 2, eraYear: 1 };
+TemporalHelpers.assertPlainMonthDay(instance.monthDayFromFields({ ...base }), 'M05', 2);

--- a/test/built-ins/Temporal/Calendar/prototype/yearMonthFromFields/one-of-era-erayear-undefined.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearMonthFromFields/one-of-era-erayear-undefined.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.yearMonthFromFields
+description: Does not throw a RangeError if only one of era/eraYear fields is present
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const base = { year: 2000, month: 5, day: 2, era: 'ce' };
+const instance = new Temporal.Calendar('iso8601');
+TemporalHelpers.assertPlainYearMonth(instance.yearMonthFromFields({ ...base }), 2000, 5, 'M05');
+
+const base2 = { year: 2000, month: 5, day: 2, eraYear: 1 };
+TemporalHelpers.assertPlainYearMonth(instance.yearMonthFromFields({ ...base }), 2000, 5, 'M05');

--- a/test/intl402/Temporal/Calendar/prototype/dateFromFields/one-of-era-erayear-undefined.js
+++ b/test/intl402/Temporal/Calendar/prototype/dateFromFields/one-of-era-erayear-undefined.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.datefromfields
+description: Throw a RangeError if only one of era/eraYear fields is present
+features: [Temporal]
+---*/
+
+const base = { year: 2000, month: 5, day: 2, era: 'ce' };
+const instance = new Temporal.Calendar('gregory');
+assert.throws(RangeError, () => {
+  instance.dateFromFields({ ...base });
+});
+
+const base2 = { year: 2000, month: 5, day: 2, eraYear: 1 };
+assert.throws(RangeError, () => {
+  instance.dateFromFields({ ...base2 });
+});

--- a/test/intl402/Temporal/Calendar/prototype/monthDayFromFields/one-of-era-erayear-undefined.js
+++ b/test/intl402/Temporal/Calendar/prototype/monthDayFromFields/one-of-era-erayear-undefined.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthdayfromfields
+description: Throw a RangeError if only one of era/eraYear fields is present
+features: [Temporal]
+---*/
+
+const base = { year: 2000, month: 5, day: 2, era: 'ce' };
+const instance = new Temporal.Calendar('gregory');
+assert.throws(RangeError, () => {
+  instance.monthDayFromFields({ ...base });
+});
+
+const base2 = { year: 2000, month: 5, day: 2, eraYear: 1 };
+assert.throws(RangeError, () => {
+  instance.dateFromFields({ ...base2 });
+});

--- a/test/intl402/Temporal/Calendar/prototype/yearMonthFromFields/one-of-era-erayear-undefined.js
+++ b/test/intl402/Temporal/Calendar/prototype/yearMonthFromFields/one-of-era-erayear-undefined.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.yearmonthfromfields
+description: Throw a RangeError if only one of era/eraYear fields is present
+features: [Temporal]
+---*/
+
+const base = { year: 2000, month: 5, day: 2, era: 'ce' };
+const instance = new Temporal.Calendar('gregory');
+assert.throws(RangeError, () => {
+  instance.yearMonthFromFields({ ...base });
+});
+
+const base2 = { year: 2000, month: 5, day: 2, eraYear: 1 };
+assert.throws(RangeError, () => {
+  instance.yearMonthFromFields({ ...base2 });
+});


### PR DESCRIPTION
Adds tests for Temporal PR: https://github.com/tc39/proposal-temporal/pull/2472

This PR makes PrepareTemporalFields not validate that either both or none of era/eraYear are present. In all cases (except when fields is to be converted to a PlainTime, in which case it doesn't matter), that is already done immediately afterwards anyway by one of the dateFromFields/yearMonthFromFields/monthDayFromFields Calendar methods, which is where we think this validation belongs.

See issue: https://github.com/tc39/proposal-temporal/issues/2465