### PR TITLE
Temporal: Tests for multiple calendar annotations with at least one critical

### DIFF
--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-calendar-annotation.js
@@ -16,7 +16,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateAdd/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.dateAdd(arg, new Temporal.Duration()),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-string-calendar-annotation.js
@@ -16,7 +16,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dateUntil/argument-string-multiple-calendar.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.dateUntil(arg, new Temporal.PlainDate(1977, 11, 19)),
+    `reject more than one calendar annotation if any critical: ${arg} (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => instance.dateUntil(new Temporal.PlainDate(1977, 11, 19), arg),
+    `reject more than one calendar annotation if any critical: ${arg} (second argument)`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/day/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/day/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.day
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.day(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfWeek/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofweek
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.dayOfWeek(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/dayOfYear/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dayofyear
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.dayOfYear(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInMonth/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinmonth
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.daysInMonth(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInWeek/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinweek
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.daysInWeek(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/daysInYear/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.daysinyear
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.daysInYear(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/inLeapYear/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.inleapyear
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.inLeapYear(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/month/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/month/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.month
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.month(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthCode/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthcode
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.monthCode(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/monthsInYear/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.monthsinyear
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.monthsInYear(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/weekOfYear/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.weekofyear
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.weekOfYear(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/year/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/year/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.year
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.year(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Calendar/prototype/yearOfWeek/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.yearofweek
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.yearOfWeek(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Instant/compare/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Instant/compare/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["1970-01-01T00:00Z[u-ca=discord]", "annotation is ignored"],
   ["1970-01-01T00:00Z[!u-ca=discord]", "annotation with ! is ignored"],
   ["1970-01-01T00:00Z[u-ca=iso8601][u-ca=discord]", "two annotations are ignored"],
-  ["1970-01-01T00:00Z[u-ca=iso8601][!u-ca=discord]", "two annotations are ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/Instant/compare/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Instant/compare/argument-string-multiple-calendar.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.compare
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00Z[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00Z[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+const epoch = new Temporal.Instant(0n);
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.Instant.compare(arg, epoch),
+    `reject more than one calendar annotation if any critical: ${arg} (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.Instant.compare(epoch, arg),
+    `reject more than one calendar annotation if any critical: ${arg} (second argument)`
+  );
+});

--- a/test/built-ins/Temporal/Instant/from/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Instant/from/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["1970-01-01T00:00Z[u-ca=discord]", "annotation is ignored"],
   ["1970-01-01T00:00Z[!u-ca=discord]", "annotation with ! is ignored"],
   ["1970-01-01T00:00Z[u-ca=iso8601][u-ca=discord]", "two annotations are ignored"],
