### PR TITLE
Update expected test results for CLDR 43

### DIFF
--- a/test/intl402/Locale/constructor-non-iana-canon.js
+++ b/test/intl402/Locale/constructor-non-iana-canon.js
@@ -86,6 +86,7 @@ var testData = [
     {
         tag: "hy-arevmda",
         canonical: "hyw",
+        maximized: "hyw-Armn-AM",
     },
 ];
 

--- a/test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js
+++ b/test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js
@@ -27,12 +27,12 @@ var testDataMinimal = {
     "und-AT": "de-AT",
 
     // https://unicode-org.atlassian.net/browse/ICU-13786
-    "aae-Latn-IT": "aae-Latn-IT",
+    "aae-Latn-IT": "aae",
     "aae-Thai-CO": "aae-Thai-CO",
 
     // https://unicode-org.atlassian.net/browse/ICU-10220
     // https://unicode-org.atlassian.net/browse/ICU-12345
-    "und-CW": "pap-CW",
+    "und-CW": "pap",
     "und-US": "en",
     "zh-Hant": "zh-TW",
     "zh-Hani": "zh-Hani",


### PR DESCRIPTION
intl402/Locale/constructor-non-iana-canon.js
- Likely subtags entry for "hyw" -> "hyw-Armn-AM" was added to supplemental/likelySubtags.xml

intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js
- Likely subtags entry for "aae" -> "aae-Latn-IT" was added to supplemental/likelySubtags.xml
- Likely subtags entry for "pap" was changed from "pap_Latn_AW" to "pap_Latn_CW"