### PR TITLE
Improvements to Temporal tests

### DIFF
--- a/harness/temporalHelpers.js
+++ b/harness/temporalHelpers.js
@@ -7,6 +7,8 @@ defines: [TemporalHelpers]
 features: [Symbol.species, Symbol.iterator, Temporal]
 ---*/
 
+const IDENTIFIER = /^[$_\p{ID_Start}][$\u200C\u200D\p{ID_Continue}]*$/u;
+
 function formatPropertyName(propertyKey, objectName = "") {
   switch (typeof propertyKey) {
     case "symbol":
@@ -17,13 +19,20 @@ function formatPropertyName(propertyKey, objectName = "") {
       } else {
         return `${objectName}[Symbol('${propertyKey.description}')]`
       }
-    case "number":
-      return `${objectName}[${propertyKey}]`;
+    case "string":
+      if (propertyKey !== String(Number(propertyKey))) {
+        if (IDENTIFIER.test(propertyKey)) {
+          return objectName ? `${objectName}.${propertyKey}` : propertyKey;
+        }
+        return `${objectName}['${propertyKey.replace(/'/g, "\\'")}']`
+      }
+      // fall through
     default:
-      // TODO: check if propertyKey is an integer index.
-      return objectName ? `${objectName}.${propertyKey}` : propertyKey;
+      // integer or string integer-index
+      return `${objectName}[${propertyKey}]`;
   }
 }
+
 const SKIP_SYMBOL = Symbol("Skip");
 
 var TemporalHelpers = {

--- a/test/built-ins/Array/fromAsync/asyncitems-arraylike-promise.js
+++ b/test/built-ins/Array/fromAsync/asyncitems-arraylike-promise.js
@@ -25,7 +25,7 @@ asyncTest(async function () {
     "get items.length",
     "get items.length.valueOf",
     "call items.length.valueOf",
-    "get items.0",
-    "get items.1",
+    "get items[0]",
+    "get items[1]",
   ]);
 });

