### PR TITLE
Add tests for RegExp `v` flag errors that were allowed with `u`

### DIFF
--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-01.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-01.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[(]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-02.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-02.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[)]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-03.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-03.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[[]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-04.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-04.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[{]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-05.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-05.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[}]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-06.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-06.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[/]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-07.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-07.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[-]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-08.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-08.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[|]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-09.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-09.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[&&]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-10.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-10.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[!!]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-11.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-11.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[##]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-12.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-12.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[$$]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-13.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-13.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[%%]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-14.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-14.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[**]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-15.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-15.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[++]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-16.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-16.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[,,]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-17.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-17.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[..]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-18.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-18.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[::]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-19.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-19.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[;;]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-20.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-20.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[<<]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-21.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-21.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[==]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-22.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-22.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[>>]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-23.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-23.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[??]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-24.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-24.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[@@]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-25.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-25.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[``]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-26.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-26.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[~~]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-27.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-27.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[^^^]/v;

--- a/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-28.js
+++ b/test/built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-28.js
@@ -1,0 +1,19 @@
+// Copyright 2023 Mathias Bynens. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+author: Mathias Bynens
+description: >
+  Some previously valid patterns with the `u` flag are now expected to
+  throw an early SyntaxError with the `v` flag.
+  https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag
+esid: sec-parsepattern
+negative:
+  phase: parse
+  type: SyntaxError
+features: [regexp-v-flag]
+---*/
+
+$DONOTEVALUATE();
+
+/[_^^]/v;


### PR DESCRIPTION
https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag

Issue: #3496
Issue: https://github.com/tc39/proposal-regexp-v-flag/issues/52