### PR TITLE
Add `Array.prototype.includes` and `exponentiation` features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,6 +380,7 @@ includes: [asyncHelpers.js]
 asyncTest(async function() {
   await assert.throwsAsync(TypeError, () => Array.fromAsync([], "not a function"), "Array.fromAsync should reject asynchronously");
 });
+```
 
 ## A Note on Python-based tools
 

--- a/features.txt
+++ b/features.txt
@@ -114,6 +114,7 @@ ArrayBuffer
 Array.prototype.at
 Array.prototype.flat
 Array.prototype.flatMap
+Array.prototype.includes
 Array.prototype.values
 arrow-function
 async-iteration
@@ -148,6 +149,7 @@ destructuring-assignment
 destructuring-binding
 dynamic-import
 error-cause
+exponentiation
 export-star-as-namespace-from-module  # https://github.com/tc39/ecma262/pull/1174
 FinalizationRegistry
 for-in-order

--- a/src/assignment-target-type/updateexpression-star-star-exponentiationexpression-0.case
+++ b/src/assignment-target-type/updateexpression-star-star-exponentiationexpression-0.case
@@ -9,6 +9,7 @@ info: |
   UpdateExpression ** ExponentiationExpression
   Static Semantics AssignmentTargetType, Return invalid.
 template: invalid
+features: [exponentiation]
 negative: 
   phase: parse
   type: SyntaxError

--- a/src/assignment-target-type/updateexpression-star-star-exponentiationexpression-1.case
+++ b/src/assignment-target-type/updateexpression-star-star-exponentiationexpression-1.case
@@ -9,6 +9,7 @@ info: |
   UpdateExpression ** ExponentiationExpression
   Static Semantics AssignmentTargetType, Return invalid.
 template: invalid
+features: [exponentiation]
 negative: 
   phase: parse
   type: SyntaxError

--- a/src/assignment-target-type/updateexpression-star-star-exponentiationexpression-2.case
+++ b/src/assignment-target-type/updateexpression-star-star-exponentiationexpression-2.case
@@ -9,6 +9,7 @@ info: |
   UpdateExpression ** ExponentiationExpression
   Static Semantics AssignmentTargetType, Return invalid.
 template: invalid
+features: [exponentiation]
 negative: 
   phase: parse
   type: SyntaxError

--- a/src/compound-assignment-private/exp.case
+++ b/src/compound-assignment-private/exp.case
@@ -4,6 +4,7 @@
 /*---
 template: default
 desc: Compound exponentiation assignment with target being a private reference
+features: [exponentiation]
 ---*/
 
 //- lhs

--- a/src/computed-property-names/computed-property-name-from-exponetiation-expression.case
+++ b/src/computed-property-names/computed-property-name-from-exponetiation-expression.case
@@ -4,7 +4,7 @@
 /*---
 desc: Computed property name from exponentiation expression
 template: evaluation
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 ---*/
 
 //- ComputedPropertyName

--- a/src/computed-property-names/computed-property-name-from-math.case
+++ b/src/computed-property-names/computed-property-name-from-math.case
@@ -4,7 +4,7 @@
 /*---
 desc: Computed property name from math
 template: evaluation
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 ---*/
 //- ComputedPropertyName
 1 + 2 - 3 * 4 / 5 ** 6

--- a/test/built-ins/Array/prototype/includes/call-with-boolean.js
+++ b/test/built-ins/Array/prototype/includes/call-with-boolean.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-array.prototype.includes
 description: Array.prototype.includes applied to boolean primitive
+features: [Array.prototype.includes]
 ---*/
 
 assert.sameValue(Array.prototype.includes.call(true), false, 'Array.prototype.includes.call(true) must return false');

--- a/test/built-ins/Array/prototype/includes/fromIndex-equal-or-greater-length-returns-false.js
+++ b/test/built-ins/Array/prototype/includes/fromIndex-equal-or-greater-length-returns-false.js
@@ -16,6 +16,7 @@ info: |
   7. Repeat, while k < len
     ...
   8. Return false.
+features: [Array.prototype.includes]
 ---*/
 
 var sample = [7, 7, 7, 7];

--- a/test/built-ins/Array/prototype/includes/fromIndex-infinity.js
+++ b/test/built-ins/Array/prototype/includes/fromIndex-infinity.js
@@ -18,6 +18,7 @@ info: |
   7. Repeat, while k < len
     ...
   8. Return false.
+features: [Array.prototype.includes]
 ---*/
 
 var sample = [42, 43, 43, 41];

--- a/test/built-ins/Array/prototype/includes/fromIndex-minus-zero.js
+++ b/test/built-ins/Array/prototype/includes/fromIndex-minus-zero.js
@@ -13,6 +13,7 @@ info: |
   ...
   7. Repeat, while k < len
   ...
+features: [Array.prototype.includes]
 ---*/
 
 var sample = [42, 43];

--- a/test/built-ins/Array/prototype/includes/get-prop.js
+++ b/test/built-ins/Array/prototype/includes/get-prop.js
@@ -12,7 +12,7 @@ info: |
     a. Let elementK be the result of ? Get(O, ! ToString(k)).
   ...
 includes: [compareArray.js]
-features: [Proxy]
+features: [Proxy, Array.prototype.includes]
 ---*/
 
 var calls;

--- a/test/built-ins/Array/prototype/includes/length-boundaries.js
+++ b/test/built-ins/Array/prototype/includes/length-boundaries.js
@@ -17,6 +17,7 @@ info: |
   2. If len ≤ +0, return +0.
   3. If len is +∞, return 2**53-1.
   4. Return min(len, 2**53-1).
+features: [Array.prototype.includes]
 ---*/
 
 var obj = {

--- a/test/built-ins/Array/prototype/includes/length-zero-returns-false.js
+++ b/test/built-ins/Array/prototype/includes/length-zero-returns-false.js
@@ -11,6 +11,7 @@ info: |
   2. Let len be ? ToLength(? Get(O, "length")).
   3. If len is 0, return false.
   ...
+features: [Array.prototype.includes]
 ---*/
 
 var calls = 0;

--- a/test/built-ins/Array/prototype/includes/length.js
+++ b/test/built-ins/Array/prototype/includes/length.js
@@ -20,6 +20,7 @@ info: |
     object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
     [[Configurable]]: true }.
 includes: [propertyHelper.js]
+features: [Array.prototype.includes]
 ---*/
 
 assert.sameValue(Array.prototype.includes.length, 1);

--- a/test/built-ins/Array/prototype/includes/name.js
+++ b/test/built-ins/Array/prototype/includes/name.js
@@ -17,6 +17,7 @@ info: |
     object, if it exists, has the attributes { [[Writable]]: false,
     [[Enumerable]]: false, [[Configurable]]: true }.
 includes: [propertyHelper.js]
+features: [Array.prototype.includes]
 ---*/
 
 assert.sameValue(Array.prototype.includes.name, "includes");

--- a/test/built-ins/Array/prototype/includes/no-arg.js
+++ b/test/built-ins/Array/prototype/includes/no-arg.js
@@ -13,6 +13,7 @@ info: |
     b. If SameValueZero(searchElement, elementK) is true, return true.
     c. Increase k by 1.
   ...
+features: [Array.prototype.includes]
 ---*/
 
 assert.sameValue([0].includes(), false, "[0].includes()");

--- a/test/built-ins/Array/prototype/includes/not-a-constructor.js
+++ b/test/built-ins/Array/prototype/includes/not-a-constructor.js
@@ -18,7 +18,7 @@ info: |
   7. If IsConstructor(constructor) is false, throw a TypeError exception.
   ...
 includes: [isConstructor.js]
-features: [Reflect.construct, arrow-function]
+features: [Reflect.construct, arrow-function, Array.prototype.includes]
 ---*/
 
 assert.sameValue(

--- a/test/built-ins/Array/prototype/includes/prop-desc.js
+++ b/test/built-ins/Array/prototype/includes/prop-desc.js
@@ -9,6 +9,7 @@ info: |
   and in Annex B.2 has the attributes { [[Writable]]: true,
   [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
 includes: [propertyHelper.js]
+features: [Array.prototype.includes]
 ---*/
 
 verifyNotEnumerable(Array.prototype, "includes");

--- a/test/built-ins/Array/prototype/includes/return-abrupt-get-length.js
+++ b/test/built-ins/Array/prototype/includes/return-abrupt-get-length.js
@@ -10,6 +10,7 @@ info: |
   ...
   2. Let len be ? ToLength(? Get(O, "length")).
   ...
+features: [Array.prototype.includes]
 ---*/
 
 var obj = {};

--- a/test/built-ins/Array/prototype/includes/return-abrupt-get-prop.js
+++ b/test/built-ins/Array/prototype/includes/return-abrupt-get-prop.js
@@ -11,6 +11,7 @@ info: |
   7. Repeat, while k < len
     a. Let elementK be the result of ? Get(O, ! ToString(k)).
   ...
+features: [Array.prototype.includes]
 ---*/
 
 var stopped = 0;

--- a/test/built-ins/Array/prototype/includes/return-abrupt-tointeger-fromindex-symbol.js
+++ b/test/built-ins/Array/prototype/includes/return-abrupt-tointeger-fromindex-symbol.js
@@ -11,7 +11,7 @@ info: |
   4. Let n be ? ToInteger(fromIndex). (If fromIndex is undefined, this step
   produces the value 0.)
   ...
-features: [Symbol]
+features: [Symbol, Array.prototype.includes]
 ---*/
 
 var fromIndex = Symbol("1");

--- a/test/built-ins/Array/prototype/includes/return-abrupt-tointeger-fromindex.js
+++ b/test/built-ins/Array/prototype/includes/return-abrupt-tointeger-fromindex.js
@@ -11,6 +11,7 @@ info: |
   4. Let n be ? ToInteger(fromIndex). (If fromIndex is undefined, this step
   produces the value 0.)
   ...
+features: [Array.prototype.includes]
 ---*/
 
 var fromIndex = {

--- a/test/built-ins/Array/prototype/includes/return-abrupt-tonumber-length-symbol.js
+++ b/test/built-ins/Array/prototype/includes/return-abrupt-tonumber-length-symbol.js
@@ -10,7 +10,7 @@ info: |
   ...
   2. Let len be ? ToLength(? Get(O, "length")).
   ...
-features: [Symbol]
+features: [Symbol, Array.prototype.includes]
 ---*/
 
 var obj = {

--- a/test/built-ins/Array/prototype/includes/return-abrupt-tonumber-length.js
+++ b/test/built-ins/Array/prototype/includes/return-abrupt-tonumber-length.js
@@ -10,6 +10,7 @@ info: |
   ...
   2. Let len be ? ToLength(? Get(O, "length")).
   ...
+features: [Array.prototype.includes]
 ---*/
 
 var obj1 = {

--- a/test/built-ins/Array/prototype/includes/samevaluezero.js
+++ b/test/built-ins/Array/prototype/includes/samevaluezero.js
@@ -13,6 +13,7 @@ info: |
     b. If SameValueZero(searchElement, elementK) is true, return true.
     c. Increase k by 1.
   ...
+features: [Array.prototype.includes]
 ---*/
 
 var sample = [42, 0, 1, NaN];

--- a/test/built-ins/Array/prototype/includes/search-found-returns-true.js
+++ b/test/built-ins/Array/prototype/includes/search-found-returns-true.js
@@ -18,7 +18,7 @@ info: |
     b. If SameValueZero(searchElement, elementK) is true, return true.
     c. Increase k by 1.
   ...
-features: [Symbol]
+features: [Symbol, Array.prototype.includes]
 ---*/
 
 var symbol = Symbol("1");

--- a/test/built-ins/Array/prototype/includes/search-not-found-returns-false.js
+++ b/test/built-ins/Array/prototype/includes/search-not-found-returns-false.js
@@ -18,7 +18,7 @@ info: |
     b. If SameValueZero(searchElement, elementK) is true, return true.
     c. Increase k by 1.
   8. Return false.
-features: [Symbol]
+features: [Symbol, Array.prototype.includes]
 ---*/
 
 assert.sameValue([42].includes(43), false, "43");

--- a/test/built-ins/Array/prototype/includes/sparse.js
+++ b/test/built-ins/Array/prototype/includes/sparse.js
@@ -18,6 +18,7 @@ info: |
     b. If SameValueZero(searchElement, elementK) is true, return true.
     c. Increase k by 1.
   ...
+features: [Array.prototype.includes]
 ---*/
 
 assert.sameValue(

--- a/test/built-ins/Array/prototype/includes/this-is-not-object.js
+++ b/test/built-ins/Array/prototype/includes/this-is-not-object.js
@@ -9,6 +9,7 @@ info: |
 
   1. Let O be ? ToObject(this value).
   ...
+features: [Array.prototype.includes]
 ---*/
 
 var includes = Array.prototype.includes;

--- a/test/built-ins/Array/prototype/includes/tointeger-fromindex.js
+++ b/test/built-ins/Array/prototype/includes/tointeger-fromindex.js
@@ -18,6 +18,7 @@ info: |
     b. If SameValueZero(searchElement, elementK) is true, return true.
     c. Increase k by 1.
   8. Return false.
+features: [Array.prototype.includes]
 ---*/
 
 var obj = {

--- a/test/built-ins/Array/prototype/includes/tolength-length.js
+++ b/test/built-ins/Array/prototype/includes/tolength-length.js
@@ -17,6 +17,7 @@ info: |
   2. If len ≤ +0, return +0.
   3. If len is +∞, return 253-1.
   4. Return min(len, 253-1).
+features: [Array.prototype.includes]
 ---*/
 
 var obj = {

--- a/test/built-ins/Array/prototype/includes/using-fromindex.js
+++ b/test/built-ins/Array/prototype/includes/using-fromindex.js
@@ -18,6 +18,7 @@ info: |
     b. If SameValueZero(searchElement, elementK) is true, return true.
     c. Increase k by 1.
   ...
+features: [Array.prototype.includes]
 ---*/
 
 var sample = ["a", "b", "c"];

--- a/test/built-ins/Array/prototype/includes/values-are-not-cached.js
+++ b/test/built-ins/Array/prototype/includes/values-are-not-cached.js
@@ -11,6 +11,7 @@ info: |
   7. Repeat, while k < len
     a. Let elementK be the result of ? Get(O, ! ToString(k)).
   ...
+features: [Array.prototype.includes]
 ---*/
 
 function getCleanObj() {

--- a/test/built-ins/Array/prototype/methods-called-as-functions.js
+++ b/test/built-ins/Array/prototype/methods-called-as-functions.js
@@ -15,7 +15,7 @@ info: |
 
     Argument Type: Undefined
     Result: Throw a TypeError exception.
-features: [Symbol, Symbol.isConcatSpreadable, Symbol.iterator, Symbol.species, Array.prototype.flat, Array.prototype.flatMap]
+features: [Symbol, Symbol.isConcatSpreadable, Symbol.iterator, Symbol.species, Array.prototype.flat, Array.prototype.flatMap, Array.prototype.includes]
 ---*/
 
 ["constructor", "length", "0", Symbol.isConcatSpreadable, Symbol.species].forEach(function(key) {

--- a/test/built-ins/Array/prototype/pop/clamps-to-integer-limit.js
+++ b/test/built-ins/Array/prototype/pop/clamps-to-integer-limit.js
@@ -14,6 +14,7 @@ info: |
   ...
   e. Perform ? Set(O, "length", newLen, true).
   ...
+features: [exponentiation]
 ---*/
 
 var arrayLike = {};

--- a/test/built-ins/Array/prototype/pop/length-near-integer-limit.js
+++ b/test/built-ins/Array/prototype/pop/length-near-integer-limit.js
@@ -15,7 +15,8 @@ info: |
     c. Let element be ? Get(O, index).
     d. Perform ? DeletePropertyOrThrow(O, index).
     e. Perform ? Set(O, "length", newLen, true).
-    f. Return element. 
+    f. Return element.
+features: [exponentiation]
 ---*/
 
 var arrayLike = {

--- a/test/built-ins/Array/prototype/push/clamps-to-integer-limit.js
+++ b/test/built-ins/Array/prototype/push/clamps-to-integer-limit.js
@@ -14,6 +14,7 @@ info: |
   ...
   7. Perform ? Set(O, "length", len, true).
   ...
+features: [exponentiation]
 ---*/
 
 var arrayLike = {};

--- a/test/built-ins/Array/prototype/push/length-near-integer-limit.js
+++ b/test/built-ins/Array/prototype/push/length-near-integer-limit.js
@@ -15,6 +15,7 @@ info: |
     ...
   7. Perform ? Set(O, "length", len, true).
   ...
+features: [exponentiation]
 ---*/
 
 var arrayLike = {

--- a/test/built-ins/Array/prototype/push/throws-if-integer-limit-exceeded.js
+++ b/test/built-ins/Array/prototype/push/throws-if-integer-limit-exceeded.js
@@ -13,6 +13,7 @@ info: |
   4. Let argCount be the number of elements in items.
   5. If len + argCount > 2^53-1, throw a TypeError exception.
   ...
+features: [exponentiation]
 ---*/
 
 var arrayLike = {};

--- a/test/built-ins/Array/prototype/reverse/length-exceeding-integer-limit-with-object.js
+++ b/test/built-ins/Array/prototype/reverse/length-exceeding-integer-limit-with-object.js
@@ -9,6 +9,7 @@ info: |
   ...
   2. Let len be ? ToLength(? Get(O, "length")).
   ...
+features: [exponentiation]
 ---*/
 
 function StopReverse() {}

--- a/test/built-ins/Array/prototype/reverse/length-exceeding-integer-limit-with-proxy.js
+++ b/test/built-ins/Array/prototype/reverse/length-exceeding-integer-limit-with-proxy.js
@@ -6,6 +6,7 @@ esid: sec-array.prototype.reverse
 description: >
   Ensure correct MOP operations are called when length exceeds 2^53-1.
 includes: [compareArray.js, proxyTrapsHelper.js]
+features: [exponentiation]
 ---*/
 
 function StopReverse() {}

--- a/test/built-ins/Array/prototype/slice/length-exceeding-integer-limit-proxied-array.js
+++ b/test/built-ins/Array/prototype/slice/length-exceeding-integer-limit-proxied-array.js
@@ -17,6 +17,7 @@ info: |
      else let final be min(relativeEnd, len).
   ...
 includes: [compareArray.js]
+features: [exponentiation]
 ---*/
 
 var array = [];

--- a/test/built-ins/Array/prototype/slice/length-exceeding-integer-limit.js
+++ b/test/built-ins/Array/prototype/slice/length-exceeding-integer-limit.js
@@ -16,6 +16,7 @@ info: |
      else let final be min(relativeEnd, len).
   ...
 includes: [compareArray.js]
+features: [exponentiation]
 ---*/
 
 var arrayLike = {

--- a/test/built-ins/Array/prototype/splice/clamps-length-to-integer-limit.js
+++ b/test/built-ins/Array/prototype/splice/clamps-length-to-integer-limit.js
@@ -15,6 +15,7 @@ info: |
   ...
   19. Perform ? Set(O, "length", len - actualDeleteCount + itemCount, true).
   ...
+features: [exponentiation]
 ---*/
 
 var arrayLike = {};

--- a/test/built-ins/Array/prototype/splice/create-species-length-exceeding-integer-limit.js
+++ b/test/built-ins/Array/prototype/splice/create-species-length-exceeding-integer-limit.js
@@ -20,7 +20,7 @@ info: |
   12. Perform ? Set(A, "length", actualDeleteCount, true).
   ...
 includes: [compareArray.js, proxyTrapsHelper.js]
-features: [Symbol.species]
+features: [Symbol.species, exponentiation]
 ---*/
 
 function StopSplice() {}

--- a/test/built-ins/Array/prototype/splice/length-and-deleteCount-exceeding-integer-limit.js
+++ b/test/built-ins/Array/prototype/splice/length-and-deleteCount-exceeding-integer-limit.js
@@ -23,6 +23,7 @@ info: |
     d. Increment k by 1.
   ...
 includes: [compareArray.js]
+features: [exponentiation]
 ---*/
 
 var arrayLike = {

--- a/test/built-ins/Array/prototype/splice/length-exceeding-integer-limit-shrink-array.js
+++ b/test/built-ins/Array/prototype/splice/length-exceeding-integer-limit-shrink-array.js
@@ -25,6 +25,7 @@ info: |
       ii. Decrease k by 1.
   ...
 includes: [compareArray.js]
+features: [exponentiation]
 ---*/
 
 var arrayLike = {

--- a/test/built-ins/Array/prototype/splice/length-near-integer-limit-grow-array.js
+++ b/test/built-ins/Array/prototype/splice/length-near-integer-limit-grow-array.js
@@ -21,6 +21,7 @@ info: |
        vi. Decrease k by 1.
   ...
 includes: [compareArray.js]
+features: [exponentiation]
 ---*/
 
 var arrayLike = {

--- a/test/built-ins/Array/prototype/splice/throws-if-integer-limit-exceeded.js
+++ b/test/built-ins/Array/prototype/splice/throws-if-integer-limit-exceeded.js
@@ -15,6 +15,7 @@ info: |
     c. Let actualDeleteCount be min(max(dc, 0), len - actualStart).
   8. If len+insertCount-actualDeleteCount > 2^53-1, throw a TypeError exception.
   ...
+features: [exponentiation]
 ---*/
 
 var arrayLike = {};

--- a/test/built-ins/Array/prototype/toReversed/length-exceeding-array-length-limit.js
+++ b/test/built-ins/Array/prototype/toReversed/length-exceeding-array-length-limit.js
@@ -16,7 +16,7 @@ info: |
   ArrayCreate ( length [, proto ] )
 
   1. If length > 2 ** 32 - 1, throw a RangeError exception.
-features: [change-array-by-copy]
+features: [change-array-by-copy, exponentiation]
 ---*/
 
 // Object with large "length" property

--- a/test/built-ins/Array/prototype/toSorted/length-exceeding-array-length-limit.js
+++ b/test/built-ins/Array/prototype/toSorted/length-exceeding-array-length-limit.js
@@ -17,7 +17,7 @@ info: |
   ArrayCreate ( length [, proto ] )
 
   1. If length > 2 ** 32 - 1, throw a RangeError exception.
-features: [change-array-by-copy]
+features: [change-array-by-copy, exponentiation]
 ---*/
 
 // Object with large "length" property

--- a/test/built-ins/Array/prototype/toSpliced/length-clamped-to-2pow53minus1.js
+++ b/test/built-ins/Array/prototype/toSpliced/length-clamped-to-2pow53minus1.js
@@ -15,7 +15,7 @@ info: |
   1. Let len be ? ToIntegerOrInfinity(argument).
   2. If len ≤ 0, return +0𝔽.
   3. Return 𝔽(min(len, 2^53 - 1))
-features: [change-array-by-copy]
+features: [change-array-by-copy, exponentiation]
 includes: [compareArray.js]
 ---*/
 

--- a/test/built-ins/Array/prototype/toSpliced/length-exceeding-array-length-limit.js
+++ b/test/built-ins/Array/prototype/toSpliced/length-exceeding-array-length-limit.js
@@ -19,7 +19,7 @@ info: |
   ArrayCreate ( length [, proto ] )
 
   1. If length > 2 ** 32 - 1, throw a RangeError exception.
-features: [change-array-by-copy]
+features: [change-array-by-copy, exponentiation]
 ---*/
 
 // Object with large "length" property

--- a/test/built-ins/Array/prototype/unshift/clamps-to-integer-limit.js
+++ b/test/built-ins/Array/prototype/unshift/clamps-to-integer-limit.js
@@ -11,6 +11,7 @@ info: |
   3. Let argCount be the number of actual arguments.
   4. If argCount > 0, then ...
   5. Perform ? Set(O, "length", len+argCount, true).
+features: [exponentiation]
 ---*/
 
 var arrayLike = {};

--- a/test/built-ins/Array/prototype/unshift/length-near-integer-limit.js
+++ b/test/built-ins/Array/prototype/unshift/length-near-integer-limit.js
@@ -21,6 +21,7 @@ info: |
         v. Else fromPresent is false,
           1. Perform ? DeletePropertyOrThrow(O, to).
        vi. Decrease k by 1.
+features: [exponentiation]
 ---*/
 
 function StopUnshift() {}

--- a/test/built-ins/Array/prototype/unshift/throws-if-integer-limit-exceeded.js
+++ b/test/built-ins/Array/prototype/unshift/throws-if-integer-limit-exceeded.js
@@ -12,6 +12,7 @@ info: |
   4. If argCount > 0, then
     a. If len+argCount > 2^53-1, throw a TypeError exception.
     b. ...
+features: [exponentiation]
 ---*/
 
 var arrayLike = {};

--- a/test/built-ins/Array/prototype/with/index-bigger-or-eq-than-length.js
+++ b/test/built-ins/Array/prototype/with/index-bigger-or-eq-than-length.js
@@ -15,7 +15,7 @@ info: |
   5. Else, let actualIndex be len + relativeIndex.
   6. If actualIndex >= len or actualIndex < 0, throw a *RangeError* exception.
   ...
-features: [change-array-by-copy]
+features: [change-array-by-copy, exponentiation]
 ---*/
 
 assert.throws(RangeError, function() {

--- a/test/built-ins/Array/prototype/with/index-smaller-than-minus-length.js
+++ b/test/built-ins/Array/prototype/with/index-smaller-than-minus-length.js
@@ -15,7 +15,7 @@ info: |
   5. Else, let actualIndex be len + relativeIndex.
   6. If actualIndex >= len or actualIndex < 0, throw a *RangeError* exception.
   ...
-features: [change-array-by-copy]
+features: [change-array-by-copy, exponentiation]
 ---*/
 
 [0, 1, 2].with(-3, 7);

--- a/test/built-ins/Array/prototype/with/length-exceeding-array-length-limit.js
+++ b/test/built-ins/Array/prototype/with/length-exceeding-array-length-limit.js
@@ -17,7 +17,7 @@ info: |
   ArrayCreate ( length [, proto ] )
 
   1. If length > 2 ** 32 - 1, throw a RangeError exception.
-features: [change-array-by-copy]
+features: [change-array-by-copy, exponentiation]
 ---*/
 
 // Object with large "length" property

--- a/test/built-ins/Atomics/isLockFree/expected-return-value.js
+++ b/test/built-ins/Atomics/isLockFree/expected-return-value.js
@@ -12,7 +12,7 @@ description: >
     If n equals 4, return true.
     If n equals 8, return AR.[[IsLockFree8]].
     Return false.
-features: [Atomics]
+features: [Atomics, Array.prototype.includes]
 ---*/
 
 // These are the only counts that we care about tracking.

--- a/test/built-ins/Function/prototype/toString/built-in-function-object.js
+++ b/test/built-ins/Function/prototype/toString/built-in-function-object.js
@@ -17,7 +17,7 @@ info: |
     set
 
 includes: [nativeFunctionMatcher.js, wellKnownIntrinsicObjects.js]
-features: [arrow-function, Reflect]
+features: [arrow-function, Reflect, Array.prototype.includes]
 ---*/
 
 const visited = [];

--- a/test/built-ins/Map/valid-keys.js
+++ b/test/built-ins/Map/valid-keys.js
@@ -11,7 +11,7 @@ info: |
   Append p as the last element of entries.
   ...
 
-features: [BigInt, Symbol, TypedArray, WeakRef]
+features: [BigInt, Symbol, TypedArray, WeakRef, exponentiation]
 ---*/
 
 

--- a/test/built-ins/Number/bigint-conversion.js
+++ b/test/built-ins/Number/bigint-conversion.js
@@ -4,7 +4,7 @@
 /*---
 description: BigInt to Number conversion
 esid: pending
-features: [BigInt]
+features: [BigInt, exponentiation]
 ---*/
 
 assert.sameValue(Number(0n), 0);

--- a/test/built-ins/Proxy/has/trap-is-null-target-is-proxy.js
+++ b/test/built-ins/Proxy/has/trap-is-null-target-is-proxy.js
@@ -14,7 +14,7 @@ info: |
   6. Let trap be ? GetMethod(handler, "has").
   7. If trap is undefined, then
     a. Return ? target.[[HasProperty]](P).
-features: [Proxy, Symbol, Reflect]
+features: [Proxy, Symbol, Reflect, Array.prototype.includes]
 ---*/
 
 var stringTarget = new Proxy(new String("str"), {});

--- a/test/built-ins/RegExp/prototype/exec/failure-lastindex-set.js
+++ b/test/built-ins/RegExp/prototype/exec/failure-lastindex-set.js
@@ -23,6 +23,7 @@ info: |
         i. If _global_ is *true* or _sticky_ is *true*, then
           1. Perform ? Set(_R_, *"lastIndex"*, *+0*<sub>𝔽</sub>, *true*).
         ii. Return *null*.
+features: [exponentiation]
 ---*/
 
 var R_g = /./g, R_y = /./y, R_gy = /./gy;

--- a/test/built-ins/Set/valid-values.js
+++ b/test/built-ins/Set/valid-values.js
@@ -14,7 +14,7 @@ info: |
   Append value as the last element of entries.
   ...
 
-features: [BigInt, Symbol, TypedArray, WeakRef]
+features: [BigInt, Symbol, TypedArray, WeakRef, exponentiation]
 ---*/
 
 

--- a/test/built-ins/ShadowRealm/prototype/evaluate/globalthis-config-only-properties.js
+++ b/test/built-ins/ShadowRealm/prototype/evaluate/globalthis-config-only-properties.js
@@ -25,7 +25,7 @@ info: |
 
   The host may use this hook to add properties to the ShadowRealm's global
   object. Those properties must be configurable.
-features: [ShadowRealm]
+features: [ShadowRealm, Array.prototype.includes]
 ---*/
 
 assert.sameValue(

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/fixed-offset-near-date-time-limits.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/fixed-offset-near-date-time-limits.js
@@ -5,7 +5,7 @@
 esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
 description: >
   Call getPossibleInstantsFor with values near the date/time limit and a fixed offset.
-features: [Temporal]
+features: [Temporal, exponentiation]
 ---*/
 
 const oneHour = 1n * 60n * 60n * 1000n**3n;

--- a/test/intl402/DateTimeFormat/casing-numbering-system-calendar-options.js
+++ b/test/intl402/DateTimeFormat/casing-numbering-system-calendar-options.js
@@ -7,6 +7,7 @@ description: >
     Tests that the options numberingSystem and calendar are mapped
     to lower case properly.
 author: Caio Lima
+features: [Array.prototype.includes]
 ---*/
 
 let defaultLocale = new Intl.DateTimeFormat().resolvedOptions().locale;

--- a/test/intl402/DateTimeFormat/prototype/format/related-year-zh.js
+++ b/test/intl402/DateTimeFormat/prototype/format/related-year-zh.js
@@ -8,6 +8,7 @@ description: >
   Checks the output of 'relatedYear' and 'yearName' type, and
   the choice of pattern based on calendar.
 locale: [zh-u-ca-chinese]
+features: [Array.prototype.includes]
 ---*/
 
 const df = new Intl.DateTimeFormat("zh-u-ca-chinese", {year: "numeric"});

--- a/test/intl402/DateTimeFormat/prototype/format/timedatestyle-en.js
+++ b/test/intl402/DateTimeFormat/prototype/format/timedatestyle-en.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-date-time-style-pattern
 description: Checks basic handling of timeStyle and dateStyle.
-features: [Intl.DateTimeFormat-datetimestyle]
+features: [Intl.DateTimeFormat-datetimestyle, Array.prototype.includes]
 locale: [en-US]
 ---*/
 

--- a/test/intl402/DateTimeFormat/prototype/formatToParts/main.js
+++ b/test/intl402/DateTimeFormat/prototype/formatToParts/main.js
@@ -3,6 +3,7 @@
 
 /*---
 description: Tests for existance and behavior of Intl.DateTimeFormat.prototype.formatToParts
+features: [Array.prototype.includes]
 ---*/
 
 function reduce(parts) {

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-timeStyle.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-timeStyle.js
@@ -7,7 +7,7 @@ description: >
   Intl.DateTimeFormat.prototype.resolvedOptions properly
   reflect hourCycle settings when using timeStyle.
 includes: [propertyHelper.js]
-features: [Intl.DateTimeFormat-datetimestyle]
+features: [Intl.DateTimeFormat-datetimestyle, Array.prototype.includes]
 ---*/
 
 const hcValues = ["h11", "h12", "h23", "h24"];

--- a/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle.js
+++ b/test/intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle.js
@@ -10,6 +10,7 @@ info: |
   12.4.5 Intl.DateTimeFormat.prototype.resolvedOptions()
 
 includes: [propertyHelper.js]
+features: [Array.prototype.includes]
 ---*/
 
 /* Values passed via unicode extension key work */

--- a/test/intl402/Intl/supportedValuesOf/calendars-accepted-by-DateTimeFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/calendars-accepted-by-DateTimeFormat.js
@@ -22,7 +22,7 @@ info: |
     Intl.DateTimeFormat objects. The list must include "gregory".
 includes: [testIntl.js]
 locale: [en]
-features: [Intl-enumeration]
+features: [Intl-enumeration, Array.prototype.includes]
 ---*/
 
 const calendars = Intl.supportedValuesOf("calendar");

--- a/test/intl402/Intl/supportedValuesOf/calendars-accepted-by-DisplayNames.js
+++ b/test/intl402/Intl/supportedValuesOf/calendars-accepted-by-DisplayNames.js
@@ -22,7 +22,7 @@ info: |
     Intl.DateTimeFormat objects. The list must include "gregory".
 includes: [testIntl.js]
 locale: [en]
-features: [Intl-enumeration, Intl.DisplayNames-v2]
+features: [Intl-enumeration, Intl.DisplayNames-v2, Array.prototype.includes]
 ---*/
 
 const calendars = Intl.supportedValuesOf("calendar");

--- a/test/intl402/Intl/supportedValuesOf/calendars.js
+++ b/test/intl402/Intl/supportedValuesOf/calendars.js
@@ -21,7 +21,7 @@ info: |
     calendars for which the implementation provides the functionality of
     Intl.DateTimeFormat objects. The list must include "gregory".
 includes: [compareArray.js]
-features: [Intl-enumeration, Intl.Locale]
+features: [Intl-enumeration, Intl.Locale, Array.prototype.includes]
 ---*/
 
 const calendars = Intl.supportedValuesOf("calendar");

--- a/test/intl402/Intl/supportedValuesOf/collations-accepted-by-Collator.js
+++ b/test/intl402/Intl/supportedValuesOf/collations-accepted-by-Collator.js
@@ -23,7 +23,7 @@ info: |
     Intl.Collator objects.
 includes: [testIntl.js]
 locale: [en, ar, de, es, ko, ln, si, sv, zh]
-features: [Intl-enumeration]
+features: [Intl-enumeration, Array.prototype.includes]
 ---*/
 
 const collations = Intl.supportedValuesOf("collation");

--- a/test/intl402/Intl/supportedValuesOf/collations.js
+++ b/test/intl402/Intl/supportedValuesOf/collations.js
@@ -22,7 +22,7 @@ info: |
     collations for which the implementation provides the functionality of
     Intl.Collator objects.
 includes: [compareArray.js]
-features: [Intl-enumeration, Intl.Locale]
+features: [Intl-enumeration, Intl.Locale, Array.prototype.includes]
 ---*/
 
 const collations = Intl.supportedValuesOf("collation");

--- a/test/intl402/Intl/supportedValuesOf/currencies-accepted-by-DisplayNames.js
+++ b/test/intl402/Intl/supportedValuesOf/currencies-accepted-by-DisplayNames.js
@@ -23,7 +23,7 @@ info: |
     for which the implementation provides the functionality of Intl.DisplayNames
     and Intl.NumberFormat objects.
 locale: [en]
-features: [Intl-enumeration, Intl.DisplayNames]
+features: [Intl-enumeration, Intl.DisplayNames, Array.prototype.includes]
 ---*/
 
 const currencies = Intl.supportedValuesOf("currency");

--- a/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-DateTimeFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-DateTimeFormat.js
@@ -25,7 +25,7 @@ info: |
     value of every row of Table 4, except the header row.
 includes: [testIntl.js]
 locale: [en]
-features: [Intl-enumeration]
+features: [Intl-enumeration, Array.prototype.includes]
 ---*/
 
 const numberingSystems = Intl.supportedValuesOf("numberingSystem");

--- a/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-NumberFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-NumberFormat.js
@@ -25,7 +25,7 @@ info: |
     value of every row of Table 4, except the header row.
 includes: [testIntl.js]
 locale: [en]
-features: [Intl-enumeration]
+features: [Intl-enumeration, Array.prototype.includes]
 ---*/
 
 const numberingSystems = Intl.supportedValuesOf("numberingSystem");

--- a/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-RelativeTimeFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/numberingSystems-accepted-by-RelativeTimeFormat.js
@@ -25,7 +25,7 @@ info: |
     value of every row of Table 4, except the header row.
 includes: [testIntl.js]
 locale: [en]
-features: [Intl-enumeration, Intl.RelativeTimeFormat]
+features: [Intl-enumeration, Intl.RelativeTimeFormat, Array.prototype.includes]
 ---*/
 
 const numberingSystems = Intl.supportedValuesOf("numberingSystem");

--- a/test/intl402/Intl/supportedValuesOf/numberingSystems-with-simple-digit-mappings.js
+++ b/test/intl402/Intl/supportedValuesOf/numberingSystems-with-simple-digit-mappings.js
@@ -24,7 +24,7 @@ info: |
     Intl.RelativeTimeFormat objects. The list must include the Numbering System
     value of every row of Table 4, except the header row.
 includes: [testIntl.js]
-features: [Intl-enumeration]
+features: [Intl-enumeration, Array.prototype.includes]
 ---*/
 
 const numberingSystems = Intl.supportedValuesOf("numberingSystem");

--- a/test/intl402/Intl/supportedValuesOf/units-accepted-by-NumberFormat.js
+++ b/test/intl402/Intl/supportedValuesOf/units-accepted-by-NumberFormat.js
@@ -22,7 +22,7 @@ info: |
     identifiers listed in every row of Table 1, except the header row.
 includes: [testIntl.js]
 locale: [en]
-features: [Intl-enumeration]
+features: [Intl-enumeration, Array.prototype.includes]
 ---*/
 
 const units = Intl.supportedValuesOf("unit");

--- a/test/intl402/Intl/supportedValuesOf/units.js
+++ b/test/intl402/Intl/supportedValuesOf/units.js
@@ -21,7 +21,7 @@ info: |
     undefined as comparefn, that contains the unique values of simple unit
     identifiers listed in every row of Table 1, except the header row.
 includes: [compareArray.js, testIntl.js]
-features: [Intl-enumeration]
+features: [Intl-enumeration, Array.prototype.includes]
 ---*/
 
 const units = Intl.supportedValuesOf("unit");

--- a/test/intl402/Locale/prototype/collations/output-array-values.js
+++ b/test/intl402/Locale/prototype/collations/output-array-values.js
@@ -14,7 +14,7 @@ info: |
   Unicode Locale Identifier, section 3.2, sorted in descending preference of
   those in common use for string comparison in locale. The values "standard"
   and "search" must be excluded from list.
-features: [Intl.Locale,Intl.Locale-info]
+features: [Intl.Locale, Intl.Locale-info, Array.prototype.includes]
 ---*/
 
 const output = new Intl.Locale('en').collations;

--- a/test/intl402/Locale/prototype/hourCycles/output-array-values.js
+++ b/test/intl402/Locale/prototype/hourCycles/output-array-values.js
@@ -13,7 +13,7 @@ info: |
   be lower case String values indicating either the 12-hour format ("h11",
   "h12") or the 24-hour format ("h23", "h24"), sorted in descending preference
   of those in common use for date and time formatting in locale.
-features: [Intl.Locale,Intl.Locale-info]
+features: [Intl.Locale, Intl.Locale-info, Array.prototype.includes]
 ---*/
 
 const output = new Intl.Locale('en').hourCycles;

--- a/test/intl402/NumberFormat/casing-numbering-system-options.js
+++ b/test/intl402/NumberFormat/casing-numbering-system-options.js
@@ -6,6 +6,7 @@ esid: sec-initializenumberformat
 description: >
     Tests that the options numberingSystem are mapped to lower case.
 author: Caio Lima
+features: [Array.prototype.includes]
 ---*/
 
 let defaultLocale = new Intl.NumberFormat().resolvedOptions().locale;

--- a/test/intl402/PluralRules/prototype/resolvedOptions/pluralCategories.js
+++ b/test/intl402/PluralRules/prototype/resolvedOptions/pluralCategories.js
@@ -7,6 +7,7 @@ description: >
     Tests that Intl.PluralRules.prototype.resolvedOptions creates a new array
     for the pluralCategories property on every call.
 includes: [propertyHelper.js, compareArray.js]
+features: [Array.prototype.includes]
 ---*/
 
 const allowedValues = ["zero", "one", "two", "few", "many", "other"];

--- a/test/intl402/Segmenter/constructor/constructor/locales-valid.js
+++ b/test/intl402/Segmenter/constructor/constructor/locales-valid.js
@@ -8,7 +8,7 @@ info: |
     Intl.Segmenter ([ locales [ , options ]])
 
     3. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
-features: [Intl.Segmenter]
+features: [Intl.Segmenter, Array.prototype.includes]
 ---*/
 
 const defaultLocale = new Intl.Segmenter().resolvedOptions().locale;

--- a/test/intl402/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/nanoseconds-subtracted-or-added-at-dst-transition.js
+++ b/test/intl402/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/nanoseconds-subtracted-or-added-at-dst-transition.js
@@ -5,7 +5,7 @@
 esid: sec-temporal.timezone.prototype.getoffsetnanosecondsfor
 description: >
   Test offset when nanoseconds are subtracted or added from DST transition.
-features: [Temporal]
+features: [Temporal, exponentiation]
 ---*/
 
 // From <https://github.com/eggert/tz/blob/main/northamerica>:

--- a/test/intl402/fallback-locales-are-supported.js
+++ b/test/intl402/fallback-locales-are-supported.js
@@ -8,6 +8,7 @@ description: >
     supported locales.
 author: Norbert Lindenberg
 includes: [testIntl.js]
+features: [Array.prototype.includes]
 ---*/
 
 testWithIntlConstructors(function (Constructor) {

--- a/test/language/expressions/assignmenttargettype/direct-updateexpression-star-star-exponentiationexpression-0.js
+++ b/test/language/expressions/assignmenttargettype/direct-updateexpression-star-star-exponentiationexpression-0.js
@@ -3,6 +3,7 @@
 // - src/assignment-target-type/invalid/direct.template
 /*---
 description: Static Semantics AssignmentTargetType, Return invalid. (Direct assignment)
+features: [exponentiation]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/expressions/assignmenttargettype/direct-updateexpression-star-star-exponentiationexpression-1.js
+++ b/test/language/expressions/assignmenttargettype/direct-updateexpression-star-star-exponentiationexpression-1.js
@@ -3,6 +3,7 @@
 // - src/assignment-target-type/invalid/direct.template
 /*---
 description: Static Semantics AssignmentTargetType, Return invalid. (Direct assignment)
+features: [exponentiation]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/expressions/assignmenttargettype/direct-updateexpression-star-star-exponentiationexpression-2.js
+++ b/test/language/expressions/assignmenttargettype/direct-updateexpression-star-star-exponentiationexpression-2.js
@@ -3,6 +3,7 @@
 // - src/assignment-target-type/invalid/direct.template
 /*---
 description: Static Semantics AssignmentTargetType, Return invalid. (Direct assignment)
+features: [exponentiation]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/expressions/assignmenttargettype/parenthesized-updateexpression-star-star-exponentiationexpression-0.js
+++ b/test/language/expressions/assignmenttargettype/parenthesized-updateexpression-star-star-exponentiationexpression-0.js
@@ -4,6 +4,7 @@
 /*---
 description: Static Semantics AssignmentTargetType, Return invalid. (ParenthesizedExpression)
 esid: sec-grouping-operator-static-semantics-assignmenttargettype
+features: [exponentiation]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/expressions/assignmenttargettype/parenthesized-updateexpression-star-star-exponentiationexpression-1.js
+++ b/test/language/expressions/assignmenttargettype/parenthesized-updateexpression-star-star-exponentiationexpression-1.js
@@ -4,6 +4,7 @@
 /*---
 description: Static Semantics AssignmentTargetType, Return invalid. (ParenthesizedExpression)
 esid: sec-grouping-operator-static-semantics-assignmenttargettype
+features: [exponentiation]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/expressions/assignmenttargettype/parenthesized-updateexpression-star-star-exponentiationexpression-2.js
+++ b/test/language/expressions/assignmenttargettype/parenthesized-updateexpression-star-star-exponentiationexpression-2.js
@@ -4,6 +4,7 @@
 /*---
 description: Static Semantics AssignmentTargetType, Return invalid. (ParenthesizedExpression)
 esid: sec-grouping-operator-static-semantics-assignmenttargettype
+features: [exponentiation]
 flags: [generated]
 negative:
   phase: parse

--- a/test/language/expressions/class/cpn-class-expr-accessors-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/expressions/class/cpn-class-expr-accessors-computed-property-name-from-exponetiation-expression.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/expressions/class/cpn-class-expr-accessors-computed-property-name-from-math.js
+++ b/test/language/expressions/class/cpn-class-expr-accessors-computed-property-name-from-math.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from math (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/expressions/class/cpn-class-expr-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/expressions/class/cpn-class-expr-computed-property-name-from-exponetiation-expression.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/expressions/class/cpn-class-expr-computed-property-name-from-math.js
+++ b/test/language/expressions/class/cpn-class-expr-computed-property-name-from-math.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from math (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/expressions/class/cpn-class-expr-fields-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/expressions/class/cpn-class-expr-fields-computed-property-name-from-exponetiation-expression.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names, class-fields-public, class-static-fields-public]
+features: [computed-property-names, exponentiation, class-fields-public, class-static-fields-public]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/expressions/class/cpn-class-expr-fields-computed-property-name-from-math.js
+++ b/test/language/expressions/class/cpn-class-expr-fields-computed-property-name-from-math.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from math (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names, class-fields-public, class-static-fields-public]
+features: [computed-property-names, exponentiation, class-fields-public, class-static-fields-public]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/expressions/class/cpn-class-expr-fields-methods-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/expressions/class/cpn-class-expr-fields-methods-computed-property-name-from-exponetiation-expression.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names, class-fields-public, class-static-fields-public]
+features: [computed-property-names, exponentiation, class-fields-public, class-static-fields-public]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/expressions/class/cpn-class-expr-fields-methods-computed-property-name-from-math.js
+++ b/test/language/expressions/class/cpn-class-expr-fields-methods-computed-property-name-from-math.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from math (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names, class-fields-public, class-static-fields-public]
+features: [computed-property-names, exponentiation, class-fields-public, class-static-fields-public]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-exp.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-exp.js
@@ -4,7 +4,7 @@
 /*---
 description: Compound exponentiation assignment with target being a private reference (to an accessor property with getter and setter)
 esid: sec-assignment-operators-runtime-semantics-evaluation
-features: [class-fields-private]
+features: [exponentiation, class-fields-private]
 flags: [generated]
 info: |
     sec-assignment-operators-runtime-semantics-evaluation

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-exp.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-data-property-exp.js
@@ -4,7 +4,7 @@
 /*---
 description: Compound exponentiation assignment with target being a private reference (to a field)
 esid: sec-assignment-operators-runtime-semantics-evaluation
-features: [class-fields-private]
+features: [exponentiation, class-fields-private]
 flags: [generated]
 info: |
     sec-assignment-operators-runtime-semantics-evaluation

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-exp.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-method-exp.js
@@ -4,7 +4,7 @@
 /*---
 description: Compound exponentiation assignment with target being a private reference (to a private method)
 esid: sec-assignment-operators-runtime-semantics-evaluation
-features: [class-fields-private]
+features: [exponentiation, class-fields-private]
 flags: [generated]
 info: |
     sec-assignment-operators-runtime-semantics-evaluation

--- a/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-exp.js
+++ b/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-exp.js
@@ -4,7 +4,7 @@
 /*---
 description: Compound exponentiation assignment with target being a private reference (to an accessor property with getter)
 esid: sec-assignment-operators-runtime-semantics-evaluation
-features: [class-fields-private]
+features: [exponentiation, class-fields-private]
 flags: [generated]
 info: |
     sec-assignment-operators-runtime-semantics-evaluation

--- a/test/language/expressions/dynamic-import/syntax/invalid/invalid-assignmenttargettype-syntax-error-17-lhs-assignment-operator-assignment-expression.js
+++ b/test/language/expressions/dynamic-import/syntax/invalid/invalid-assignmenttargettype-syntax-error-17-lhs-assignment-operator-assignment-expression.js
@@ -40,7 +40,7 @@ info: |
 negative:
     phase: parse
     type: SyntaxError
-features: [dynamic-import]
+features: [dynamic-import, exponentiation]
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A1.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A1.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If exponent is NaN, the result is NaN.
+features: [exponentiation]
 ---*/
 
 var exponent = NaN;

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A11.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A11.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is +∞ and exponent > 0, the result is +∞.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A12.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A12.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is +∞ and exponent < 0, the result is +0.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A13.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A13.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is −∞ and exponent > 0 and exponent is an odd integer, the result is −∞.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A14.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A14.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is −∞ and exponent > 0 and exponent is not an odd integer, the result is +∞.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A15.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A15.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is −∞ and exponent < 0 and exponent is an odd integer, the result is −0.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A16.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A16.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is −∞ and exponent < 0 and exponent is not an odd integer, the result is +0.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A17.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A17.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is +0 and exponent > 0, the result is +0.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A18.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A18.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is +0 and exponent < 0, the result is +∞.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A19.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A19.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is −0 and exponent > 0 and exponent is an odd integer, the result is −0.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A2.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A2.js
@@ -5,6 +5,7 @@
 esid: sec-applying-the-exp-operator
 description: >
     If exponent is +0, the result is 1, even if base is NaN.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A20.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A20.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is −0 and exponent > 0 and exponent is not an odd integer, the result is +0.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A21.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A21.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is −0 and exponent < 0 and exponent is an odd integer, the result is −∞.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A22.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A22.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is −0 and exponent < 0 and exponent is not an odd integer, the result is +∞.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A23.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A23.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base < 0 and base is finite and exponent is finite and exponent is not an integer, the result is NaN.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A3.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A3.js
@@ -5,6 +5,7 @@
 esid: sec-applying-the-exp-operator
 description: >
     If exponent is −0, the result is 1, even if base is NaN.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A4.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A4.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If base is NaN and exponent is nonzero, the result is NaN.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A5.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A5.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If abs(base) > 1 and exponent is +∞, the result is +∞.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A6.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A6.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If abs(base) > 1 and exponent is −∞, the result is +0.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A7.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A7.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If abs(base) is 1 and exponent is +∞, the result is NaN.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A8.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A8.js
@@ -4,6 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If abs(base) is 1 and exponent is −∞, the result is NaN.
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/applying-the-exp-operator_A9.js
+++ b/test/language/expressions/exponentiation/applying-the-exp-operator_A9.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-applying-the-exp-operator
 description: If abs(base) < 1 and exponent is +∞, the result is +0.
-
+features: [exponentiation]
 ---*/
 
 

--- a/test/language/expressions/exponentiation/bigint-and-number.js
+++ b/test/language/expressions/exponentiation/bigint-and-number.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-exp-operator-runtime-semantics-evaluation
 description: Mixing BigInt and Number produces a TypeError for exponentiation operator
-features: [BigInt]
+features: [BigInt, exponentiation]
 info: |
   Let base be ? ToNumeric(leftValue).
   Let exponent be ? ToNumeric(rightValue).

--- a/test/language/expressions/exponentiation/bigint-arithmetic.js
+++ b/test/language/expressions/exponentiation/bigint-arithmetic.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-exp-operator-runtime-semantics-evaluation
 description: BigInt exponentiation arithmetic
-features: [BigInt]
+features: [BigInt, exponentiation]
 ---*/
 assert.sameValue(
   0x123n ** 0x123n,

--- a/test/language/expressions/exponentiation/bigint-errors.js
+++ b/test/language/expressions/exponentiation/bigint-errors.js
@@ -3,7 +3,7 @@
 /*---
 description: exponentiation operator ToNumeric with BigInt operands
 esid: sec-exp-operator-runtime-semantics-evaluation
-features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names]
+features: [BigInt, Symbol, Symbol.toPrimitive, computed-property-names, exponentiation]
 ---*/
 assert.throws(TypeError, function() {
   Symbol('1') ** 0n;

--- a/test/language/expressions/exponentiation/bigint-negative-exponent-throws.js
+++ b/test/language/expressions/exponentiation/bigint-negative-exponent-throws.js
@@ -13,7 +13,7 @@ info: |
 
   1. If exponent < 0, throw a RangeError exception.
   ...
-features: [BigInt]
+features: [BigInt, exponentiation]
 ---*/
 assert.throws(RangeError, function() {
   1n ** -1n;

--- a/test/language/expressions/exponentiation/bigint-toprimitive.js
+++ b/test/language/expressions/exponentiation/bigint-toprimitive.js
@@ -3,7 +3,7 @@
 /*---
 description: exponentiation operator ToNumeric with BigInt operands
 esid: sec-exp-operator-runtime-semantics-evaluation
-features: [BigInt, Symbol.toPrimitive, computed-property-names]
+features: [BigInt, Symbol.toPrimitive, computed-property-names, exponentiation]
 ---*/
 function err() {
   throw new Test262Error();

--- a/test/language/expressions/exponentiation/bigint-wrapped-values.js
+++ b/test/language/expressions/exponentiation/bigint-wrapped-values.js
@@ -3,7 +3,7 @@
 /*---
 description: exponentiation operator ToNumeric with BigInt operands
 esid: sec-exp-operator-runtime-semantics-evaluation
-features: [BigInt, Symbol.toPrimitive, computed-property-names]
+features: [BigInt, Symbol.toPrimitive, computed-property-names, exponentiation]
 ---*/
 assert.sameValue(Object(2n) ** 1n, 2n, 'The result of (Object(2n) ** 1n) is 2n');
 assert.sameValue(1n ** Object(2n), 1n, 'The result of (1n ** Object(2n)) is 1n');

--- a/test/language/expressions/exponentiation/bigint-zero-base-zero-exponent.js
+++ b/test/language/expressions/exponentiation/bigint-zero-base-zero-exponent.js
@@ -15,6 +15,6 @@ info: |
   2. If base is 0n and exponent is 0n, return 1n.
   3. Return a BigInt representing the mathematical value of base raised to the power exponent.
   ...
-features: [BigInt]
+features: [BigInt, exponentiation]
 ---*/
 assert.sameValue(0n ** 0n, 1n, 'The result of (0n ** 0n) is 1n');

--- a/test/language/expressions/exponentiation/exp-assignment-operator.js
+++ b/test/language/expressions/exponentiation/exp-assignment-operator.js
@@ -17,7 +17,7 @@ info: |
     6. Let r be the result of applying op to lval and rval as if evaluating the expression lval op rval.
     7. Perform ? PutValue(lref, r).
     8. Return r.
-
+features: [exponentiation]
 ---*/
 
 var base = -3;

--- a/test/language/expressions/exponentiation/exp-operator-evaluation-order.js
+++ b/test/language/expressions/exponentiation/exp-operator-evaluation-order.js
@@ -16,6 +16,7 @@ info: |
     5. Let base be ? ToNumber(leftValue).
     6. Let exponent be ? ToNumber(rightValue).
     7. Return the result of Applying the ** operator with base and exponent as specified in 12.7.3.4.
+features: [exponentiation]
 ---*/
 
 var capture = [];

--- a/test/language/expressions/exponentiation/exp-operator-precedence-unary-expression-semantics.js
+++ b/test/language/expressions/exponentiation/exp-operator-precedence-unary-expression-semantics.js
@@ -19,6 +19,7 @@ info: |
     `-` UnaryExpression
     `~` UnaryExpression
     `!` UnaryExpression
+features: [exponentiation]
 ---*/
 
 assert.sameValue(-(3 ** 2), -9, "-(3 ** 2) === -9");

--- a/test/language/expressions/exponentiation/exp-operator-precedence-update-expression-semantics.js
+++ b/test/language/expressions/exponentiation/exp-operator-precedence-update-expression-semantics.js
@@ -15,6 +15,7 @@ info: |
     LeftHandSideExpression `--`
     `++` UnaryExpression
     `--` UnaryExpression
+features: [exponentiation]
 ---*/
 
 var base = 4;

--- a/test/language/expressions/exponentiation/exp-operator-syntax-error-bitnot-unary-expression-base.js
+++ b/test/language/expressions/exponentiation/exp-operator-syntax-error-bitnot-unary-expression-base.js
@@ -14,6 +14,7 @@ info: |
     ...
     `~` UnaryExpression
     ...
+features: [exponentiation]
 
 negative:
   phase: parse

--- a/test/language/expressions/exponentiation/exp-operator-syntax-error-delete-unary-expression-base.js
+++ b/test/language/expressions/exponentiation/exp-operator-syntax-error-delete-unary-expression-base.js
@@ -14,6 +14,7 @@ info: |
     ...
     `delete` UnaryExpression
     ...
+features: [exponentiation]
 
 negative:
   phase: parse

--- a/test/language/expressions/exponentiation/exp-operator-syntax-error-logical-not-unary-expression-base.js
+++ b/test/language/expressions/exponentiation/exp-operator-syntax-error-logical-not-unary-expression-base.js
@@ -14,6 +14,7 @@ info: |
     ...
     `!` UnaryExpression
     ...
+features: [exponentiation]
 
 negative:
   phase: parse

--- a/test/language/expressions/exponentiation/exp-operator-syntax-error-negate-unary-expression-base.js
+++ b/test/language/expressions/exponentiation/exp-operator-syntax-error-negate-unary-expression-base.js
@@ -14,6 +14,7 @@ info: |
     ...
     `-` UnaryExpression
     ...
+features: [exponentiation]
 
 negative:
   phase: parse

--- a/test/language/expressions/exponentiation/exp-operator-syntax-error-plus-unary-expression-base.js
+++ b/test/language/expressions/exponentiation/exp-operator-syntax-error-plus-unary-expression-base.js
@@ -14,6 +14,7 @@ info: |
     ...
     `+` UnaryExpression
     ...
+features: [exponentiation]
 
 negative:
   phase: parse

--- a/test/language/expressions/exponentiation/exp-operator-syntax-error-typeof-unary-expression-base.js
+++ b/test/language/expressions/exponentiation/exp-operator-syntax-error-typeof-unary-expression-base.js
@@ -14,6 +14,7 @@ info: |
     ...
     `typeof` UnaryExpression
     ...
+features: [exponentiation]
 
 negative:
   phase: parse

--- a/test/language/expressions/exponentiation/exp-operator-syntax-error-void-unary-expression-base.js
+++ b/test/language/expressions/exponentiation/exp-operator-syntax-error-void-unary-expression-base.js
@@ -14,6 +14,7 @@ info: |
     ...
     `void` UnaryExpression
     ...
+features: [exponentiation]
 
 negative:
   phase: parse

--- a/test/language/expressions/exponentiation/exp-operator.js
+++ b/test/language/expressions/exponentiation/exp-operator.js
@@ -6,6 +6,7 @@ author: Rick Waldron
 esid: sec-exp-operator
 description: >
     Performs exponential calculation on operands. Same algorithm as %MathPow%(base, exponent)
+features: [exponentiation]
 ---*/
 
 var exponent = 2;

--- a/test/language/expressions/exponentiation/int32_min-exponent.js
+++ b/test/language/expressions/exponentiation/int32_min-exponent.js
@@ -6,6 +6,7 @@ esid: sec-applying-the-exp-operator
 description: >
     Using -(2**31) as exponent with the exponentiation operator should behave
     as expected.
+features: [exponentiation]
 ---*/
 
 const INT32_MIN = -2147483648;

--- a/test/language/expressions/exponentiation/order-of-evaluation.js
+++ b/test/language/expressions/exponentiation/order-of-evaluation.js
@@ -3,7 +3,7 @@
 /*---
 esid: sec-exp-operator-runtime-semantics-evaluation
 description: Type coercion order of operations for exponentiation operator
-features: [Symbol]
+features: [Symbol, exponentiation]
 info: |
   Evaluate lhs
   Evaluate rhs

--- a/test/language/expressions/object/cpn-obj-lit-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/expressions/object/cpn-obj-lit-computed-property-name-from-exponetiation-expression.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from exponentiation expression (ComputedPropertyName in ObjectLiteral)
 esid: prod-ComputedPropertyName
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 flags: [generated]
 info: |
     ObjectLiteral:

--- a/test/language/expressions/object/cpn-obj-lit-computed-property-name-from-math.js
+++ b/test/language/expressions/object/cpn-obj-lit-computed-property-name-from-math.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from math (ComputedPropertyName in ObjectLiteral)
 esid: prod-ComputedPropertyName
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 flags: [generated]
 info: |
     ObjectLiteral:

--- a/test/language/statements/class/cpn-class-decl-accessors-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/statements/class/cpn-class-decl-accessors-computed-property-name-from-exponetiation-expression.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from exponentiation expression (ComputedPropertyName in ClassDeclaration)
 esid: prod-ComputedPropertyName
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/statements/class/cpn-class-decl-accessors-computed-property-name-from-math.js
+++ b/test/language/statements/class/cpn-class-decl-accessors-computed-property-name-from-math.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from math (ComputedPropertyName in ClassDeclaration)
 esid: prod-ComputedPropertyName
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/statements/class/cpn-class-decl-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/statements/class/cpn-class-decl-computed-property-name-from-exponetiation-expression.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from exponentiation expression (ComputedPropertyName in ClassDeclaration)
 esid: prod-ComputedPropertyName
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/statements/class/cpn-class-decl-computed-property-name-from-math.js
+++ b/test/language/statements/class/cpn-class-decl-computed-property-name-from-math.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from math (ComputedPropertyName in ClassDeclaration)
 esid: prod-ComputedPropertyName
-features: [computed-property-names]
+features: [computed-property-names, exponentiation]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/statements/class/cpn-class-decl-fields-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/statements/class/cpn-class-decl-fields-computed-property-name-from-exponetiation-expression.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names, class-fields-public, class-static-fields-public]
+features: [computed-property-names, exponentiation, class-fields-public, class-static-fields-public]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/statements/class/cpn-class-decl-fields-computed-property-name-from-math.js
+++ b/test/language/statements/class/cpn-class-decl-fields-computed-property-name-from-math.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from math (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names, class-fields-public, class-static-fields-public]
+features: [computed-property-names, exponentiation, class-fields-public, class-static-fields-public]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/statements/class/cpn-class-decl-fields-methods-computed-property-name-from-exponetiation-expression.js
+++ b/test/language/statements/class/cpn-class-decl-fields-methods-computed-property-name-from-exponetiation-expression.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from exponentiation expression (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names, class-fields-public, class-static-fields-public]
+features: [computed-property-names, exponentiation, class-fields-public, class-static-fields-public]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/language/statements/class/cpn-class-decl-fields-methods-computed-property-name-from-math.js
+++ b/test/language/statements/class/cpn-class-decl-fields-methods-computed-property-name-from-math.js
@@ -4,7 +4,7 @@
 /*---
 description: Computed property name from math (ComputedPropertyName in ClassExpression)
 esid: prod-ComputedPropertyName
-features: [computed-property-names, class-fields-public, class-static-fields-public]
+features: [computed-property-names, exponentiation, class-fields-public, class-static-fields-public]
 flags: [generated]
 info: |
     ClassExpression:

--- a/test/staging/ArrayBuffer/resizable/includes-parameter-conversion-resizes.js
+++ b/test/staging/ArrayBuffer/resizable/includes-parameter-conversion-resizes.js
@@ -6,7 +6,7 @@ esid: sec-arraybuffer-length
 description: >
   Automatically ported from IncludesParameterConversionResizes test
   in V8's mjsunit test typedarray-resizablearraybuffer.js
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, Array.prototype.includes]
 flags: [onlyStrict]
 ---*/
 

--- a/test/staging/ArrayBuffer/resizable/includes.js
+++ b/test/staging/ArrayBuffer/resizable/includes.js
@@ -6,7 +6,7 @@ esid: sec-arraybuffer-length
 description: >
   Automatically ported from Includes test
   in V8's mjsunit test typedarray-resizablearraybuffer.js
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, Array.prototype.includes]
 flags: [onlyStrict]
 ---*/
 

--- a/test/staging/ArrayBuffer/resizable/sort-callback-shrinks.js
+++ b/test/staging/ArrayBuffer/resizable/sort-callback-shrinks.js
@@ -7,7 +7,7 @@ description: >
   Automatically ported from SortCallbackShrinks test
   in V8's mjsunit test typedarray-resizablearraybuffer.js
 includes: [compareArray.js]
-features: [resizable-arraybuffer]
+features: [resizable-arraybuffer, Array.prototype.includes]
 flags: [onlyStrict]
 ---*/
 

--- a/test/staging/Intl402/Temporal/old/non-iso-calendars.js
+++ b/test/staging/Intl402/Temporal/old/non-iso-calendars.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal-intl
 description: Non-ISO Calendars
-features: [Temporal]
+features: [Temporal, Array.prototype.includes]
 ---*/
 
 var testChineseData = new Date("2001-02-01T00:00Z").toLocaleString("en-US-u-ca-chinese", {

--- a/test/staging/Temporal/UserCalendar/old/calendar-extra-fields.js
+++ b/test/staging/Temporal/UserCalendar/old/calendar-extra-fields.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal-zoneddatetime-objects
 description: calendar with extra fields
-features: [Temporal]
+features: [Temporal, Array.prototype.includes]
 ---*/
 
 class SeasonCalendar extends Temporal.Calendar {

--- a/test/staging/Temporal/UserCalendar/old/calendar-non-trivial-mergefields.js
+++ b/test/staging/Temporal/UserCalendar/old/calendar-non-trivial-mergefields.js
@@ -4,7 +4,7 @@
 /*---
 esid: sec-temporal-zoneddatetime-objects
 description: calendar with nontrivial mergeFields implementation
-features: [Temporal]
+features: [Temporal, Array.prototype.includes]
 ---*/
 
 class CenturyCalendar extends Temporal.Calendar {


### PR DESCRIPTION
While trying to use the `features` metadata to classify tests per ECMAScript edition, I realized there weren't features for the `Array.prototype.includes` function, nor the `**` operator. Seeing that even ES6 features  like `class`, `let` or `const` have their own features, it'd be more consistent to also have the same labeling for ES7 features.   

This PR introduces the features `Array.prototype.includes` and `exponentiation`, and adds them to the corresponding tests.