--- a/test/built-ins/Temporal/Calendar/prototype/mergeFields/order-of-operations.js
+++ b/test/built-ins/Temporal/Calendar/prototype/mergeFields/order-of-operations.js
@@ -21,8 +21,8 @@ const expected = [
   "get fields.extra",
   // CopyDataProperties on additionalFields
   "ownKeys additionalFields",
-  "getOwnPropertyDescriptor additionalFields.3",
-  "get additionalFields.3",
+  "getOwnPropertyDescriptor additionalFields[3]",
+  "get additionalFields[3]",
   "getOwnPropertyDescriptor additionalFields.monthCode",
   "get additionalFields.monthCode",
   "getOwnPropertyDescriptor additionalFields[Symbol('extra')]",

--- a/test/built-ins/Temporal/Duration/compare/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/compare/order-of-operations.js
@@ -171,6 +171,30 @@ Temporal.Duration.compare(
 assert.compareArray(actual, expectedOpsForPlainRelativeTo, "order of operations with PlainDate relativeTo and no calendar units");
 actual.splice(0); // clear
 
+// code path through UnbalanceDurationRelative that balances higher units down
+// to days:
+const expectedOpsForPlainDayBalancing = expectedOpsForPlainRelativeTo.concat(
+  [
+    // UnbalanceDurationRelative
+    "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
+    // UnbalanceDurationRelative again for the second argument:
+    "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
+  ]
+);
+Temporal.Duration.compare(
+  createDurationPropertyBagObserver("one", 1, 1, 1),
+  createDurationPropertyBagObserver("two", 1, 1, 1, 1),
+  createOptionsObserver(plainRelativeTo)
+);
+assert.compareArray(actual, expectedOpsForPlainDayBalancing, "order of operations with PlainDate relativeTo and calendar units");
+actual.splice(0); // clear
+
 const expectedOpsForZonedRelativeTo = expected.concat([
   // ToRelativeTemporalObject
   "get options.relativeTo.calendar",
@@ -240,6 +264,9 @@ const expectedOpsForZonedRelativeTo = expected.concat([
   "call options.relativeTo.timeZone.getPossibleInstantsFor",
   "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+]);
+
+const expectedOpsForCalculateOffsetShift = [
   // CalculateOffsetShift on first argument
   "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
@@ -264,7 +291,7 @@ const expectedOpsForZonedRelativeTo = expected.concat([
   "call options.relativeTo.timeZone.getPossibleInstantsFor",
   "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
   "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-]);
+];
 
 const zonedRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
   year: 2001,
@@ -282,33 +309,66 @@ const zonedRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
   timeZone: TemporalHelpers.timeZoneObserver(actual, "options.relativeTo.timeZone"),
 }, "options.relativeTo");
 
-// order of observable operations with zoned relativeTo and without calendar units
+// order of observable operations with zoned relativeTo and without calendar units except days
 Temporal.Duration.compare(
   createDurationPropertyBagObserver("one", 0, 0, 0, 7),
   createDurationPropertyBagObserver("two", 0, 0, 0, 6),
   createOptionsObserver(zonedRelativeTo)
 );
-assert.compareArray(actual, expectedOpsForZonedRelativeTo, "order of operations with ZonedDateTime relativeTo and no calendar units");
+assert.compareArray(
+  actual,
+  expectedOpsForZonedRelativeTo.concat(expectedOpsForCalculateOffsetShift),
+  "order of operations with ZonedDateTime relativeTo and no calendar units except days"
+);
+actual.splice(0); // clear
+
+// order of observable operations with zoned relativeTo and with only time units
+Temporal.Duration.compare(
+  createDurationPropertyBagObserver("one", 0, 0, 0, 0, 7),
+  createDurationPropertyBagObserver("two", 0, 0, 0, 0, 6),
+  createOptionsObserver(zonedRelativeTo)
+);
+assert.compareArray(
+  actual,
+  expectedOpsForZonedRelativeTo.concat([
+    // CalculateOffsetShift on first arg
+    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+    // AddZonedDateTime
+    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+    // CalculateOffsetShift on second arg
+    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+    // AddZonedDateTime
+    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",
+    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  ]),
+  "order of operations with ZonedDateTime relativeTo and only time units"
+);
 actual.splice(0); // clear
 
 // code path through UnbalanceDurationRelative that balances higher units down
 // to days:
-const expectedOpsForDayBalancing = expectedOpsForZonedRelativeTo.concat([
-  // UnbalanceDurationRelative
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 7.a ToTemporalDate
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
-  // UnbalanceDurationRelative again for the second argument:
-  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 7.a ToTemporalDate
-  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
-  "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
-  "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
-]);
+const expectedOpsForDayBalancing = expectedOpsForZonedRelativeTo.concat(
+  expectedOpsForCalculateOffsetShift,
+  [
+    // UnbalanceDurationRelative
+    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 7.a ToTemporalDate
+    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+    "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
+    // UnbalanceDurationRelative again for the second argument:
+    "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 7.a ToTemporalDate
+    "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+    "get options.relativeTo.calendar.dateAdd",   // 11.a.ii
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.iii.1 MoveRelativeDate
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.iv.1 MoveRelativeDate
+    "call options.relativeTo.calendar.dateAdd",  // 11.a.v.1 MoveRelativeDate
+  ]
+);
 Temporal.Duration.compare(
   createDurationPropertyBagObserver("one", 1, 1, 1),
   createDurationPropertyBagObserver("two", 1, 1, 1, 1),

--- a/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/order-of-operations.js
@@ -351,3 +351,44 @@ const zonedRelativeTo = TemporalHelpers.propertyBagObserver(actual, {
 // basic order of operations with ZonedDateTime relativeTo:
 instance.round(createOptionsObserver({ relativeTo: zonedRelativeTo }));
 assert.compareArray(actual, expectedOpsForZonedRelativeTo, "order of operations for ZonedDateTime relativeTo");
+actual.splice(0); // clear
+
+// code path through RoundDuration that rounds to the nearest year:
+const expectedOpsForYearRoundingZoned = expectedOpsForZonedRelativeTo.concat([
+  // NanosecondsToDays
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 7. GetPlainDateTimeFor
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 11. GetPlainDateTimeFor
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateUntil",                // 12. DifferenceISODateTime
+  "call options.relativeTo.calendar.dateUntil",
+  // NanosecondsToDays → AddZonedDateTime
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 5. GetPlainDateTimeFor
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",                  // 8.
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",   // 10. GetInstantFor
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  // NanosecondsToDays → AddZonedDateTime
+  "get options.relativeTo.timeZone.getOffsetNanosecondsFor",  // 5. GetPlainDateTimeFor
+  "call options.relativeTo.timeZone.getOffsetNanosecondsFor",
+  "get options.relativeTo.calendar.dateAdd",                  // 8.
+  "call options.relativeTo.calendar.dateAdd",
+  "get options.relativeTo.timeZone.getPossibleInstantsFor",   // 10. GetInstantFor
+  "call options.relativeTo.timeZone.getPossibleInstantsFor",
+  "get options.relativeTo.calendar.dateAdd",     // 9.b
+  "call options.relativeTo.calendar.dateAdd",    // 9.c
+  "call options.relativeTo.calendar.dateAdd",    // 9.e
+  "call options.relativeTo.calendar.dateAdd",    // 9.j
+  "get options.relativeTo.calendar.dateUntil",   // 9.m
+  "call options.relativeTo.calendar.dateUntil",  // 9.m
+  "call options.relativeTo.calendar.dateAdd",    // 9.r
+  "call options.relativeTo.calendar.dateAdd",    // 9.w MoveRelativeDate
+]);
+instance.round(createOptionsObserver({ smallestUnit: "years", relativeTo: zonedRelativeTo }));
+assert.compareArray(
+  actual,
+  expectedOpsForYearRoundingZoned,
+  "order of operations with smallestUnit = years and ZonedDateTime relativeTo"
+);
+actual.splice(0); // clear

--- a/test/built-ins/Temporal/Duration/prototype/round/relativeto-zoneddatetime-nanoseconds-to-days-range-errors.js
+++ b/test/built-ins/Temporal/Duration/prototype/round/relativeto-zoneddatetime-nanoseconds-to-days-range-errors.js
@@ -54,7 +54,8 @@ assert.throws(RangeError, () =>
   oneNsDuration.round({
     relativeTo: zdt,
     smallestUnit: "days",
-  })
+  }),
+  "RangeError when days < 0 and sign = 1"
 );
 
 // NanosecondsToDays.20: days > 0 and sign = -1
@@ -74,7 +75,8 @@ assert.throws(RangeError, () =>
   negOneNsDuration.round({
     relativeTo: zdt,
     smallestUnit: "days",
-  })
+  }),
+  "RangeError when days > 0 and sign = -1"
 );
 
 // NanosecondsToDays.22: nanoseconds > 0 and sign = -1
@@ -93,9 +95,10 @@ zdt = new Temporal.ZonedDateTime(
   )
 );
 assert.throws(RangeError, () =>
-  // Using -1ns duration sets _nanoseocnds_ to -1 and _sign_ to -1
+  // Using -1ns duration sets _nanoseconds_ to -1 and _sign_ to -1
   negOneNsDuration.round({
     relativeTo: zdt,
     smallestUnit: "days",
-  })
+  }),
+  "RangeError when nanoseconds > 0 and sign = -1"
 );

--- a/test/built-ins/Temporal/Duration/prototype/total/relativeto-zoneddatetime-nanoseconds-to-days-range-errors.js
+++ b/test/built-ins/Temporal/Duration/prototype/total/relativeto-zoneddatetime-nanoseconds-to-days-range-errors.js
@@ -53,7 +53,8 @@ assert.throws(RangeError, () =>
   oneNsDuration.total({
     relativeTo: zdt,
     unit: "day",
-  })
+  }),
+  "RangeError when days < 0 and sign = 1"
 );
 
 // NanosecondsToDays.20: days > 0 and sign = -1
