### PR TITLE
Patch tests with new evaluation order for member assignment

### DIFF
--- a/test/language/expressions/assignment/target-member-computed-reference-null.js
+++ b/test/language/expressions/assignment/target-member-computed-reference-null.js
@@ -39,11 +39,11 @@ assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {
-    throw new DummyError();
+    throw new Test262Error("right-hand side expression evaluated");
   };
 
   base[prop] = expr();

--- a/test/language/expressions/assignment/target-member-computed-reference-undefined.js
+++ b/test/language/expressions/assignment/target-member-computed-reference-undefined.js
@@ -39,11 +39,11 @@ assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {
-    throw new DummyError();
+    throw new Test262Error("right-hand side expression evaluated");
   };
 
   base[prop] = expr();

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.10_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.10_T1.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] ^= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.10_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.10_T2.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] ^= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.11_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.11_T1.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] |= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.11_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.11_T2.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] |= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.1_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.1_T1.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] *= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.1_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.1_T2.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] *= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.2_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.2_T1.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] /= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.2_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.2_T2.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] /= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.3_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.3_T1.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] %= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.3_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.3_T2.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] %= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.4_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.4_T1.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] += expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.4_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.4_T2.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] += expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.5_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.5_T1.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] -= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.5_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.5_T2.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] -= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.6_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.6_T1.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] <<= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.6_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.6_T2.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] <<= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.7_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.7_T1.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] >>= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.7_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.7_T2.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] >>= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.8_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.8_T1.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] >>>= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.8_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.8_T2.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] >>>= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.9_T1.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.9_T1.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] &= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/compound-assignment/S11.13.2_A7.9_T2.js
+++ b/test/language/expressions/compound-assignment/S11.13.2_A7.9_T2.js
@@ -24,11 +24,11 @@ assert.throws(DummyError, function() {
   base[prop()] &= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/logical-assignment/lgcl-and-assignment-operator-lhs-before-rhs.js
+++ b/test/language/expressions/logical-assignment/lgcl-and-assignment-operator-lhs-before-rhs.js
@@ -23,11 +23,11 @@ assert.throws(DummyError, function() {
   base[prop()] &&= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/logical-assignment/lgcl-nullish-assignment-operator-lhs-before-rhs.js
+++ b/test/language/expressions/logical-assignment/lgcl-nullish-assignment-operator-lhs-before-rhs.js
@@ -23,11 +23,11 @@ assert.throws(DummyError, function() {
   base[prop()] ??= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/logical-assignment/lgcl-or-assignment-operator-lhs-before-rhs.js
+++ b/test/language/expressions/logical-assignment/lgcl-or-assignment-operator-lhs-before-rhs.js
@@ -23,11 +23,11 @@ assert.throws(DummyError, function() {
   base[prop()] ||= expr();
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
   var expr = function() {

--- a/test/language/expressions/postfix-decrement/S11.3.2_A6_T1.js
+++ b/test/language/expressions/postfix-decrement/S11.3.2_A6_T1.js
@@ -19,11 +19,11 @@ assert.throws(DummyError, function() {
   base[prop()]--;
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
 

--- a/test/language/expressions/postfix-decrement/S11.3.2_A6_T2.js
+++ b/test/language/expressions/postfix-decrement/S11.3.2_A6_T2.js
@@ -19,11 +19,11 @@ assert.throws(DummyError, function() {
   base[prop()]--;
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
 

--- a/test/language/expressions/postfix-increment/S11.3.1_A6_T1.js
+++ b/test/language/expressions/postfix-increment/S11.3.1_A6_T1.js
@@ -19,11 +19,11 @@ assert.throws(DummyError, function() {
   base[prop()]++;
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
 

--- a/test/language/expressions/postfix-increment/S11.3.1_A6_T2.js
+++ b/test/language/expressions/postfix-increment/S11.3.1_A6_T2.js
@@ -19,11 +19,11 @@ assert.throws(DummyError, function() {
   base[prop()]++;
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
 

--- a/test/language/expressions/prefix-decrement/S11.4.5_A6_T1.js
+++ b/test/language/expressions/prefix-decrement/S11.4.5_A6_T1.js
@@ -19,11 +19,11 @@ assert.throws(DummyError, function() {
   --base[prop()];
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
 

--- a/test/language/expressions/prefix-decrement/S11.4.5_A6_T2.js
+++ b/test/language/expressions/prefix-decrement/S11.4.5_A6_T2.js
@@ -19,11 +19,11 @@ assert.throws(DummyError, function() {
   --base[prop()];
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
 

--- a/test/language/expressions/prefix-increment/S11.4.4_A6_T1.js
+++ b/test/language/expressions/prefix-increment/S11.4.4_A6_T1.js
@@ -19,11 +19,11 @@ assert.throws(DummyError, function() {
   ++base[prop()];
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = null;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
 

--- a/test/language/expressions/prefix-increment/S11.4.4_A6_T2.js
+++ b/test/language/expressions/prefix-increment/S11.4.4_A6_T2.js
@@ -19,11 +19,11 @@ assert.throws(DummyError, function() {
   ++base[prop()];
 });
 
-assert.throws(TypeError, function() {
+assert.throws(DummyError, function() {
   var base = undefined;
   var prop = {
     toString: function() {
-      throw new Test262Error("property key evaluated");
+      throw new DummyError();
     }
   };
 


### PR DESCRIPTION
Fixes #3407, see issue for context.
Should wait for a decision on https://github.com/tc39/ecma262/issues/2659 before merging.

Mutually exclusive with #3825. This should only be merged if the new behaviour is NOT considered a bug on the specification.


