### PR TITLE
Test for postfix and prefix increment and decrement operations on `this`

### DIFF
--- a/test/language/expressions/postfix-decrement/this.js
+++ b/test/language/expressions/postfix-decrement/this.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Ecma International.  All rights reserved.
+// Copyright (c) 2023 Veera Sivarajan Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -8,15 +8,15 @@ description: >
 info: |
   sec-static-semantics-assignmenttargettype
 
-  PrimaryExpression : this 
+    PrimaryExpression: this 
 
-  Return invalid.
+    Return invalid.
 
   sec-update-expressions-static-semantics-early-errors
 
-  UpdateExpression: LeftHandSideExpression --
+    UpdateExpression: LeftHandSideExpression --
 
-  It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
+    It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/postfix-decrement/this.js
+++ b/test/language/expressions/postfix-decrement/this.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Ecma International.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-update-expressions-static-semantics-early-errors
+description: >
+  It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple. (this)
+info: |
+  sec-static-semantics-assignmenttargettype
+
+  PrimaryExpression : this 
+
+  Return invalid.
+
+  sec-update-expressions-static-semantics-early-errors
+
+  UpdateExpression: LeftHandSideExpression --
+
+  It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+this--;

--- a/test/language/expressions/postfix-decrement/this.js
+++ b/test/language/expressions/postfix-decrement/this.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Veera Sivarajan Ecma International.  All rights reserved.
+// Copyright (C) 2023 Veera Sivarajan. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---

--- a/test/language/expressions/postfix-increment/this.js
+++ b/test/language/expressions/postfix-increment/this.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Ecma International.  All rights reserved.
+// Copyright (c) 2023 Veera Sivarajan Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -8,15 +8,15 @@ description: >
 info: |
   sec-static-semantics-assignmenttargettype
 
-  PrimaryExpression : this 
+    PrimaryExpression: this 
 
-  Return invalid.
+    Return invalid.
 
   sec-update-expressions-static-semantics-early-errors
 
-  UpdateExpression: LeftHandSideExpression ++
+    UpdateExpression: LeftHandSideExpression ++
 
-  It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
+    It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/postfix-increment/this.js
+++ b/test/language/expressions/postfix-increment/this.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Ecma International.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-update-expressions-static-semantics-early-errors
+description: >
+  It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple. (this)
+info: |
+  sec-static-semantics-assignmenttargettype
+
+  PrimaryExpression : this 
+
+  Return invalid.
+
+  sec-update-expressions-static-semantics-early-errors
+
+  UpdateExpression: LeftHandSideExpression ++
+
+  It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+this++;

--- a/test/language/expressions/postfix-increment/this.js
+++ b/test/language/expressions/postfix-increment/this.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Veera Sivarajan Ecma International.  All rights reserved.
+// Copyright (C) 2023 Veera Sivarajan. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---

--- a/test/language/expressions/prefix-decrement/this.js
+++ b/test/language/expressions/prefix-decrement/this.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Veera Sivarajan Ecma International.  All rights reserved.
+// Copyright (C) 2023 Veera Sivarajan. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---

--- a/test/language/expressions/prefix-decrement/this.js
+++ b/test/language/expressions/prefix-decrement/this.js
@@ -4,22 +4,22 @@
 /*---
 esid: sec-update-expressions-static-semantics-early-errors
 description: >
-It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple. (this)
-info: |
-  sec-static-semantics-assignmenttargettype
+    It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple. (this)
+info: | 
+    sec-static-semantics-assignmenttargettype
 
-    PrimaryExpression: this 
+      PrimaryExpression: this
 
-    Return invalid.
+      Return invalid.
 
-  sec-update-expressions-static-semantics-early-errors
+    sec-update-expressions-static-semantics-early-errors
 
-    UpdateExpression: -- UnaryExpression 
+      UpdateExpression: -- UnaryExpression 
 
-    It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple.
-negative:
-  phase: parse
-  type: SyntaxError
+      It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple.
+negative: 
+    phase: parse
+    type: SyntaxError
 ---*/
 
 $DONOTEVALUATE();

--- a/test/language/expressions/prefix-decrement/this.js
+++ b/test/language/expressions/prefix-decrement/this.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Ecma International.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-update-expressions-static-semantics-early-errors
+description: >
+It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple. (this)
+info: |
+  sec-static-semantics-assignmenttargettype
+
+  PrimaryExpression : this 
+
+  Return invalid.
+
+  sec-update-expressions-static-semantics-early-errors
+
+  UpdateExpression: -- UnaryExpression 
+
+  It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple.
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+--this;

--- a/test/language/expressions/prefix-decrement/this.js
+++ b/test/language/expressions/prefix-decrement/this.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Ecma International.  All rights reserved.
+// Copyright (c) 2023 Veera Sivarajan Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
@@ -8,15 +8,15 @@ It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not si
 info: |
   sec-static-semantics-assignmenttargettype
 
-  PrimaryExpression : this 
+    PrimaryExpression: this 
 
-  Return invalid.
+    Return invalid.
 
   sec-update-expressions-static-semantics-early-errors
 
-  UpdateExpression: -- UnaryExpression 
+    UpdateExpression: -- UnaryExpression 
 
-  It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple.
+    It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple.
 negative:
   phase: parse
   type: SyntaxError

--- a/test/language/expressions/prefix-increment/this.js
+++ b/test/language/expressions/prefix-increment/this.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-  esid: sec-update-expressions-static-semantics-early-errors
+esid: sec-update-expressions-static-semantics-early-errors
 description: >
   It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple. (this)
 info: |

--- a/test/language/expressions/prefix-increment/this.js
+++ b/test/language/expressions/prefix-increment/this.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Ecma International.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-update-expressions-static-semantics-early-errors
+description: >
+It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple. (this)
+info: |
+  sec-static-semantics-assignmenttargettype
+
+  PrimaryExpression : this 
+
+  Return invalid.
+
+  sec-update-expressions-static-semantics-early-errors
+
+  UpdateExpression: ++ UnaryExpression 
+
+  It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple.
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+++this;

--- a/test/language/expressions/prefix-increment/this.js
+++ b/test/language/expressions/prefix-increment/this.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Veera Sivarajan Ecma International.  All rights reserved.
+// Copyright (C) 2023 Veera Sivarajan. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---

--- a/test/language/expressions/prefix-increment/this.js
+++ b/test/language/expressions/prefix-increment/this.js
@@ -1,22 +1,22 @@
-// Copyright (c) 2023 Ecma International.  All rights reserved.
+// Copyright (c) 2023 Veera Sivarajan Ecma International.  All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-update-expressions-static-semantics-early-errors
+  esid: sec-update-expressions-static-semantics-early-errors
 description: >
-It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple. (this)
+  It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple. (this)
 info: |
   sec-static-semantics-assignmenttargettype
 
-  PrimaryExpression : this 
+    PrimaryExpression: this 
 
-  Return invalid.
+    Return invalid.
 
   sec-update-expressions-static-semantics-early-errors
 
-  UpdateExpression: ++ UnaryExpression 
+    UpdateExpression: ++ UnaryExpression 
 
-  It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple.
+    It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple.
 negative:
   phase: parse
   type: SyntaxError


### PR DESCRIPTION
This PR adds tests to check if postfix and prefix increment and decrement operations on `this` throws a syntax error as mentioned in [spec](https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors). 

We found that test262 does not test this case when fixing [related bug](https://github.com/boa-dev/boa/pull/2507#pullrequestreview-1230300104) in Boa.

P.S: First time contributing here. ~~Please let me know how to fix the frontmatter~~.