### PR TITLE
Test for Unicode Escape in Literals

### DIFF
--- a/test/language/literals/boolean/false-with-unicode.js
+++ b/test/language/literals/boolean/false-with-unicode.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Veera Sivarajan. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-keywords-and-reserved-words
+description: >
+  ReservedWord (false) cannot contain UnicodeEscapeSequence.
+info: | 
+  Note 1
+
+  Per 5.1.5, keywords in the grammar match literal sequences of specific SourceCharacter elements.
+  A code point in a keyword cannot be expressed by a \ UnicodeEscapeSequence.
+negative: 
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+f\u{61}lse;

--- a/test/language/literals/boolean/true-with-unicode.js
+++ b/test/language/literals/boolean/true-with-unicode.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Veera Sivarajan. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-keywords-and-reserved-words
+description: >
+  ReservedWord (true) cannot contain UnicodeEscapeSequence.
+info: | 
+  Note 1
+
+  Per 5.1.5, keywords in the grammar match literal sequences of specific SourceCharacter elements.
+  A code point in a keyword cannot be expressed by a \ UnicodeEscapeSequence.
+negative: 
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+tru\u{65};

--- a/test/language/literals/null/null-with-unicode.js
+++ b/test/language/literals/null/null-with-unicode.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Veera Sivarajan. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-keywords-and-reserved-words
+description: >
+  ReservedWord (null) cannot contain UnicodeEscapeSequence.
+info: | 
+  Note 1
+
+  Per 5.1.5, keywords in the grammar match literal sequences of specific SourceCharacter elements.
+  A code point in a keyword cannot be expressed by a \ UnicodeEscapeSequence.
+negative: 
+  phase: parse
+  type: SyntaxError
+---*/
+
+$DONOTEVALUATE();
+
+n\u{75}ll;


### PR DESCRIPTION
This PR adds tests to check if literals (`true`, `false`, and `null`) containing Unicode escape sequence throws a syntax error as mentioned in NOTE 1 in the [spec](https://tc39.es/ecma262/#sec-keywords-and-reserved-words).