### PR TITLE
Fix phase on some negative module tests

### DIFF
--- a/test/language/module-code/instn-iee-err-ambiguous-as.js
+++ b/test/language/module-code/instn-iee-err-ambiguous-as.js
@@ -31,9 +31,11 @@ info: |
                   SameValue(resolution.[[BindingName]],
                   starResolution.[[BindingName]]) is false, return "ambiguous".
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 export { x as y } from './instn-iee-err-ambiguous_FIXTURE.js';

--- a/test/language/module-code/instn-iee-err-ambiguous.js
+++ b/test/language/module-code/instn-iee-err-ambiguous.js
@@ -31,9 +31,11 @@ info: |
                   SameValue(resolution.[[BindingName]],
                   starResolution.[[BindingName]]) is false, return "ambiguous".
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 export { x } from './instn-iee-err-ambiguous_FIXTURE.js';

--- a/test/language/module-code/instn-iee-err-circular-as.js
+++ b/test/language/module-code/instn-iee-err-circular-as.js
@@ -20,9 +20,11 @@ info: |
           i. Assert: this is a circular import request.
           ii. Return null.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 export { x as y } from './instn-iee-err-circular_FIXTURE.js';

--- a/test/language/module-code/instn-iee-err-circular.js
+++ b/test/language/module-code/instn-iee-err-circular.js
@@ -20,9 +20,11 @@ info: |
           i. Assert: this is a circular import request.
           ii. Return null.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 export { x } from './instn-iee-err-circular_FIXTURE.js';

--- a/test/language/module-code/instn-iee-err-dflt-thru-star-as.js
+++ b/test/language/module-code/instn-iee-err-dflt-thru-star-as.js
@@ -19,9 +19,11 @@ info: |
        b. Throw a SyntaxError exception.
        c. NOTE A default export cannot be provided by an export *.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 export { default as x } from './instn-iee-err-dflt-thru-star-int_FIXTURE.js';

--- a/test/language/module-code/instn-iee-err-dflt-thru-star.js
+++ b/test/language/module-code/instn-iee-err-dflt-thru-star.js
@@ -19,9 +19,11 @@ info: |
        b. Throw a SyntaxError exception.
        c. NOTE A default export cannot be provided by an export *.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 export { default } from './instn-iee-err-dflt-thru-star-int_FIXTURE.js';

--- a/test/language/module-code/instn-iee-err-not-found-as.js
+++ b/test/language/module-code/instn-iee-err-not-found-as.js
@@ -19,9 +19,11 @@ info: |
         [...]
     11. Return starResolution.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 export { x as y } from './instn-iee-err-not-found-empty_FIXTURE.js';

--- a/test/language/module-code/instn-iee-err-not-found.js
+++ b/test/language/module-code/instn-iee-err-not-found.js
@@ -19,9 +19,11 @@ info: |
         [...]
     11. Return starResolution.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 export { x } from './instn-iee-err-not-found-empty_FIXTURE.js';

--- a/test/language/module-code/instn-named-err-ambiguous-as.js
+++ b/test/language/module-code/instn-named-err-ambiguous-as.js
@@ -36,9 +36,11 @@ info: |
                   SameValue(resolution.[[BindingName]],
                   starResolution.[[BindingName]]) is false, return "ambiguous".
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 import { x as y } from './instn-named-err-ambiguous_FIXTURE.js';

--- a/test/language/module-code/instn-named-err-ambiguous.js
+++ b/test/language/module-code/instn-named-err-ambiguous.js
@@ -36,9 +36,11 @@ info: |
                   SameValue(resolution.[[BindingName]],
                   starResolution.[[BindingName]]) is false, return "ambiguous".
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 import { x } from './instn-named-err-ambiguous_FIXTURE.js';

--- a/test/language/module-code/instn-named-err-dflt-thru-star-as.js
+++ b/test/language/module-code/instn-named-err-dflt-thru-star-as.js
@@ -24,9 +24,11 @@ info: |
        b. Throw a SyntaxError exception.
        c. NOTE A default export cannot be provided by an export *.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 import { default as x } from './instn-named-err-dflt-thru-star-int_FIXTURE.js';

--- a/test/language/module-code/instn-named-err-dflt-thru-star-dflt.js
+++ b/test/language/module-code/instn-named-err-dflt-thru-star-dflt.js
@@ -24,9 +24,11 @@ info: |
        b. Throw a SyntaxError exception.
        c. NOTE A default export cannot be provided by an export *.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 import x from './instn-named-err-dflt-thru-star-int_FIXTURE.js';

--- a/test/language/module-code/instn-named-err-not-found-as.js
+++ b/test/language/module-code/instn-named-err-not-found-as.js
@@ -24,9 +24,11 @@ info: |
         [...]
     11. Return starResolution.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 import { x as y } from './instn-named-err-not-found-empty_FIXTURE.js';

--- a/test/language/module-code/instn-named-err-not-found-dflt.js
+++ b/test/language/module-code/instn-named-err-not-found-dflt.js
@@ -24,9 +24,11 @@ info: |
         [...]
     11. Return starResolution.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 import x from './instn-named-err-not-found-empty_FIXTURE.js';

--- a/test/language/module-code/instn-named-err-not-found.js
+++ b/test/language/module-code/instn-named-err-not-found.js
@@ -24,9 +24,11 @@ info: |
         [...]
     11. Return starResolution.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 import { x } from './instn-named-err-not-found-empty_FIXTURE.js';

--- a/test/language/module-code/instn-star-err-not-found.js
+++ b/test/language/module-code/instn-star-err-not-found.js
@@ -23,9 +23,11 @@ info: |
           i. Let resolution be ? module.ResolveExport(name, « », « »).
           ii. If resolution is null, throw a SyntaxError exception.
 negative:
-  phase: runtime
+  phase: resolution
   type: SyntaxError
 flags: [module]
 ---*/
+
+$DONOTEVALUATE();
 
 import * as ns from './instn-star-err-not-found-faulty_FIXTURE.js';


### PR DESCRIPTION
A couple of negative tests had an incorrect phase tagged, since their errors happen at linking time, which is part of the "resolution" phase. However, they were marked as happening at runtime.

This PR fixes those tests and additionally adds a `$DONOTEVALUATE` marker to them.