### PR TITLE
Patch test with old evaluation order for member assignment

### DIFF
--- a/test/language/expressions/assignment/S11.13.1_A7_T3.js
+++ b/test/language/expressions/assignment/S11.13.1_A7_T3.js
@@ -5,8 +5,8 @@
 info: Assignment Operator evaluates its operands from left to right.
 description: >
     The left-hand side expression is evaluated before the right-hand side.
-    Left-hand side expression is MemberExpression: base[prop]. Evaluating
-    ToPropertyKey(prop) throws an error.
+    Left-hand side expression is MemberExpression: base[prop]. ToPropertyKey(prop)
+    is not called.
 ---*/
 
 function DummyError() { }
@@ -15,11 +15,11 @@ assert.throws(DummyError, function() {
   var base = {};
   var prop = {
     toString: function() {
-      throw new DummyError();
+      throw new Test262Error("property key evaluated");
     }
   };
   var expr = function() {
-    throw new Test262Error("right-hand side expression evaluated");
+    throw new DummyError();
   };
 
   base[prop] = expr();


### PR DESCRIPTION
Fixes #3407, see issue for context.
Should wait for a decision on https://github.com/tc39/ecma262/issues/2659 before merging.

Mutually exclusive with #3824. This should only be merged if the new behaviour is considered a bug on the specification.
