### PR TITLE
Don't require Inflect for linting files

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -5,7 +5,6 @@
 from __future__ import print_function
 
 import argparse
-import inflect
 import os
 try:
     from pip._internal import main as pip
@@ -15,7 +14,14 @@ except ImportError:
     from pip.req import parse_requirements, InstallRequirement
 import sys
 
-ie = inflect.engine()
+try:
+    import inflect
+    ie = inflect.engine()
+except ImportError:
+    class InflectMock:
+        def plural(self, name, count):
+            return name
+    ie = InflectMock()
 
 try:
     __import__('yaml')

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -15,15 +15,6 @@ except ImportError:
 import sys
 
 try:
-    import inflect
-    ie = inflect.engine()
-except ImportError:
-    class InflectMock:
-        def plural(self, name, count):
-            return name
-    ie = InflectMock()
-
-try:
     __import__('yaml')
 except ImportError:
     for item in parse_requirements("./tools/lint/requirements.txt", session="test262"):
@@ -103,7 +94,7 @@ if __name__ == '__main__':
 
     files = [path for _path in args.path for path in collect_files(_path)]
     file_count = len(files)
-    print('Linting %s %s' % (file_count, ie.plural('file', file_count)))
+    print('Linting %s file(s)' % (file_count))
 
     all_errors = lint(files)
     unexpected_errors = dict(all_errors)
@@ -115,7 +106,7 @@ if __name__ == '__main__':
             del unexpected_errors[file_name]
 
     error_count = len(unexpected_errors)
-    print('Linting complete. %s %s found.' % (error_count, ie.plural('error', error_count)))
+    print('Linting complete. %s error(s) found.' % (error_count))
 
     if error_count == 0:
         sys.exit(0)

--- a/tools/lint/requirements.txt
+++ b/tools/lint/requirements.txt
@@ -1,2 +1,1 @@
 PyYAML==5.1.2
-inflect==0.2.5


### PR DESCRIPTION
Allow to lint files even when the "inflect" module isn't available.