-  ["1970-01-01T00:00Z[u-ca=iso8601][!u-ca=discord]", "two annotations are ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/Instant/from/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Instant/from/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.from
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00Z[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00Z[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.Instant.from(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Instant/prototype/equals/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["1970-01-01T00:00Z[u-ca=discord]", "annotation is ignored"],
   ["1970-01-01T00:00Z[!u-ca=discord]", "annotation with ! is ignored"],
   ["1970-01-01T00:00Z[u-ca=iso8601][u-ca=discord]", "two annotations are ignored"],
-  ["1970-01-01T00:00Z[u-ca=iso8601][!u-ca=discord]", "two annotations are ignored even with !"],
 ];
 
 const instance = new Temporal.Instant(0n);

--- a/test/built-ins/Temporal/Instant/prototype/equals/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Instant/prototype/equals/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.equals
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00Z[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00Z[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Instant(0n);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Instant/prototype/since/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/argument-string-calendar-annotation.js
@@ -16,7 +16,6 @@ const tests = [
   ["1970-01-01T00:00Z[u-ca=discord]", "annotation is ignored"],
   ["1970-01-01T00:00Z[!u-ca=discord]", "annotation with ! is ignored"],
   ["1970-01-01T00:00Z[u-ca=iso8601][u-ca=discord]", "two annotations are ignored"],
-  ["1970-01-01T00:00Z[u-ca=iso8601][!u-ca=discord]", "two annotations are ignored even with !"],
 ];
 
 const instance = new Temporal.Instant(0n);

--- a/test/built-ins/Temporal/Instant/prototype/since/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Instant/prototype/since/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00Z[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00Z[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Instant(0n);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/Instant/prototype/until/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/argument-string-calendar-annotation.js
@@ -16,7 +16,6 @@ const tests = [
   ["1970-01-01T00:00Z[u-ca=discord]", "annotation is ignored"],
   ["1970-01-01T00:00Z[!u-ca=discord]", "annotation with ! is ignored"],
   ["1970-01-01T00:00Z[u-ca=iso8601][u-ca=discord]", "two annotations are ignored"],
-  ["1970-01-01T00:00Z[u-ca=iso8601][!u-ca=discord]", "two annotations are ignored even with !"],
 ];
 
 const instance = new Temporal.Instant(0n);

--- a/test/built-ins/Temporal/Instant/prototype/until/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/Instant/prototype/until/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00Z[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00Z[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Instant(0n);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/compare/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/PlainDate/compare/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDate/compare/argument-string-multiple-calendar.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.compare
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.compare(arg, new Temporal.PlainDate(1976, 11, 18)),
+    `reject more than one calendar annotation if any critical: ${arg} (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.compare(new Temporal.PlainDate(1976, 11, 18), arg),
+    `reject more than one calendar annotation if any critical: ${arg} (second argument)`
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/from/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-string-calendar-annotation.js
@@ -16,7 +16,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/PlainDate/from/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDate/from/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.from
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDate.from(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainDate(2000, 5, 2);

--- a/test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.equals
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainDate(2000, 5, 2);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-string-calendar-annotation.js
@@ -16,7 +16,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainDate(2000, 5, 2);

--- a/test/built-ins/Temporal/PlainDate/prototype/since/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/since/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainDate(2000, 5, 2);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-calendar-annotation.js
@@ -25,7 +25,6 @@ const tests = [
   ["12:34:56.987654321[u-ca=unknown]", "calendar annotation ignored even if unknown calendar"],
   ["12:34:56.987654321[!u-ca=unknown]", "calendar annotation ignored even if unknown calendar with !"],
   ["1970-01-01T12:34:56.987654321[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T12:34:56.987654321[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainDate(2000, 5, 2);

--- a/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplaindatetime
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainDate(2000, 5, 2);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.toPlainDateTime(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-calendar-annotation.js
@@ -24,7 +24,6 @@ const tests = [
   ["12:34:56.987654321[u-ca=unknown]", "calendar annotation ignored even if unknown calendar"],
   ["12:34:56.987654321[!u-ca=unknown]", "calendar annotation ignored even if unknown calendar with !"],
   ["1970-01-01T12:34:56.987654321[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T12:34:56.987654321[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainDate(2000, 5, 2);

--- a/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainDate(2000, 5, 2);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.toZonedDateTime({ plainTime: arg, timeZone: "UTC" }),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-string-calendar-annotation.js
@@ -16,7 +16,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainDate(2000, 5, 2);

--- a/test/built-ins/Temporal/PlainDate/prototype/until/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDate/prototype/until/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainDate(2000, 5, 2);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-string-calendar-annotation.js
@@ -13,7 +13,6 @@ const tests = [
   ["1976-11-18T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["1976-11-18T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["1976-11-18T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1976-11-18T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/PlainDateTime/compare/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/compare/argument-string-multiple-calendar.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.compare(arg, new Temporal.PlainDateTime(1976, 11, 18)),
+    `reject more than one calendar annotation if any critical: ${arg} (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.compare(new Temporal.PlainDateTime(1976, 11, 18), arg),
+    `reject more than one calendar annotation if any critical: ${arg} (second argument)`
+  );
+});

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-string-calendar-annotation.js
@@ -14,7 +14,6 @@ const tests = [
   ["1976-11-18T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["1976-11-18T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["1976-11-18T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1976-11-18T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/PlainDateTime/from/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/from/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainDateTime.from(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-calendar-annotation.js
@@ -13,7 +13,6 @@ const tests = [
   ["1976-11-18T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["1976-11-18T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["1976-11-18T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1976-11-18T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-string-calendar-annotation.js
@@ -14,7 +14,6 @@ const tests = [
   ["1976-11-18T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["1976-11-18T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["1976-11-18T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1976-11-18T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/since/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-string-calendar-annotation.js
@@ -14,7 +14,6 @@ const tests = [
   ["1976-11-18T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["1976-11-18T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["1976-11-18T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1976-11-18T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/until/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-calendar-annotation.js
@@ -16,7 +16,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaindate
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.withPlainDate(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-calendar-annotation.js
@@ -25,7 +25,6 @@ const tests = [
   ["12:34:56.987654321[u-ca=unknown]", "calendar annotation ignored even if unknown calendar"],
   ["12:34:56.987654321[!u-ca=unknown]", "calendar annotation ignored even if unknown calendar with !"],
   ["1970-01-01T12:34:56.987654321[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T12:34:56.987654321[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainDateTime(1976, 11, 18, 15, 23);

--- a/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaintime
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.withPlainTime(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-string-calendar-annotation.js
@@ -14,7 +14,6 @@ const tests = [
   ["1976-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["1976-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["1976-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1976-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/PlainMonthDay/from/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainMonthDay/from/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.from
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainMonthDay.from(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-calendar-annotation.js
@@ -13,7 +13,6 @@ const tests = [
   ["1976-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["1976-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["1976-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1976-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainMonthDay(5, 2);

--- a/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.equals
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainMonthDay(5, 2);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/compare/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainTime/compare/argument-string-calendar-annotation.js
@@ -21,7 +21,6 @@ const tests = [
   ["1970-01-01T12:34:56.987654321[!u-ca=iso8601]", "with !, date, and no time zone"],
   ["1970-01-01T12:34:56.987654321[UTC][!u-ca=iso8601]", "with !, date, and time zone"],
   ["1970-01-01T12:34:56.987654321[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T12:34:56.987654321[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/PlainTime/compare/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainTime/compare/argument-string-multiple-calendar.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.compare
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainTime.compare(arg, new Temporal.PlainTime(12, 34, 56, 987, 654, 321)),
+    `reject more than one calendar annotation if any critical: ${arg} (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainTime.compare(new Temporal.PlainTime(12, 34, 56, 987, 654, 321), arg),
+    `reject more than one calendar annotation if any critical: ${arg} (first argument)`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/from/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-string-calendar-annotation.js
@@ -25,7 +25,6 @@ const tests = [
   ["12:34:56.987654321[u-ca=unknown]", "calendar annotation ignored even if unknown calendar"],
   ["12:34:56.987654321[!u-ca=unknown]", "calendar annotation ignored even if unknown calendar with !"],
   ["1970-01-01T12:34:56.987654321[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T12:34:56.987654321[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/PlainTime/from/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainTime/from/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.from
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainTime.from(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-calendar-annotation.js
@@ -24,7 +24,6 @@ const tests = [
   ["12:34:56.987654321[u-ca=unknown]", "calendar annotation ignored even if unknown calendar"],
   ["12:34:56.987654321[!u-ca=unknown]", "calendar annotation ignored even if unknown calendar with !"],
   ["1970-01-01T12:34:56.987654321[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T12:34:56.987654321[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);

--- a/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.equals
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-calendar-annotation.js
@@ -25,7 +25,6 @@ const tests = [
   ["12:34:56.987654321[u-ca=unknown]", "calendar annotation ignored even if unknown calendar"],
   ["12:34:56.987654321[!u-ca=unknown]", "calendar annotation ignored even if unknown calendar with !"],
   ["1970-01-01T12:34:56.987654321[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T12:34:56.987654321[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);

--- a/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/since/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-string-calendar-annotation.js
@@ -16,7 +16,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);

--- a/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.toplaindatetime
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.toPlainDateTime(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);

--- a/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/toZonedDateTime/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.toZonedDateTime({ plainDate: arg, timeZone: "UTC" }),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-calendar-annotation.js
@@ -25,7 +25,6 @@ const tests = [
   ["12:34:56.987654321[u-ca=unknown]", "calendar annotation ignored even if unknown calendar"],
   ["12:34:56.987654321[!u-ca=unknown]", "calendar annotation ignored even if unknown calendar with !"],
   ["1970-01-01T12:34:56.987654321[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T12:34:56.987654321[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);

--- a/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainTime/prototype/until/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-string-calendar-annotation.js
@@ -13,7 +13,6 @@ const tests = [
   ["2019-12-15T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2019-12-15T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2019-12-15T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2019-12-15T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/PlainYearMonth/compare/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainYearMonth/compare/argument-string-multiple-calendar.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.compare
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.compare(arg, new Temporal.PlainYearMonth(2019, 6)),
+    `reject more than one calendar annotation if any critical: ${arg} (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.compare(new Temporal.PlainYearMonth(2019, 6), arg),
+    `reject more than one calendar annotation if any critical: ${arg} (second argument)`
+  );
+});

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-string-calendar-annotation.js
@@ -14,7 +14,6 @@ const tests = [
   ["2019-12-15T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2019-12-15T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2019-12-15T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2019-12-15T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/PlainYearMonth/from/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainYearMonth/from/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.from
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.PlainYearMonth.from(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-calendar-annotation.js
@@ -13,7 +13,6 @@ const tests = [
   ["2019-12-15T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2019-12-15T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2019-12-15T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2019-12-15T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainYearMonth(2019, 12);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.equals
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainYearMonth(2000, 5);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-calendar-annotation.js
@@ -14,7 +14,6 @@ const tests = [
   ["2019-12-15T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2019-12-15T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2019-12-15T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2019-12-15T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainYearMonth(2019, 12);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainYearMonth(2000, 5);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-calendar-annotation.js
@@ -14,7 +14,6 @@ const tests = [
   ["2019-12-15T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2019-12-15T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2019-12-15T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2019-12-15T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.PlainYearMonth(2019, 12);

--- a/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.PlainYearMonth(2000, 5);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-string-calendar-annotation.js
@@ -13,7 +13,6 @@ const tests = [
   ["1976-11-18T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["1976-11-18T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["1976-11-18T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1976-11-18T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getInstantFor/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.TimeZone("UTC");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.getInstantFor(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["1970-01-01T00:00Z[u-ca=discord]", "annotation is ignored"],
   ["1970-01-01T00:00Z[!u-ca=discord]", "annotation with ! is ignored"],
   ["1970-01-01T00:00Z[u-ca=iso8601][u-ca=discord]", "two annotations are ignored"],
-  ["1970-01-01T00:00Z[u-ca=iso8601][!u-ca=discord]", "two annotations are ignored even with !"],
 ];
 
 const instance = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getNextTransition/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getnexttransition
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00Z[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00Z[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.TimeZone("UTC");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.getNextTransition(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["1970-01-01T00:00Z[u-ca=discord]", "annotation is ignored"],
   ["1970-01-01T00:00Z[!u-ca=discord]", "annotation with ! is ignored"],
   ["1970-01-01T00:00Z[u-ca=iso8601][u-ca=discord]", "two annotations are ignored"],
-  ["1970-01-01T00:00Z[u-ca=iso8601][!u-ca=discord]", "two annotations are ignored even with !"],
 ];
 
 const instance = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetNanosecondsFor/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getoffsetnanosecondsfor
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00Z[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00Z[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.TimeZone("UTC");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.getOffsetNanosecondsFor(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["1970-01-01T00:00Z[u-ca=discord]", "annotation is ignored"],
   ["1970-01-01T00:00Z[!u-ca=discord]", "annotation with ! is ignored"],
   ["1970-01-01T00:00Z[u-ca=iso8601][u-ca=discord]", "two annotations are ignored"],
-  ["1970-01-01T00:00Z[u-ca=iso8601][!u-ca=discord]", "two annotations are ignored even with !"],
 ];
 
 const instance = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getOffsetStringFor/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getoffsetstringfor
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00Z[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00Z[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.TimeZone("UTC");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.getOffsetStringFor(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-string-calendar-annotation.js
@@ -16,7 +16,6 @@ const tests = [
   ["1970-01-01T00:00Z[u-ca=discord]", "annotation is ignored"],
   ["1970-01-01T00:00Z[!u-ca=discord]", "annotation with ! is ignored"],
   ["1970-01-01T00:00Z[u-ca=iso8601][u-ca=discord]", "two annotations are ignored"],
-  ["1970-01-01T00:00Z[u-ca=iso8601][!u-ca=discord]", "two annotations are ignored even with !"],
 ];
 
 const instance = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPlainDateTimeFor/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00Z[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00Z[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.TimeZone("UTC");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.getPlainDateTimeFor(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-string-calendar-annotation.js
@@ -14,7 +14,6 @@ const tests = [
   ["1976-11-18T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["1976-11-18T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["1976-11-18T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1976-11-18T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPossibleInstantsFor/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.TimeZone("UTC");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.getPossibleInstantsFor(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["1970-01-01T00:00Z[u-ca=discord]", "annotation is ignored"],
   ["1970-01-01T00:00Z[!u-ca=discord]", "annotation with ! is ignored"],
   ["1970-01-01T00:00Z[u-ca=iso8601][u-ca=discord]", "two annotations are ignored"],
-  ["1970-01-01T00:00Z[u-ca=iso8601][!u-ca=discord]", "two annotations are ignored even with !"],
 ];
 
 const instance = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/TimeZone/prototype/getPreviousTransition/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getprevioustransition
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00Z[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00Z[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00Z[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.TimeZone("UTC");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.getPreviousTransition(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-string-calendar-annotation.js
@@ -11,7 +11,6 @@ const tests = [
   ["1970-01-01T00:00[UTC][u-ca=iso8601]", "without !"],
   ["1970-01-01T00:00[UTC][!u-ca=iso8601]", "with !"],
   ["1970-01-01T00:00[UTC][u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/ZonedDateTime/compare/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/compare/argument-string-multiple-calendar.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.compare
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+const datetime = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.compare(arg, datetime),
+    `reject more than one calendar annotation if any critical: ${arg} (first argument)`
+  );
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.compare(datetime, arg),
+    `reject more than one calendar annotation if any critical: ${arg} (second argument)`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-string-calendar-annotation.js
@@ -11,7 +11,6 @@ const tests = [
   ["1970-01-01T00:00[UTC][u-ca=iso8601]", "without !"],
   ["1970-01-01T00:00[UTC][!u-ca=iso8601]", "with !"],
   ["1970-01-01T00:00[UTC][u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 tests.forEach(([arg, description]) => {

--- a/test/built-ins/Temporal/ZonedDateTime/from/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/from/argument-string-multiple-calendar.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.from
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => Temporal.ZonedDateTime.from(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-string-calendar-annotation.js
@@ -11,7 +11,6 @@ const tests = [
   ["1970-01-01T00:00[UTC][u-ca=iso8601]", "without !"],
   ["1970-01-01T00:00[UTC][!u-ca=iso8601]", "with !"],
   ["1970-01-01T00:00[UTC][u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const timeZone = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.equals
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.equals(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-string-calendar-annotation.js
@@ -12,7 +12,6 @@ const tests = [
   ["1970-01-01T00:00[UTC][u-ca=iso8601]", "without !"],
   ["1970-01-01T00:00[UTC][!u-ca=iso8601]", "with !"],
   ["1970-01-01T00:00[UTC][u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const timeZone = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.since(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-string-calendar-annotation.js
@@ -12,7 +12,6 @@ const tests = [
   ["1970-01-01T00:00[UTC][u-ca=iso8601]", "without !"],
   ["1970-01-01T00:00[UTC][!u-ca=iso8601]", "with !"],
   ["1970-01-01T00:00[UTC][u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const timeZone = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-string-multiple-calendar.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.until(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const timeZone = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate/argument-string-multiple-calendar.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.withPlainDate(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-calendar-annotation.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-calendar-annotation.js
@@ -24,7 +24,6 @@ const tests = [
   ["12:34:56.987654321[u-ca=unknown]", "calendar annotation ignored even if unknown calendar"],
   ["12:34:56.987654321[!u-ca=unknown]", "calendar annotation ignored even if unknown calendar with !"],
   ["1970-01-01T12:34:56.987654321[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["1970-01-01T12:34:56.987654321[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const timeZone = new Temporal.TimeZone("UTC");

--- a/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-multiple-calendar.js
+++ b/test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-multiple-calendar.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaintime
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const timeZone = new Temporal.TimeZone("UTC");
+const instance = new Temporal.ZonedDateTime(0n, timeZone);
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.withPlainTime(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-string-calendar-annotation.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/intl402/Temporal/Calendar/prototype/era/argument-string-multiple-calendar.js
+++ b/test/intl402/Temporal/Calendar/prototype/era/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.era
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.era(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-string-calendar-annotation.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-string-calendar-annotation.js
@@ -15,7 +15,6 @@ const tests = [
   ["2000-05-02T15:23[!u-ca=iso8601]", "with ! and no time zone"],
   ["2000-05-02T15:23[UTC][!u-ca=iso8601]", "with ! and time zone"],
   ["2000-05-02T15:23[u-ca=iso8601][u-ca=discord]", "second annotation ignored"],
-  ["2000-05-02T15:23[u-ca=iso8601][!u-ca=discord]", "second annotation ignored even with !"],
 ];
 
 const instance = new Temporal.Calendar("iso8601");

--- a/test/intl402/Temporal/Calendar/prototype/eraYear/argument-string-multiple-calendar.js
+++ b/test/intl402/Temporal/Calendar/prototype/eraYear/argument-string-multiple-calendar.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.erayear
+description: >
+  More than one calendar annotation is not syntactical if any have the criical
+  flag
+features: [Temporal]
+---*/
+
+const invalidStrings = [
+  "1970-01-01[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[!u-ca=iso8601][u-ca=iso8601]",
+  "1970-01-01T00:00[UTC][u-ca=iso8601][!u-ca=iso8601]",
+  "1970-01-01T00:00[u-ca=iso8601][foo=bar][!u-ca=iso8601]",
+];
+const instance = new Temporal.Calendar("iso8601");
+invalidStrings.forEach((arg) => {
+  assert.throws(
+    RangeError,
+    () => instance.eraYear(arg),
+    `reject more than one calendar annotation if any critical: ${arg}`
+  );
+});


### PR DESCRIPTION
As per IETF review, an IXDTF string (ISO 8601 with annotations) is no longer valid if it contains more than one u-ca annotation and at least one of the annotations is marked critical.

Removes tests where such a string was assumed to be valid, and adds new ones with a few variations on invalid strings.

Corresponds to a normative change: tc39/proposal-temporal#2572.