### PR TITLE
Replace arrow function with regular function in harness/sta.js

### DIFF
--- a/harness/sta.js
+++ b/harness/sta.js
@@ -18,7 +18,7 @@ Test262Error.prototype.toString = function () {
   return "Test262Error: " + this.message;
 };
 
-Test262Error.thrower = (message) => {
+Test262Error.thrower = function (message) {
   throw new Test262Error(message);
 };
 


### PR DESCRIPTION
All functions in `assert.js` and `sta.js` (which are the two files required for every test) are already regular functions, except this one.