@@ -72,7 +73,8 @@ assert.throws(RangeError, () =>
   negOneNsDuration.total({
     relativeTo: zdt,
     unit: "day",
-  })
+  }),
+  "RangeError when days > 0 and sign = -1"
 );
 
 // NanosecondsToDays.22: nanoseconds > 0 and sign = -1
@@ -94,5 +96,6 @@ assert.throws(RangeError, () =>
   negOneNsDuration.total({
     relativeTo: zdt,
     unit: "day",
-  })
+  }),
+  "RangeError when nanoseconds > 0 and sign = -1"
 );

--- a/test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js
@@ -18,10 +18,16 @@ const expected = [
   // PrepareTemporalFields on receiver
   "get this.calendar.day",
   "call this.calendar.day",
+  "get this.hour",
+  "get this.microsecond",
+  "get this.millisecond",
+  "get this.minute",
   "get this.calendar.month",
   "call this.calendar.month",
   "get this.calendar.monthCode",
   "call this.calendar.monthCode",
+  "get this.nanosecond",
+  "get this.second",
   "get this.calendar.year",
   "call this.calendar.year",
   // PrepareTemporalFields on argument
@@ -75,6 +81,13 @@ const calendar = TemporalHelpers.calendarObserver(actual, "this.calendar");
 const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
 // clear observable operations that occurred during the constructor call
 actual.splice(0);
+
+TemporalHelpers.observeProperty(actual, instance, "hour", 12, "this");
+TemporalHelpers.observeProperty(actual, instance, "minute", 34, "this");
+TemporalHelpers.observeProperty(actual, instance, "second", 56, "this");
+TemporalHelpers.observeProperty(actual, instance, "millisecond", 987, "this");
+TemporalHelpers.observeProperty(actual, instance, "microsecond", 654, "this");
+TemporalHelpers.observeProperty(actual, instance, "nanosecond", 321, "this");
 
 const fields = TemporalHelpers.propertyBagObserver(actual, {
   year: 1.7,

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/getISOFields/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/getISOFields/order-of-operations.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.getisofields
+description: >
+  Properties on the calendar or time zone of the receiver of getISOFields()
+  are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+];
+const actual = [];
+
+const instance = new Temporal.ZonedDateTime(
+  988786472_987_654_321n,  /* 2001-05-02T06:54:32.987654321Z */
+  TemporalHelpers.timeZoneObserver(actual, "this.timeZone"),
+  TemporalHelpers.calendarObserver(actual, "this.calendar"),
+);
+// clear any observable operations that happen due to time zone or calendar
+// calls on the constructor
+actual.splice(0);
+
+instance.getISOFields();
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/round/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/round/order-of-operations.js
@@ -1,0 +1,61 @@
+// Copyright (C) 2022 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: Properties on objects passed to equals() are accessed in the correct order
+includes: [compareArray.js, temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expected = [
+  "get options.roundingIncrement",
+  "get options.roundingIncrement.valueOf",
+  "call options.roundingIncrement.valueOf",
+  "get options.roundingMode",
+  "get options.roundingMode.toString",
+  "call options.roundingMode.toString",
+  "get options.smallestUnit",
+  "get options.smallestUnit.toString",
+  "call options.smallestUnit.toString",
+  // GetPlainDateTimeFor on receiver's instant
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  // GetInstantFor on preceding midnight
+  "get this.timeZone.getPossibleInstantsFor",
+  "call this.timeZone.getPossibleInstantsFor",
+  // AddZonedDateTime
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  "get this.calendar.dateAdd",
+  "call this.calendar.dateAdd",
+  "get this.timeZone.getPossibleInstantsFor",
+  "call this.timeZone.getPossibleInstantsFor",
+  // GetOffsetNanosecondsFor
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+  // InterpretISODateTimeOffset
+  "get this.timeZone.getPossibleInstantsFor",
+  "call this.timeZone.getPossibleInstantsFor",
+  "get this.timeZone.getOffsetNanosecondsFor",
+  "call this.timeZone.getOffsetNanosecondsFor",
+];
+const actual = [];
+
+const options = TemporalHelpers.propertyBagObserver(actual, {
+  smallestUnit: "nanoseconds",
+  roundingMode: "halfExpand",
+  roundingIncrement: 1,
+}, "options");
+
+const instance = new Temporal.ZonedDateTime(
+  988786472_987_654_321n,  /* 2001-05-02T06:54:32.987654321Z */
+  TemporalHelpers.timeZoneObserver(actual, "this.timeZone"),
+  TemporalHelpers.calendarObserver(actual, "this.calendar"),
+);
+// clear any observable operations that happen due to time zone or calendar
+// calls on the constructor
+actual.splice(0);
+
+instance.round(options);
+assert.compareArray(actual, expected, "order of operations");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
@@ -247,3 +247,7 @@ const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDiffere
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with smallestUnit = weeks");
 actual.splice(0); // clear
+
+instance.since(otherDateTimePropertyBag, createOptionsObserver({ largestUnit: "hours" }));
+assert.compareArray(actual, expected, "order of operations with largestUnit being a time unit");
+actual.splice(0);  // clear

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/order-of-operations.js
@@ -245,4 +245,5 @@ const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDiffere
   "call this.calendar.dateAdd",  // 11.d MoveRelativeDate
 ]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
 instance.since(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
-assert.compareArray(actual.slice(expected.length), expectedOpsForWeekRounding.slice(expected.length), "order of operations with smallestUnit = weeks");
+assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with smallestUnit = weeks");
+actual.splice(0); // clear

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
@@ -247,3 +247,7 @@ const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDiffere
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
 assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with smallestUnit = weeks");
 actual.splice(0);  // clear
+
+instance.until(otherDateTimePropertyBag, createOptionsObserver({ largestUnit: "hours" }));
+assert.compareArray(actual, expected, "order of operations with largestUnit being a time unit");
+actual.splice(0);  // clear

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/order-of-operations.js
@@ -245,4 +245,5 @@ const expectedOpsForWeekRounding = expected.concat(expectedOpsForCalendarDiffere
   "call this.calendar.dateAdd",  // 11.d MoveRelativeDate
 ]);  // (11.g.iii MoveRelativeDate not called because days already balanced)
 instance.until(otherDateTimePropertyBag, createOptionsObserver({ smallestUnit: "weeks" }));
-assert.compareArray(actual.slice(expected.length), expectedOpsForWeekRounding.slice(expected.length), "order of operations with smallestUnit = weeks");
+assert.compareArray(actual, expectedOpsForWeekRounding, "order of operations with smallestUnit = weeks");
+actual.splice(0);  // clear


### PR DESCRIPTION
- Fix a leftover from debugging
- Improve comments and assertion messages
- Improve printing of property names in observer helpers
- Improve coverage of order-of-operations tests in preparation for tc39/proposal-temporal#2519